### PR TITLE
chore: database and migration on otel compose

### DIFF
--- a/etc/telemetry/compose.yaml
+++ b/etc/telemetry/compose.yaml
@@ -31,7 +31,7 @@ services:
     restart: unless-stopped
 
   collector:
-    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.119.0
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.127.0
     command: ["--config=/otel-collector-config.yaml"]
     volumes:
       - './config-collector.yaml:/otel-collector-config.yaml:z'


### PR DESCRIPTION
* For convenience, avoiding 2 extra terminals opened during development experiments.