### PR TITLE
Add id indexes to speed up purl resolution.

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -82,6 +82,7 @@ mod m0000630_create_product_version_range;
 mod m0000631_alter_product_cpe_key;
 mod m0000640_create_product_status;
 mod m0000650_alter_advisory_tracking;
+mod m0000660_purl_id_indexes;
 
 pub struct Migrator;
 
@@ -171,6 +172,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000631_alter_product_cpe_key::Migration),
             Box::new(m0000640_create_product_status::Migration),
             Box::new(m0000650_alter_advisory_tracking::Migration),
+            Box::new(m0000660_purl_id_indexes::Migration),
         ]
     }
 }

--- a/migration/src/m0000660_purl_id_indexes.rs
+++ b/migration/src/m0000660_purl_id_indexes.rs
@@ -1,0 +1,97 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .table(BasePurl::Table)
+                    .name(Indexes::BasePurlIdIdx.to_string())
+                    .col(BasePurl::Id)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .table(VersionedPurl::Table)
+                    .name(Indexes::VersionedPurlIdIdx.to_string())
+                    .col(VersionedPurl::Id)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .table(QualifiedPurl::Table)
+                    .name(Indexes::QualifiedPurlIdIdx.to_string())
+                    .col(QualifiedPurl::Id)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(QualifiedPurl::Table)
+                    .name(Indexes::QualifiedPurlIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(VersionedPurl::Table)
+                    .name(Indexes::VersionedPurlIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(BasePurl::Table)
+                    .name(Indexes::BasePurlIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+enum Indexes {
+    BasePurlIdIdx,
+    VersionedPurlIdIdx,
+    QualifiedPurlIdIdx,
+}
+
+#[derive(DeriveIden)]
+enum BasePurl {
+    Table,
+    Id,
+}
+
+#[derive(DeriveIden)]
+enum VersionedPurl {
+    Table,
+    Id,
+}
+
+#[derive(DeriveIden)]
+enum QualifiedPurl {
+    Table,
+    Id,
+}


### PR DESCRIPTION
This mitigates perf problem seen in #837 by adding simple indexes on **id** for base_purl, versioned_purl and qualified_purl tables. 

Probably the last of the 'obvious' indexes.