### PR TITLE
chore: default order should be by name and version

### DIFF
--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -173,7 +173,9 @@ impl SbomService {
                     .add_columns(sbom_package_cpe_ref::Entity)
                     .add_columns(sbom_package_purl_ref::Entity),
             )?
-            .order_by_asc(sbom_package::Column::NodeId); // default order
+            // default order
+            .order_by_asc(sbom_node::Column::Name)
+            .order_by_asc(sbom_package::Column::Version);
 
         // limit and execute
 


### PR DESCRIPTION
The Node ID isn't visible to the user, having the "name" as a primary element in the list view, I think it makes sense to use the name as a default column for sorting. Second, the version.