### PR TITLE
TC-2564 : Add versions column to sbom to allow version filtering

### DIFF
--- a/entity/src/sbom.rs
+++ b/entity/src/sbom.rs
@@ -21,6 +21,8 @@ pub struct Model {
 
     pub source_document_id: Option<Uuid>,
 
+    pub versions: Vec<String>,
+
     #[cfg_attr(
         feature = "async-graphql",
         graphql(derived(owned, into = "HashMap<String,String>", with = "Labels::from"))

--- a/etc/test-data/cyclonedx/container.json
+++ b/etc/test-data/cyclonedx/container.json
@@ -1,0 +1,28034 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid:6972bd6d-919f-483a-9bfc-97b879bc60f2",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-05-29T02:38:28Z",
+    "tools": [
+      {
+        "vendor": "anchore",
+        "name": "syft",
+        "version": "1.19.0"
+      }
+    ],
+    "component": {
+      "bom-ref": "8b3cf52115dba09d",
+      "type": "container",
+      "name": "/tmp/files/image",
+      "version": "sha256:fbf470d8b5b84606f797d78775b9de88e14fdb43cc47b2db6ff3747b46df323e"
+    },
+    "properties": [
+      {
+        "name": "syft:image:labels:architecture",
+        "value": "x86_64"
+      },
+      {
+        "name": "syft:image:labels:build-date",
+        "value": "2025-05-14T18:14:25"
+      },
+      {
+        "name": "syft:image:labels:com.redhat.component",
+        "value": "openjdk-21-runtime-ubi9-container"
+      },
+      {
+        "name": "syft:image:labels:com.redhat.license_terms",
+        "value": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+      },
+      {
+        "name": "syft:image:labels:description",
+        "value": "Image for Red Hat OpenShift providing OpenJDK 21 runtime"
+      },
+      {
+        "name": "syft:image:labels:distribution-scope",
+        "value": "public"
+      },
+      {
+        "name": "syft:image:labels:io.buildah.version",
+        "value": "1.37.6"
+      },
+      {
+        "name": "syft:image:labels:io.cekit.version",
+        "value": "4.13.0.dev0"
+      },
+      {
+        "name": "syft:image:labels:io.k8s.description",
+        "value": "Platform for running plain Java applications (fat-jar and flat classpath)"
+      },
+      {
+        "name": "syft:image:labels:io.k8s.display-name",
+        "value": "Java Applications"
+      },
+      {
+        "name": "syft:image:labels:io.openshift.tags",
+        "value": "java"
+      },
+      {
+        "name": "syft:image:labels:maintainer",
+        "value": "Red Hat OpenJDK \u003Copenjdk@redhat.com\u003E"
+      },
+      {
+        "name": "syft:image:labels:name",
+        "value": "ubi9/openjdk-21-runtime"
+      },
+      {
+        "name": "syft:image:labels:org.jboss.product",
+        "value": "openjdk"
+      },
+      {
+        "name": "syft:image:labels:org.jboss.product.openjdk.version",
+        "value": "21"
+      },
+      {
+        "name": "syft:image:labels:org.jboss.product.version",
+        "value": "21"
+      },
+      {
+        "name": "syft:image:labels:org.opencontainers.image.documentation",
+        "value": "https://rh-openjdk.github.io/redhat-openjdk-containers/"
+      },
+      {
+        "name": "syft:image:labels:release",
+        "value": "1.1747241886"
+      },
+      {
+        "name": "syft:image:labels:summary",
+        "value": "Image for Red Hat OpenShift providing OpenJDK 21 runtime"
+      },
+      {
+        "name": "syft:image:labels:url",
+        "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9/openjdk-21-runtime/images/1.22-1.1747241886"
+      },
+      {
+        "name": "syft:image:labels:usage",
+        "value": "https://rh-openjdk.github.io/redhat-openjdk-containers/"
+      },
+      {
+        "name": "syft:image:labels:vcs-ref",
+        "value": "3046cb98398d69976eb27f0d2f1ff1458a9612cf"
+      },
+      {
+        "name": "syft:image:labels:vcs-type",
+        "value": "git"
+      },
+      {
+        "name": "syft:image:labels:vendor",
+        "value": "Red Hat, Inc."
+      },
+      {
+        "name": "syft:image:labels:version",
+        "value": "1.22"
+      }
+    ]
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.2.2?package-id=7505e809fd605d6b",
+      "type": "library",
+      "group": "org.hdrhistogram",
+      "name": "HdrHistogram",
+      "version": "2.2.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://creativecommons.org/publicdomain/zero/1.0/, https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:org.hdrhistogram.HdrHistogram:HdrHistogram:2.2.2:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.hdrhistogram/HdrHistogram@2.2.2",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "7959933ebcc0f05b2eaa5af0a0c8689fa257b15c"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.hdrhistogram:HdrHistogram:2.2.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:HdrHistogram:HdrHistogram:2.2.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:hdrhistogram:HdrHistogram:2.2.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.hdrhistogram.HdrHistogram-2.2.2.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "HdrHistogram"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.hdrhistogram"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.hdrhistogram.HdrHistogram-2.2.2.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3?package-id=1fe95ccd58f31aca",
+      "type": "library",
+      "group": "org.latencyutils",
+      "name": "LatencyUtils",
+      "version": "2.0.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain, per Creative Commons CC0",
+            "url": "http://creativecommons.org/publicdomain/zero/1.0/"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:org.latencyutils:LatencyUtils:2.0.3:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "769c0b82cb2421c8256300e907298a9410a2a3d3"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:LatencyUtils:LatencyUtils:2.0.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:latencyutils:LatencyUtils:2.0.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.latencyutils.LatencyUtils-2.0.3.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "LatencyUtils"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.latencyutils"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.latencyutils.LatencyUtils-2.0.3.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/alsa-lib@1.2.13-2.el9?arch=x86_64&distro=rhel-9.6&package-id=c6d3f4fac5cd90c4&upstream=alsa-lib-1.2.13-2.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "alsa-lib",
+      "version": "1.2.13-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:alsa-lib:alsa-lib:1.2.13-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/alsa-lib@1.2.13-2.el9?arch=x86_64&distro=rhel-9.6&upstream=alsa-lib-1.2.13-2.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:alsa-lib:alsa_lib:1.2.13-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:alsa_lib:alsa-lib:1.2.13-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:alsa_lib:alsa_lib:1.2.13-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:alsa-lib:1.2.13-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:alsa_lib:1.2.13-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:alsa:alsa-lib:1.2.13-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:alsa:alsa_lib:1.2.13-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "2.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1516779"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "alsa-lib-1.2.13-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64&distro=rhel-9.6&package-id=1d92a866b3c8fee3&upstream=chkconfig-1.24-2.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "alternatives",
+      "version": "1.24-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-only"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:alternatives:alternatives:1.24-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64&distro=rhel-9.6&upstream=chkconfig-1.24-2.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:alternatives:1.24-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "2.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "63489"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "chkconfig-1.24-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.eclipse.angus/angus-activation@2.0.2?package-id=319a0388fbf2851c",
+      "type": "library",
+      "group": "org.eclipse.angus",
+      "name": "angus-activation",
+      "version": "2.0.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:eclipse-foundation:angus-activation:2.0.2:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.eclipse.angus/angus-activation@2.0.2",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "41f1e0ddd157c856926ed149ab837d110955a9fc"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:angus_activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:angus-activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:angus_activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.eclipse.angus:angus-activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.eclipse.angus:angus_activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:angus-activation:angus-activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:angus-activation:angus_activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:angus_activation:angus-activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:angus_activation:angus_activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:angus:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:angus-activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:angus_activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:angus:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.eclipse.angus:angus:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:angus-activation:angus:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:angus:angus-activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:angus:angus_activation:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:angus_activation:angus:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:angus:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:angus:angus:2.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.eclipse.angus.angus-activation-2.0.2.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "angus-activation"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.eclipse.angus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.eclipse.angus.angus-activation-2.0.2.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus.arc/arc@3.19.1?package-id=cb5050e75d8774bc",
+      "type": "library",
+      "group": "io.quarkus.arc",
+      "name": "arc",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.quarkus.arc:arc:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus.arc/arc@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "671f65b206012fe6e87c464e3532e783432f9b8a"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:arc:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:arc:arc:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.arc.arc-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "arc"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus.arc"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.arc.arc-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0?package-id=a9e0c91829f360cf",
+      "type": "library",
+      "group": "com.ibm.async",
+      "name": "asyncutil",
+      "version": "0.1.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache Software License, Version 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:com.ibm.async:asyncutil:0.1.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "440941c382166029a299602e6c9ff5abde1b5143"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:asyncutil:asyncutil:0.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:com.ibm.async:async:0.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:async:asyncutil:0.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:asyncutil:async:0.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ibm:asyncutil:0.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:async:async:0.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ibm:async:0.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/com.ibm.async.asyncutil-0.1.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "asyncutil"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "com.ibm.async"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/com.ibm.async.asyncutil-0.1.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/audit-libs@3.1.5-4.el9?arch=x86_64&distro=rhel-9.6&package-id=ec77664bfe6dc2c0&upstream=audit-3.1.5-4.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "audit-libs",
+      "version": "3.1.5-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:audit-libs:audit-libs:3.1.5-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/audit-libs@3.1.5-4.el9?arch=x86_64&distro=rhel-9.6&upstream=audit-3.1.5-4.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:audit-libs:audit_libs:3.1.5-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:audit_libs:audit-libs:3.1.5-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:audit_libs:audit_libs:3.1.5-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:audit-libs:3.1.5-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:audit_libs:3.1.5-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:audit:audit-libs:3.1.5-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:audit:audit_libs:3.1.5-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "4.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "338481"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "audit-3.1.5-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/avahi-libs@0.8-22.el9_6?arch=x86_64&distro=rhel-9.6&package-id=0fd42a816d402858&upstream=avahi-0.8-22.el9_6.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "avahi-libs",
+      "version": "0.8-22.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:avahi-libs:avahi-libs:0.8-22.el9_6:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/avahi-libs@0.8-22.el9_6?arch=x86_64&distro=rhel-9.6&upstream=avahi-0.8-22.el9_6.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:avahi-libs:avahi_libs:0.8-22.el9_6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:avahi_libs:avahi-libs:0.8-22.el9_6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:avahi_libs:avahi_libs:0.8-22.el9_6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:avahi-libs:0.8-22.el9_6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:avahi_libs:0.8-22.el9_6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:avahi:avahi-libs:0.8-22.el9_6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:avahi:avahi_libs:0.8-22.el9_6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "22.el9_6"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "177286"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "avahi-0.8-22.el9_6.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch&distro=rhel-9.6&package-id=3066bacfe81791e1&upstream=basesystem-11-13.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "basesystem",
+      "version": "11-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:basesystem:basesystem:11-13.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch&distro=rhel-9.6&upstream=basesystem-11-13.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:basesystem:11-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "13.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "0"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "basesystem-11-13.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "bash",
+      "version": "5.1.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:bash:5.1.8-9.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&upstream=bash-5.1.8-9.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bash:bash:5.1.8-9.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "9.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "7738778"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "bash-5.1.8-9.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.16.0?package-id=296412f44d6360c3",
+      "type": "library",
+      "group": "com.aayushatharva.brotli4j",
+      "name": "brotli4j",
+      "version": "1.16.0",
+      "cpe": "cpe:2.3:a:com.aayushatharva.brotli4j:brotli4j:1.16.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.16.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "990e983bb462867d036c7c243c6566f65fdca68f"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:aayushatharva:brotli4j:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:brotli4j:brotli4j:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/com.aayushatharva.brotli4j.brotli4j-1.16.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "brotli4j"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "com.aayushatharva.brotli4j"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/com.aayushatharva.brotli4j.brotli4j-1.16.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64&distro=rhel-9.6&package-id=6e824ef360f5dc6e&upstream=bzip2-1.0.8-10.el9_5.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "bzip2-libs",
+      "version": "1.0.8-10.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:bzip2-libs:bzip2-libs:1.0.8-10.el9_5:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64&distro=rhel-9.6&upstream=bzip2-1.0.8-10.el9_5.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bzip2-libs:bzip2_libs:1.0.8-10.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bzip2_libs:bzip2-libs:1.0.8-10.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bzip2_libs:bzip2_libs:1.0.8-10.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:bzip2-libs:1.0.8-10.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:bzip2_libs:1.0.8-10.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bzip2:bzip2-libs:1.0.8-10.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bzip2:bzip2_libs:1.0.8-10.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "10.el9_5"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "78228"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "bzip2-1.0.8-10.el9_5.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch&distro=rhel-9.6&package-id=5bd0ac95528d06e7&upstream=ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "ca-certificates",
+      "version": "2024.2.69_v8.0.303-91.4.el9_4",
+      "licenses": [
+        {
+          "expression": "MIT AND GPL-2.0-or-later"
+        }
+      ],
+      "cpe": "cpe:2.3:a:ca-certificates:ca-certificates:2024.2.69_v8.0.303-91.4.el9_4:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch&distro=rhel-9.6&upstream=ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ca-certificates:ca_certificates:2024.2.69_v8.0.303-91.4.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ca_certificates:ca-certificates:2024.2.69_v8.0.303-91.4.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ca_certificates:ca_certificates:2024.2.69_v8.0.303-91.4.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ca-certificates:2024.2.69_v8.0.303-91.4.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ca_certificates:2024.2.69_v8.0.303-91.4.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ca:ca-certificates:2024.2.69_v8.0.303-91.4.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ca:ca_certificates:2024.2.69_v8.0.303-91.4.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "91.4.el9_4"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "2698659"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.acme/code-with-quarkus@1.0.0-SNAPSHOT?package-id=2c1138ba5b330ad4",
+      "type": "library",
+      "name": "code-with-quarkus",
+      "version": "1.0.0-SNAPSHOT",
+      "cpe": "cpe:2.3:a:code-with-quarkus:code-with-quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.acme/code-with-quarkus@1.0.0-SNAPSHOT",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-pom-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:code-with-quarkus:code_with_quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:code_with_quarkus:code-with-quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:code_with_quarkus:code_with_quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:code-with:code-with-quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:code-with:code_with_quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:code_with:code-with-quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:code_with:code_with_quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.acme:code-with-quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.acme:code_with_quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:acme:code-with-quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:acme:code_with_quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:code:code-with-quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:code:code_with_quarkus:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/pom.xml"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/copy-jdk-configs@4.0-3.el9?arch=noarch&distro=rhel-9.6&package-id=39579b98f4c4b9fb&upstream=copy-jdk-configs-4.0-3.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "copy-jdk-configs",
+      "version": "4.0-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:copy-jdk-configs:copy-jdk-configs:4.0-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/copy-jdk-configs@4.0-3.el9?arch=noarch&distro=rhel-9.6&upstream=copy-jdk-configs-4.0-3.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:copy-jdk-configs:copy_jdk_configs:4.0-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:copy_jdk_configs:copy-jdk-configs:4.0-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:copy_jdk_configs:copy_jdk_configs:4.0-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:copy-jdk:copy-jdk-configs:4.0-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:copy-jdk:copy_jdk_configs:4.0-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:copy_jdk:copy-jdk-configs:4.0-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:copy_jdk:copy_jdk_configs:4.0-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:copy-jdk-configs:4.0-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:copy_jdk_configs:4.0-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:copy:copy-jdk-configs:4.0-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:copy:copy_jdk_configs:4.0-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "3.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "19806"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "copy-jdk-configs-4.0-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64&distro=rhel-9.6&package-id=f58fd0c56048619d&upstream=coreutils-8.32-39.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "coreutils-single",
+      "version": "8.32-39.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:coreutils-single:coreutils-single:8.32-39.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64&distro=rhel-9.6&upstream=coreutils-8.32-39.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:coreutils-single:coreutils_single:8.32-39.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:coreutils_single:coreutils-single:8.32-39.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:coreutils_single:coreutils_single:8.32-39.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:coreutils:coreutils-single:8.32-39.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:coreutils:coreutils_single:8.32-39.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:coreutils-single:8.32-39.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:coreutils_single:8.32-39.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "39.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1403185"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "coreutils-8.32-39.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&package-id=64df59775f05049c&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "crypto-policies",
+      "version": "20250128-1.git5269e22.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:crypto-policies:crypto-policies:20250128-1.git5269e22.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto-policies:crypto_policies:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto_policies:crypto-policies:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto_policies:crypto_policies:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto:crypto-policies:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto:crypto_policies:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:crypto-policies:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:crypto_policies:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.git5269e22.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "91854"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "crypto-policies-20250128-1.git5269e22.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/crypto-policies-scripts@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&package-id=464ea69fc556f4ad&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "crypto-policies-scripts",
+      "version": "20250128-1.git5269e22.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:crypto-policies-scripts:crypto-policies-scripts:20250128-1.git5269e22.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/crypto-policies-scripts@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto-policies-scripts:crypto_policies_scripts:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto_policies_scripts:crypto-policies-scripts:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto_policies_scripts:crypto_policies_scripts:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto-policies:crypto-policies-scripts:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto-policies:crypto_policies_scripts:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto_policies:crypto-policies-scripts:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto_policies:crypto_policies_scripts:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto:crypto-policies-scripts:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto:crypto_policies_scripts:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:crypto-policies-scripts:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:crypto_policies_scripts:20250128-1.git5269e22.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.git5269e22.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "253705"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "crypto-policies-20250128-1.git5269e22.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/cups-libs@2.3.3op2-33.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=a3e336e82d2ec332&upstream=cups-2.3.3op2-33.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "cups-libs",
+      "version": "1:2.3.3op2-33.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 and zlib"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:cups-libs:cups-libs:1\\:2.3.3op2-33.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/cups-libs@2.3.3op2-33.el9?arch=x86_64&distro=rhel-9.6&epoch=1&upstream=cups-2.3.3op2-33.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cups-libs:cups_libs:1\\:2.3.3op2-33.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cups_libs:cups-libs:1\\:2.3.3op2-33.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cups_libs:cups_libs:1\\:2.3.3op2-33.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:cups-libs:1\\:2.3.3op2-33.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:cups_libs:1\\:2.3.3op2-33.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cups:cups-libs:1\\:2.3.3op2-33.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cups:cups_libs:1\\:2.3.3op2-33.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:epoch",
+          "value": "1"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "33.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "686489"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "cups-2.3.3op2-33.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/curl-minimal@7.76.1-31.el9?arch=x86_64&distro=rhel-9.6&package-id=f509087c83d84120&upstream=curl-7.76.1-31.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "curl-minimal",
+      "version": "7.76.1-31.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:curl-minimal:curl-minimal:7.76.1-31.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/curl-minimal@7.76.1-31.el9?arch=x86_64&distro=rhel-9.6&upstream=curl-7.76.1-31.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:curl-minimal:curl_minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:curl_minimal:curl-minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:curl_minimal:curl_minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:curl-minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:curl_minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:curl:curl-minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:curl:curl_minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "31.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "245289"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "curl-7.76.1-31.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64&distro=rhel-9.6&package-id=d55618a97ad843dd&upstream=cyrus-sasl-2.1.27-21.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "cyrus-sasl-lib",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:cyrus-sasl-lib:cyrus-sasl-lib:2.1.27-21.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64&distro=rhel-9.6&upstream=cyrus-sasl-2.1.27-21.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus-sasl-lib:cyrus_sasl_lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus_sasl_lib:cyrus-sasl-lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus_sasl_lib:cyrus_sasl_lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus-sasl:cyrus-sasl-lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus-sasl:cyrus_sasl_lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus_sasl:cyrus-sasl-lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus_sasl:cyrus_sasl_lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:cyrus-sasl-lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:cyrus_sasl_lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus:cyrus-sasl-lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus:cyrus_sasl_lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "21.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "2380384"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "cyrus-sasl-2.1.27-21.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=b03f2d59aa419aaa&upstream=dbus-1.12.20-8.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "dbus-libs",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:dbus-libs:dbus-libs:1\\:1.12.20-8.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&distro=rhel-9.6&epoch=1&upstream=dbus-1.12.20-8.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus-libs:dbus_libs:1\\:1.12.20-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus_libs:dbus-libs:1\\:1.12.20-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus_libs:dbus_libs:1\\:1.12.20-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dbus-libs:1\\:1.12.20-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dbus_libs:1\\:1.12.20-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus:dbus-libs:1\\:1.12.20-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus:dbus_libs:1\\:1.12.20-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:epoch",
+          "value": "1"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "8.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "372990"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "dbus-1.12.20-8.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch&distro=rhel-9.6&package-id=cfc22ea58527299d&upstream=dejavu-fonts-2.37-18.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "dejavu-sans-fonts",
+      "version": "2.37-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bitstream Vera and Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:dejavu-sans-fonts:dejavu-sans-fonts:2.37-18.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch&distro=rhel-9.6&upstream=dejavu-fonts-2.37-18.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu-sans-fonts:dejavu_sans_fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu_sans_fonts:dejavu-sans-fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu_sans_fonts:dejavu_sans_fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu-sans:dejavu-sans-fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu-sans:dejavu_sans_fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu_sans:dejavu-sans-fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu_sans:dejavu_sans_fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu:dejavu-sans-fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu:dejavu_sans_fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dejavu-sans-fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dejavu_sans_fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "18.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "5930958"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "dejavu-fonts-2.37-18.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/dnf-data@4.14.0-25.el9?arch=noarch&distro=rhel-9.6&package-id=9e2c17fe427676e7&upstream=dnf-4.14.0-25.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "dnf-data",
+      "version": "4.14.0-25.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:dnf-data:dnf-data:4.14.0-25.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/dnf-data@4.14.0-25.el9?arch=noarch&distro=rhel-9.6&upstream=dnf-4.14.0-25.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dnf-data:dnf_data:4.14.0-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dnf_data:dnf-data:4.14.0-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dnf_data:dnf_data:4.14.0-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dnf-data:4.14.0-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dnf_data:4.14.0-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dnf:dnf-data:4.14.0-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dnf:dnf_data:4.14.0-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "25.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "39397"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "dnf-4.14.0-25.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/expat@2.5.0-5.el9_6?arch=x86_64&distro=rhel-9.6&package-id=66e9bceb48b8d8cb&upstream=expat-2.5.0-5.el9_6.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "expat",
+      "version": "2.5.0-5.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:expat:2.5.0-5.el9_6:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/expat@2.5.0-5.el9_6?arch=x86_64&distro=rhel-9.6&upstream=expat-2.5.0-5.el9_6.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:expat:expat:2.5.0-5.el9_6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "5.el9_6"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "309138"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "expat-2.5.0-5.el9_6.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus.bootstrap.runner.QuarkusEntryPoint/export-run-artifact@1.0.0-SNAPSHOT?package-id=4274fa070df7bee7",
+      "type": "library",
+      "name": "export-run-artifact",
+      "version": "1.0.0-SNAPSHOT",
+      "cpe": "cpe:2.3:a:io.quarkus.bootstrap.runner.QuarkusEntryPoint:export-run-artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus.bootstrap.runner.QuarkusEntryPoint/export-run-artifact@1.0.0-SNAPSHOT",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b02a8b2d9608249a6a5de27e06269a2cf38d131f"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus.bootstrap.runner.QuarkusEntryPoint:export_run_artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus.bootstrap.runner.QuarkusEntryPoint:QuarkusEntryPoint:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus.bootstrap.runner.QuarkusEntryPoint:bootstrap:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus.bootstrap.runner.QuarkusEntryPoint:runner:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export-run-artifact:export-run-artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export-run-artifact:export_run_artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export_run_artifact:export-run-artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export_run_artifact:export_run_artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:QuarkusEntryPoint:export-run-artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:QuarkusEntryPoint:export_run_artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export-run-artifact:QuarkusEntryPoint:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export_run_artifact:QuarkusEntryPoint:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:QuarkusEntryPoint:QuarkusEntryPoint:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export-run:export-run-artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export-run:export_run_artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export_run:export-run-artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export_run:export_run_artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bootstrap:export-run-artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bootstrap:export_run_artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export-run-artifact:bootstrap:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export_run_artifact:bootstrap:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export-run:QuarkusEntryPoint:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export_run:QuarkusEntryPoint:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:QuarkusEntryPoint:bootstrap:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bootstrap:QuarkusEntryPoint:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:export-run-artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:export_run_artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export-run-artifact:runner:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export:export-run-artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export:export_run_artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export_run_artifact:runner:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:runner:export-run-artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:runner:export_run_artifact:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:QuarkusEntryPoint:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:QuarkusEntryPoint:runner:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export:QuarkusEntryPoint:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:runner:QuarkusEntryPoint:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export-run:bootstrap:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export_run:bootstrap:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bootstrap:bootstrap:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export-run:runner:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export_run:runner:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:bootstrap:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bootstrap:runner:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export:bootstrap:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:runner:bootstrap:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:runner:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:export:runner:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:runner:runner:1.0.0-SNAPSHOT:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/export-run-artifact.jar"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/export-run-artifact.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64&distro=rhel-9.6&package-id=87c5a5bd9220edaf&upstream=file-5.39-16.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "file-libs",
+      "version": "5.39-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:file-libs:file-libs:5.39-16.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64&distro=rhel-9.6&upstream=file-5.39-16.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:file-libs:file_libs:5.39-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:file_libs:file-libs:5.39-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:file_libs:file_libs:5.39-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:file-libs:5.39-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:file_libs:5.39-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:file:file-libs:5.39-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:file:file_libs:5.39-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "16.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "8086748"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "file-5.39-16.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64&distro=rhel-9.6&package-id=4887a6ed0441d418&upstream=filesystem-3.16-5.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "filesystem",
+      "version": "3.16-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:filesystem:filesystem:3.16-5.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64&distro=rhel-9.6&upstream=filesystem-3.16-5.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:filesystem:3.16-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "5.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "106"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "filesystem-3.16-5.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/findutils@4.8.0-7.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=9f05b8368b69d363&upstream=findutils-4.8.0-7.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "findutils",
+      "version": "1:4.8.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:findutils:findutils:1\\:4.8.0-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/findutils@4.8.0-7.el9?arch=x86_64&distro=rhel-9.6&epoch=1&upstream=findutils-4.8.0-7.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:findutils:1\\:4.8.0-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:epoch",
+          "value": "1"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "7.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1756958"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "findutils-4.8.0-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&distro=rhel-9.6&epoch=1&package-id=bcf36e2c3425d2bc&upstream=fonts-rpm-macros-2.0.5-7.el9.1.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "fonts-filesystem",
+      "version": "1:2.0.5-7.el9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:fonts-filesystem:fonts-filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&distro=rhel-9.6&epoch=1&upstream=fonts-rpm-macros-2.0.5-7.el9.1.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fonts-filesystem:fonts_filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fonts_filesystem:fonts-filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fonts_filesystem:fonts_filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:fonts-filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:fonts_filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fonts:fonts-filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fonts:fonts_filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:epoch",
+          "value": "1"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "7.el9.1"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "0"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "fonts-rpm-macros-2.0.5-7.el9.1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64&distro=rhel-9.6&package-id=36081d8966c7e43f&upstream=gawk-5.1.0-6.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gawk",
+      "version": "5.1.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv2+ and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:gawk:5.1.0-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64&distro=rhel-9.6&upstream=gawk-5.1.0-6.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gawk:gawk:5.1.0-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "6.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1685726"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gawk-5.1.0-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=aefb88b0150eda0f&upstream=gdbm-1.23-1.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gdbm-libs",
+      "version": "1:1.23-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:gdbm-libs:gdbm-libs:1\\:1.23-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&distro=rhel-9.6&epoch=1&upstream=gdbm-1.23-1.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gdbm-libs:gdbm_libs:1\\:1.23-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gdbm_libs:gdbm-libs:1\\:1.23-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gdbm_libs:gdbm_libs:1\\:1.23-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:gdbm-libs:1\\:1.23-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:gdbm_libs:1\\:1.23-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gdbm:gdbm-libs:1\\:1.23-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gdbm:gdbm_libs:1\\:1.23-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:epoch",
+          "value": "1"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "128586"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gdbm-1.23-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/glib2@2.68.4-16.el9?arch=x86_64&distro=rhel-9.6&package-id=b153f7fb65cd8222&upstream=glib2-2.68.4-16.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "glib2",
+      "version": "2.68.4-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:glib2:2.68.4-16.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/glib2@2.68.4-16.el9?arch=x86_64&distro=rhel-9.6&upstream=glib2-2.68.4-16.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glib2:glib2:2.68.4-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "16.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "13445086"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "glib2-2.68.4-16.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "glibc",
+      "version": "2.34-168.el9_6.14",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:glibc:2.34-168.el9_6.14:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc:glibc:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "168.el9_6.14"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "6420883"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "glibc-2.34-168.el9_6.14.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/glibc-common@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=26690b7b770c59f8&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "glibc-common",
+      "version": "2.34-168.el9_6.14",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:glibc-common:glibc-common:2.34-168.el9_6.14:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/glibc-common@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc-common:glibc_common:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc_common:glibc-common:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc_common:glibc_common:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:glibc-common:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:glibc_common:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc:glibc-common:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc:glibc_common:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "168.el9_6.14"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1081374"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "glibc-2.34-168.el9_6.14.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=f8d441a9d7378143&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "glibc-minimal-langpack",
+      "version": "2.34-168.el9_6.14",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:glibc-minimal-langpack:glibc-minimal-langpack:2.34-168.el9_6.14:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc-minimal-langpack:glibc_minimal_langpack:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc_minimal_langpack:glibc-minimal-langpack:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc_minimal_langpack:glibc_minimal_langpack:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc-minimal:glibc-minimal-langpack:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc-minimal:glibc_minimal_langpack:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc_minimal:glibc-minimal-langpack:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc_minimal:glibc_minimal_langpack:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:glibc-minimal-langpack:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:glibc_minimal_langpack:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc:glibc-minimal-langpack:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc:glibc_minimal_langpack:2.34-168.el9_6.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "168.el9_6.14"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "0"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "glibc-2.34-168.el9_6.14.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=e4c2cf4f6c98da18&upstream=gmp-6.2.0-13.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gmp",
+      "version": "1:6.2.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:gmp:1\\:6.2.0-13.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&distro=rhel-9.6&epoch=1&upstream=gmp-6.2.0-13.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gmp:gmp:1\\:6.2.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:epoch",
+          "value": "1"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "13.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "816844"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gmp-6.2.0-13.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64&distro=rhel-9.6&package-id=8f60bb6d2342f505&upstream=gnupg2-2.3.3-4.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gnupg2",
+      "version": "2.3.3-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:gnupg2:gnupg2:2.3.3-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64&distro=rhel-9.6&upstream=gnupg2-2.3.3-4.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:gnupg2:2.3.3-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "4.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "9227533"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gnupg2-2.3.3-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gnutls@3.8.3-6.el9?arch=x86_64&distro=rhel-9.6&package-id=bf12c6dd0c8e2348&upstream=gnutls-3.8.3-6.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gnutls",
+      "version": "3.8.3-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:gnutls:gnutls:3.8.3-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gnutls@3.8.3-6.el9?arch=x86_64&distro=rhel-9.6&upstream=gnutls-3.8.3-6.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:gnutls:3.8.3-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "6.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "3452581"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gnutls-3.8.3-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64&distro=rhel-9.6&package-id=02965c1a03015521&upstream=gobject-introspection-1.68.0-11.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gobject-introspection",
+      "version": "1.68.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:gobject-introspection:gobject-introspection:1.68.0-11.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64&distro=rhel-9.6&upstream=gobject-introspection-1.68.0-11.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gobject-introspection:gobject_introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gobject_introspection:gobject-introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gobject_introspection:gobject_introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gobject:gobject-introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gobject:gobject_introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:gobject-introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:gobject_introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "11.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "936649"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gobject-introspection-1.68.0-11.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e?distro=rhel-9.6&package-id=332e88ae996f3d51",
+      "type": "library",
+      "name": "gpg-pubkey",
+      "version": "5a6340b3-6229229e",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:gpg-pubkey:gpg-pubkey:5a6340b3-6229229e:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e?distro=rhel-9.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg-pubkey:gpg_pubkey:5a6340b3-6229229e:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg_pubkey:gpg-pubkey:5a6340b3-6229229e:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg_pubkey:gpg_pubkey:5a6340b3-6229229e:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg:gpg-pubkey:5a6340b3-6229229e:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg:gpg_pubkey:5a6340b3-6229229e:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "6229229e"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b?distro=rhel-9.6&package-id=fd091620a323bcdd",
+      "type": "library",
+      "name": "gpg-pubkey",
+      "version": "fd431d51-4ae0493b",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:gpg-pubkey:gpg-pubkey:fd431d51-4ae0493b:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b?distro=rhel-9.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg-pubkey:gpg_pubkey:fd431d51-4ae0493b:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg_pubkey:gpg-pubkey:fd431d51-4ae0493b:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg_pubkey:gpg_pubkey:fd431d51-4ae0493b:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg:gpg-pubkey:fd431d51-4ae0493b:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg:gpg_pubkey:fd431d51-4ae0493b:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "4ae0493b"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64&distro=rhel-9.6&package-id=8dfabda3e3f19eec&upstream=gpgme-1.15.1-6.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gpgme",
+      "version": "1.15.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:gpgme:1.15.1-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64&distro=rhel-9.6&upstream=gpgme-1.15.1-6.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpgme:gpgme:1.15.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "6.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "576065"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gpgme-1.15.1-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&distro=rhel-9.6&package-id=cb09cd721d5a9f23&upstream=grep-3.6-5.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "grep",
+      "version": "3.6-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:grep:3.6-5.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&distro=rhel-9.6&upstream=grep-3.6-5.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:grep:grep:3.6-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "5.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "857840"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "grep-3.6-5.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?package-id=353bc57517179f34",
+      "type": "library",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-core",
+      "version": "2.18.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:com.fasterxml.jackson.core.jackson-core:jackson-core:2.18.2:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "fb64ccac5c27dca8819418eb4e443a9f496d9ee7"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:com.fasterxml.jackson.core.jackson-core:jackson_core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:com.fasterxml.jackson.core.jackson-core:jackson:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:com.fasterxml.jackson.core.jackson-core:core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:com.fasterxml.jackson.core:jackson-core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:com.fasterxml.jackson.core:jackson_core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:com.fasterxml.jackson.core:jackson:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:com.fasterxml.jackson.core:core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jackson-core:jackson-core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jackson-core:jackson_core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jackson_core:jackson-core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jackson_core:jackson_core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fasterxml:jackson-core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fasterxml:jackson_core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jackson-core:jackson:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jackson:jackson-core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jackson:jackson_core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jackson_core:jackson:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:core:jackson-core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:core:jackson_core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fasterxml:jackson:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jackson-core:core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jackson_core:core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jackson:jackson:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fasterxml:core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:core:jackson:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jackson:core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:core:core:2.18.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/com.fasterxml.jackson.core.jackson-core-2.18.2.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jackson-core"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "com.fasterxml.jackson.core"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/com.fasterxml.jackson.core.jackson-core-2.18.2.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@2.1.3?package-id=bd03a60acfd5b174",
+      "type": "library",
+      "group": "jakarta.activation",
+      "name": "jakarta.activation-api",
+      "version": "2.1.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jakarta.activation-api:jakarta.activation-api:2.1.3:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.activation/jakarta.activation-api@2.1.3",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "fa165bd70cda600368eee31555222776a46b881f"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.activation-api:jakarta.activation_api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.activation_api:jakarta.activation-api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.activation_api:jakarta.activation_api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.activation-api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.activation_api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.activation-api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.activation_api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.activation:jakarta.activation-api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.activation:jakarta.activation_api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.activation.jakarta.activation-api-2.1.3.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.activation-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.activation"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.activation.jakarta.activation-api-2.1.3.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@3.0.0?package-id=152f5bf2f25c6653",
+      "type": "library",
+      "group": "jakarta.annotation",
+      "name": "jakarta.annotation-api",
+      "version": "3.0.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jakarta.annotation-api:jakarta.annotation-api:3.0.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@3.0.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "54f928fadec906a99d558536756d171917b9d936"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.annotation-api:jakarta.annotation_api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.annotation_api:jakarta.annotation-api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.annotation_api:jakarta.annotation_api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.annotation-api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.annotation_api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.annotation-api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.annotation_api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.annotation:jakarta.annotation-api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.annotation:jakarta.annotation_api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.glassfish:jakarta.annotation-api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.glassfish:jakarta.annotation_api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glassfish:jakarta.annotation-api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glassfish:jakarta.annotation_api:3.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.annotation.jakarta.annotation-api-3.0.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.annotation-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.annotation"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.annotation.jakarta.annotation-api-3.0.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.el/jakarta.el-api@5.0.1?package-id=e8a7f36c89ff9cf2",
+      "type": "library",
+      "group": "jakarta.el",
+      "name": "jakarta.el-api",
+      "version": "5.0.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt, https://www.gnu.org/software/classpath/license.html"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:eclipse-foundation:jakarta.el-api:5.0.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.el/jakarta.el-api@5.0.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6f46fb9143b18b7956806a657275fc41376d1a50"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.el_api:5.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.el-api:5.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.el_api:5.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.el-api:jakarta.el-api:5.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.el-api:jakarta.el_api:5.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.el_api:jakarta.el-api:5.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.el_api:jakarta.el_api:5.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.el:jakarta.el-api:5.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.el:jakarta.el_api:5.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.el.jakarta.el-api-5.0.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.el-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.el"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.el.jakarta.el-api-5.0.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@4.1.0?package-id=5983fda21822ccdb",
+      "type": "library",
+      "group": "jakarta.enterprise",
+      "name": "jakarta.enterprise.cdi-api",
+      "version": "4.1.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jakarta.enterprise.cdi-api:jakarta.enterprise.cdi-api:4.1.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@4.1.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "fed9518709d33252bfe0817fe61ad4dfd1b2e848"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.enterprise.cdi-api:jakarta.enterprise.cdi_api:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.enterprise.cdi_api:jakarta.enterprise.cdi-api:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.enterprise.cdi_api:jakarta.enterprise.cdi_api:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.enterprise.cdi:jakarta.enterprise.cdi-api:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.enterprise.cdi:jakarta.enterprise.cdi_api:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.enterprise.jakarta.enterprise.cdi-api-4.1.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.enterprise.cdi-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.enterprise"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.enterprise.jakarta.enterprise.cdi-api-4.1.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.lang-model@4.1.0?package-id=0245696a5aebf2bc",
+      "type": "library",
+      "group": "jakarta.enterprise",
+      "name": "jakarta.enterprise.lang-model",
+      "version": "4.1.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jakarta.enterprise.lang-model:jakarta.enterprise.lang-model:4.1.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.enterprise/jakarta.enterprise.lang-model@4.1.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9270ae3df4239d4f337215403ebc9801fe659a2b"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.enterprise.lang-model:jakarta.enterprise.lang_model:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.enterprise.lang_model:jakarta.enterprise.lang-model:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.enterprise.lang_model:jakarta.enterprise.lang_model:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.enterprise.lang:jakarta.enterprise.lang-model:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.enterprise.lang:jakarta.enterprise.lang_model:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.enterprise.jakarta.enterprise.lang-model-4.1.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.enterprise.lang-model"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.enterprise"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.enterprise.jakarta.enterprise.lang-model-4.1.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.inject/jakarta.inject-api@2.0.1?package-id=89fea4b0e47c9954",
+      "type": "library",
+      "group": "jakarta.inject",
+      "name": "jakarta.inject-api",
+      "version": "2.0.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jakarta.inject-api:jakarta.inject-api:2.0.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.inject/jakarta.inject-api@2.0.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4c28afe1991a941d7702fe1362c365f0a8641d1e"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.inject-api:jakarta.inject_api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.inject_api:jakarta.inject-api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.inject_api:jakarta.inject_api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.inject:jakarta.inject-api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.inject:jakarta.inject_api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.inject.jakarta.inject-api-2.0.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.inject-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.inject"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.inject.jakarta.inject-api-2.0.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@2.2.0?package-id=26a51ca46a63d32d",
+      "type": "library",
+      "group": "jakarta.interceptor",
+      "name": "jakarta.interceptor-api",
+      "version": "2.2.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jakarta.interceptor-api:jakarta.interceptor-api:2.2.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@2.2.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ed3605f9c5428d45549d4720235f3e943339f39a"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.interceptor-api:jakarta.interceptor_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.interceptor_api:jakarta.interceptor-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.interceptor_api:jakarta.interceptor_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.interceptor:jakarta.interceptor-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.interceptor:jakarta.interceptor_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.interceptor-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.interceptor_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.interceptor-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.interceptor_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:oracle-corporation:jakarta.interceptor-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:oracle-corporation:jakarta.interceptor_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:oracle_corporation:jakarta.interceptor-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:oracle_corporation:jakarta.interceptor_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.glassfish:jakarta.interceptor-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.glassfish:jakarta.interceptor_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glassfish:jakarta.interceptor-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glassfish:jakarta.interceptor_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.interceptor.jakarta.interceptor-api-2.2.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.interceptor-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.interceptor"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.interceptor.jakarta.interceptor-api-2.2.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.json/jakarta.json-api@2.1.3?package-id=527372436da82f79",
+      "type": "library",
+      "group": "jakarta.json",
+      "name": "jakarta.json-api",
+      "version": "2.1.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://projects.eclipse.org/license/epl-2.0, https://projects.eclipse.org/license/secondary-gpl-2.0-cp"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:eclipse-foundation:jakarta.json-api:2.1.3:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.json/jakarta.json-api@2.1.3",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4febd83e1d9d1561d078af460ecd19532383735c"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.json_api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.json-api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.json_api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.json-api:jakarta.json-api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.json-api:jakarta.json_api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.json_api:jakarta.json-api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.json_api:jakarta.json_api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.json:jakarta.json-api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.json:jakarta.json_api:2.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.json.jakarta.json-api-2.1.3.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.json-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.json"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.json.jakarta.json-api-2.1.3.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.servlet/jakarta.servlet-api@6.0.0?package-id=144ec99db8556992",
+      "type": "library",
+      "group": "jakarta.servlet",
+      "name": "jakarta.servlet-api",
+      "version": "6.0.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jakarta.servlet-api:jakarta.servlet-api:6.0.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.servlet/jakarta.servlet-api@6.0.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "abecc699286e65035ebba9844c03931357a6a963"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.servlet-api:jakarta.servlet_api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.servlet_api:jakarta.servlet-api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.servlet_api:jakarta.servlet_api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.servlet-api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.servlet_api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.servlet-api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.servlet_api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.servlet:jakarta.servlet-api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.servlet:jakarta.servlet_api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.eclipse:jakarta.servlet-api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.eclipse:jakarta.servlet_api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:jakarta.servlet-api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:jakarta.servlet_api:6.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.servlet.jakarta.servlet-api-6.0.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.servlet-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.servlet"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.servlet.jakarta.servlet-api-6.0.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@2.0.1?package-id=5b7479c7c61c9862",
+      "type": "library",
+      "group": "jakarta.transaction",
+      "name": "jakarta.transaction-api",
+      "version": "2.0.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jakarta.transaction-api:jakarta.transaction-api:2.0.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@2.0.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "51a520e3fae406abb84e2e1148e6746ce3f80a1a"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.transaction-api:jakarta.transaction_api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.transaction_api:jakarta.transaction-api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.transaction_api:jakarta.transaction_api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.transaction:jakarta.transaction-api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.transaction:jakarta.transaction_api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:oracle-corporation:jakarta.transaction-api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:oracle-corporation:jakarta.transaction_api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:oracle_corporation:jakarta.transaction-api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:oracle_corporation:jakarta.transaction_api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ee4j-community:jakarta.transaction-api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ee4j-community:jakarta.transaction_api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ee4j_community:jakarta.transaction-api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ee4j_community:jakarta.transaction_api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.glassfish:jakarta.transaction-api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.glassfish:jakarta.transaction_api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glassfish:jakarta.transaction-api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glassfish:jakarta.transaction_api:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.transaction.jakarta.transaction-api-2.0.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.transaction-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.transaction"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.transaction.jakarta.transaction-api-2.0.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@3.0.2?package-id=a4b6688710738243",
+      "type": "library",
+      "group": "jakarta.validation",
+      "name": "jakarta.validation-api",
+      "version": "3.0.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jakarta.validation-api:jakarta.validation-api:3.0.2:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.validation/jakarta.validation-api@3.0.2",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "92b6631659ba35ca09e44874d3eb936edfeee532"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.validation-api:jakarta.validation_api:3.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.validation_api:jakarta.validation-api:3.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.validation_api:jakarta.validation_api:3.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.validation:jakarta.validation-api:3.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.validation:jakarta.validation_api:3.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.validation.jakarta.validation-api-3.0.2.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.validation-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.validation"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.validation.jakarta.validation-api-3.0.2.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.ws.rs/jakarta.ws.rs-api@3.1.0?package-id=e639a46d528b70d7",
+      "type": "library",
+      "group": "jakarta.ws.rs",
+      "name": "jakarta.ws.rs-api",
+      "version": "3.1.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:eclipse-foundation:jakarta.ws.rs-api:3.1.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.ws.rs/jakarta.ws.rs-api@3.1.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "15ce10d249a38865b58fc39521f10f29ab0e3363"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.ws.rs_api:3.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.ws.rs-api:3.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.ws.rs_api:3.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.ws.rs-api:jakarta.ws.rs-api:3.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.ws.rs-api:jakarta.ws.rs_api:3.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.ws.rs_api:jakarta.ws.rs-api:3.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.ws.rs_api:jakarta.ws.rs_api:3.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.ws.rs:jakarta.ws.rs-api:3.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.ws.rs:jakarta.ws.rs_api:3.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.ws.rs.jakarta.ws.rs-api-3.1.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.ws.rs-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.ws.rs"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.ws.rs.jakarta.ws.rs-api-3.1.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@4.0.2?package-id=652eb28d3202a918",
+      "type": "library",
+      "group": "jakarta.xml.bind",
+      "name": "jakarta.xml.bind-api",
+      "version": "4.0.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jakarta.xml.bind-api:jakarta.xml.bind-api:4.0.2:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@4.0.2",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6cd5a999b834b63238005b7144136379dc36cad2"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.xml.bind-api:jakarta.xml.bind_api:4.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.xml.bind_api:jakarta.xml.bind-api:4.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.xml.bind_api:jakarta.xml.bind_api:4.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.xml.bind-api:4.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse-foundation:jakarta.xml.bind_api:4.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.xml.bind-api:4.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse_foundation:jakarta.xml.bind_api:4.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.xml.bind:jakarta.xml.bind-api:4.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jakarta.xml.bind:jakarta.xml.bind_api:4.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/jakarta.xml.bind.jakarta.xml.bind-api-4.0.2.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jakarta.xml.bind-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "jakarta.xml.bind"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/jakarta.xml.bind.jakarta.xml.bind-api-4.0.2.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.7.0.6-1.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=1d88987370aeaf8d&upstream=java-21-openjdk-21.0.7.0.6-1.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "java-21-openjdk-headless",
+      "version": "1:21.0.7.0.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:java-21-openjdk-headless:java-21-openjdk-headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.7.0.6-1.el9?arch=x86_64&distro=rhel-9.6&epoch=1&upstream=java-21-openjdk-21.0.7.0.6-1.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java-21-openjdk-headless:java_21_openjdk_headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java_21_openjdk_headless:java-21-openjdk-headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java_21_openjdk_headless:java_21_openjdk_headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java-21-openjdk:java-21-openjdk-headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java-21-openjdk:java_21_openjdk_headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java_21_openjdk:java-21-openjdk-headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java_21_openjdk:java_21_openjdk_headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java-21:java-21-openjdk-headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java-21:java_21_openjdk_headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java_21:java-21-openjdk-headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java_21:java_21_openjdk_headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:java-21-openjdk-headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:java_21_openjdk_headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java:java-21-openjdk-headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:java:java_21_openjdk_headless:1\\:21.0.7.0.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:epoch",
+          "value": "1"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "221260806"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "java-21-openjdk-21.0.7.0.6-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/javapackages-filesystem@6.4.0-1.el9?arch=noarch&distro=rhel-9.6&package-id=68f86a534d515f4c&upstream=javapackages-tools-6.4.0-1.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "javapackages-filesystem",
+      "version": "6.4.0-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:javapackages-filesystem:javapackages-filesystem:6.4.0-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/javapackages-filesystem@6.4.0-1.el9?arch=noarch&distro=rhel-9.6&upstream=javapackages-tools-6.4.0-1.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:javapackages-filesystem:javapackages_filesystem:6.4.0-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:javapackages_filesystem:javapackages-filesystem:6.4.0-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:javapackages_filesystem:javapackages_filesystem:6.4.0-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:javapackages:javapackages-filesystem:6.4.0-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:javapackages:javapackages_filesystem:6.4.0-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:javapackages-filesystem:6.4.0-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:javapackages_filesystem:6.4.0-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "2063"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "javapackages-tools-6.4.0-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.6.1.Final?package-id=363f9646c91afc56",
+      "type": "library",
+      "group": "org.jboss.logging",
+      "name": "jboss-logging",
+      "version": "3.6.1.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://repository.jboss.org/licenses/apache-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:org.jboss.logging.jboss-logging:jboss-logging:3.6.1.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.jboss.logging/jboss-logging@3.6.1.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "886afbb445b4016a37c8960a7aef6ebd769ce7e5"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.logging.jboss-logging:jboss_logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.logging.jboss-logging:logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.logging:jboss-logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.logging:jboss_logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:jboss-logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:jboss_logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:jboss-logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:jboss_logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-logging:jboss-logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-logging:jboss_logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_logging:jboss-logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_logging:jboss_logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.logging:logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-logging:logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_logging:logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:logging:jboss-logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:logging:jboss_logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:jboss-logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:jboss_logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:logging:logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:logging:3.6.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/org.jboss.logging.jboss-logging-3.6.1.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jboss-logging"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.jboss.logging"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/org.jboss.logging.jboss-logging-3.6.1.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.jboss.logging/jboss-logging-annotations@3.0.3.Final?package-id=2af41739a4a7ba69",
+      "type": "library",
+      "group": "org.jboss.logging",
+      "name": "jboss-logging-annotations",
+      "version": "3.0.3.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0",
+            "url": "https://repository.jboss.org/licenses/apache-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jboss-logging-annotations:jboss-logging-annotations:3.0.3.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.jboss.logging/jboss-logging-annotations@3.0.3.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "934fb678aac299affbc24446d0e55a49e66051ae"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-logging-annotations:jboss_logging_annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_logging_annotations:jboss-logging-annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_logging_annotations:jboss_logging_annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.logging:jboss-logging-annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.logging:jboss_logging_annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:jboss-logging-annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:jboss_logging_annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:jboss-logging-annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:jboss_logging_annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-logging:jboss-logging-annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-logging:jboss_logging_annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_logging:jboss-logging-annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_logging:jboss_logging_annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:logging:jboss-logging-annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:logging:jboss_logging_annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:jboss-logging-annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:jboss_logging_annotations:3.0.3.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.jboss.logging.jboss-logging-annotations-3.0.3.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jboss-logging-annotations"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.jboss.logging"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.jboss.logging.jboss-logging-annotations-3.0.3.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager@3.1.1.Final?package-id=25c9fe824d09f8dd",
+      "type": "library",
+      "group": "org.jboss.logmanager",
+      "name": "jboss-logmanager",
+      "version": "3.1.1.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0",
+            "url": "https://repository.jboss.org/licenses/apache-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:org.jboss.logmanager:jboss-logmanager:3.1.1.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.jboss.logmanager/jboss-logmanager@3.1.1.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d480319c27f162eb5f72b2e0390303718157b8ec"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.logmanager:jboss_logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:jboss-logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:jboss_logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-logmanager:jboss-logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-logmanager:jboss_logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:jboss-logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:jboss_logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_logmanager:jboss-logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_logmanager:jboss_logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.logmanager:logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-logmanager:logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_logmanager:logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:logmanager:jboss-logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:logmanager:jboss_logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:jboss-logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:jboss_logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:logmanager:logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:logmanager:3.1.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/org.jboss.logmanager.jboss-logmanager-3.1.1.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jboss-logmanager"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.jboss.logmanager"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/org.jboss.logmanager.jboss-logmanager-3.1.1.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.8.0.Final?package-id=295d635e5cd88973",
+      "type": "library",
+      "group": "org.jboss.threads",
+      "name": "jboss-threads",
+      "version": "3.8.0.Final",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:org.jboss.threads:jboss-threads:3.8.0.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.jboss.threads/jboss-threads@3.8.0.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "185bd83cf5fc5f7479a4ef2279dd1bbe0e677d97"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.threads:jboss_threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:jboss-threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:jboss_threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:jboss-threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:jboss_threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-threads:jboss-threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-threads:jboss_threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_threads:jboss-threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_threads:jboss_threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.threads:threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-threads:threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_threads:threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:threads:jboss-threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:threads:jboss_threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:jboss-threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:jboss_threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:threads:threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:threads:3.8.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.jboss.threads.jboss-threads-3.8.0.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jboss-threads"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.jboss.threads"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.jboss.threads.jboss-threads-3.8.0.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.jctools/jctools-core@4.0.5?package-id=015131ccded61f68",
+      "type": "library",
+      "group": "org.jctools",
+      "name": "jctools-core",
+      "version": "4.0.5",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jctools-core:jctools-core:4.0.5:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.jctools/jctools-core@4.0.5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools-core:jctools_core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools_core:jctools-core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools_core:jctools_core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jctools:jctools-core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jctools:jctools_core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools:jctools-core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools:jctools_core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-common-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jctools-core"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.jctools"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-common-4.1.118.Final.jar:org.jctools:jctools-core"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.jctools/jctools-core@4.0.5?package-id=42043945a9339ec6",
+      "type": "library",
+      "group": "org.jctools",
+      "name": "jctools-core",
+      "version": "4.0.5",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:org.jctools.core:jctools-core:4.0.5:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.jctools/jctools-core@4.0.5",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9ab38ca19877236986db4894ef1400a7ca23db80"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jctools.core:jctools_core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools-core:jctools-core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools-core:jctools_core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools_core:jctools-core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools_core:jctools_core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jctools:jctools-core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jctools:jctools_core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jctools.core:core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools:jctools-core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools:jctools_core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:core:jctools-core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:core:jctools_core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools-core:core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools_core:core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jctools:core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jctools:core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:core:core:4.0.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.jctools.jctools-core-4.0.5.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "jctools-core"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.jctools"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.jctools.jctools-core-4.0.5.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/jrt-fs/jrt-fs@21.0.7?package-id=5f0cc9f71aa96302",
+      "type": "library",
+      "name": "jrt-fs",
+      "version": "21.0.7",
+      "cpe": "cpe:2.3:a:oracle-corporation:jrt-fs:21.0.7:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/jrt-fs/jrt-fs@21.0.7",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "41451658536167c5f91beed18a30bca365d463d9"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:oracle-corporation:jrt_fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:oracle_corporation:jrt-fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:oracle_corporation:jrt_fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:red-hat\\,-inc-:jrt-fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:red-hat\\,-inc-:jrt_fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:red_hat\\,_inc_:jrt-fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:red_hat\\,_inc_:jrt_fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jrt-fs:jrt-fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jrt-fs:jrt_fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jrt_fs:jrt-fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jrt_fs:jrt_fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jrt:jrt-fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jrt:jrt_fs:21.0.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib/jvm/java-21-openjdk-21.0.7.0.6-1.el9.x86_64/lib/jrt-fs.jar"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/usr/lib/jvm/java-21-openjdk-21.0.7.0.6-1.el9.x86_64/lib/jrt-fs.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64&distro=rhel-9.6&package-id=11df62c698c61ae7&upstream=json-c-0.14-11.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "json-c",
+      "version": "0.14-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:json-c:json-c:0.14-11.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64&distro=rhel-9.6&upstream=json-c-0.14-11.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json-c:json_c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json_c:json-c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json_c:json_c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:json-c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:json_c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json:json-c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json:json_c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "11.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "79282"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "json-c-0.14-11.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64&distro=rhel-9.6&package-id=637773da489d3afe&upstream=json-glib-1.6.6-1.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "json-glib",
+      "version": "1.6.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:json-glib:json-glib:1.6.6-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64&distro=rhel-9.6&upstream=json-glib-1.6.6-1.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json-glib:json_glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json_glib:json-glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json_glib:json_glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:json-glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:json_glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json:json-glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json:json_glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "555868"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "json-glib-1.6.6-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64&distro=rhel-9.6&package-id=39e2c2a43040d9a9&upstream=keyutils-1.6.3-1.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "keyutils-libs",
+      "version": "1.6.3-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:keyutils-libs:keyutils-libs:1.6.3-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64&distro=rhel-9.6&upstream=keyutils-1.6.3-1.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:keyutils-libs:keyutils_libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:keyutils_libs:keyutils-libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:keyutils_libs:keyutils_libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:keyutils:keyutils-libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:keyutils:keyutils_libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:keyutils-libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:keyutils_libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "55267"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "keyutils-1.6.3-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/krb5-libs@1.21.1-6.el9?arch=x86_64&distro=rhel-9.6&package-id=9f490f7cfcb7b19c&upstream=krb5-1.21.1-6.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "krb5-libs",
+      "version": "1.21.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:krb5-libs:krb5-libs:1.21.1-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/krb5-libs@1.21.1-6.el9?arch=x86_64&distro=rhel-9.6&upstream=krb5-1.21.1-6.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:krb5-libs:krb5_libs:1.21.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:krb5_libs:krb5-libs:1.21.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:krb5_libs:krb5_libs:1.21.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:krb5-libs:1.21.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:krb5_libs:1.21.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:krb5:krb5-libs:1.21.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:krb5:krb5_libs:1.21.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "6.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "2504201"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "krb5-1.21.1-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch&distro=rhel-9.6&package-id=88a1132a4baefaca&upstream=langpacks-3.0-16.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "langpacks-core-en",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:langpacks-core-en:langpacks-core-en:3.0-16.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch&distro=rhel-9.6&upstream=langpacks-3.0-16.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core-en:langpacks_core_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core_en:langpacks-core-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core_en:langpacks_core_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core:langpacks-core-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core:langpacks_core_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core:langpacks-core-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core:langpacks_core_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks:langpacks-core-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks:langpacks_core_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:langpacks-core-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:langpacks_core_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "16.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "398"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "langpacks-3.0-16.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch&distro=rhel-9.6&package-id=fe6c1588a87ba80e&upstream=langpacks-3.0-16.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "langpacks-core-font-en",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:langpacks-core-font-en:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch&distro=rhel-9.6&upstream=langpacks-3.0-16.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core-font-en:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core_font_en:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core_font_en:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core-font:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core-font:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core_font:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core_font:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "16.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "351"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "langpacks-3.0-16.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch&distro=rhel-9.6&package-id=40aceea966cab95e&upstream=langpacks-3.0-16.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "langpacks-en",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:langpacks-en:langpacks-en:3.0-16.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch&distro=rhel-9.6&upstream=langpacks-3.0-16.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-en:langpacks_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_en:langpacks-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_en:langpacks_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks:langpacks-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks:langpacks_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:langpacks-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:langpacks_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "16.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "400"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "langpacks-3.0-16.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=5bd7c806cb0b843c&upstream=acl-2.3.1-4.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libacl",
+      "version": "2.3.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libacl:libacl:2.3.1-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64&distro=rhel-9.6&upstream=acl-2.3.1-4.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libacl:2.3.1-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "4.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "40554"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "acl-2.3.1-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9?arch=x86_64&distro=rhel-9.6&package-id=d8ddf54736613a1b&upstream=libarchive-3.5.3-4.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libarchive",
+      "version": "3.5.3-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libarchive:libarchive:3.5.3-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libarchive@3.5.3-4.el9?arch=x86_64&distro=rhel-9.6&upstream=libarchive-3.5.3-4.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libarchive:3.5.3-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "4.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "906150"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libarchive-3.5.3-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64&distro=rhel-9.6&package-id=e33783c9327f80b3&upstream=libassuan-2.5.5-3.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libassuan",
+      "version": "2.5.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libassuan:libassuan:2.5.5-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64&distro=rhel-9.6&upstream=libassuan-2.5.5-3.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libassuan:2.5.5-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "3.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "171165"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libassuan-2.5.5-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64&distro=rhel-9.6&package-id=3677ea600c46b6c8&upstream=attr-2.5.1-3.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libattr",
+      "version": "2.5.1-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libattr:libattr:2.5.1-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64&distro=rhel-9.6&upstream=attr-2.5.1-3.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libattr:2.5.1-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "3.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "29429"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "attr-2.5.1-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libblkid@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=e30d806f54044f6c&upstream=util-linux-2.37.4-21.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libblkid",
+      "version": "2.37.4-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libblkid:libblkid:2.37.4-21.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libblkid@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&upstream=util-linux-2.37.4-21.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libblkid:2.37.4-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "21.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "229849"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "util-linux-2.37.4-21.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&distro=rhel-9.6&package-id=f7699c7a69eaad5a&upstream=libcap-2.48-9.el9_2.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libcap",
+      "version": "2.48-9.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libcap:libcap:2.48-9.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&distro=rhel-9.6&upstream=libcap-2.48-9.el9_2.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcap:2.48-9.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "9.el9_2"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "177471"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libcap-2.48-9.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64&distro=rhel-9.6&package-id=2b860dd13e2eda6e&upstream=libcap-ng-0.8.2-7.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libcap-ng",
+      "version": "0.8.2-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libcap-ng:libcap-ng:0.8.2-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64&distro=rhel-9.6&upstream=libcap-ng-0.8.2-7.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcap-ng:libcap_ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcap_ng:libcap-ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcap_ng:libcap_ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcap:libcap-ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcap:libcap_ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcap-ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcap_ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "7.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "75196"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libcap-ng-0.8.2-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libcom_err@1.46.5-7.el9?arch=x86_64&distro=rhel-9.6&package-id=95fdc60216e1260b&upstream=e2fsprogs-1.46.5-7.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libcom_err",
+      "version": "1.46.5-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libcom-err:libcom-err:1.46.5-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libcom_err@1.46.5-7.el9?arch=x86_64&distro=rhel-9.6&upstream=e2fsprogs-1.46.5-7.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcom-err:libcom_err:1.46.5-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcom_err:libcom-err:1.46.5-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcom_err:libcom_err:1.46.5-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcom:libcom-err:1.46.5-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcom:libcom_err:1.46.5-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcom-err:1.46.5-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcom_err:1.46.5-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "7.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "68513"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "e2fsprogs-1.46.5-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9?arch=x86_64&distro=rhel-9.6&package-id=45626a0f59bc1233&upstream=curl-7.76.1-31.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libcurl-minimal",
+      "version": "7.76.1-31.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libcurl-minimal:libcurl-minimal:7.76.1-31.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9?arch=x86_64&distro=rhel-9.6&upstream=curl-7.76.1-31.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcurl-minimal:libcurl_minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcurl_minimal:libcurl-minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcurl_minimal:libcurl_minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcurl:libcurl-minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcurl:libcurl_minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcurl-minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcurl_minimal:7.76.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "31.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "518294"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "curl-7.76.1-31.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libdnf@0.69.0-13.el9?arch=x86_64&distro=rhel-9.6&package-id=809fcd79847e161a&upstream=libdnf-0.69.0-13.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libdnf",
+      "version": "0.69.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libdnf:libdnf:0.69.0-13.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libdnf@0.69.0-13.el9?arch=x86_64&distro=rhel-9.6&upstream=libdnf-0.69.0-13.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libdnf:0.69.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "13.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "2130573"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libdnf-0.69.0-13.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64&distro=rhel-9.6&package-id=57ef373f1974e156&upstream=libevent-2.1.12-8.el9_4.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libevent",
+      "version": "2.1.12-8.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and ISC"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libevent:libevent:2.1.12-8.el9_4:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64&distro=rhel-9.6&upstream=libevent-2.1.12-8.el9_4.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libevent:2.1.12-8.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "8.el9_4"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "928090"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libevent-2.1.12-8.el9_4.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64&distro=rhel-9.6&package-id=2dc370039d6ee9af&upstream=libffi-3.4.2-8.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libffi",
+      "version": "3.4.2-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libffi:libffi:3.4.2-8.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64&distro=rhel-9.6&upstream=libffi-3.4.2-8.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libffi:3.4.2-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "8.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "65761"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libffi-3.4.2-8.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=7512670668215a38&upstream=gcc-11.5.0-5.el9_5.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libgcc",
+      "version": "11.5.0-5.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libgcc:libgcc:11.5.0-5.el9_5:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&upstream=gcc-11.5.0-5.el9_5.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libgcc:11.5.0-5.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "5.el9_5"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "198756"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gcc-11.5.0-5.el9_5.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64&distro=rhel-9.6&package-id=4365797aed5f61b4&upstream=libgcrypt-1.10.0-11.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libgcrypt",
+      "version": "1.10.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libgcrypt:libgcrypt:1.10.0-11.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64&distro=rhel-9.6&upstream=libgcrypt-1.10.0-11.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libgcrypt:1.10.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "11.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1398394"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libgcrypt-1.10.0-11.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&distro=rhel-9.6&package-id=69466ff7e66043b2&upstream=libgpg-error-1.42-5.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libgpg-error",
+      "version": "1.42-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libgpg-error:libgpg-error:1.42-5.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&distro=rhel-9.6&upstream=libgpg-error-1.42-5.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libgpg-error:libgpg_error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libgpg_error:libgpg-error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libgpg_error:libgpg_error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libgpg:libgpg-error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libgpg:libgpg_error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libgpg-error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libgpg_error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "5.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "837088"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libgpg-error-1.42-5.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64&distro=rhel-9.6&package-id=ae22cc67cd082c17&upstream=libidn2-2.3.0-7.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libidn2",
+      "version": "2.3.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or LGPLv3+) and GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libidn2:libidn2:2.3.0-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64&distro=rhel-9.6&upstream=libidn2-2.3.0-7.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libidn2:2.3.0-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "7.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "253460"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libidn2-2.3.0-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64&distro=rhel-9.6&package-id=7e6cbd5a17d74705&upstream=libksba-1.5.1-7.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libksba",
+      "version": "1.5.1-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(LGPLv3+ or GPLv2+) and GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libksba:libksba:1.5.1-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64&distro=rhel-9.6&upstream=libksba-1.5.1-7.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libksba:1.5.1-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "7.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "394486"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libksba-1.5.1-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64&distro=rhel-9.6&package-id=2adb1fa18118feb1&upstream=libmodulemd-2.13.0-2.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libmodulemd",
+      "version": "2.13.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libmodulemd:libmodulemd:2.13.0-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64&distro=rhel-9.6&upstream=libmodulemd-2.13.0-2.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libmodulemd:2.13.0-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "2.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "733911"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libmodulemd-2.13.0-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libmount@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=ade2b8b9765efaa0&upstream=util-linux-2.37.4-21.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libmount",
+      "version": "2.37.4-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libmount:libmount:2.37.4-21.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libmount@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&upstream=util-linux-2.37.4-21.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libmount:2.37.4-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "21.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "318437"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "util-linux-2.37.4-21.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64&distro=rhel-9.6&package-id=cea05d8f439115cd&upstream=nghttp2-1.43.0-6.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libnghttp2",
+      "version": "1.43.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libnghttp2:libnghttp2:1.43.0-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64&distro=rhel-9.6&upstream=nghttp2-1.43.0-6.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libnghttp2:1.43.0-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "6.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "169892"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "nghttp2-1.43.0-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64&distro=rhel-9.6&package-id=2edcab74dc977b20&upstream=libpeas-1.30.0-4.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libpeas",
+      "version": "1.30.0-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libpeas:libpeas:1.30.0-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64&distro=rhel-9.6&upstream=libpeas-1.30.0-4.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libpeas:1.30.0-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "4.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "370454"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libpeas-1.30.0-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64&distro=rhel-9.6&package-id=e6c08b7d843fe388&upstream=librepo-1.14.5-2.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "librepo",
+      "version": "1.14.5-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:librepo:librepo:1.14.5-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64&distro=rhel-9.6&upstream=librepo-1.14.5-2.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:librepo:1.14.5-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "2.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "220524"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "librepo-1.14.5-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch&distro=rhel-9.6&package-id=d34bc390023607f7&upstream=libreport-2.15.2-6.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libreport-filesystem",
+      "version": "2.15.2-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libreport-filesystem:libreport-filesystem:2.15.2-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch&distro=rhel-9.6&upstream=libreport-2.15.2-6.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libreport-filesystem:libreport_filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libreport_filesystem:libreport-filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libreport_filesystem:libreport_filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libreport:libreport-filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libreport:libreport_filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libreport-filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libreport_filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "6.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "0"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libreport-2.15.2-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64&distro=rhel-9.6&package-id=cce68c3ca91abeec&upstream=librhsm-0.0.3-9.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "librhsm",
+      "version": "0.0.3-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:librhsm:librhsm:0.0.3-9.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64&distro=rhel-9.6&upstream=librhsm-0.0.3-9.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:librhsm:0.0.3-9.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "9.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "79578"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "librhsm-0.0.3-9.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libselinux",
+      "version": "3.6-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libselinux:libselinux:3.6-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&upstream=libselinux-3.6-3.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libselinux:3.6-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "3.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "176845"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libselinux-3.6-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libsemanage@3.6-5.el9_6?arch=x86_64&distro=rhel-9.6&package-id=0540d4b49021576a&upstream=libsemanage-3.6-5.el9_6.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libsemanage",
+      "version": "3.6-5.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libsemanage:libsemanage:3.6-5.el9_6:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libsemanage@3.6-5.el9_6?arch=x86_64&distro=rhel-9.6&upstream=libsemanage-3.6-5.el9_6.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libsemanage:3.6-5.el9_6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "5.el9_6"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "307182"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libsemanage-3.6-5.el9_6.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libsepol@3.6-2.el9?arch=x86_64&distro=rhel-9.6&package-id=c296ae344ca36222&upstream=libsepol-3.6-2.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libsepol",
+      "version": "3.6-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libsepol:libsepol:3.6-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libsepol@3.6-2.el9?arch=x86_64&distro=rhel-9.6&upstream=libsepol-3.6-2.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libsepol:3.6-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "2.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "829339"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libsepol-3.6-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64&distro=rhel-9.6&package-id=b68d31d7f353f7c3&upstream=libsigsegv-2.13-4.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libsigsegv",
+      "version": "2.13-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libsigsegv:libsigsegv:2.13-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64&distro=rhel-9.6&upstream=libsigsegv-2.13-4.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libsigsegv:2.13-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "4.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "50338"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libsigsegv-2.13-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=0edd82fc42eab4d9&upstream=util-linux-2.37.4-21.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libsmartcols",
+      "version": "2.37.4-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libsmartcols:libsmartcols:2.37.4-21.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&upstream=util-linux-2.37.4-21.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libsmartcols:2.37.4-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "21.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "134899"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "util-linux-2.37.4-21.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64&distro=rhel-9.6&package-id=fa42e742fa144174&upstream=libsolv-0.7.24-3.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libsolv",
+      "version": "0.7.24-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libsolv:libsolv:0.7.24-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64&distro=rhel-9.6&upstream=libsolv-0.7.24-3.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libsolv:0.7.24-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "3.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "917082"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libsolv-0.7.24-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=8db809343fa3fe29&upstream=gcc-11.5.0-5.el9_5.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libstdc++",
+      "version": "11.5.0-5.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libstdc\\+\\+:libstdc\\+\\+:11.5.0-5.el9_5:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&upstream=gcc-11.5.0-5.el9_5.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libstdc\\+\\+:11.5.0-5.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "5.el9_5"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "2537774"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gcc-11.5.0-5.el9_5.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64&distro=rhel-9.6&package-id=f7f8d943bdae553f&upstream=libtasn1-4.16.0-9.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libtasn1",
+      "version": "4.16.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libtasn1:libtasn1:4.16.0-9.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64&distro=rhel-9.6&upstream=libtasn1-4.16.0-9.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libtasn1:4.16.0-9.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "9.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "183364"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libtasn1-4.16.0-9.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libtool-ltdl@2.4.6-46.el9?arch=x86_64&distro=rhel-9.6&package-id=d97fb91fff35f4ca&upstream=libtool-2.4.6-46.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libtool-ltdl",
+      "version": "2.4.6-46.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libtool-ltdl:libtool-ltdl:2.4.6-46.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libtool-ltdl@2.4.6-46.el9?arch=x86_64&distro=rhel-9.6&upstream=libtool-2.4.6-46.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libtool-ltdl:libtool_ltdl:2.4.6-46.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libtool_ltdl:libtool-ltdl:2.4.6-46.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libtool_ltdl:libtool_ltdl:2.4.6-46.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libtool:libtool-ltdl:2.4.6-46.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libtool:libtool_ltdl:2.4.6-46.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libtool-ltdl:2.4.6-46.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libtool_ltdl:2.4.6-46.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "46.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "71568"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libtool-2.4.6-46.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64&distro=rhel-9.6&package-id=615059ec73826c8d&upstream=libunistring-0.9.10-15.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libunistring",
+      "version": "0.9.10-15.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libunistring:libunistring:0.9.10-15.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64&distro=rhel-9.6&upstream=libunistring-0.9.10-15.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libunistring:0.9.10-15.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "15.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1643051"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libunistring-0.9.10-15.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64&distro=rhel-9.6&package-id=042b2ea74c010cf0&upstream=libusbx-1.0.26-1.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libusbx",
+      "version": "1.0.26-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libusbx:libusbx:1.0.26-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64&distro=rhel-9.6&upstream=libusbx-1.0.26-1.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libusbx:1.0.26-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "169790"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libusbx-1.0.26-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=fc13a0dc78469351&upstream=util-linux-2.37.4-21.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libuuid",
+      "version": "2.37.4-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libuuid:libuuid:2.37.4-21.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&upstream=util-linux-2.37.4-21.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libuuid:2.37.4-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "21.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "38109"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "util-linux-2.37.4-21.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64&distro=rhel-9.6&package-id=644d34646f10f7ae&upstream=libverto-0.3.2-3.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libverto",
+      "version": "0.3.2-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libverto:libverto:0.3.2-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64&distro=rhel-9.6&upstream=libverto-0.3.2-3.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libverto:0.3.2-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "3.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "30365"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libverto-0.3.2-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&distro=rhel-9.6&package-id=d3709e4a8db9b6bc&upstream=libxcrypt-4.4.18-3.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libxcrypt",
+      "version": "4.4.18-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and BSD and Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libxcrypt:libxcrypt:4.4.18-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&distro=rhel-9.6&upstream=libxcrypt-4.4.18-3.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libxcrypt:4.4.18-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "3.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "270692"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libxcrypt-4.4.18-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libxml2@2.9.13-9.el9_6?arch=x86_64&distro=rhel-9.6&package-id=142e0c5184768e72&upstream=libxml2-2.9.13-9.el9_6.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libxml2",
+      "version": "2.9.13-9.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libxml2:libxml2:2.9.13-9.el9_6:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libxml2@2.9.13-9.el9_6?arch=x86_64&distro=rhel-9.6&upstream=libxml2-2.9.13-9.el9_6.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libxml2:2.9.13-9.el9_6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "9.el9_6"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1955388"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libxml2-2.9.13-9.el9_6.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64&distro=rhel-9.6&package-id=9c63ee03e6e500ad&upstream=libyaml-0.2.5-7.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libyaml",
+      "version": "0.2.5-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libyaml:libyaml:0.2.5-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64&distro=rhel-9.6&upstream=libyaml-0.2.5-7.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libyaml:0.2.5-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "7.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "138283"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libyaml-0.2.5-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64&distro=rhel-9.6&package-id=cdd2d94a9c38f292&upstream=zstd-1.5.5-1.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libzstd",
+      "version": "1.5.5-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libzstd:libzstd:1.5.5-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64&distro=rhel-9.6&upstream=zstd-1.5.5-1.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libzstd:1.5.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "773894"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "zstd-1.5.5-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/lksctp-tools@1.0.19-3.el9_4?arch=x86_64&distro=rhel-9.6&package-id=1bbb198e66b70e43&upstream=lksctp-tools-1.0.19-3.el9_4.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "lksctp-tools",
+      "version": "1.0.19-3.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2 and MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:lksctp-tools:lksctp-tools:1.0.19-3.el9_4:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/lksctp-tools@1.0.19-3.el9_4?arch=x86_64&distro=rhel-9.6&upstream=lksctp-tools-1.0.19-3.el9_4.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lksctp-tools:lksctp_tools:1.0.19-3.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lksctp_tools:lksctp-tools:1.0.19-3.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lksctp_tools:lksctp_tools:1.0.19-3.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lksctp:lksctp-tools:1.0.19-3.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lksctp:lksctp_tools:1.0.19-3.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:lksctp-tools:1.0.19-3.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:lksctp_tools:1.0.19-3.el9_4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "3.el9_4"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "275711"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "lksctp-tools-1.0.19-3.el9_4.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/lua@5.4.4-4.el9?arch=x86_64&distro=rhel-9.6&package-id=44d71b9802b1a6c4&upstream=lua-5.4.4-4.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "lua",
+      "version": "5.4.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:lua:5.4.4-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/lua@5.4.4-4.el9?arch=x86_64&distro=rhel-9.6&upstream=lua-5.4.4-4.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua:lua:5.4.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "4.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "607685"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "lua-5.4.4-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64&distro=rhel-9.6&package-id=0d89ff6591ed24aa&upstream=lua-5.4.4-4.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "lua-libs",
+      "version": "5.4.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:lua-libs:lua-libs:5.4.4-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64&distro=rhel-9.6&upstream=lua-5.4.4-4.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua-libs:lua_libs:5.4.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua_libs:lua-libs:5.4.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua_libs:lua_libs:5.4.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:lua-libs:5.4.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:lua_libs:5.4.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua:lua-libs:5.4.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua:lua_libs:5.4.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "4.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "287331"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "lua-5.4.4-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/lua-posix@35.0-8.el9?arch=x86_64&distro=rhel-9.6&package-id=535d7017d3fa6879&upstream=lua-posix-35.0-8.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "lua-posix",
+      "version": "35.0-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:lua-posix:lua-posix:35.0-8.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/lua-posix@35.0-8.el9?arch=x86_64&distro=rhel-9.6&upstream=lua-posix-35.0-8.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua-posix:lua_posix:35.0-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua_posix:lua-posix:35.0-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua_posix:lua_posix:35.0-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:lua-posix:35.0-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:lua_posix:35.0-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua:lua-posix:35.0-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua:lua_posix:35.0-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "8.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "628922"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "lua-posix-35.0-8.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64&distro=rhel-9.6&package-id=96b4cd464ad16cf1&upstream=lz4-1.9.3-5.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "lz4-libs",
+      "version": "1.9.3-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:lz4-libs:lz4-libs:1.9.3-5.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64&distro=rhel-9.6&upstream=lz4-1.9.3-5.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lz4-libs:lz4_libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lz4_libs:lz4-libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lz4_libs:lz4_libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:lz4-libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:lz4_libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lz4:lz4-libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lz4:lz4_libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "5.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "145483"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "lz4-1.9.3-5.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.takari/maven-wrapper@0.5.6?package-id=1c1da384a3e991c8",
+      "type": "library",
+      "group": "io.takari",
+      "name": "maven-wrapper",
+      "version": "0.5.6",
+      "cpe": "cpe:2.3:a:maven-wrapper:maven-wrapper:0.5.6:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.takari/maven-wrapper@0.5.6",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "99c11907918309fe94d7e7574a144c7c08077dd4"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:maven-wrapper:maven_wrapper:0.5.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:maven_wrapper:maven-wrapper:0.5.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:maven_wrapper:maven_wrapper:0.5.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.takari:maven-wrapper:0.5.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.takari:maven_wrapper:0.5.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:takari:maven-wrapper:0.5.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:takari:maven_wrapper:0.5.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:maven:maven-wrapper:0.5.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:maven:maven_wrapper:0.5.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/.mvn/wrapper/maven-wrapper.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "maven-wrapper"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.takari"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/.mvn/wrapper/maven-wrapper.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64&distro=rhel-9.6&package-id=fbf9bcecd48d49b1&upstream=microdnf-3.9.1-3.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "microdnf",
+      "version": "3.9.1-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:microdnf:microdnf:3.9.1-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64&distro=rhel-9.6&upstream=microdnf-3.9.1-3.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:microdnf:3.9.1-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "3.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "125966"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "microdnf-3.9.1-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.micrometer/micrometer-commons@1.14.4?package-id=e64dd669d88d529e",
+      "type": "library",
+      "name": "micrometer-commons",
+      "version": "1.14.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:micrometer-commons:micrometer-commons:1.14.4:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.micrometer/micrometer-commons@1.14.4",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3664f95586514d8f9adc81a5f7a5ef9f66b65599"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer-commons:micrometer_commons:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer_commons:micrometer-commons:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer_commons:micrometer_commons:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.micrometer:micrometer-commons:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.micrometer:micrometer_commons:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer:micrometer-commons:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer:micrometer_commons:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.micrometer.micrometer-commons-1.14.4.jar"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.micrometer.micrometer-commons-1.14.4.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.micrometer/micrometer-core@1.14.4?package-id=6cd260bdd5c88b0e",
+      "type": "library",
+      "name": "micrometer-core",
+      "version": "1.14.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:micrometer-core:micrometer-core:1.14.4:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.micrometer/micrometer-core@1.14.4",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "05686f90bba1d2f7ba0d3adb14f90b95659a6461"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer-core:micrometer_core:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer_core:micrometer-core:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer_core:micrometer_core:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.micrometer:micrometer-core:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.micrometer:micrometer_core:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer:micrometer-core:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer:micrometer_core:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.micrometer.micrometer-core-1.14.4.jar"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.micrometer.micrometer-core-1.14.4.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.micrometer/micrometer-observation@1.14.4?package-id=84432d01922b6e45",
+      "type": "library",
+      "name": "micrometer-observation",
+      "version": "1.14.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:micrometer-observation:micrometer-observation:1.14.4:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.micrometer/micrometer-observation@1.14.4",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c17efe9e6695a0a849a95d0e77422516a345e779"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer-observation:micrometer_observation:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer_observation:micrometer-observation:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer_observation:micrometer_observation:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.micrometer:micrometer-observation:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.micrometer:micrometer_observation:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer:micrometer-observation:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:micrometer:micrometer_observation:1.14.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.micrometer.micrometer-observation-1.14.4.jar"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.micrometer.micrometer-observation-1.14.4.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.jboss.resteasy.microprofile/microprofile-config@3.0.1.Final?package-id=f8a8d3d7954c5dbf",
+      "type": "library",
+      "group": "org.jboss.resteasy.microprofile",
+      "name": "microprofile-config",
+      "version": "3.0.1.Final",
+      "cpe": "cpe:2.3:a:org.jboss.resteasy.microprofile:microprofile-config:3.0.1.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.jboss.resteasy.microprofile/microprofile-config@3.0.1.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "cd918b7f2178ff477bae3133317ac6e8a310b9f9"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.resteasy.microprofile:microprofile_config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.resteasy.microprofile:microprofile:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-config:microprofile-config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-config:microprofile_config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_config:microprofile-config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_config:microprofile_config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:microprofile-config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:microprofile_config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:microprofile-config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:microprofile_config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-config:microprofile:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile:microprofile-config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile:microprofile_config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_config:microprofile:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:microprofile:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:microprofile:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy:microprofile-config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy:microprofile_config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:microprofile-config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:microprofile_config:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile:microprofile:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy:microprofile:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:microprofile:3.0.1.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.jboss.resteasy.microprofile.microprofile-config-3.0.1.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "microprofile-config"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.jboss.resteasy.microprofile"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.jboss.resteasy.microprofile.microprofile-config-3.0.1.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@3.1?package-id=0f8de24cac99ac97",
+      "type": "library",
+      "group": "org.eclipse.microprofile.config",
+      "name": "microprofile-config-api",
+      "version": "3.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "\"Apache License, Version 2.0\";link=\"https://www.apache.org/licenses/LICENSE-2.0.txt\""
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:org.eclipse.microprofile.config:microprofile-config-api:3.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@3.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "cef8b70598a93582a4084fe67f4686eb399e70fd"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.eclipse.microprofile.config:microprofile_config_api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-config-api:microprofile-config-api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-config-api:microprofile_config_api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_config_api:microprofile-config-api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_config_api:microprofile_config_api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.eclipse.microprofile.config:microprofile:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-config:microprofile-config-api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-config:microprofile_config_api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_config:microprofile-config-api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_config:microprofile_config_api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-config-api:microprofile:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile:microprofile-config-api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile:microprofile_config_api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_config_api:microprofile:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-config:microprofile:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_config:microprofile:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:microprofile-config-api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:microprofile_config_api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:config:microprofile-config-api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:config:microprofile_config_api:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile:microprofile:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:microprofile:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:config:microprofile:3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.eclipse.microprofile.config.microprofile-config-api-3.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "microprofile-config-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.eclipse.microprofile.config"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.eclipse.microprofile.config.microprofile-config-api-3.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3?package-id=24b246d5e0d67126",
+      "type": "library",
+      "group": "org.eclipse.microprofile.context-propagation",
+      "name": "microprofile-context-propagation-api",
+      "version": "1.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "\"Apache License, Version 2.0\";link=\"https://www.apache.org/licenses/LICENSE-2.0.txt\";description=\"A business-friendly OSS license\""
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.3:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "aab6a415754137629e725a9927702a5cd68038c2"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.eclipse.microprofile.context-propagation:microprofile_context_propagation_api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-context-propagation-api:microprofile-context-propagation-api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-context-propagation-api:microprofile_context_propagation_api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_context_propagation_api:microprofile-context-propagation-api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_context_propagation_api:microprofile_context_propagation_api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-context-propagation:microprofile-context-propagation-api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-context-propagation:microprofile_context_propagation_api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_context_propagation:microprofile-context-propagation-api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_context_propagation:microprofile_context_propagation_api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-context:microprofile-context-propagation-api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-context:microprofile_context_propagation_api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_context:microprofile-context-propagation-api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_context:microprofile_context_propagation_api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.eclipse.microprofile.context-propagation:microprofile:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:context-propagation:microprofile-context-propagation-api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:context-propagation:microprofile_context_propagation_api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:context_propagation:microprofile-context-propagation-api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:context_propagation:microprofile_context_propagation_api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-context-propagation-api:microprofile:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile:microprofile-context-propagation-api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile:microprofile_context_propagation_api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_context_propagation_api:microprofile:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-context-propagation:microprofile:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_context_propagation:microprofile:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:context:microprofile-context-propagation-api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:context:microprofile_context_propagation_api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:microprofile-context-propagation-api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:microprofile_context_propagation_api:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-context:microprofile:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_context:microprofile:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:context-propagation:microprofile:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:context_propagation:microprofile:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile:microprofile:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:context:microprofile:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:microprofile:1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.eclipse.microprofile.context-propagation.microprofile-context-propagation-api-1.3.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "microprofile-context-propagation-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.eclipse.microprofile.context-propagation"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.eclipse.microprofile.context-propagation.microprofile-context-propagation-api-1.3.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.eclipse.microprofile.health/microprofile-health-api@4.0.1?package-id=fee6fe55670da121",
+      "type": "library",
+      "group": "org.eclipse.microprofile.health",
+      "name": "microprofile-health-api",
+      "version": "4.0.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:org.eclipse.microprofile.health:microprofile-health-api:4.0.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.eclipse.microprofile.health/microprofile-health-api@4.0.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "395ea08f4f636696fb23b84a18ba81430cfebe7c"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.eclipse.microprofile.health:microprofile_health_api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-health-api:microprofile-health-api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-health-api:microprofile_health_api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_health_api:microprofile-health-api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_health_api:microprofile_health_api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.eclipse.microprofile.health:microprofile:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-health:microprofile-health-api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-health:microprofile_health_api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_health:microprofile-health-api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_health:microprofile_health_api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-health-api:microprofile:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile:microprofile-health-api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile:microprofile_health_api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_health_api:microprofile:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile-health:microprofile:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile_health:microprofile:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:microprofile-health-api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:microprofile_health_api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:health:microprofile-health-api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:health:microprofile_health_api:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:microprofile:microprofile:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:microprofile:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:health:microprofile:4.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.eclipse.microprofile.health.microprofile-health-api-4.0.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "microprofile-health-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.eclipse.microprofile.health"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.eclipse.microprofile.health.microprofile-health-api-4.0.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64&distro=rhel-9.6&package-id=f465e8751bc1071e&upstream=mpfr-4.1.0-7.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "mpfr",
+      "version": "4.1.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:mpfr:4.1.0-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64&distro=rhel-9.6&upstream=mpfr-4.1.0-7.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mpfr:mpfr:4.1.0-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "7.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "802539"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "mpfr-4.1.0-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@2.8.0?package-id=196dcbdd31c86c32",
+      "type": "library",
+      "group": "io.smallrye.reactive",
+      "name": "mutiny",
+      "version": "2.8.0",
+      "cpe": "cpe:2.3:a:io.smallrye.reactive:mutiny:2.8.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.reactive/mutiny@2.8.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "56c05d093fadc864ec991859dd7436d612f805a1"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:mutiny:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:mutiny:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:mutiny:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.reactive.mutiny-2.8.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "mutiny"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.reactive"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.reactive.mutiny-2.8.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@2.8.0?package-id=bb1e5c38d89c527b",
+      "type": "library",
+      "group": "io.smallrye.reactive",
+      "name": "mutiny-smallrye-context-propagation",
+      "version": "2.8.0",
+      "cpe": "cpe:2.3:a:mutiny-smallrye-context-propagation:mutiny-smallrye-context-propagation:2.8.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@2.8.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b63776d3e7a0d26c04804b6e9055fe4200e15f7a"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny-smallrye-context-propagation:mutiny_smallrye_context_propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny_smallrye_context_propagation:mutiny-smallrye-context-propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny_smallrye_context_propagation:mutiny_smallrye_context_propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny-smallrye-context:mutiny-smallrye-context-propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny-smallrye-context:mutiny_smallrye_context_propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny_smallrye_context:mutiny-smallrye-context-propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny_smallrye_context:mutiny_smallrye_context_propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:mutiny-smallrye-context-propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:mutiny_smallrye_context_propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny-smallrye:mutiny-smallrye-context-propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny-smallrye:mutiny_smallrye_context_propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny_smallrye:mutiny-smallrye-context-propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny_smallrye:mutiny_smallrye_context_propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:mutiny-smallrye-context-propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:mutiny_smallrye_context_propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:mutiny-smallrye-context-propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:mutiny_smallrye_context_propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:mutiny-smallrye-context-propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:mutiny_smallrye_context_propagation:2.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.reactive.mutiny-smallrye-context-propagation-2.8.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "mutiny-smallrye-context-propagation"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.reactive"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.reactive.mutiny-smallrye-context-propagation-2.8.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.16.0?package-id=8be4a82031d8f3ed",
+      "type": "library",
+      "group": "com.aayushatharva.brotli4j",
+      "name": "native-linux-x86_64",
+      "version": "1.16.0",
+      "cpe": "cpe:2.3:a:com.aayushatharva.brotli4j:native-linux-x86-64:1.16.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.16.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e72d451319f3b95879f47db7eeea7f720cb84d62"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:com.aayushatharva.brotli4j:native-linux-x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:com.aayushatharva.brotli4j:native_linux_x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native-linux-x86-64:native-linux-x86-64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native-linux-x86-64:native-linux-x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native-linux-x86-64:native_linux_x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native-linux-x86_64:native-linux-x86-64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native-linux-x86_64:native-linux-x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native-linux-x86_64:native_linux_x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native_linux_x86_64:native-linux-x86-64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native_linux_x86_64:native-linux-x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native_linux_x86_64:native_linux_x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native-linux-x86:native-linux-x86-64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native-linux-x86:native-linux-x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native-linux-x86:native_linux_x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native_linux_x86:native-linux-x86-64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native_linux_x86:native-linux-x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native_linux_x86:native_linux_x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:aayushatharva:native-linux-x86-64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:aayushatharva:native-linux-x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:aayushatharva:native_linux_x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native-linux:native-linux-x86-64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native-linux:native-linux-x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native-linux:native_linux_x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native_linux:native-linux-x86-64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native_linux:native-linux-x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native_linux:native_linux_x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:brotli4j:native-linux-x86-64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:brotli4j:native-linux-x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:brotli4j:native_linux_x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native:native-linux-x86-64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native:native-linux-x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:native:native_linux_x86_64:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/com.aayushatharva.brotli4j.native-linux-x86_64-1.16.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "native-linux-x86_64"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "com.aayushatharva.brotli4j"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/com.aayushatharva.brotli4j.native-linux-x86_64-1.16.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9?arch=noarch&distro=rhel-9.6&package-id=a1613b552d5c15c8&upstream=ncurses-6.2-10.20210508.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "ncurses-base",
+      "version": "6.2-10.20210508.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:ncurses-base:ncurses-base:6.2-10.20210508.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9?arch=noarch&distro=rhel-9.6&upstream=ncurses-6.2-10.20210508.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses-base:ncurses_base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses_base:ncurses-base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses_base:ncurses_base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses:ncurses-base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses:ncurses_base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ncurses-base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ncurses_base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "10.20210508.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "307293"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "ncurses-6.2-10.20210508.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9?arch=x86_64&distro=rhel-9.6&package-id=4e4811efdca08c7d&upstream=ncurses-6.2-10.20210508.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "ncurses-libs",
+      "version": "6.2-10.20210508.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:ncurses-libs:ncurses-libs:6.2-10.20210508.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9?arch=x86_64&distro=rhel-9.6&upstream=ncurses-6.2-10.20210508.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses-libs:ncurses_libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses_libs:ncurses-libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses_libs:ncurses_libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses:ncurses-libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses:ncurses_libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ncurses-libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ncurses_libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "10.20210508.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "994375"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "ncurses-6.2-10.20210508.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/nettle@3.10.1-1.el9?arch=x86_64&distro=rhel-9.6&package-id=4c77a55779264dcf&upstream=nettle-3.10.1-1.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "nettle",
+      "version": "3.10.1-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:nettle:nettle:3.10.1-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/nettle@3.10.1-1.el9?arch=x86_64&distro=rhel-9.6&upstream=nettle-3.10.1-1.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:nettle:3.10.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1169592"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "nettle-3.10.1-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.118.Final?package-id=94c7f0bb9f343896",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-buffer",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.buffer:netty-buffer:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-buffer@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "7022990af1e0d449f9d5322035899745e19735c5"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.buffer:netty_buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-buffer:netty-buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-buffer:netty_buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_buffer:netty-buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_buffer:netty_buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.buffer:buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:buffer:netty-buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:buffer:netty_buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-buffer:buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_buffer:buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:buffer:buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:buffer:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-buffer-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-buffer"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-buffer-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-codec@4.1.118.Final?package-id=5d42831905e7d77d",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-codec",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.codec:netty-codec:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-codec@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "307f665c08ce57333121de4f460479fc0c3c94d4"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec:netty_codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:netty-codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:netty_codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:netty-codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:netty_codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec:codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:netty-codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:netty_codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:codec:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-codec-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-codec"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-codec-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-codec-dns@4.1.118.Final?package-id=4718feef42c2b993",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-codec-dns",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.codec-dns:netty-codec-dns:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-codec-dns@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0e04bf6679ab5e1bedae12047c4e049887476993"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-dns:netty_codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-dns:netty-codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-dns:netty_codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_dns:netty-codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_dns:netty_codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-dns:codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-dns:codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:netty-codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:netty_codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:netty-codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:netty_codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-dns:netty-codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-dns:netty_codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_dns:netty-codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_dns:netty_codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-dns:codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-dns:codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_dns:codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_dns:codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:netty-codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:netty_codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-dns:codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-dns:codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_dns:codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_dns:codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:codec-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:codec_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-codec-dns-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-codec-dns"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-codec-dns-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.118.Final?package-id=daad1890d0ef4247",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-codec-haproxy",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.codec-haproxy:netty-codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-codec-haproxy@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b8a82b07009c45de868245f8125d6f8002368613"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-haproxy:netty_codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-haproxy:netty-codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-haproxy:netty_codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_haproxy:netty-codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_haproxy:netty_codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-haproxy:codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-haproxy:codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-haproxy:netty-codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-haproxy:netty_codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_haproxy:netty-codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_haproxy:netty_codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-haproxy:codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-haproxy:codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_haproxy:codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_haproxy:codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:netty-codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:netty_codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:netty-codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:netty_codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-haproxy:codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-haproxy:codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_haproxy:codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_haproxy:codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:netty-codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:netty_codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:codec-haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:codec_haproxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-codec-haproxy-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-codec-haproxy"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-codec-haproxy-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-codec-http@4.1.118.Final?package-id=9c9212eecc2599f1",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-codec-http",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.codec-http:netty-codec-http:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-codec-http@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "eda08a71294afe78c779b85fd696bc13491507a8"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-http:netty_codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-http:netty-codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-http:netty_codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_http:netty-codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_http:netty_codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-http:codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-http:codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:netty-codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:netty_codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:netty-codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:netty_codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-http:netty-codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-http:netty_codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_http:netty-codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_http:netty_codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-http:codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-http:codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_http:codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_http:codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:netty-codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:netty_codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-http:codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-http:codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_http:codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_http:codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:codec-http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:codec_http:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-codec-http-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-codec-http"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-codec-http-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-codec-http2@4.1.118.Final?package-id=fd1b9ec09bb9f213",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-codec-http2",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.codec-http2:netty-codec-http2:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-codec-http2@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e3c35c0685ec9e84c4f84b79feea7c9d185a08d3"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-http2:netty_codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-http2:netty-codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-http2:netty_codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_http2:netty-codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_http2:netty_codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-http2:codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-http2:codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-http2:netty-codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-http2:netty_codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_http2:netty-codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_http2:netty_codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-http2:codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-http2:codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:netty-codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:netty_codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:netty-codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:netty_codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_http2:codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_http2:codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-http2:codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-http2:codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:netty-codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:netty_codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_http2:codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_http2:codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:codec-http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:codec_http2:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-codec-http2-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-codec-http2"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-codec-http2-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-codec-socks@4.1.118.Final?package-id=3d41b22d33ca9eea",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-codec-socks",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.codec-socks:netty-codec-socks:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-codec-socks@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "488a67579f062bba2d2d20ce46f9bb28a68b0875"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-socks:netty_codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-socks:netty-codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-socks:netty_codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_socks:netty-codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_socks:netty_codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-socks:codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.codec-socks:codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-socks:netty-codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-socks:netty_codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_socks:netty-codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_socks:netty_codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-socks:codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec-socks:codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:netty-codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:netty_codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:netty-codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:netty_codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_socks:codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec_socks:codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-socks:codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec-socks:codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:netty-codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:netty_codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_socks:codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec_socks:codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-codec:codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_codec:codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codec:codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:codec-socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:codec_socks:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-codec-socks-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-codec-socks"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-codec-socks-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-common@4.1.118.Final?package-id=9ba204bbc3bcc4bd",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-common",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.common:netty-common:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-common@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4bb0f9899146484fa89f7b9bc27389d5b8e2ecde"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.common:netty_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-common:netty-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-common:netty_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_common:netty-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_common:netty_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.common:common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:netty-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:netty_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-common:common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_common:common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-common-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-common"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-common-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-handler@4.1.118.Final?package-id=3353ba0cbeffed8a",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-handler",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.handler:netty-handler:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-handler@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "30ebb05b6b0fb071dbfcf713017c4a767a97bb9b"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.handler:netty_handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-handler:netty-handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-handler:netty_handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_handler:netty-handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_handler:netty_handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.handler:handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler:netty-handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler:netty_handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-handler:handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_handler:handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler:handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:handler:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-handler-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-handler"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-handler-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.118.Final?package-id=dc70c086220f07a0",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-handler-proxy",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.handler-proxy:netty-handler-proxy:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-handler-proxy@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "28d6c41b72df614e09440ae0bed53a43fbcfbe27"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.handler-proxy:netty_handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-handler-proxy:netty-handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-handler-proxy:netty_handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_handler_proxy:netty-handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_handler_proxy:netty_handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.handler-proxy:handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.handler-proxy:handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler-proxy:netty-handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler-proxy:netty_handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler_proxy:netty-handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler_proxy:netty_handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-handler-proxy:handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-handler-proxy:handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-handler:netty-handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-handler:netty_handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_handler:netty-handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_handler:netty_handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_handler_proxy:handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_handler_proxy:handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler-proxy:handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler-proxy:handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler:netty-handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler:netty_handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler_proxy:handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler_proxy:handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-handler:handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-handler:handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_handler:handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_handler:handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler:handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:handler:handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:handler-proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:handler_proxy:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-handler-proxy-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-handler-proxy"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-handler-proxy-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.118.Final?package-id=f475eba6ffab0047",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-resolver",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.resolver:netty-resolver:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-resolver@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "28c378c19c1779eca1104b400452627f3ebc4aea"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.resolver:netty_resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-resolver:netty-resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-resolver:netty_resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_resolver:netty-resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_resolver:netty_resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.resolver:resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-resolver:resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_resolver:resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver:netty-resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver:netty_resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver:resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:resolver:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-resolver-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-resolver"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-resolver-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.118.Final?package-id=822c126681ec2f4b",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-resolver-dns",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.resolver-dns:netty-resolver-dns:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ff5bfb643ccc5a809c4c21b10167b8d214ceaeeb"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.resolver-dns:netty_resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-resolver-dns:netty-resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-resolver-dns:netty_resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_resolver_dns:netty-resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_resolver_dns:netty_resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.resolver-dns:resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.resolver-dns:resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-resolver:netty-resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-resolver:netty_resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_resolver:netty-resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_resolver:netty_resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-resolver-dns:resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-resolver-dns:resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_resolver_dns:resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_resolver_dns:resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver-dns:netty-resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver-dns:netty_resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver_dns:netty-resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver_dns:netty_resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-resolver:resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-resolver:resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_resolver:resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_resolver:resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver:netty-resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver:netty_resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver-dns:resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver-dns:resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver_dns:resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver_dns:resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver:resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resolver:resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:resolver-dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:resolver_dns:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-resolver-dns-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-resolver-dns"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-resolver-dns-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-transport@4.1.118.Final?package-id=982cc0d1c08f3ca2",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-transport",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.transport:netty-transport:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-transport@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5a27232e5d08218722d94ca14f0b1b4576e7711c"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.transport:netty_transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport:netty-transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport:netty_transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport:netty-transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport:netty_transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.transport:transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport:transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport:transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport:netty-transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport:netty_transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport:transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:transport:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-transport-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-transport"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-transport-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.118.Final?package-id=1c69f32a6c699f22",
+      "type": "library",
+      "group": "io.netty",
+      "name": "netty-transport-native-unix-common",
+      "version": "4.1.118.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.netty.transport-native-unix-common:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.118.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9da25a94e6a0edac90da0bc7894e5a54efcb866b"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.transport-native-unix-common:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport-native-unix-common:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport-native-unix-common:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport_native_unix_common:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport_native_unix_common:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.transport-native-unix-common:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty.transport-native-unix-common:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport-native-unix-common:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport-native-unix-common:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport_native_unix_common:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport_native_unix_common:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport-native-unix-common:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport-native-unix-common:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport_native_unix_common:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport_native_unix_common:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport-native-unix:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport-native-unix:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport_native_unix:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport_native_unix:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport-native:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport-native:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport_native:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport_native:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport-native-unix-common:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport-native-unix-common:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport_native_unix_common:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport_native_unix_common:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport-native-unix:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport-native-unix:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport_native_unix:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport_native_unix:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport-native-unix:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport-native-unix:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport_native_unix:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport_native_unix:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport-native:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport-native:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport_native:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport_native:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport-native:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport-native:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport_native:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport_native:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport-native-unix:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport-native-unix:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport_native_unix:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport_native_unix:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport-native:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport-native:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport_native:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport_native:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-transport:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_transport:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty-project:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty_project:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty-transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:netty_transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:transport:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.netty:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:transport-native-unix-common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:netty:transport_native_unix_common:4.1.118.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.netty.netty-transport-native-unix-common-4.1.118.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "netty-transport-native-unix-common"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.netty"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.netty.netty-transport-native-unix-common-4.1.118.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64&distro=rhel-9.6&package-id=30469a89d3a6f339&upstream=npth-1.6-8.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "npth",
+      "version": "1.6-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:npth:1.6-8.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64&distro=rhel-9.6&upstream=npth-1.6-8.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:npth:npth:1.6-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "8.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "50619"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "npth-1.6-8.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/nspr@4.35.0-17.el9_2?arch=x86_64&distro=rhel-9.6&package-id=26c308145aa5c3e3&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "nspr",
+      "version": "4.35.0-17.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:nspr:4.35.0-17.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/nspr@4.35.0-17.el9_2?arch=x86_64&distro=rhel-9.6&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nspr:nspr:4.35.0-17.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "17.el9_2"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "320992"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "nss-3.101.0-10.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/nss@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=06626f8f3944db6c&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "nss",
+      "version": "3.101.0-10.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:nss:3.101.0-10.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/nss@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss:nss:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "10.el9_2"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1968327"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "nss-3.101.0-10.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/nss-softokn@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=686e1510063b263e&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "nss-softokn",
+      "version": "3.101.0-10.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:nss-softokn:nss-softokn:3.101.0-10.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/nss-softokn@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss-softokn:nss_softokn:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss_softokn:nss-softokn:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss_softokn:nss_softokn:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:nss-softokn:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:nss_softokn:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss:nss-softokn:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss:nss_softokn:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "10.el9_2"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1317731"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "nss-3.101.0-10.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/nss-softokn-freebl@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=6a79f4bde0e99cf0&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "nss-softokn-freebl",
+      "version": "3.101.0-10.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:nss-softokn-freebl:nss-softokn-freebl:3.101.0-10.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/nss-softokn-freebl@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss-softokn-freebl:nss_softokn_freebl:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss_softokn_freebl:nss-softokn-freebl:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss_softokn_freebl:nss_softokn_freebl:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss-softokn:nss-softokn-freebl:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss-softokn:nss_softokn_freebl:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss_softokn:nss-softokn-freebl:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss_softokn:nss_softokn_freebl:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:nss-softokn-freebl:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:nss_softokn_freebl:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss:nss-softokn-freebl:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss:nss_softokn_freebl:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "10.el9_2"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "840118"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "nss-3.101.0-10.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/nss-sysinit@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=f1fb560bb7aa6723&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "nss-sysinit",
+      "version": "3.101.0-10.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:nss-sysinit:nss-sysinit:3.101.0-10.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/nss-sysinit@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss-sysinit:nss_sysinit:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss_sysinit:nss-sysinit:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss_sysinit:nss_sysinit:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:nss-sysinit:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:nss_sysinit:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss:nss-sysinit:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss:nss_sysinit:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "10.el9_2"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "18178"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "nss-3.101.0-10.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/nss-util@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=406e16374f3b021f&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "nss-util",
+      "version": "3.101.0-10.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:nss-util:nss-util:3.101.0-10.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/nss-util@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss-util:nss_util:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss_util:nss-util:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss_util:nss_util:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:nss-util:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:nss_util:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss:nss-util:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nss:nss_util:3.101.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "10.el9_2"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "238048"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "nss-3.101.0-10.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/openldap@2.6.8-4.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8d626f8fe6c707&upstream=openldap-2.6.8-4.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "openldap",
+      "version": "2.6.8-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "OLDAP-2.8"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:openldap:openldap:2.6.8-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/openldap@2.6.8-4.el9?arch=x86_64&distro=rhel-9.6&upstream=openldap-2.6.8-4.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openldap:2.6.8-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "4.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1087273"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "openldap-2.6.8-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-6.el9_5?arch=x86_64&distro=rhel-9.6&package-id=42a7b60cc274a3e4&upstream=openssl-fips-provider-3.0.7-6.el9_5.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "openssl-fips-provider",
+      "version": "3.0.7-6.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:openssl-fips-provider:openssl-fips-provider:3.0.7-6.el9_5:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-6.el9_5?arch=x86_64&distro=rhel-9.6&upstream=openssl-fips-provider-3.0.7-6.el9_5.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl-fips-provider:openssl_fips_provider:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_fips_provider:openssl-fips-provider:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_fips_provider:openssl_fips_provider:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl-fips:openssl-fips-provider:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl-fips:openssl_fips_provider:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_fips:openssl-fips-provider:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_fips:openssl_fips_provider:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl:openssl-fips-provider:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl:openssl_fips_provider:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openssl-fips-provider:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openssl_fips_provider:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "6.el9_5"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "251"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "openssl-fips-provider-3.0.7-6.el9_5.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-6.el9_5?arch=x86_64&distro=rhel-9.6&package-id=bcbb7401c1be39ef&upstream=openssl-fips-provider-3.0.7-6.el9_5.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "openssl-fips-provider-so",
+      "version": "3.0.7-6.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:openssl-fips-provider-so:openssl-fips-provider-so:3.0.7-6.el9_5:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-6.el9_5?arch=x86_64&distro=rhel-9.6&upstream=openssl-fips-provider-3.0.7-6.el9_5.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl-fips-provider-so:openssl_fips_provider_so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_fips_provider_so:openssl-fips-provider-so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_fips_provider_so:openssl_fips_provider_so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl-fips-provider:openssl-fips-provider-so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl-fips-provider:openssl_fips_provider_so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_fips_provider:openssl-fips-provider-so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_fips_provider:openssl_fips_provider_so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl-fips:openssl-fips-provider-so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl-fips:openssl_fips_provider_so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_fips:openssl-fips-provider-so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_fips:openssl_fips_provider_so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl:openssl-fips-provider-so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl:openssl_fips_provider_so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openssl-fips-provider-so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openssl_fips_provider_so:3.0.7-6.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "6.el9_5"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1337154"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "openssl-fips-provider-3.0.7-6.el9_5.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "openssl-libs",
+      "version": "1:3.2.2-6.el9_5.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:openssl-libs:openssl-libs:1\\:3.2.2-6.el9_5.1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&upstream=openssl-3.2.2-6.el9_5.1.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl-libs:openssl_libs:1\\:3.2.2-6.el9_5.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_libs:openssl-libs:1\\:3.2.2-6.el9_5.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_libs:openssl_libs:1\\:3.2.2-6.el9_5.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl:openssl-libs:1\\:3.2.2-6.el9_5.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl:openssl_libs:1\\:3.2.2-6.el9_5.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openssl-libs:1\\:3.2.2-6.el9_5.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openssl_libs:1\\:3.2.2-6.el9_5.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:epoch",
+          "value": "1"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "6.el9_5.1"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "6674440"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "openssl-3.2.2-6.el9_5.1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.github.crac/org-crac@0.1.3?package-id=0965386298995f3c",
+      "type": "library",
+      "group": "io.github.crac",
+      "name": "org-crac",
+      "version": "0.1.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "url": "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.github.crac:org-crac:0.1.3:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.github.crac/org-crac@0.1.3",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "78ca3679ec8ff707c18b17885ef589467780c486"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.github.crac:org_crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.github.crac:crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org-crac:org-crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org-crac:org_crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org_crac:org-crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org_crac:org_crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:github:org-crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:github:org_crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crac:org-crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crac:org_crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org-crac:crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org_crac:crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org:org-crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org:org_crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:github:crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crac:crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org:crac:0.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.github.crac.org-crac-0.1.3.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "org-crac"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.github.crac"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.github.crac.org-crac-0.1.3.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64&distro=rhel-9.6&package-id=a9586bae56dbbae8&upstream=p11-kit-0.25.3-3.el9_5.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "p11-kit",
+      "version": "0.25.3-3.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:p11-kit:p11-kit:0.25.3-3.el9_5:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64&distro=rhel-9.6&upstream=p11-kit-0.25.3-3.el9_5.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11-kit:p11_kit:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11_kit:p11-kit:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11_kit:p11_kit:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:p11-kit:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:p11_kit:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11:p11-kit:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11:p11_kit:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "3.el9_5"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "2530659"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "p11-kit-0.25.3-3.el9_5.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64&distro=rhel-9.6&package-id=3deb984e0c342d5f&upstream=p11-kit-0.25.3-3.el9_5.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "p11-kit-trust",
+      "version": "0.25.3-3.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:p11-kit-trust:p11-kit-trust:0.25.3-3.el9_5:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64&distro=rhel-9.6&upstream=p11-kit-0.25.3-3.el9_5.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11-kit-trust:p11_kit_trust:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11_kit_trust:p11-kit-trust:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11_kit_trust:p11_kit_trust:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11-kit:p11-kit-trust:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11-kit:p11_kit_trust:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11_kit:p11-kit-trust:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11_kit:p11_kit_trust:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:p11-kit-trust:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:p11_kit_trust:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11:p11-kit-trust:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11:p11_kit_trust:0.25.3-3.el9_5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "3.el9_5"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "478116"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "p11-kit-0.25.3-3.el9_5.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.eclipse.parsson/parsson@1.1.7?package-id=4651edb464533473",
+      "type": "library",
+      "group": "org.eclipse.parsson",
+      "name": "parsson",
+      "version": "1.1.7",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://projects.eclipse.org/license/epl-2.0, https://projects.eclipse.org/license/secondary-gpl-2.0-cp"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:org.eclipse.parsson:parsson:1.1.7:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.eclipse.parsson/parsson@1.1.7",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f5825abecd373006262dd319d7df8c5cdbd140ca"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:parsson:1.1.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:parsson:parsson:1.1.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.eclipse.parsson.parsson-1.1.7.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "parsson"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.eclipse.parsson"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.eclipse.parsson.parsson-1.1.7.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64&distro=rhel-9.6&package-id=73518a205b7179dc&upstream=pcre-8.44-4.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "pcre",
+      "version": "8.44-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:pcre:8.44-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64&distro=rhel-9.6&upstream=pcre-8.44-4.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre:pcre:8.44-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "4.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "537728"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "pcre-8.44-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64&distro=rhel-9.6&package-id=b35dca0d876967e5&upstream=pcre2-10.40-6.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "pcre2",
+      "version": "10.40-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:pcre2:10.40-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64&distro=rhel-9.6&upstream=pcre2-10.40-6.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre2:pcre2:10.40-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "6.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "652298"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "pcre2-10.40-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch&distro=rhel-9.6&package-id=6f41357881f43a79&upstream=pcre2-10.40-6.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "pcre2-syntax",
+      "version": "10.40-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:pcre2-syntax:pcre2-syntax:10.40-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch&distro=rhel-9.6&upstream=pcre2-10.40-6.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre2-syntax:pcre2_syntax:10.40-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre2_syntax:pcre2-syntax:10.40-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre2_syntax:pcre2_syntax:10.40-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:pcre2-syntax:10.40-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:pcre2_syntax:10.40-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre2:pcre2-syntax:10.40-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre2:pcre2_syntax:10.40-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "6.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "234324"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "pcre2-10.40-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64&distro=rhel-9.6&package-id=aece279b92ad1633&upstream=popt-1.18-8.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "popt",
+      "version": "1.18-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:popt:1.18-8.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64&distro=rhel-9.6&upstream=popt-1.18-8.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:popt:popt:1.18-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "8.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "130360"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "popt-1.18-8.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3@3.9.21-2.el9?arch=x86_64&distro=rhel-9.6&package-id=b4c5c33a2372a96a&upstream=python3.9-3.9.21-2.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3",
+      "version": "3.9.21-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:python3:python3:3.9.21-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3@3.9.21-2.el9?arch=x86_64&distro=rhel-9.6&upstream=python3.9-3.9.21-2.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3:3.9.21-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "2.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "32837"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "python3.9-3.9.21-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-libs@3.9.21-2.el9?arch=x86_64&distro=rhel-9.6&package-id=372f3aac35f4501e&upstream=python3.9-3.9.21-2.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-libs",
+      "version": "3.9.21-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:python3-libs:python3-libs:3.9.21-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-libs@3.9.21-2.el9?arch=x86_64&distro=rhel-9.6&upstream=python3.9-3.9.21-2.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-libs:python3_libs:3.9.21-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_libs:python3-libs:3.9.21-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_libs:python3_libs:3.9.21-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-libs:3.9.21-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_libs:3.9.21-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-libs:3.9.21-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_libs:3.9.21-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "2.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "33064107"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "python3.9-3.9.21-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-pip-wheel@21.3.1-1.el9?arch=noarch&distro=rhel-9.6&package-id=17815ed06966e551&upstream=python-pip-21.3.1-1.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-pip-wheel",
+      "version": "21.3.1-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:python3-pip-wheel:python3-pip-wheel:21.3.1-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-pip-wheel@21.3.1-1.el9?arch=noarch&distro=rhel-9.6&upstream=python-pip-21.3.1-1.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-pip-wheel:python3_pip_wheel:21.3.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_pip_wheel:python3-pip-wheel:21.3.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_pip_wheel:python3_pip_wheel:21.3.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-pip:python3-pip-wheel:21.3.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-pip:python3_pip_wheel:21.3.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_pip:python3-pip-wheel:21.3.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_pip:python3_pip_wheel:21.3.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-pip-wheel:21.3.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_pip_wheel:21.3.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-pip-wheel:21.3.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_pip_wheel:21.3.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1232785"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "python-pip-21.3.1-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-13.el9?arch=noarch&distro=rhel-9.6&package-id=b2df5204eb3d0deb&upstream=python-setuptools-53.0.0-13.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-setuptools-wheel",
+      "version": "53.0.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and (BSD or ASL 2.0)"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:python3-setuptools-wheel:python3-setuptools-wheel:53.0.0-13.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-13.el9?arch=noarch&distro=rhel-9.6&upstream=python-setuptools-53.0.0-13.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-setuptools-wheel:python3_setuptools_wheel:53.0.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_setuptools_wheel:python3-setuptools-wheel:53.0.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_setuptools_wheel:python3_setuptools_wheel:53.0.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-setuptools:python3-setuptools-wheel:53.0.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-setuptools:python3_setuptools_wheel:53.0.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_setuptools:python3-setuptools-wheel:53.0.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_setuptools:python3_setuptools_wheel:53.0.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-setuptools-wheel:53.0.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_setuptools_wheel:53.0.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-setuptools-wheel:53.0.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_setuptools_wheel:53.0.0-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "13.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "562606"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "python-setuptools-53.0.0-13.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-arc@3.19.1?package-id=2f63225acfff1f73",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-arc",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-arc:quarkus-arc:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-arc@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4c9f5816f95e532dcafc9405a2c646bf34baa13d"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-arc:quarkus_arc:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_arc:quarkus-arc:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_arc:quarkus_arc:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-arc:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_arc:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-arc:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_arc:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-arc-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-arc"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-arc-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-arc?package-id=ba7d9ba8a0975b7e",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-arc",
+      "version": "UNKNOWN",
+      "cpe": "cpe:2.3:a:quarkus-arc:quarkus-arc:*:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-arc",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-pom-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-arc:quarkus_arc:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_arc:quarkus-arc:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_arc:quarkus_arc:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-arc:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_arc:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-arc:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_arc:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/pom.xml"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-arc"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@3.19.1?package-id=09cc20274850e4ac",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-bootstrap-runner",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-bootstrap-runner:quarkus-bootstrap-runner:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "43f0fcb56afdb22d247fd77124a1b63e3580edaf"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-bootstrap-runner:quarkus_bootstrap_runner:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_bootstrap_runner:quarkus-bootstrap-runner:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_bootstrap_runner:quarkus_bootstrap_runner:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-bootstrap:quarkus-bootstrap-runner:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-bootstrap:quarkus_bootstrap_runner:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_bootstrap:quarkus-bootstrap-runner:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_bootstrap:quarkus_bootstrap_runner:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-bootstrap-runner:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_bootstrap_runner:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-bootstrap-runner:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_bootstrap_runner:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.quarkus.quarkus-bootstrap-runner-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-bootstrap-runner"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.quarkus.quarkus-bootstrap-runner-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-classloader-commons@3.19.1?package-id=4a703a6db7dd0ae0",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-classloader-commons",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-classloader-commons:quarkus-classloader-commons:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-classloader-commons@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "84fbdaa0a18d9e170f45c42d431c8d8e7b64f01c"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-classloader-commons:quarkus_classloader_commons:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_classloader_commons:quarkus-classloader-commons:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_classloader_commons:quarkus_classloader_commons:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-classloader:quarkus-classloader-commons:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-classloader:quarkus_classloader_commons:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_classloader:quarkus-classloader-commons:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_classloader:quarkus_classloader_commons:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-classloader-commons:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_classloader_commons:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-classloader-commons:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_classloader_commons:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.quarkus.quarkus-classloader-commons-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-classloader-commons"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.quarkus.quarkus-classloader-commons-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-container-image@3.19.1?package-id=d110ef9c18406485",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-container-image",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-container-image:quarkus-container-image:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-container-image@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "90cb807d1ebd463e9c37622f8baf010371d83b6c"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-container-image:quarkus_container_image:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_container_image:quarkus-container-image:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_container_image:quarkus_container_image:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-container:quarkus-container-image:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-container:quarkus_container_image:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_container:quarkus-container-image:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_container:quarkus_container_image:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-container-image:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_container_image:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-container-image:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_container_image:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-container-image-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-container-image"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-container-image-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-container-image-openshift@3.19.1?package-id=4768d9f7de14a3b3",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-container-image-openshift",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-container-image-openshift:quarkus-container-image-openshift:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-container-image-openshift@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "385fa1bd68a71dc9bdd67a39b79037e8df96669b"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-container-image-openshift:quarkus_container_image_openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_container_image_openshift:quarkus-container-image-openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_container_image_openshift:quarkus_container_image_openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-container-image:quarkus-container-image-openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-container-image:quarkus_container_image_openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_container_image:quarkus-container-image-openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_container_image:quarkus_container_image_openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-container:quarkus-container-image-openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-container:quarkus_container_image_openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_container:quarkus-container-image-openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_container:quarkus_container_image_openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-container-image-openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_container_image_openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-container-image-openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_container_image_openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-container-image-openshift-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-container-image-openshift"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-container-image-openshift-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-core@3.19.1?package-id=9f4703e648f27cee",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-core",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-core:quarkus-core:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-core@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b92a15afff4008a64d078935714ce1917f569ea4"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-core:quarkus_core:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_core:quarkus-core:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_core:quarkus_core:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-core:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_core:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-core:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_core:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-core-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-core"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-core-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-credentials@3.19.1?package-id=f9290fbdf1377bef",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-credentials",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-credentials:quarkus-credentials:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-credentials@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "da50fa57b48fce74575c3c115108b9c97a8423f6"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-credentials:quarkus_credentials:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_credentials:quarkus-credentials:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_credentials:quarkus_credentials:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-credentials:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_credentials:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-credentials:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_credentials:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-credentials-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-credentials"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-credentials-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-development-mode-spi@3.19.1?package-id=d1d2e2a47435d446",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-development-mode-spi",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-development-mode-spi:quarkus-development-mode-spi:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-development-mode-spi@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d90a994c27be8c2c752c1c9f6288e09dd72a9c01"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-development-mode-spi:quarkus_development_mode_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_development_mode_spi:quarkus-development-mode-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_development_mode_spi:quarkus_development_mode_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-development-mode:quarkus-development-mode-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-development-mode:quarkus_development_mode_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_development_mode:quarkus-development-mode-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_development_mode:quarkus_development_mode_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-development:quarkus-development-mode-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-development:quarkus_development_mode_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_development:quarkus-development-mode-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_development:quarkus_development_mode_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-development-mode-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_development_mode_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-development-mode-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_development_mode_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.quarkus.quarkus-development-mode-spi-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-development-mode-spi"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.quarkus.quarkus-development-mode-spi-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.10?package-id=cd68f4486dd682e2",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-fs-util",
+      "version": "0.0.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:jboss-by-red-hat:quarkus-fs-util:0.0.10:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.10",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "1fd00b93c4566a2b8e4bcb1597efb357bdee2175"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:quarkus_fs_util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:quarkus-fs-util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:quarkus_fs_util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-fs-util:quarkus-fs-util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-fs-util:quarkus_fs_util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_fs_util:quarkus-fs-util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_fs_util:quarkus_fs_util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-fs-util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_fs_util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-fs:quarkus-fs-util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-fs:quarkus_fs_util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_fs:quarkus-fs-util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_fs:quarkus_fs_util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-fs-util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_fs_util:0.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-fs-util-0.0.10.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-fs-util"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-fs-util-0.0.10.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-jsonp@3.19.1?package-id=7152b741d3e5765f",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-jsonp",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-jsonp:quarkus-jsonp:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-jsonp@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9f240703b6faba7c0426b42864232e02c8b17596"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-jsonp:quarkus_jsonp:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_jsonp:quarkus-jsonp:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_jsonp:quarkus_jsonp:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-jsonp:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_jsonp:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-jsonp:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_jsonp:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-jsonp-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-jsonp"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-jsonp-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-junit5?package-id=6e686c858447e256",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-junit5",
+      "version": "UNKNOWN",
+      "cpe": "cpe:2.3:a:quarkus-junit5:quarkus-junit5:*:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-junit5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-pom-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-junit5:quarkus_junit5:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_junit5:quarkus-junit5:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_junit5:quarkus_junit5:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-junit5:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_junit5:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-junit5:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_junit5:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/pom.xml"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-junit5"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-kubernetes@3.19.1?package-id=14c069a57896f647",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-kubernetes",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-kubernetes:quarkus-kubernetes:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-kubernetes@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4e8ab439bee6a63fc24bbdba80da7c7dd6ea6459"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-kubernetes:quarkus_kubernetes:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_kubernetes:quarkus-kubernetes:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_kubernetes:quarkus_kubernetes:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-kubernetes:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_kubernetes:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-kubernetes:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_kubernetes:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-kubernetes-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-kubernetes"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-kubernetes-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-kubernetes-client-internal@3.19.1?package-id=12e984ee633c922f",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-kubernetes-client-internal",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-kubernetes-client-internal:quarkus-kubernetes-client-internal:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-kubernetes-client-internal@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0f271d7c50cc112e3204ddadee72d308bd0195f8"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-kubernetes-client-internal:quarkus_kubernetes_client_internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_kubernetes_client_internal:quarkus-kubernetes-client-internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_kubernetes_client_internal:quarkus_kubernetes_client_internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-kubernetes-client:quarkus-kubernetes-client-internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-kubernetes-client:quarkus_kubernetes_client_internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_kubernetes_client:quarkus-kubernetes-client-internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_kubernetes_client:quarkus_kubernetes_client_internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-kubernetes:quarkus-kubernetes-client-internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-kubernetes:quarkus_kubernetes_client_internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_kubernetes:quarkus-kubernetes-client-internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_kubernetes:quarkus_kubernetes_client_internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-kubernetes-client-internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_kubernetes_client_internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-kubernetes-client-internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_kubernetes_client_internal:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-kubernetes-client-internal-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-kubernetes-client-internal"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-kubernetes-client-internal-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-micrometer@3.19.1?package-id=26c1e3c73781ad5b",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-micrometer",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-micrometer:quarkus-micrometer:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-micrometer@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "286c98be40a07fac8a64e0806aa422d2a7cdac22"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-micrometer:quarkus_micrometer:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_micrometer:quarkus-micrometer:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_micrometer:quarkus_micrometer:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-micrometer:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_micrometer:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-micrometer:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_micrometer:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-micrometer-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-micrometer"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-micrometer-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-micrometer?package-id=c009f6c58e645c08",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-micrometer",
+      "version": "UNKNOWN",
+      "cpe": "cpe:2.3:a:quarkus-micrometer:quarkus-micrometer:*:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-micrometer",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-pom-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-micrometer:quarkus_micrometer:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_micrometer:quarkus-micrometer:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_micrometer:quarkus_micrometer:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-micrometer:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_micrometer:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-micrometer:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_micrometer:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/pom.xml"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-micrometer"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny@3.19.1?package-id=9f48ab9c5f164c59",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-mutiny",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-mutiny:quarkus-mutiny:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-mutiny@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a6278380cb4f065044b1cc27481867e06aec6cfd"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-mutiny:quarkus_mutiny:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_mutiny:quarkus-mutiny:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_mutiny:quarkus_mutiny:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-mutiny:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_mutiny:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-mutiny:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_mutiny:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-mutiny-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-mutiny"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-mutiny-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-netty@3.19.1?package-id=f101649a6cd4e928",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-netty",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-netty:quarkus-netty:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-netty@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "297daa5af5f024ddd93f20bc8871c712f336e8bb"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-netty:quarkus_netty:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_netty:quarkus-netty:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_netty:quarkus_netty:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-netty:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_netty:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-netty:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_netty:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-netty-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-netty"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-netty-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-openshift@3.19.1?package-id=e0ef02757a6854a4",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-openshift",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-openshift:quarkus-openshift:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-openshift@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "659bddcde71abe25068c333748b588eb58608088"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-openshift:quarkus_openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_openshift:quarkus-openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_openshift:quarkus_openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_openshift:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-openshift-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-openshift"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-openshift-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-openshift?package-id=90d898b294312b5c",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-openshift",
+      "version": "UNKNOWN",
+      "cpe": "cpe:2.3:a:quarkus-openshift:quarkus-openshift:*:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-openshift",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-pom-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-openshift:quarkus_openshift:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_openshift:quarkus-openshift:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_openshift:quarkus_openshift:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-openshift:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_openshift:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-openshift:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_openshift:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/pom.xml"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-openshift"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@3.19.1?package-id=09bdbf48d2e90cc2",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-resteasy",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-resteasy:quarkus-resteasy:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-resteasy@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "2780a7b5e9b25ec61163c478e94501b9f36e3ea0"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-resteasy:quarkus_resteasy:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy:quarkus-resteasy:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy:quarkus_resteasy:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-resteasy:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_resteasy:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-resteasy:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_resteasy:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-resteasy-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-resteasy"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-resteasy-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy?package-id=1387f3e6bcc8291a",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-resteasy",
+      "version": "UNKNOWN",
+      "cpe": "cpe:2.3:a:quarkus-resteasy:quarkus-resteasy:*:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-resteasy",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-pom-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-resteasy:quarkus_resteasy:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy:quarkus-resteasy:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy:quarkus_resteasy:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-resteasy:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_resteasy:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-resteasy:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_resteasy:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/pom.xml"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-resteasy"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@3.19.1?package-id=237b4b1888c50081",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-resteasy-common",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-resteasy-common:quarkus-resteasy-common:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-resteasy-common@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "cb9fcd74bb171078f2b6091140116ba7b3805684"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-resteasy-common:quarkus_resteasy_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy_common:quarkus-resteasy-common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy_common:quarkus_resteasy_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-resteasy:quarkus-resteasy-common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-resteasy:quarkus_resteasy_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy:quarkus-resteasy-common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy:quarkus_resteasy_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-resteasy-common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_resteasy_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-resteasy-common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_resteasy_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-resteasy-common-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-resteasy-common"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-resteasy-common-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@3.19.1?package-id=9e7cd985391a77aa",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-resteasy-server-common",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-resteasy-server-common:quarkus-resteasy-server-common:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8acb089cc43fa9e2f5297bf685b629cf89471917"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-resteasy-server-common:quarkus_resteasy_server_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy_server_common:quarkus-resteasy-server-common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy_server_common:quarkus_resteasy_server_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-resteasy-server:quarkus-resteasy-server-common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-resteasy-server:quarkus_resteasy_server_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy_server:quarkus-resteasy-server-common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy_server:quarkus_resteasy_server_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-resteasy:quarkus-resteasy-server-common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-resteasy:quarkus_resteasy_server_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy:quarkus-resteasy-server-common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_resteasy:quarkus_resteasy_server_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-resteasy-server-common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_resteasy_server_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-resteasy-server-common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_resteasy_server_common:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-resteasy-server-common-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-resteasy-server-common"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-resteasy-server-common-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus.security/quarkus-security@2.2.0?package-id=86b1d8c7b50b3db6",
+      "type": "library",
+      "group": "io.quarkus.security",
+      "name": "quarkus-security",
+      "version": "2.2.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache Software License, Version 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.quarkus.security.api:quarkus-security:2.2.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus.security/quarkus-security@2.2.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f6ccdfa599d08ca65d25bb6fd4a787f24c91433b"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus.security.api:quarkus_security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus.security:quarkus-security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus.security:quarkus_security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:quarkus-security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:quarkus_security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:quarkus-security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:quarkus_security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-security:quarkus-security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-security:quarkus_security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_security:quarkus-security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_security:quarkus_security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus.security.api:security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus.security:security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-security:security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_security:security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:security:quarkus-security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:security:quarkus_security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:api:quarkus-security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:api:quarkus_security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:security:security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:api:security:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.security.quarkus-security-2.2.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-security"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus.security"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.security.quarkus-security-2.2.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@3.19.1?package-id=30f7206dcb2ea12f",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-security-runtime-spi",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-security-runtime-spi:quarkus-security-runtime-spi:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "63d6da9ea855adaac7e54acb4de712aa59845933"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-security-runtime-spi:quarkus_security_runtime_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_security_runtime_spi:quarkus-security-runtime-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_security_runtime_spi:quarkus_security_runtime_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-security-runtime:quarkus-security-runtime-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-security-runtime:quarkus_security_runtime_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_security_runtime:quarkus-security-runtime-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_security_runtime:quarkus_security_runtime_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-security:quarkus-security-runtime-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-security:quarkus_security_runtime_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_security:quarkus-security-runtime-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_security:quarkus_security_runtime_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-security-runtime-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_security_runtime_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-security-runtime-spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_security_runtime_spi:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-security-runtime-spi-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-security-runtime-spi"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-security-runtime-spi-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@3.19.1?package-id=05d3a977fddf8679",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-smallrye-context-propagation",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-smallrye-context-propagation:quarkus-smallrye-context-propagation:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ea356fafe2aeb22be7099987c94c9d3e395eac56"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-smallrye-context-propagation:quarkus_smallrye_context_propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye_context_propagation:quarkus-smallrye-context-propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye_context_propagation:quarkus_smallrye_context_propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-smallrye-context:quarkus-smallrye-context-propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-smallrye-context:quarkus_smallrye_context_propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye_context:quarkus-smallrye-context-propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye_context:quarkus_smallrye_context_propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-smallrye:quarkus-smallrye-context-propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-smallrye:quarkus_smallrye_context_propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye:quarkus-smallrye-context-propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye:quarkus_smallrye_context_propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-smallrye-context-propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_smallrye_context_propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-smallrye-context-propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_smallrye_context_propagation:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-smallrye-context-propagation-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-smallrye-context-propagation"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-smallrye-context-propagation-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-health@3.19.1?package-id=f5a9375b3b6b8f1f",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-smallrye-health",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-smallrye-health:quarkus-smallrye-health:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-smallrye-health@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "cb0a3e6dcfda277953e0ea1036ccda6189189902"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-smallrye-health:quarkus_smallrye_health:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye_health:quarkus-smallrye-health:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye_health:quarkus_smallrye_health:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-smallrye:quarkus-smallrye-health:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-smallrye:quarkus_smallrye_health:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye:quarkus-smallrye-health:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye:quarkus_smallrye_health:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-smallrye-health:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_smallrye_health:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-smallrye-health:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_smallrye_health:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-smallrye-health-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-smallrye-health"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-smallrye-health-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-health?package-id=5502d82ff0cabfb4",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-smallrye-health",
+      "version": "UNKNOWN",
+      "cpe": "cpe:2.3:a:quarkus-smallrye-health:quarkus-smallrye-health:*:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-smallrye-health",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-pom-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-smallrye-health:quarkus_smallrye_health:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye_health:quarkus-smallrye-health:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye_health:quarkus_smallrye_health:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-smallrye:quarkus-smallrye-health:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-smallrye:quarkus_smallrye_health:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye:quarkus-smallrye-health:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_smallrye:quarkus_smallrye_health:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-smallrye-health:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_smallrye_health:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-smallrye-health:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_smallrye_health:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/pom.xml"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-smallrye-health"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-tls-registry@3.19.1?package-id=3f19fc9e340d961b",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-tls-registry",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-tls-registry:quarkus-tls-registry:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-tls-registry@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "202412afa5b9c48ca9de0760dc9706548f425788"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-tls-registry:quarkus_tls_registry:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_tls_registry:quarkus-tls-registry:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_tls_registry:quarkus_tls_registry:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-tls:quarkus-tls-registry:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-tls:quarkus_tls_registry:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_tls:quarkus-tls-registry:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_tls:quarkus_tls_registry:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-tls-registry:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_tls_registry:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-tls-registry:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_tls_registry:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-tls-registry-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-tls-registry"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-tls-registry-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-vertx@3.19.1?package-id=caadbb6a5a3b3f0a",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-vertx",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-vertx:quarkus-vertx:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-vertx@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "484127f9f39923f865c3abba57294f7e512e9324"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx:quarkus_vertx:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx:quarkus-vertx:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx:quarkus_vertx:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-vertx:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_vertx:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-vertx:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_vertx:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-vertx-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-vertx"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-vertx-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http@3.19.1?package-id=ddeba928f22fd808",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-vertx-http",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-vertx-http:quarkus-vertx-http:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-vertx-http@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "931f3549f55668bea255c7a3b9d36974ea9f8180"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx-http:quarkus_vertx_http:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx_http:quarkus-vertx-http:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx_http:quarkus_vertx_http:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx:quarkus-vertx-http:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx:quarkus_vertx_http:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx:quarkus-vertx-http:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx:quarkus_vertx_http:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-vertx-http:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_vertx_http:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-vertx-http:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_vertx_http:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-vertx-http-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-vertx-http"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-vertx-http-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@3.19.1?package-id=8c0db2bbbb404a1e",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-vertx-latebound-mdc-provider",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-vertx-latebound-mdc-provider:quarkus-vertx-latebound-mdc-provider:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bc6be3db417a977643fd76cc76664f96427fc708"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx-latebound-mdc-provider:quarkus_vertx_latebound_mdc_provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx_latebound_mdc_provider:quarkus-vertx-latebound-mdc-provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx_latebound_mdc_provider:quarkus_vertx_latebound_mdc_provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx-latebound-mdc:quarkus-vertx-latebound-mdc-provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx-latebound-mdc:quarkus_vertx_latebound_mdc_provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx_latebound_mdc:quarkus-vertx-latebound-mdc-provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx_latebound_mdc:quarkus_vertx_latebound_mdc_provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx-latebound:quarkus-vertx-latebound-mdc-provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx-latebound:quarkus_vertx_latebound_mdc_provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx_latebound:quarkus-vertx-latebound-mdc-provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx_latebound:quarkus_vertx_latebound_mdc_provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx:quarkus-vertx-latebound-mdc-provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx:quarkus_vertx_latebound_mdc_provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx:quarkus-vertx-latebound-mdc-provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx:quarkus_vertx_latebound_mdc_provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-vertx-latebound-mdc-provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_vertx_latebound_mdc_provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-vertx-latebound-mdc-provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_vertx_latebound_mdc_provider:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.quarkus.quarkus-vertx-latebound-mdc-provider-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-vertx-latebound-mdc-provider"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.quarkus.quarkus-vertx-latebound-mdc-provider-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus.vertx.utils/quarkus-vertx-utils@3.19.1?package-id=5dff0be34ab97699",
+      "type": "library",
+      "group": "io.quarkus.vertx.utils",
+      "name": "quarkus-vertx-utils",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:io.quarkus.vertx.utils:quarkus-vertx-utils:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus.vertx.utils/quarkus-vertx-utils@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3ac59c0c001dc942880eb097d7b5c2ac03cd3e30"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus.vertx.utils:quarkus_vertx_utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx-utils:quarkus-vertx-utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx-utils:quarkus_vertx_utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx_utils:quarkus-vertx-utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx_utils:quarkus_vertx_utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx:quarkus-vertx-utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx:quarkus_vertx_utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx:quarkus-vertx-utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx:quarkus_vertx_utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus.vertx.utils:utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-vertx-utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_vertx_utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx-utils:utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx_utils:utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:utils:quarkus-vertx-utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:utils:quarkus_vertx_utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:quarkus-vertx-utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:quarkus_vertx_utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-vertx:utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_vertx:utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:utils:utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:utils:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.vertx.utils.quarkus-vertx-utils-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-vertx-utils"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus.vertx.utils"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.vertx.utils.quarkus-vertx-utils-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.quarkus/quarkus-virtual-threads@3.19.1?package-id=dfba1840510aaef0",
+      "type": "library",
+      "group": "io.quarkus",
+      "name": "quarkus-virtual-threads",
+      "version": "3.19.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:quarkus-virtual-threads:quarkus-virtual-threads:3.19.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.quarkus/quarkus-virtual-threads@3.19.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8a8b4066781d1e5ced6097896d85964517a76688"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-virtual-threads:quarkus_virtual_threads:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_virtual_threads:quarkus-virtual-threads:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_virtual_threads:quarkus_virtual_threads:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-virtual:quarkus-virtual-threads:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus-virtual:quarkus_virtual_threads:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_virtual:quarkus-virtual-threads:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus_virtual:quarkus_virtual_threads:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus-virtual-threads:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.quarkus:quarkus_virtual_threads:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus-virtual-threads:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:quarkus:quarkus_virtual_threads:3.19.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-virtual-threads-3.19.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "quarkus-virtual-threads"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.quarkus"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.quarkus.quarkus-virtual-threads-3.19.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.4?package-id=a9c469ce955bc12a",
+      "type": "library",
+      "name": "reactive-streams",
+      "version": "1.0.4",
+      "cpe": "cpe:2.3:a:org.reactivestreams:reactive-streams:1.0.4:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.4",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3864a1320d97d7b045f729a326e1e077661f31b7"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.reactivestreams:reactive_streams:1.0.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive-streams:reactive-streams:1.0.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive-streams:reactive_streams:1.0.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive_streams:reactive-streams:1.0.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive_streams:reactive_streams:1.0.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactivestreams:reactive-streams:1.0.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactivestreams:reactive_streams:1.0.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:reactive-streams:1.0.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:reactive_streams:1.0.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.reactivestreams.reactive-streams-1.0.4.jar"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.reactivestreams.reactive-streams-1.0.4.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=ef4d6a42c39b6034&upstream=readline-8.1-4.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "readline",
+      "version": "8.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:readline:readline:8.1-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&distro=rhel-9.6&upstream=readline-8.1-4.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:readline:8.1-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "4.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "492844"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "readline-8.1-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/redhat-release@9.6-0.1.el9?arch=x86_64&distro=rhel-9.6&package-id=a37845ef28f958fe&upstream=redhat-release-9.6-0.1.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "redhat-release",
+      "version": "9.6-0.1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat-release:redhat-release:9.6-0.1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/redhat-release@9.6-0.1.el9?arch=x86_64&distro=rhel-9.6&upstream=redhat-release-9.6-0.1.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat-release:redhat_release:9.6-0.1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat_release:redhat-release:9.6-0.1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat_release:redhat_release:9.6-0.1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:redhat-release:9.6-0.1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:redhat_release:9.6-0.1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "0.1.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "58842"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "redhat-release-9.6-0.1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.rest-assured/rest-assured?package-id=7d914624f2d15b66",
+      "type": "library",
+      "group": "io.rest-assured",
+      "name": "rest-assured",
+      "version": "UNKNOWN",
+      "cpe": "cpe:2.3:a:io.rest-assured:rest-assured:*:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.rest-assured/rest-assured",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-pom-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.rest-assured:rest_assured:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rest-assured:rest-assured:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rest-assured:rest_assured:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rest_assured:rest-assured:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rest_assured:rest_assured:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rest:rest-assured:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rest:rest_assured:*:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/pom.xml"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "rest-assured"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.rest-assured"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-cdi@6.2.11.Final?package-id=83e35192978b9625",
+      "type": "library",
+      "group": "org.jboss.resteasy",
+      "name": "resteasy-cdi",
+      "version": "6.2.11.Final",
+      "cpe": "cpe:2.3:a:org.jboss.resteasy:resteasy-cdi:6.2.11.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.jboss.resteasy/resteasy-cdi@6.2.11.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e060eaa0b4eda71603e308f1664562add06c83d3"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.resteasy:resteasy_cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:resteasy-cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:resteasy_cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:resteasy-cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:resteasy_cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.resteasy:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy-cdi:resteasy-cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy-cdi:resteasy_cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy_cdi:resteasy-cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy_cdi:resteasy_cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy-cdi:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy:resteasy-cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy:resteasy_cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy_cdi:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:resteasy-cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:resteasy_cdi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.jboss.resteasy.resteasy-cdi-6.2.11.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "resteasy-cdi"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.jboss.resteasy"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.jboss.resteasy.resteasy-cdi-6.2.11.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core@6.2.11.Final?package-id=ec1f9df6dd360307",
+      "type": "library",
+      "group": "org.jboss.resteasy",
+      "name": "resteasy-core",
+      "version": "6.2.11.Final",
+      "cpe": "cpe:2.3:a:org.jboss.resteasy:resteasy-core:6.2.11.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.jboss.resteasy/resteasy-core@6.2.11.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ceb296efcba0df34ffa9801be70ed74f60f67d9c"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.resteasy:resteasy_core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:resteasy-core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:resteasy_core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:resteasy-core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:resteasy_core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.resteasy:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy-core:resteasy-core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy-core:resteasy_core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy_core:resteasy-core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy_core:resteasy_core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy-core:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy:resteasy-core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy:resteasy_core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy_core:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:resteasy-core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:resteasy_core:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.jboss.resteasy.resteasy-core-6.2.11.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "resteasy-core"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.jboss.resteasy"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.jboss.resteasy.resteasy-core-6.2.11.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@6.2.11.Final?package-id=9d22eaa9ca580c74",
+      "type": "library",
+      "group": "org.jboss.resteasy",
+      "name": "resteasy-core-spi",
+      "version": "6.2.11.Final",
+      "cpe": "cpe:2.3:a:org.jboss.resteasy:resteasy-core-spi:6.2.11.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@6.2.11.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "10a23f701ca009f46c75d202f8caf994324e6c99"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.resteasy:resteasy_core_spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy-core-spi:resteasy-core-spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy-core-spi:resteasy_core_spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy_core_spi:resteasy-core-spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy_core_spi:resteasy_core_spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:resteasy-core-spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:resteasy_core_spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:resteasy-core-spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:resteasy_core_spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy-core:resteasy-core-spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy-core:resteasy_core_spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy_core:resteasy-core-spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy_core:resteasy_core_spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.resteasy:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy-core-spi:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy:resteasy-core-spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy:resteasy_core_spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy_core_spi:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:resteasy-core-spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:resteasy_core_spi:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy-core:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy_core:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:resteasy:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:resteasy:6.2.11.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.jboss.resteasy.resteasy-core-spi-6.2.11.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "resteasy-core-spi"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.jboss.resteasy"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.jboss.resteasy.resteasy-core-spi-6.2.11.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/rootfiles@8.1-34.el9?arch=noarch&distro=rhel-9.6&package-id=c3e23175e7c73167&upstream=rootfiles-8.1-34.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "rootfiles",
+      "version": "8.1-34.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:rootfiles:rootfiles:8.1-34.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/rootfiles@8.1-34.el9?arch=noarch&distro=rhel-9.6&upstream=rootfiles-8.1-34.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:rootfiles:8.1-34.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "34.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1216"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "rootfiles-8.1-34.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/rpm@4.16.1.3-37.el9?arch=x86_64&distro=rhel-9.6&package-id=afe7d85639239102&upstream=rpm-4.16.1.3-37.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "rpm",
+      "version": "4.16.1.3-37.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:rpm:4.16.1.3-37.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/rpm@4.16.1.3-37.el9?arch=x86_64&distro=rhel-9.6&upstream=rpm-4.16.1.3-37.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:rpm:4.16.1.3-37.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "37.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "2750727"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "rpm-4.16.1.3-37.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-37.el9?arch=x86_64&distro=rhel-9.6&package-id=dacf99b05b2295f6&upstream=rpm-4.16.1.3-37.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "rpm-libs",
+      "version": "4.16.1.3-37.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:rpm-libs:rpm-libs:4.16.1.3-37.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/rpm-libs@4.16.1.3-37.el9?arch=x86_64&distro=rhel-9.6&upstream=rpm-4.16.1.3-37.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-libs:rpm_libs:4.16.1.3-37.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_libs:rpm-libs:4.16.1.3-37.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_libs:rpm_libs:4.16.1.3-37.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:rpm-libs:4.16.1.3-37.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:rpm_libs:4.16.1.3-37.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:rpm-libs:4.16.1.3-37.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:rpm_libs:4.16.1.3-37.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "37.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "769188"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "rpm-4.16.1.3-37.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=da6ad46252374ced&upstream=sed-4.8-9.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "sed",
+      "version": "4.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:sed:4.8-9.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&distro=rhel-9.6&upstream=sed-4.8-9.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sed:sed:4.8-9.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "9.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "813599"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "sed-4.8-9.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.aayushatharva.brotli4j/service@1.16.0?package-id=674ef41583312170",
+      "type": "library",
+      "group": "com.aayushatharva.brotli4j",
+      "name": "service",
+      "version": "1.16.0",
+      "cpe": "cpe:2.3:a:com.aayushatharva.brotli4j:service:1.16.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/com.aayushatharva.brotli4j/service@1.16.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bd45e3f5a7165e190ea759abf220ce87d5f59103"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:aayushatharva:service:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:brotli4j:service:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:service:service:1.16.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/com.aayushatharva.brotli4j.service-1.16.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "service"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "com.aayushatharva.brotli4j"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/com.aayushatharva.brotli4j.service-1.16.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch&distro=rhel-9.6&package-id=7ce0aa004f15fb1c&upstream=setup-2.13.7-10.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "setup",
+      "version": "2.13.7-10.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:setup:2.13.7-10.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch&distro=rhel-9.6&upstream=setup-2.13.7-10.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:setup:setup:2.13.7-10.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "10.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "725932"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "setup-2.13.7-10.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/shadow-utils@4.9-12.el9?arch=x86_64&distro=rhel-9.6&epoch=2&package-id=6c28440cd547a15f&upstream=shadow-utils-4.9-12.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "shadow-utils",
+      "version": "2:4.9-12.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:shadow-utils:shadow-utils:2\\:4.9-12.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/shadow-utils@4.9-12.el9?arch=x86_64&distro=rhel-9.6&epoch=2&upstream=shadow-utils-4.9-12.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:shadow-utils:shadow_utils:2\\:4.9-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:shadow_utils:shadow-utils:2\\:4.9-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:shadow_utils:shadow_utils:2\\:4.9-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:shadow-utils:2\\:4.9-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:shadow_utils:2\\:4.9-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:shadow:shadow-utils:2\\:4.9-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:shadow:shadow_utils:2\\:4.9-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:epoch",
+          "value": "2"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "12.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "3816549"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "shadow-utils-4.9-12.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.slf4j/slf4j-api@2.0.6?package-id=2da2a86e59771f69",
+      "type": "library",
+      "group": "org.slf4j",
+      "name": "slf4j-api",
+      "version": "2.0.6",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.opensource.org/licenses/mit-license.php"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:org.slf4j.api:slf4j-api:2.0.6:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.slf4j/slf4j-api@2.0.6",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "88c40d8b4f33326f19a7d3c0aaf2c7e8721d4953"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.slf4j.api:slf4j_api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.slf4j:slf4j-api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.slf4j:slf4j_api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j-api:slf4j-api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j-api:slf4j_api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j_api:slf4j-api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j_api:slf4j_api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.slf4j.api:api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j:slf4j-api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j:slf4j_api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:api:slf4j-api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:api:slf4j_api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.slf4j:api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j-api:api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j_api:api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j:api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:api:api:2.0.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.slf4j.slf4j-api-2.0.6.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "slf4j-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.slf4j"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.slf4j.slf4j-api-2.0.6.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@2.0.0.Final?package-id=7eac27a475e006d5",
+      "type": "library",
+      "group": "org.jboss.slf4j",
+      "name": "slf4j-jboss-logmanager",
+      "version": "2.0.0.Final",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0",
+            "url": "https://repository.jboss.org/licenses/apache-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:slf4j-jboss-logmanager:slf4j-jboss-logmanager:2.0.0.Final:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@2.0.0.Final",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "accb024e15025215cb5ef8c8f41ce5b684fddbf0"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j-jboss-logmanager:slf4j_jboss_logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j_jboss_logmanager:slf4j-jboss-logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j_jboss_logmanager:slf4j_jboss_logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:slf4j-jboss-logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:slf4j_jboss_logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:slf4j-jboss-logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:slf4j_jboss_logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.slf4j:slf4j-jboss-logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.slf4j:slf4j_jboss_logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j-jboss:slf4j-jboss-logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j-jboss:slf4j_jboss_logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j_jboss:slf4j-jboss-logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j_jboss:slf4j_jboss_logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:slf4j-jboss-logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:slf4j_jboss_logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j-jboss-logmanager:slf4j:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j:slf4j-jboss-logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j:slf4j_jboss_logmanager:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j_jboss_logmanager:slf4j:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:slf4j:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:slf4j:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.jboss.slf4j:slf4j:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j-jboss:slf4j:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j_jboss:slf4j:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss:slf4j:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:slf4j:slf4j:2.0.0.Final:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.jboss.slf4j.slf4j-jboss-logmanager-2.0.0.Final.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "slf4j-jboss-logmanager"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.jboss.slf4j"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.jboss.slf4j.slf4j-jboss-logmanager-2.0.0.Final.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@2.10.0?package-id=6c2dd0347841d2ad",
+      "type": "library",
+      "group": "io.smallrye.common",
+      "name": "smallrye-common-annotation",
+      "version": "2.10.0",
+      "cpe": "cpe:2.3:a:smallrye-common-annotation:smallrye-common-annotation:2.10.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.common/smallrye-common-annotation@2.10.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5addf7e4c939b297649469f687780a5cea54538c"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-annotation:smallrye_common_annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_annotation:smallrye-common-annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_annotation:smallrye_common_annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye-common-annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye_common_annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye-common-annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye_common_annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye-common-annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye_common_annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-common-annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_common_annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-common-annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_common_annotation:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.common.smallrye-common-annotation-2.10.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-common-annotation"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.common"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.common.smallrye-common-annotation-2.10.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@2.10.0?package-id=d25b395a50fad417",
+      "type": "library",
+      "group": "io.smallrye.common",
+      "name": "smallrye-common-classloader",
+      "version": "2.10.0",
+      "cpe": "cpe:2.3:a:smallrye-common-classloader:smallrye-common-classloader:2.10.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.common/smallrye-common-classloader@2.10.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "78faebf75cbaf854a554972a5ee7ca7b0a778b22"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-classloader:smallrye_common_classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_classloader:smallrye-common-classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_classloader:smallrye_common_classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye-common-classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye_common_classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye-common-classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye_common_classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye-common-classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye_common_classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-common-classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_common_classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-common-classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_common_classloader:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.common.smallrye-common-classloader-2.10.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-common-classloader"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.common"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.common.smallrye-common-classloader-2.10.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@2.10.0?package-id=c6f9f9b81563c9c1",
+      "type": "library",
+      "group": "io.smallrye.common",
+      "name": "smallrye-common-constraint",
+      "version": "2.10.0",
+      "cpe": "cpe:2.3:a:smallrye-common-constraint:smallrye-common-constraint:2.10.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.common/smallrye-common-constraint@2.10.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e13f4ccde247e94e22144f5a4c66db09fd145448"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-constraint:smallrye_common_constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_constraint:smallrye-common-constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_constraint:smallrye_common_constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye-common-constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye_common_constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye-common-constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye_common_constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye-common-constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye_common_constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-common-constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_common_constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-common-constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_common_constraint:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-constraint-2.10.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-common-constraint"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.common"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-constraint-2.10.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-cpu@2.10.0?package-id=1a6ba30dfa146146",
+      "type": "library",
+      "group": "io.smallrye.common",
+      "name": "smallrye-common-cpu",
+      "version": "2.10.0",
+      "cpe": "cpe:2.3:a:smallrye-common-cpu:smallrye-common-cpu:2.10.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.common/smallrye-common-cpu@2.10.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "7630f374deb2f02ec06b7ce692f9937000b5cfd1"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-cpu:smallrye_common_cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_cpu:smallrye-common-cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_cpu:smallrye_common_cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye-common-cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye_common_cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye-common-cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye_common_cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye-common-cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye_common_cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-common-cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_common_cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-common-cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_common_cpu:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-cpu-2.10.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-common-cpu"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.common"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-cpu-2.10.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@2.10.0?package-id=6cfd84be52051d48",
+      "type": "library",
+      "group": "io.smallrye.common",
+      "name": "smallrye-common-expression",
+      "version": "2.10.0",
+      "cpe": "cpe:2.3:a:smallrye-common-expression:smallrye-common-expression:2.10.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.common/smallrye-common-expression@2.10.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0e1bd2cc935737befef53025efb155a7c7900cab"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-expression:smallrye_common_expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_expression:smallrye-common-expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_expression:smallrye_common_expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye-common-expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye_common_expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye-common-expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye_common_expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye-common-expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye_common_expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-common-expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_common_expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-common-expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_common_expression:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-expression-2.10.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-common-expression"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.common"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-expression-2.10.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-function@2.10.0?package-id=55883694aee25fec",
+      "type": "library",
+      "group": "io.smallrye.common",
+      "name": "smallrye-common-function",
+      "version": "2.10.0",
+      "cpe": "cpe:2.3:a:smallrye-common-function:smallrye-common-function:2.10.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.common/smallrye-common-function@2.10.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "581d71e40ea41c2bbb8a0b20851d8e3144ff0fa4"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-function:smallrye_common_function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_function:smallrye-common-function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_function:smallrye_common_function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye-common-function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye_common_function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye-common-function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye_common_function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye-common-function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye_common_function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-common-function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_common_function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-common-function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_common_function:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-function-2.10.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-common-function"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.common"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-function-2.10.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-io@2.10.0?package-id=a40708072e9ae7af",
+      "type": "library",
+      "group": "io.smallrye.common",
+      "name": "smallrye-common-io",
+      "version": "2.10.0",
+      "cpe": "cpe:2.3:a:io.smallrye.common:smallrye-common-io:2.10.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.common/smallrye-common-io@2.10.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "088a3450f6c7d763bd1f90bf89103326257467b7"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye_common_io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-io:smallrye-common-io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-io:smallrye_common_io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_io:smallrye-common-io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_io:smallrye_common_io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye-common-io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye_common_io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye-common-io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye_common_io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-common-io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_common_io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-common-io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_common_io:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-io-2.10.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-common-io"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.common"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-io-2.10.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-net@2.10.0?package-id=916775b7b4c04c2d",
+      "type": "library",
+      "group": "io.smallrye.common",
+      "name": "smallrye-common-net",
+      "version": "2.10.0",
+      "cpe": "cpe:2.3:a:smallrye-common-net:smallrye-common-net:2.10.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.common/smallrye-common-net@2.10.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b5b6da76d56c3fff0cae31a7397757978e0e4184"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-net:smallrye_common_net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_net:smallrye-common-net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_net:smallrye_common_net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye-common-net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye_common_net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye-common-net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye_common_net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye-common-net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye_common_net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-common-net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_common_net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-common-net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_common_net:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-net-2.10.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-common-net"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.common"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-net-2.10.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-os@2.10.0?package-id=de3f312045a2c0fe",
+      "type": "library",
+      "group": "io.smallrye.common",
+      "name": "smallrye-common-os",
+      "version": "2.10.0",
+      "cpe": "cpe:2.3:a:io.smallrye.common:smallrye-common-os:2.10.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.common/smallrye-common-os@2.10.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f119fc3e77796d7569eb64d19b71f655abceb715"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye_common_os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-os:smallrye-common-os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-os:smallrye_common_os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_os:smallrye-common-os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_os:smallrye_common_os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye-common-os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye_common_os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye-common-os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye_common_os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-common-os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_common_os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-common-os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_common_os:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-os-2.10.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-common-os"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.common"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-os-2.10.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-ref@2.10.0?package-id=13dec643101af03d",
+      "type": "library",
+      "group": "io.smallrye.common",
+      "name": "smallrye-common-ref",
+      "version": "2.10.0",
+      "cpe": "cpe:2.3:a:smallrye-common-ref:smallrye-common-ref:2.10.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.common/smallrye-common-ref@2.10.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "7d67f1b58b9107e98b746268f172f37d872a9b66"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-ref:smallrye_common_ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_ref:smallrye-common-ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_ref:smallrye_common_ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye-common-ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye_common_ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye-common-ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye_common_ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye-common-ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye_common_ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-common-ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_common_ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-common-ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_common_ref:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-ref-2.10.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-common-ref"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.common"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/boot/io.smallrye.common.smallrye-common-ref-2.10.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@2.10.0?package-id=9ee5a249993fc548",
+      "type": "library",
+      "group": "io.smallrye.common",
+      "name": "smallrye-common-vertx-context",
+      "version": "2.10.0",
+      "cpe": "cpe:2.3:a:smallrye-common-vertx-context:smallrye-common-vertx-context:2.10.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@2.10.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6da6e49a205848db2240c1637399ba198ea9cc88"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-vertx-context:smallrye_common_vertx_context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_vertx_context:smallrye-common-vertx-context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_vertx_context:smallrye_common_vertx_context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-vertx:smallrye-common-vertx-context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common-vertx:smallrye_common_vertx_context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_vertx:smallrye-common-vertx-context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common_vertx:smallrye_common_vertx_context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye-common-vertx-context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.common:smallrye_common_vertx_context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye-common-vertx-context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-common:smallrye_common_vertx_context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye-common-vertx-context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_common:smallrye_common_vertx_context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-common-vertx-context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_common_vertx_context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-common-vertx-context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_common_vertx_context:2.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.common.smallrye-common-vertx-context-2.10.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-common-vertx-context"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.common"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.common.smallrye-common-vertx-context-2.10.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.config/smallrye-config@3.11.4?package-id=9567496f81b59db6",
+      "type": "library",
+      "group": "io.smallrye.config",
+      "name": "smallrye-config",
+      "version": "3.11.4",
+      "cpe": "cpe:2.3:a:io.smallrye.config:smallrye-config:3.11.4:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.config/smallrye-config@3.11.4",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b867a0036c84706ae0cfd37d0599c2c632acf845"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.config:smallrye_config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-config:smallrye-config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-config:smallrye_config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_config:smallrye-config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_config:smallrye_config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.config:config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:config:smallrye-config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:config:smallrye_config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-config:config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_config:config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:config:config:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.config.smallrye-config-3.11.4.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-config"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.config"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.config.smallrye-config-3.11.4.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-common@3.11.4?package-id=32b36a6e78b6a0cd",
+      "type": "library",
+      "group": "io.smallrye.config",
+      "name": "smallrye-config-common",
+      "version": "3.11.4",
+      "cpe": "cpe:2.3:a:smallrye-config-common:smallrye-config-common:3.11.4:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.config/smallrye-config-common@3.11.4",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "21b05b963f102bde504d064c45b73d84169a0e76"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-config-common:smallrye_config_common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_config_common:smallrye-config-common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_config_common:smallrye_config_common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.config:smallrye-config-common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.config:smallrye_config_common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-config:smallrye-config-common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-config:smallrye_config_common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_config:smallrye-config-common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_config:smallrye_config_common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-config-common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_config_common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:config:smallrye-config-common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:config:smallrye_config_common:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.config.smallrye-config-common-3.11.4.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-config-common"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.config"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.config.smallrye-config-common-3.11.4.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-core@3.11.4?package-id=22caa24a27ad05eb",
+      "type": "library",
+      "group": "io.smallrye.config",
+      "name": "smallrye-config-core",
+      "version": "3.11.4",
+      "cpe": "cpe:2.3:a:smallrye-config-core:smallrye-config-core:3.11.4:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.config/smallrye-config-core@3.11.4",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9dca22b505b195831e47f05363f97872c2e27e2d"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-config-core:smallrye_config_core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_config_core:smallrye-config-core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_config_core:smallrye_config_core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.config:smallrye-config-core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.config:smallrye_config_core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-config:smallrye-config-core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-config:smallrye_config_core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_config:smallrye-config-core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_config:smallrye_config_core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-config-core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_config_core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:config:smallrye-config-core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:config:smallrye_config_core:3.11.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.config.smallrye-config-core-3.11.4.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-config-core"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.config"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.config.smallrye-config-core-3.11.4.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation@2.2.0?package-id=db7a3b56dd9962ad",
+      "type": "library",
+      "group": "io.smallrye",
+      "name": "smallrye-context-propagation",
+      "version": "2.2.0",
+      "cpe": "cpe:2.3:a:smallrye-context-propagation:smallrye-context-propagation:2.2.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye/smallrye-context-propagation@2.2.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ad37a87af87d3b095860f0ab4748835fad9870f5"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context-propagation:smallrye_context_propagation:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context_propagation:smallrye-context-propagation:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context_propagation:smallrye_context_propagation:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context:smallrye-context-propagation:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context:smallrye_context_propagation:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context:smallrye-context-propagation:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context:smallrye_context_propagation:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye-context-propagation:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye_context_propagation:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-context-propagation:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_context_propagation:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-context-propagation-2.2.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-context-propagation"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-context-propagation-2.2.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@2.2.0?package-id=dcd4f1be6f77e589",
+      "type": "library",
+      "group": "io.smallrye",
+      "name": "smallrye-context-propagation-api",
+      "version": "2.2.0",
+      "cpe": "cpe:2.3:a:smallrye-context-propagation-api:smallrye-context-propagation-api:2.2.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye/smallrye-context-propagation-api@2.2.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "1b0d6c00602eee9b4183ec5cbdc83d46b2cb03d0"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context-propagation-api:smallrye_context_propagation_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context_propagation_api:smallrye-context-propagation-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context_propagation_api:smallrye_context_propagation_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context-propagation:smallrye-context-propagation-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context-propagation:smallrye_context_propagation_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context_propagation:smallrye-context-propagation-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context_propagation:smallrye_context_propagation_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context:smallrye-context-propagation-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context:smallrye_context_propagation_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context:smallrye-context-propagation-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context:smallrye_context_propagation_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye-context-propagation-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye_context_propagation_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-context-propagation-api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_context_propagation_api:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-context-propagation-api-2.2.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-context-propagation-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-context-propagation-api-2.2.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@2.2.0?package-id=325b970623eca916",
+      "type": "library",
+      "group": "io.smallrye",
+      "name": "smallrye-context-propagation-storage",
+      "version": "2.2.0",
+      "cpe": "cpe:2.3:a:smallrye-context-propagation-storage:smallrye-context-propagation-storage:2.2.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@2.2.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3ae549aa808d7559a727e4b4ac32e60afb304bb0"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context-propagation-storage:smallrye_context_propagation_storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context_propagation_storage:smallrye-context-propagation-storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context_propagation_storage:smallrye_context_propagation_storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context-propagation:smallrye-context-propagation-storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context-propagation:smallrye_context_propagation_storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context_propagation:smallrye-context-propagation-storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context_propagation:smallrye_context_propagation_storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context:smallrye-context-propagation-storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-context:smallrye_context_propagation_storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context:smallrye-context-propagation-storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_context:smallrye_context_propagation_storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye-context-propagation-storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye_context_propagation_storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-context-propagation-storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_context_propagation_storage:2.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-context-propagation-storage-2.2.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-context-propagation-storage"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-context-propagation-storage-2.2.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@6.8.0?package-id=77e4066abd5e3abc",
+      "type": "library",
+      "group": "io.smallrye",
+      "name": "smallrye-fault-tolerance-vertx",
+      "version": "6.8.0",
+      "cpe": "cpe:2.3:a:smallrye-fault-tolerance-vertx:smallrye-fault-tolerance-vertx:6.8.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@6.8.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4f1ee29366a2466289ea9b947585830be11e1da8"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-fault-tolerance-vertx:smallrye_fault_tolerance_vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_fault_tolerance_vertx:smallrye-fault-tolerance-vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_fault_tolerance_vertx:smallrye_fault_tolerance_vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-fault-tolerance:smallrye-fault-tolerance-vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-fault-tolerance:smallrye_fault_tolerance_vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_fault_tolerance:smallrye-fault-tolerance-vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_fault_tolerance:smallrye_fault_tolerance_vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-fault:smallrye-fault-tolerance-vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-fault:smallrye_fault_tolerance_vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_fault:smallrye-fault-tolerance-vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_fault:smallrye_fault_tolerance_vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye-fault-tolerance-vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye_fault_tolerance_vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-fault-tolerance-vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_fault_tolerance_vertx:6.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-fault-tolerance-vertx-6.8.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-fault-tolerance-vertx"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-fault-tolerance-vertx-6.8.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye/smallrye-health@4.2.0?package-id=76d15a9bdd6198a3",
+      "type": "library",
+      "group": "io.smallrye",
+      "name": "smallrye-health",
+      "version": "4.2.0",
+      "cpe": "cpe:2.3:a:smallrye-health:smallrye-health:4.2.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye/smallrye-health@4.2.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "db514f0eff1fdd3287974fa0591ddda00442a2d9"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-health:smallrye_health:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_health:smallrye-health:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_health:smallrye_health:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye-health:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye_health:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-health:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_health:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-health-4.2.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-health"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-health-4.2.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye/smallrye-health-api@4.2.0?package-id=6b2870fa19816ea8",
+      "type": "library",
+      "group": "io.smallrye",
+      "name": "smallrye-health-api",
+      "version": "4.2.0",
+      "cpe": "cpe:2.3:a:smallrye-health-api:smallrye-health-api:4.2.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye/smallrye-health-api@4.2.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "040056062b20c03b045d89e5ced7e2432bbe855b"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-health-api:smallrye_health_api:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_health_api:smallrye-health-api:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_health_api:smallrye_health_api:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-health:smallrye-health-api:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-health:smallrye_health_api:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_health:smallrye-health-api:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_health:smallrye_health_api:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye-health-api:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye_health_api:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-health-api:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_health_api:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-health-api-4.2.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-health-api"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-health-api-4.2.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye/smallrye-health-provided-checks@4.2.0?package-id=d9d115d939c3fd05",
+      "type": "library",
+      "group": "io.smallrye",
+      "name": "smallrye-health-provided-checks",
+      "version": "4.2.0",
+      "cpe": "cpe:2.3:a:smallrye-health-provided-checks:smallrye-health-provided-checks:4.2.0:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye/smallrye-health-provided-checks@4.2.0",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "036739149090d1a2f96c0ab124869fde25b7e5a9"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-health-provided-checks:smallrye_health_provided_checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_health_provided_checks:smallrye-health-provided-checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_health_provided_checks:smallrye_health_provided_checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-health-provided:smallrye-health-provided-checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-health-provided:smallrye_health_provided_checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_health_provided:smallrye-health-provided-checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_health_provided:smallrye_health_provided_checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-health:smallrye-health-provided-checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-health:smallrye_health_provided_checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_health:smallrye-health-provided-checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_health:smallrye_health_provided_checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye-health-provided-checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye:smallrye_health_provided_checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-health-provided-checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_health_provided_checks:4.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-health-provided-checks-4.2.0.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-health-provided-checks"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.smallrye-health-provided-checks-4.2.0.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@3.18.1?package-id=ccb060df6b11c7e1",
+      "type": "library",
+      "group": "io.smallrye.reactive",
+      "name": "smallrye-mutiny-vertx-auth-common",
+      "version": "3.18.1",
+      "cpe": "cpe:2.3:a:io.smallrye.mutiny.vertx.auth.common:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@3.18.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "fee65b73cf5c61a98417cda836c17fd9bda6ac81"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.auth.common:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-auth-common:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-auth-common:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_auth_common:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_auth_common:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-auth:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-auth:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_auth:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_auth:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.auth.common:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-auth-common:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_auth_common:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:auth:smallrye-mutiny-vertx-auth-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:auth:smallrye_mutiny_vertx_auth_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-auth:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_auth:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:auth:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-auth-common-3.18.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-mutiny-vertx-auth-common"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.reactive"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-auth-common-3.18.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@3.18.1?package-id=d4993ad13d4bb259",
+      "type": "library",
+      "group": "io.smallrye.reactive",
+      "name": "smallrye-mutiny-vertx-bridge-common",
+      "version": "3.18.1",
+      "cpe": "cpe:2.3:a:io.smallrye.mutiny.vertx.bridge.common:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@3.18.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ccec23c3aba3db1706dc3cfe6bed76e4149ba19b"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.bridge.common:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-bridge-common:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-bridge-common:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_bridge_common:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_bridge_common:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-bridge:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-bridge:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_bridge:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_bridge:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.bridge.common:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bridge:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bridge:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-bridge-common:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_bridge_common:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye-mutiny-vertx-bridge-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye_mutiny_vertx_bridge_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-bridge:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_bridge:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bridge:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-bridge-common-3.18.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-mutiny-vertx-bridge-common"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.reactive"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-bridge-common-3.18.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@3.18.1?package-id=2ed72ad9f930dde3",
+      "type": "library",
+      "group": "io.smallrye.reactive",
+      "name": "smallrye-mutiny-vertx-core",
+      "version": "3.18.1",
+      "cpe": "cpe:2.3:a:io.smallrye.mutiny.vertx.core:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@3.18.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a360a0a1f987c539236c92b5b100e66611b0d5a6"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.core:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-core:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-core:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_core:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_core:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.core:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:core:smallrye-mutiny-vertx-core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:core:smallrye_mutiny_vertx_core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-core:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_core:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:core:core:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-core-3.18.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-mutiny-vertx-core"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.reactive"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-core-3.18.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@3.18.1?package-id=13f50e9b84badd0e",
+      "type": "library",
+      "group": "io.smallrye.reactive",
+      "name": "smallrye-mutiny-vertx-runtime",
+      "version": "3.18.1",
+      "cpe": "cpe:2.3:a:io.smallrye.mutiny.vertx.runtime:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@3.18.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "54d1289160105ad8a9ff23f5a9ed1accf42dafe2"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.runtime:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-runtime:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-runtime:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_runtime:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_runtime:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.runtime:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:runtime:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:runtime:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-runtime:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_runtime:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye-mutiny-vertx-runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye_mutiny_vertx_runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:runtime:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:runtime:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-runtime-3.18.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-mutiny-vertx-runtime"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.reactive"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-runtime-3.18.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@3.18.1?package-id=9fed5ff0e38f3b3a",
+      "type": "library",
+      "group": "io.smallrye.reactive",
+      "name": "smallrye-mutiny-vertx-uri-template",
+      "version": "3.18.1",
+      "cpe": "cpe:2.3:a:io.smallrye.mutiny.vertx.uri.template:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@3.18.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bf933d78e7a5b9534f91bb5fae19f9b94377ca65"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.uri.template:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-uri-template:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-uri-template:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_uri_template:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_uri_template:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-uri:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-uri:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_uri:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_uri:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.uri.template:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-uri-template:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_uri_template:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:template:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:template:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:uri:smallrye-mutiny-vertx-uri-template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:uri:smallrye_mutiny_vertx_uri_template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-uri:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_uri:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:template:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:uri:template:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-uri-template-3.18.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-mutiny-vertx-uri-template"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.reactive"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-uri-template-3.18.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@3.18.1?package-id=f43bc6c51652fc87",
+      "type": "library",
+      "group": "io.smallrye.reactive",
+      "name": "smallrye-mutiny-vertx-web",
+      "version": "3.18.1",
+      "cpe": "cpe:2.3:a:io.smallrye.mutiny.vertx.web:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@3.18.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3e467dea4c4b5072c8001b46f17985c8ef9a552a"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.web:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-web:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-web:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_web:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_web:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.web:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-web:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_web:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:web:smallrye-mutiny-vertx-web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:web:smallrye_mutiny_vertx_web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:web:web:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-web-3.18.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-mutiny-vertx-web"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.reactive"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-web-3.18.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@3.18.1?package-id=dbeacca080ee1d00",
+      "type": "library",
+      "group": "io.smallrye.reactive",
+      "name": "smallrye-mutiny-vertx-web-common",
+      "version": "3.18.1",
+      "cpe": "cpe:2.3:a:io.smallrye.mutiny.vertx.web.common:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@3.18.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f8ba6c841d2ea7ec602b92b2362f2c8afc724d53"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.web.common:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-web-common:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-web-common:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_web_common:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_web_common:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-web:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-web:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_web:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_web:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.mutiny.vertx.web.common:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-web-common:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_web_common:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:web:smallrye-mutiny-vertx-web-common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:web:smallrye_mutiny_vertx_web_common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx-web:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx_web:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny-vertx:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny_vertx:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-mutiny:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_mutiny:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mutiny:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:web:common:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-web-common-3.18.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-mutiny-vertx-web-common"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.reactive"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.reactive.smallrye-mutiny-vertx-web-common-3.18.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.certs/smallrye-private-key-pem-parser@0.9.2?package-id=0474166bf1b2d6fc",
+      "type": "library",
+      "group": "io.smallrye.certs",
+      "name": "smallrye-private-key-pem-parser",
+      "version": "0.9.2",
+      "cpe": "cpe:2.3:a:smallrye-private-key-pem-parser:smallrye-private-key-pem-parser:0.9.2:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.certs/smallrye-private-key-pem-parser@0.9.2",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "fffc0c86069623b021d8d2d222d09db52ae81994"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-private-key-pem-parser:smallrye_private_key_pem_parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_private_key_pem_parser:smallrye-private-key-pem-parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_private_key_pem_parser:smallrye_private_key_pem_parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-private-key-pem:smallrye-private-key-pem-parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-private-key-pem:smallrye_private_key_pem_parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_private_key_pem:smallrye-private-key-pem-parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_private_key_pem:smallrye_private_key_pem_parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-private-key:smallrye-private-key-pem-parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-private-key:smallrye_private_key_pem_parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_private_key:smallrye-private-key-pem-parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_private_key:smallrye_private_key_pem_parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.certs:smallrye-private-key-pem-parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.certs:smallrye_private_key_pem_parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-private:smallrye-private-key-pem-parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye-private:smallrye_private_key_pem_parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_private:smallrye-private-key-pem-parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye_private:smallrye_private_key_pem_parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye-private-key-pem-parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:smallrye_private_key_pem_parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:certs:smallrye-private-key-pem-parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:certs:smallrye_private_key_pem_parser:0.9.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.certs.smallrye-private-key-pem-parser-0.9.2.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "smallrye-private-key-pem-parser"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.certs"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.certs.smallrye-private-key-pem-parser-0.9.2.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_3?arch=x86_64&distro=rhel-9.6&package-id=892e1356fdb52665&upstream=sqlite-3.34.1-7.el9_3.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "sqlite-libs",
+      "version": "3.34.1-7.el9_3",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:sqlite-libs:sqlite-libs:3.34.1-7.el9_3:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_3?arch=x86_64&distro=rhel-9.6&upstream=sqlite-3.34.1-7.el9_3.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sqlite-libs:sqlite_libs:3.34.1-7.el9_3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sqlite_libs:sqlite-libs:3.34.1-7.el9_3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sqlite_libs:sqlite_libs:3.34.1-7.el9_3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:sqlite-libs:3.34.1-7.el9_3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:sqlite_libs:3.34.1-7.el9_3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sqlite:sqlite-libs:3.34.1-7.el9_3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sqlite:sqlite_libs:3.34.1-7.el9_3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "7.el9_3"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1310944"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "sqlite-3.34.1-7.el9_3.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/systemd-libs@252-51.el9?arch=x86_64&distro=rhel-9.6&package-id=ab1fadc1d33a9f1e&upstream=systemd-252-51.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "systemd-libs",
+      "version": "252-51.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:systemd-libs:systemd-libs:252-51.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/systemd-libs@252-51.el9?arch=x86_64&distro=rhel-9.6&upstream=systemd-252-51.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-libs:systemd_libs:252-51.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_libs:systemd-libs:252-51.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_libs:systemd_libs:252-51.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd:systemd-libs:252-51.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd:systemd_libs:252-51.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:systemd-libs:252-51.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:systemd_libs:252-51.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "51.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1811128"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "systemd-252-51.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/tar@1.34-7.el9?arch=x86_64&distro=rhel-9.6&epoch=2&package-id=58ae95ba550bdd36&upstream=tar-1.34-7.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "tar",
+      "version": "2:1.34-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:tar:2\\:1.34-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/tar@1.34-7.el9?arch=x86_64&distro=rhel-9.6&epoch=2&upstream=tar-1.34-7.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tar:tar:2\\:1.34-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:epoch",
+          "value": "2"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "7.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "3155442"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "tar-1.34-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch&distro=rhel-9.6&package-id=dda8022ed5c64e66&upstream=tzdata-2025b-1.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "tzdata",
+      "version": "2025b-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:tzdata:2025b-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch&distro=rhel-9.6&upstream=tzdata-2025b-1.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tzdata:tzdata:2025b-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "1664708"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "tzdata-2025b-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/tzdata-java@2025b-1.el9?arch=noarch&distro=rhel-9.6&package-id=8ef897250b00cf3e&upstream=tzdata-2025b-1.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "tzdata-java",
+      "version": "2025b-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:tzdata-java:tzdata-java:2025b-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/tzdata-java@2025b-1.el9?arch=noarch&distro=rhel-9.6&upstream=tzdata-2025b-1.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tzdata-java:tzdata_java:2025b-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tzdata_java:tzdata-java:2025b-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tzdata_java:tzdata_java:2025b-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:tzdata-java:2025b-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:tzdata_java:2025b-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tzdata:tzdata-java:2025b-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tzdata:tzdata_java:2025b-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "1.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "339545"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "tzdata-2025b-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.vertx/vertx-auth-common@4.5.13?package-id=6d825258bdb697e8",
+      "type": "library",
+      "group": "io.vertx",
+      "name": "vertx-auth-common",
+      "version": "4.5.13",
+      "cpe": "cpe:2.3:a:vertx-auth-common:vertx-auth-common:4.5.13:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.vertx/vertx-auth-common@4.5.13",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4f40a552d3341d2f4c37d201dc49267b69642a95"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-auth-common:vertx_auth_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_auth_common:vertx-auth-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_auth_common:vertx_auth_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-auth:vertx-auth-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-auth:vertx_auth_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_auth:vertx-auth-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_auth:vertx_auth_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx-auth-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx_auth_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:vertx-auth-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:vertx_auth_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx-auth-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx_auth_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.vertx.vertx-auth-common-4.5.13.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "vertx-auth-common"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.vertx"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.vertx.vertx-auth-common-4.5.13.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.vertx/vertx-bridge-common@4.5.13?package-id=c6095db2f705482f",
+      "type": "library",
+      "group": "io.vertx",
+      "name": "vertx-bridge-common",
+      "version": "4.5.13",
+      "cpe": "cpe:2.3:a:vertx-bridge-common:vertx-bridge-common:4.5.13:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.vertx/vertx-bridge-common@4.5.13",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e5ccdddbae90b7705a8085d6a97e681723367a32"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-bridge-common:vertx_bridge_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_bridge_common:vertx-bridge-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_bridge_common:vertx_bridge_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-bridge:vertx-bridge-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-bridge:vertx_bridge_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_bridge:vertx-bridge-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_bridge:vertx_bridge_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx-bridge-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx_bridge_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:vertx-bridge-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:vertx_bridge_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx-bridge-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx_bridge_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.vertx.vertx-bridge-common-4.5.13.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "vertx-bridge-common"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.vertx"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.vertx.vertx-bridge-common-4.5.13.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.vertx/vertx-codegen@4.5.13?package-id=94d2c12689d82406",
+      "type": "library",
+      "group": "io.vertx",
+      "name": "vertx-codegen",
+      "version": "4.5.13",
+      "cpe": "cpe:2.3:a:io.vertx.codegen:vertx-codegen:4.5.13:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.vertx/vertx-codegen@4.5.13",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "22ae36f3623398d1b268b650a56db444a24f5990"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx.codegen:vertx_codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-codegen:vertx-codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-codegen:vertx_codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_codegen:vertx-codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_codegen:vertx_codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx.codegen:codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx-codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx_codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codegen:vertx-codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codegen:vertx_codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-codegen:codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_codegen:codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx-codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx_codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:codegen:codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:codegen:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.vertx.vertx-codegen-4.5.13.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "vertx-codegen"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.vertx"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.vertx.vertx-codegen-4.5.13.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.vertx/vertx-core@4.5.13?package-id=e6478ec637e44462",
+      "type": "library",
+      "group": "io.vertx",
+      "name": "vertx-core",
+      "version": "4.5.13",
+      "licenses": [
+        {
+          "license": {
+            "name": "Eclipse Public License - v 2.0",
+            "url": "http://www.eclipse.org/legal/epl-v20.html"
+          }
+        },
+        {
+          "license": {
+            "name": "The Apache Software License, Version 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:vertx-core:vertx-core:4.5.13:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.vertx/vertx-core@4.5.13",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "263cbaaa757a6adc2edc426c51c3e8698ebd9314"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-core:vertx_core:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_core:vertx-core:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_core:vertx_core:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx-core:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx_core:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:vertx-core:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:vertx_core:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx-core:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx_core:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.vertx.vertx-core-4.5.13.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "vertx-core"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.vertx"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.vertx.vertx-core-4.5.13.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@3.18.1?package-id=f3468b35afd91b77",
+      "type": "library",
+      "group": "io.smallrye.reactive",
+      "name": "vertx-mutiny-generator",
+      "version": "3.18.1",
+      "cpe": "cpe:2.3:a:vertx-mutiny-generator:vertx-mutiny-generator:3.18.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@3.18.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "004f95cf195aa84e76e9baa2e23bbaf66455dc2d"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-mutiny-generator:vertx_mutiny_generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_mutiny_generator:vertx-mutiny-generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_mutiny_generator:vertx_mutiny_generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:vertx-mutiny-generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.smallrye.reactive:vertx_mutiny_generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-mutiny:vertx-mutiny-generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-mutiny:vertx_mutiny_generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_mutiny:vertx-mutiny-generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_mutiny:vertx_mutiny_generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:vertx-mutiny-generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:reactive:vertx_mutiny_generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:vertx-mutiny-generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:smallrye:vertx_mutiny_generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx-mutiny-generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx_mutiny_generator:3.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.smallrye.reactive.vertx-mutiny-generator-3.18.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "vertx-mutiny-generator"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.smallrye.reactive"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.smallrye.reactive.vertx-mutiny-generator-3.18.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.vertx/vertx-uri-template@4.5.13?package-id=26e9bc6b733c2d2f",
+      "type": "library",
+      "group": "io.vertx",
+      "name": "vertx-uri-template",
+      "version": "4.5.13",
+      "cpe": "cpe:2.3:a:vertx-uri-template:vertx-uri-template:4.5.13:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.vertx/vertx-uri-template@4.5.13",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5d1df29c56d92f91c09c00773b828f659f1f7de6"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-uri-template:vertx_uri_template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_uri_template:vertx-uri-template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_uri_template:vertx_uri_template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-uri:vertx-uri-template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-uri:vertx_uri_template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_uri:vertx-uri-template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_uri:vertx_uri_template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx-uri-template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx_uri_template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:vertx-uri-template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:vertx_uri_template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx-uri-template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx_uri_template:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.vertx.vertx-uri-template-4.5.13.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "vertx-uri-template"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.vertx"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.vertx.vertx-uri-template-4.5.13.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.vertx/vertx-web@4.5.13?package-id=dfacbda132fe86b6",
+      "type": "library",
+      "group": "io.vertx",
+      "name": "vertx-web",
+      "version": "4.5.13",
+      "licenses": [
+        {
+          "license": {
+            "name": "Eclipse Public License - v 2.0",
+            "url": "http://www.eclipse.org/legal/epl-v20.html"
+          }
+        },
+        {
+          "license": {
+            "name": "The Apache Software License, Version 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:vertx-web:vertx-web:4.5.13:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.vertx/vertx-web@4.5.13",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "247ea1c5eb1e6cd46c31ec7307d8ce4a8b2162aa"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-web:vertx_web:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_web:vertx-web:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_web:vertx_web:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx-web:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx_web:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:vertx-web:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:vertx_web:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx-web:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx_web:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.vertx.vertx-web-4.5.13.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "vertx-web"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.vertx"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.vertx.vertx-web-4.5.13.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.vertx/vertx-web-common@4.5.13?package-id=7e82852e7dfef05b",
+      "type": "library",
+      "group": "io.vertx",
+      "name": "vertx-web-common",
+      "version": "4.5.13",
+      "cpe": "cpe:2.3:a:vertx-web-common:vertx-web-common:4.5.13:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/io.vertx/vertx-web-common@4.5.13",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "fa5362b266d979259be1062358a7cd9b7602320b"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-web-common:vertx_web_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_web_common:vertx-web-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_web_common:vertx_web_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-web:vertx-web-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx-web:vertx_web_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_web:vertx-web-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx_web:vertx_web_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx-web-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:io.vertx:vertx_web_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:vertx-web-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:eclipse:vertx_web_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx-web-common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vertx:vertx_web_common:4.5.13:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/io.vertx.vertx-web-common-4.5.13.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "vertx-web-common"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "io.vertx"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/io.vertx.vertx-web-common-4.5.13.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@2.0.1?package-id=f90f4adb3ad14211",
+      "type": "library",
+      "group": "org.wildfly.common",
+      "name": "wildfly-common",
+      "version": "2.0.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License 2.0",
+            "url": "http://repository.jboss.org/licenses/apache-2.0.txt"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:org.wildfly.common:wildfly-common:2.0.1:*:*:*:*:*:*:*",
+      "purl": "pkg:maven/org.wildfly.common/wildfly-common@2.0.1",
+      "externalReferences": [
+        {
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5db5c5f2d04a1c0a3f7fe678030d3ec3760f81a3"
+            }
+          ],
+          "type": "build-meta"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "java-archive-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "java"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "java-archive"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.wildfly.common:wildfly_common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:wildfly-common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:wildfly_common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:wildfly-common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:wildfly_common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:wildfly-common:wildfly-common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:wildfly-common:wildfly_common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:wildfly_common:wildfly-common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:wildfly_common:wildfly_common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:org.wildfly.common:common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss-by-red-hat:common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:jboss_by_red_hat:common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:wildfly:wildfly-common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:wildfly:wildfly_common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:wildfly-common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:wildfly_common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:wildfly-common:common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:wildfly_common:common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:wildfly:common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:common:common:2.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:0cdab3bced31feb0cea9cee9a4062b6ac820102ca827355c63c05318ffe80864"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/deployments/lib/main/org.wildfly.common.wildfly-common-2.0.1.jar"
+        },
+        {
+          "name": "syft:metadata:-:artifactID",
+          "value": "wildfly-common"
+        },
+        {
+          "name": "syft:metadata:-:groupID",
+          "value": "org.wildfly.common"
+        },
+        {
+          "name": "syft:metadata:virtualPath",
+          "value": "/deployments/lib/main/org.wildfly.common.wildfly-common-2.0.1.jar"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&distro=rhel-9.6&package-id=16ca2392190fccfe&upstream=xz-5.2.5-8.el9_0.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "xz-libs",
+      "version": "5.2.5-8.el9_0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:xz-libs:xz-libs:5.2.5-8.el9_0:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&distro=rhel-9.6&upstream=xz-5.2.5-8.el9_0.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:xz-libs:xz_libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:xz_libs:xz-libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:xz_libs:xz_libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:xz-libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:xz_libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:xz:xz-libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:xz:xz_libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "8.el9_0"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "181573"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "xz-5.2.5-8.el9_0.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "zlib",
+      "version": "1.2.11-40.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Boost"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:zlib:1.2.11-40.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&upstream=zlib-1.2.11-40.el9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "rpm-db-entry"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:zlib:zlib:1.2.11-40.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:c2fc6409ec0848340d48a96a33e03ef000e304ce7b4ff48fd3d2c1e923915d87"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "40.el9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "202921"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "zlib-1.2.11-40.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "os:rhel@9.6",
+      "type": "operating-system",
+      "name": "rhel",
+      "version": "9.6",
+      "description": "Red Hat Enterprise Linux 9.6 (Plow)",
+      "cpe": "cpe:2.3:o:redhat:enterprise_linux:9:*:baseos:*:*:*:*:*",
+      "swid": {
+        "tagId": "rhel",
+        "name": "rhel",
+        "version": "9.6"
+      },
+      "externalReferences": [
+        {
+          "url": "https://issues.redhat.com/",
+          "type": "issue-tracker"
+        },
+        {
+          "url": "https://www.redhat.com/",
+          "type": "website"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:distro:id",
+          "value": "rhel"
+        },
+        {
+          "name": "syft:distro:idLike:0",
+          "value": "fedora"
+        },
+        {
+          "name": "syft:distro:prettyName",
+          "value": "Red Hat Enterprise Linux 9.6 (Plow)"
+        },
+        {
+          "name": "syft:distro:versionID",
+          "value": "9.6"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:maven/io.netty/netty-common@4.1.118.Final?package-id=9ba204bbc3bcc4bd",
+      "dependsOn": [
+        "pkg:maven/org.jctools/jctools-core@4.0.5?package-id=015131ccded61f68"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/alsa-lib@1.2.13-2.el9?arch=x86_64&distro=rhel-9.6&package-id=c6d3f4fac5cd90c4&upstream=alsa-lib-1.2.13-2.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64&distro=rhel-9.6&package-id=1d92a866b3c8fee3&upstream=chkconfig-1.24-2.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/audit-libs@3.1.5-4.el9?arch=x86_64&distro=rhel-9.6&package-id=ec77664bfe6dc2c0&upstream=audit-3.1.5-4.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64&distro=rhel-9.6&package-id=2b860dd13e2eda6e&upstream=libcap-ng-0.8.2-7.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/avahi-libs@0.8-22.el9_6?arch=x86_64&distro=rhel-9.6&package-id=0fd42a816d402858&upstream=avahi-0.8-22.el9_6.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=b03f2d59aa419aaa&upstream=dbus-1.12.20-8.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64&distro=rhel-9.6&package-id=57ef373f1974e156&upstream=libevent-2.1.12-8.el9_4.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch&distro=rhel-9.6&package-id=3066bacfe81791e1&upstream=basesystem-11-13.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64&distro=rhel-9.6&package-id=4887a6ed0441d418&upstream=filesystem-3.16-5.el9.src.rpm",
+        "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch&distro=rhel-9.6&package-id=7ce0aa004f15fb1c&upstream=setup-2.13.7-10.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64&distro=rhel-9.6&package-id=4887a6ed0441d418&upstream=filesystem-3.16-5.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9?arch=x86_64&distro=rhel-9.6&package-id=4e4811efdca08c7d&upstream=ncurses-6.2-10.20210508.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64&distro=rhel-9.6&package-id=6e824ef360f5dc6e&upstream=bzip2-1.0.8-10.el9_5.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch&distro=rhel-9.6&package-id=5bd0ac95528d06e7&upstream=ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64&distro=rhel-9.6&package-id=f58fd0c56048619d&upstream=coreutils-8.32-39.el9.src.rpm",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&distro=rhel-9.6&package-id=cb09cd721d5a9f23&upstream=grep-3.6-5.el9.src.rpm",
+        "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64&distro=rhel-9.6&package-id=3deb984e0c342d5f&upstream=p11-kit-0.25.3-3.el9_5.src.rpm",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=da6ad46252374ced&upstream=sed-4.8-9.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/copy-jdk-configs@4.0-3.el9?arch=noarch&distro=rhel-9.6&package-id=39579b98f4c4b9fb&upstream=copy-jdk-configs-4.0-3.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/findutils@4.8.0-7.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=9f05b8368b69d363&upstream=findutils-4.8.0-7.el9.src.rpm",
+        "pkg:rpm/redhat/lua-posix@35.0-8.el9?arch=x86_64&distro=rhel-9.6&package-id=535d7017d3fa6879&upstream=lua-posix-35.0-8.el9.src.rpm",
+        "pkg:rpm/redhat/lua@5.4.4-4.el9?arch=x86_64&distro=rhel-9.6&package-id=44d71b9802b1a6c4&upstream=lua-5.4.4-4.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64&distro=rhel-9.6&package-id=f58fd0c56048619d&upstream=coreutils-8.32-39.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=5bd7c806cb0b843c&upstream=acl-2.3.1-4.el9.src.rpm",
+        "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64&distro=rhel-9.6&package-id=3677ea600c46b6c8&upstream=attr-2.5.1-3.el9.src.rpm",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&distro=rhel-9.6&package-id=f7699c7a69eaad5a&upstream=libcap-2.48-9.el9_2.src.rpm",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies-scripts@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&package-id=464ea69fc556f4ad&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&package-id=64df59775f05049c&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+        "pkg:rpm/redhat/python3@3.9.21-2.el9?arch=x86_64&distro=rhel-9.6&package-id=b4c5c33a2372a96a&upstream=python3.9-3.9.21-2.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&package-id=64df59775f05049c&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/cups-libs@2.3.3op2-33.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=a3e336e82d2ec332&upstream=cups-2.3.3op2-33.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/avahi-libs@0.8-22.el9_6?arch=x86_64&distro=rhel-9.6&package-id=0fd42a816d402858&upstream=avahi-0.8-22.el9_6.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/gnutls@3.8.3-6.el9?arch=x86_64&distro=rhel-9.6&package-id=bf12c6dd0c8e2348&upstream=gnutls-3.8.3-6.el9.src.rpm",
+        "pkg:rpm/redhat/krb5-libs@1.21.1-6.el9?arch=x86_64&distro=rhel-9.6&package-id=9f490f7cfcb7b19c&upstream=krb5-1.21.1-6.el9.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/curl-minimal@7.76.1-31.el9?arch=x86_64&distro=rhel-9.6&package-id=f509087c83d84120&upstream=curl-7.76.1-31.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9?arch=x86_64&distro=rhel-9.6&package-id=45626a0f59bc1233&upstream=curl-7.76.1-31.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64&distro=rhel-9.6&package-id=d55618a97ad843dd&upstream=cyrus-sasl-2.1.27-21.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=aefb88b0150eda0f&upstream=gdbm-1.23-1.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/krb5-libs@1.21.1-6.el9?arch=x86_64&distro=rhel-9.6&package-id=9f490f7cfcb7b19c&upstream=krb5-1.21.1-6.el9.src.rpm",
+        "pkg:rpm/redhat/libcom_err@1.46.5-7.el9?arch=x86_64&distro=rhel-9.6&package-id=95fdc60216e1260b&upstream=e2fsprogs-1.46.5-7.el9.src.rpm",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&distro=rhel-9.6&package-id=d3709e4a8db9b6bc&upstream=libxcrypt-4.4.18-3.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=b03f2d59aa419aaa&upstream=dbus-1.12.20-8.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/systemd-libs@252-51.el9?arch=x86_64&distro=rhel-9.6&package-id=ab1fadc1d33a9f1e&upstream=systemd-252-51.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch&distro=rhel-9.6&package-id=cfc22ea58527299d&upstream=dejavu-fonts-2.37-18.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&distro=rhel-9.6&epoch=1&package-id=bcf36e2c3425d2bc&upstream=fonts-rpm-macros-2.0.5-7.el9.1.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-data@4.14.0-25.el9?arch=noarch&distro=rhel-9.6&package-id=9e2c17fe427676e7&upstream=dnf-4.14.0-25.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch&distro=rhel-9.6&package-id=d34bc390023607f7&upstream=libreport-2.15.2-6.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/expat@2.5.0-5.el9_6?arch=x86_64&distro=rhel-9.6&package-id=66e9bceb48b8d8cb&upstream=expat-2.5.0-5.el9_6.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64&distro=rhel-9.6&package-id=87c5a5bd9220edaf&upstream=file-5.39-16.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64&distro=rhel-9.6&package-id=4887a6ed0441d418&upstream=filesystem-3.16-5.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch&distro=rhel-9.6&package-id=7ce0aa004f15fb1c&upstream=setup-2.13.7-10.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/findutils@4.8.0-7.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=9f05b8368b69d363&upstream=findutils-4.8.0-7.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64&distro=rhel-9.6&package-id=36081d8966c7e43f&upstream=gawk-5.1.0-6.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64&distro=rhel-9.6&package-id=4887a6ed0441d418&upstream=filesystem-3.16-5.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=e4c2cf4f6c98da18&upstream=gmp-6.2.0-13.el9.src.rpm",
+        "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64&distro=rhel-9.6&package-id=b68d31d7f353f7c3&upstream=libsigsegv-2.13-4.el9.src.rpm",
+        "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64&distro=rhel-9.6&package-id=f465e8751bc1071e&upstream=mpfr-4.1.0-7.el9.src.rpm",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=ef4d6a42c39b6034&upstream=readline-8.1-4.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=aefb88b0150eda0f&upstream=gdbm-1.23-1.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib2@2.68.4-16.el9?arch=x86_64&distro=rhel-9.6&package-id=b153f7fb65cd8222&upstream=glib2-2.68.4-16.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/gnutls@3.8.3-6.el9?arch=x86_64&distro=rhel-9.6&package-id=bf12c6dd0c8e2348&upstream=gnutls-3.8.3-6.el9.src.rpm",
+        "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64&distro=rhel-9.6&package-id=2dc370039d6ee9af&upstream=libffi-3.4.2-8.el9.src.rpm",
+        "pkg:rpm/redhat/libmount@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=ade2b8b9765efaa0&upstream=util-linux-2.37.4-21.el9.src.rpm",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm",
+        "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64&distro=rhel-9.6&package-id=73518a205b7179dc&upstream=pcre-8.44-4.el9.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-common@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=26690b7b770c59f8&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch&distro=rhel-9.6&package-id=dda8022ed5c64e66&upstream=tzdata-2025b-1.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=f8d441a9d7378143&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc-common@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=26690b7b770c59f8&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch&distro=rhel-9.6&package-id=3066bacfe81791e1&upstream=basesystem-11-13.el9.src.rpm",
+        "pkg:rpm/redhat/glibc-common@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=26690b7b770c59f8&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/glibc-minimal-langpack@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=f8d441a9d7378143&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=7512670668215a38&upstream=gcc-11.5.0-5.el9_5.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=e4c2cf4f6c98da18&upstream=gmp-6.2.0-13.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64&distro=rhel-9.6&package-id=8f60bb6d2342f505&upstream=gnupg2-2.3.3-4.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64&distro=rhel-9.6&package-id=6e824ef360f5dc6e&upstream=bzip2-1.0.8-10.el9_5.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/gnutls@3.8.3-6.el9?arch=x86_64&distro=rhel-9.6&package-id=bf12c6dd0c8e2348&upstream=gnutls-3.8.3-6.el9.src.rpm",
+        "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64&distro=rhel-9.6&package-id=e33783c9327f80b3&upstream=libassuan-2.5.5-3.el9.src.rpm",
+        "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64&distro=rhel-9.6&package-id=4365797aed5f61b4&upstream=libgcrypt-1.10.0-11.el9.src.rpm",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&distro=rhel-9.6&package-id=69466ff7e66043b2&upstream=libgpg-error-1.42-5.el9.src.rpm",
+        "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64&distro=rhel-9.6&package-id=7e6cbd5a17d74705&upstream=libksba-1.5.1-7.el9.src.rpm",
+        "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64&distro=rhel-9.6&package-id=30469a89d3a6f339&upstream=npth-1.6-8.el9.src.rpm",
+        "pkg:rpm/redhat/openldap@2.6.8-4.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8d626f8fe6c707&upstream=openldap-2.6.8-4.el9.src.rpm",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=ef4d6a42c39b6034&upstream=readline-8.1-4.el9.src.rpm",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_3?arch=x86_64&distro=rhel-9.6&package-id=892e1356fdb52665&upstream=sqlite-3.34.1-7.el9_3.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnutls@3.8.3-6.el9?arch=x86_64&distro=rhel-9.6&package-id=bf12c6dd0c8e2348&upstream=gnutls-3.8.3-6.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&package-id=64df59775f05049c&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64&distro=rhel-9.6&package-id=ae22cc67cd082c17&upstream=libidn2-2.3.0-7.el9.src.rpm",
+        "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64&distro=rhel-9.6&package-id=f7f8d943bdae553f&upstream=libtasn1-4.16.0-9.el9.src.rpm",
+        "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64&distro=rhel-9.6&package-id=615059ec73826c8d&upstream=libunistring-0.9.10-15.el9.src.rpm",
+        "pkg:rpm/redhat/nettle@3.10.1-1.el9?arch=x86_64&distro=rhel-9.6&package-id=4c77a55779264dcf&upstream=nettle-3.10.1-1.el9.src.rpm",
+        "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64&distro=rhel-9.6&package-id=3deb984e0c342d5f&upstream=p11-kit-0.25.3-3.el9_5.src.rpm",
+        "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64&distro=rhel-9.6&package-id=a9586bae56dbbae8&upstream=p11-kit-0.25.3-3.el9_5.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64&distro=rhel-9.6&package-id=02965c1a03015521&upstream=gobject-introspection-1.68.0-11.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glib2@2.68.4-16.el9?arch=x86_64&distro=rhel-9.6&package-id=b153f7fb65cd8222&upstream=glib2-2.68.4-16.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64&distro=rhel-9.6&package-id=2dc370039d6ee9af&upstream=libffi-3.4.2-8.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64&distro=rhel-9.6&package-id=8dfabda3e3f19eec&upstream=gpgme-1.15.1-6.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64&distro=rhel-9.6&package-id=8f60bb6d2342f505&upstream=gnupg2-2.3.3-4.el9.src.rpm",
+        "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64&distro=rhel-9.6&package-id=e33783c9327f80b3&upstream=libassuan-2.5.5-3.el9.src.rpm",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&distro=rhel-9.6&package-id=69466ff7e66043b2&upstream=libgpg-error-1.42-5.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&distro=rhel-9.6&package-id=cb09cd721d5a9f23&upstream=grep-3.6-5.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64&distro=rhel-9.6&package-id=b68d31d7f353f7c3&upstream=libsigsegv-2.13-4.el9.src.rpm",
+        "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64&distro=rhel-9.6&package-id=73518a205b7179dc&upstream=pcre-8.44-4.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.7.0.6-1.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=1d88987370aeaf8d&upstream=java-21-openjdk-21.0.7.0.6-1.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/alsa-lib@1.2.13-2.el9?arch=x86_64&distro=rhel-9.6&package-id=c6d3f4fac5cd90c4&upstream=alsa-lib-1.2.13-2.el9.src.rpm",
+        "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64&distro=rhel-9.6&package-id=1d92a866b3c8fee3&upstream=chkconfig-1.24-2.el9.src.rpm",
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch&distro=rhel-9.6&package-id=5bd0ac95528d06e7&upstream=ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.src.rpm",
+        "pkg:rpm/redhat/copy-jdk-configs@4.0-3.el9?arch=noarch&distro=rhel-9.6&package-id=39579b98f4c4b9fb&upstream=copy-jdk-configs-4.0-3.el9.src.rpm",
+        "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&package-id=64df59775f05049c&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+        "pkg:rpm/redhat/cups-libs@2.3.3op2-33.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=a3e336e82d2ec332&upstream=cups-2.3.3op2-33.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/javapackages-filesystem@6.4.0-1.el9?arch=noarch&distro=rhel-9.6&package-id=68f86a534d515f4c&upstream=javapackages-tools-6.4.0-1.el9.src.rpm",
+        "pkg:rpm/redhat/lksctp-tools@1.0.19-3.el9_4?arch=x86_64&distro=rhel-9.6&package-id=1bbb198e66b70e43&upstream=lksctp-tools-1.0.19-3.el9_4.src.rpm",
+        "pkg:rpm/redhat/nss@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=06626f8f3944db6c&upstream=nss-3.101.0-10.el9_2.src.rpm",
+        "pkg:rpm/redhat/tzdata-java@2025b-1.el9?arch=noarch&distro=rhel-9.6&package-id=8ef897250b00cf3e&upstream=tzdata-2025b-1.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64&distro=rhel-9.6&package-id=11df62c698c61ae7&upstream=json-c-0.14-11.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64&distro=rhel-9.6&package-id=637773da489d3afe&upstream=json-glib-1.6.6-1.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glib2@2.68.4-16.el9?arch=x86_64&distro=rhel-9.6&package-id=b153f7fb65cd8222&upstream=glib2-2.68.4-16.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64&distro=rhel-9.6&package-id=39e2c2a43040d9a9&upstream=keyutils-1.6.3-1.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/krb5-libs@1.21.1-6.el9?arch=x86_64&distro=rhel-9.6&package-id=9f490f7cfcb7b19c&upstream=krb5-1.21.1-6.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64&distro=rhel-9.6&package-id=f58fd0c56048619d&upstream=coreutils-8.32-39.el9.src.rpm",
+        "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&package-id=64df59775f05049c&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+        "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64&distro=rhel-9.6&package-id=36081d8966c7e43f&upstream=gawk-5.1.0-6.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&distro=rhel-9.6&package-id=cb09cd721d5a9f23&upstream=grep-3.6-5.el9.src.rpm",
+        "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64&distro=rhel-9.6&package-id=39e2c2a43040d9a9&upstream=keyutils-1.6.3-1.el9.src.rpm",
+        "pkg:rpm/redhat/libcom_err@1.46.5-7.el9?arch=x86_64&distro=rhel-9.6&package-id=95fdc60216e1260b&upstream=e2fsprogs-1.46.5-7.el9.src.rpm",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm",
+        "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64&distro=rhel-9.6&package-id=644d34646f10f7ae&upstream=libverto-0.3.2-3.el9.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=da6ad46252374ced&upstream=sed-4.8-9.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch&distro=rhel-9.6&package-id=88a1132a4baefaca&upstream=langpacks-3.0-16.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch&distro=rhel-9.6&package-id=fe6c1588a87ba80e&upstream=langpacks-3.0-16.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch&distro=rhel-9.6&package-id=fe6c1588a87ba80e&upstream=langpacks-3.0-16.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch&distro=rhel-9.6&package-id=cfc22ea58527299d&upstream=dejavu-fonts-2.37-18.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch&distro=rhel-9.6&package-id=40aceea966cab95e&upstream=langpacks-3.0-16.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch&distro=rhel-9.6&package-id=88a1132a4baefaca&upstream=langpacks-3.0-16.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=5bd7c806cb0b843c&upstream=acl-2.3.1-4.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64&distro=rhel-9.6&package-id=3677ea600c46b6c8&upstream=attr-2.5.1-3.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9?arch=x86_64&distro=rhel-9.6&package-id=d8ddf54736613a1b&upstream=libarchive-3.5.3-4.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64&distro=rhel-9.6&package-id=6e824ef360f5dc6e&upstream=bzip2-1.0.8-10.el9_5.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=5bd7c806cb0b843c&upstream=acl-2.3.1-4.el9.src.rpm",
+        "pkg:rpm/redhat/libxml2@2.9.13-9.el9_6?arch=x86_64&distro=rhel-9.6&package-id=142e0c5184768e72&upstream=libxml2-2.9.13-9.el9_6.src.rpm",
+        "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64&distro=rhel-9.6&package-id=cdd2d94a9c38f292&upstream=zstd-1.5.5-1.el9.src.rpm",
+        "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64&distro=rhel-9.6&package-id=96b4cd464ad16cf1&upstream=lz4-1.9.3-5.el9.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&distro=rhel-9.6&package-id=16ca2392190fccfe&upstream=xz-5.2.5-8.el9_0.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64&distro=rhel-9.6&package-id=e33783c9327f80b3&upstream=libassuan-2.5.5-3.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&distro=rhel-9.6&package-id=69466ff7e66043b2&upstream=libgpg-error-1.42-5.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64&distro=rhel-9.6&package-id=3677ea600c46b6c8&upstream=attr-2.5.1-3.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libblkid@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=e30d806f54044f6c&upstream=util-linux-2.37.4-21.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64&distro=rhel-9.6&package-id=f58fd0c56048619d&upstream=coreutils-8.32-39.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=fc13a0dc78469351&upstream=util-linux-2.37.4-21.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64&distro=rhel-9.6&package-id=2b860dd13e2eda6e&upstream=libcap-ng-0.8.2-7.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&distro=rhel-9.6&package-id=f7699c7a69eaad5a&upstream=libcap-2.48-9.el9_2.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=7512670668215a38&upstream=gcc-11.5.0-5.el9_5.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcom_err@1.46.5-7.el9?arch=x86_64&distro=rhel-9.6&package-id=95fdc60216e1260b&upstream=e2fsprogs-1.46.5-7.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9?arch=x86_64&distro=rhel-9.6&package-id=45626a0f59bc1233&upstream=curl-7.76.1-31.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/krb5-libs@1.21.1-6.el9?arch=x86_64&distro=rhel-9.6&package-id=9f490f7cfcb7b19c&upstream=krb5-1.21.1-6.el9.src.rpm",
+        "pkg:rpm/redhat/libcom_err@1.46.5-7.el9?arch=x86_64&distro=rhel-9.6&package-id=95fdc60216e1260b&upstream=e2fsprogs-1.46.5-7.el9.src.rpm",
+        "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64&distro=rhel-9.6&package-id=cea05d8f439115cd&upstream=nghttp2-1.43.0-6.el9.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf@0.69.0-13.el9?arch=x86_64&distro=rhel-9.6&package-id=809fcd79847e161a&upstream=libdnf-0.69.0-13.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glib2@2.68.4-16.el9?arch=x86_64&distro=rhel-9.6&package-id=b153f7fb65cd8222&upstream=glib2-2.68.4-16.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64&distro=rhel-9.6&package-id=8dfabda3e3f19eec&upstream=gpgme-1.15.1-6.el9.src.rpm",
+        "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64&distro=rhel-9.6&package-id=11df62c698c61ae7&upstream=json-c-0.14-11.el9.src.rpm",
+        "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=7512670668215a38&upstream=gcc-11.5.0-5.el9_5.src.rpm",
+        "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64&distro=rhel-9.6&package-id=2adb1fa18118feb1&upstream=libmodulemd-2.13.0-2.el9.src.rpm",
+        "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64&distro=rhel-9.6&package-id=e6c08b7d843fe388&upstream=librepo-1.14.5-2.el9.src.rpm",
+        "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64&distro=rhel-9.6&package-id=cce68c3ca91abeec&upstream=librhsm-0.0.3-9.el9.src.rpm",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=0edd82fc42eab4d9&upstream=util-linux-2.37.4-21.el9.src.rpm",
+        "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64&distro=rhel-9.6&package-id=fa42e742fa144174&upstream=libsolv-0.7.24-3.el9.src.rpm",
+        "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=8db809343fa3fe29&upstream=gcc-11.5.0-5.el9_5.src.rpm",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-37.el9?arch=x86_64&distro=rhel-9.6&package-id=dacf99b05b2295f6&upstream=rpm-4.16.1.3-37.el9.src.rpm",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_3?arch=x86_64&distro=rhel-9.6&package-id=892e1356fdb52665&upstream=sqlite-3.34.1-7.el9_3.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64&distro=rhel-9.6&package-id=57ef373f1974e156&upstream=libevent-2.1.12-8.el9_4.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64&distro=rhel-9.6&package-id=2dc370039d6ee9af&upstream=libffi-3.4.2-8.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64&distro=rhel-9.6&package-id=4365797aed5f61b4&upstream=libgcrypt-1.10.0-11.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&distro=rhel-9.6&package-id=69466ff7e66043b2&upstream=libgpg-error-1.42-5.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&distro=rhel-9.6&package-id=69466ff7e66043b2&upstream=libgpg-error-1.42-5.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64&distro=rhel-9.6&package-id=ae22cc67cd082c17&upstream=libidn2-2.3.0-7.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64&distro=rhel-9.6&package-id=615059ec73826c8d&upstream=libunistring-0.9.10-15.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64&distro=rhel-9.6&package-id=7e6cbd5a17d74705&upstream=libksba-1.5.1-7.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&distro=rhel-9.6&package-id=69466ff7e66043b2&upstream=libgpg-error-1.42-5.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64&distro=rhel-9.6&package-id=2adb1fa18118feb1&upstream=libmodulemd-2.13.0-2.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64&distro=rhel-9.6&package-id=87c5a5bd9220edaf&upstream=file-5.39-16.el9.src.rpm",
+        "pkg:rpm/redhat/glib2@2.68.4-16.el9?arch=x86_64&distro=rhel-9.6&package-id=b153f7fb65cd8222&upstream=glib2-2.68.4-16.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=7512670668215a38&upstream=gcc-11.5.0-5.el9_5.src.rpm",
+        "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64&distro=rhel-9.6&package-id=9c63ee03e6e500ad&upstream=libyaml-0.2.5-7.el9.src.rpm",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-37.el9?arch=x86_64&distro=rhel-9.6&package-id=dacf99b05b2295f6&upstream=rpm-4.16.1.3-37.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmount@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=ade2b8b9765efaa0&upstream=util-linux-2.37.4-21.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libblkid@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=e30d806f54044f6c&upstream=util-linux-2.37.4-21.el9.src.rpm",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm",
+        "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=fc13a0dc78469351&upstream=util-linux-2.37.4-21.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64&distro=rhel-9.6&package-id=cea05d8f439115cd&upstream=nghttp2-1.43.0-6.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64&distro=rhel-9.6&package-id=2edcab74dc977b20&upstream=libpeas-1.30.0-4.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glib2@2.68.4-16.el9?arch=x86_64&distro=rhel-9.6&package-id=b153f7fb65cd8222&upstream=glib2-2.68.4-16.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64&distro=rhel-9.6&package-id=02965c1a03015521&upstream=gobject-introspection-1.68.0-11.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64&distro=rhel-9.6&package-id=e6c08b7d843fe388&upstream=librepo-1.14.5-2.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glib2@2.68.4-16.el9?arch=x86_64&distro=rhel-9.6&package-id=b153f7fb65cd8222&upstream=glib2-2.68.4-16.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64&distro=rhel-9.6&package-id=8dfabda3e3f19eec&upstream=gpgme-1.15.1-6.el9.src.rpm",
+        "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9?arch=x86_64&distro=rhel-9.6&package-id=45626a0f59bc1233&upstream=curl-7.76.1-31.el9.src.rpm",
+        "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=7512670668215a38&upstream=gcc-11.5.0-5.el9_5.src.rpm",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm",
+        "pkg:rpm/redhat/libxml2@2.9.13-9.el9_6?arch=x86_64&distro=rhel-9.6&package-id=142e0c5184768e72&upstream=libxml2-2.9.13-9.el9_6.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64&distro=rhel-9.6&package-id=cce68c3ca91abeec&upstream=librhsm-0.0.3-9.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glib2@2.68.4-16.el9?arch=x86_64&distro=rhel-9.6&package-id=b153f7fb65cd8222&upstream=glib2-2.68.4-16.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64&distro=rhel-9.6&package-id=637773da489d3afe&upstream=json-glib-1.6.6-1.el9.src.rpm",
+        "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=7512670668215a38&upstream=gcc-11.5.0-5.el9_5.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libsepol@3.6-2.el9?arch=x86_64&distro=rhel-9.6&package-id=c296ae344ca36222&upstream=libsepol-3.6-2.el9.src.rpm",
+        "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64&distro=rhel-9.6&package-id=b35dca0d876967e5&upstream=pcre2-10.40-6.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsemanage@3.6-5.el9_6?arch=x86_64&distro=rhel-9.6&package-id=0540d4b49021576a&upstream=libsemanage-3.6-5.el9_6.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/audit-libs@3.1.5-4.el9?arch=x86_64&distro=rhel-9.6&package-id=ec77664bfe6dc2c0&upstream=audit-3.1.5-4.el9.src.rpm",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64&distro=rhel-9.6&package-id=6e824ef360f5dc6e&upstream=bzip2-1.0.8-10.el9_5.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm",
+        "pkg:rpm/redhat/libsepol@3.6-2.el9?arch=x86_64&distro=rhel-9.6&package-id=c296ae344ca36222&upstream=libsepol-3.6-2.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsepol@3.6-2.el9?arch=x86_64&distro=rhel-9.6&package-id=c296ae344ca36222&upstream=libsepol-3.6-2.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64&distro=rhel-9.6&package-id=b68d31d7f353f7c3&upstream=libsigsegv-2.13-4.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=0edd82fc42eab4d9&upstream=util-linux-2.37.4-21.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64&distro=rhel-9.6&package-id=fa42e742fa144174&upstream=libsolv-0.7.24-3.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64&distro=rhel-9.6&package-id=6e824ef360f5dc6e&upstream=bzip2-1.0.8-10.el9_5.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libxml2@2.9.13-9.el9_6?arch=x86_64&distro=rhel-9.6&package-id=142e0c5184768e72&upstream=libxml2-2.9.13-9.el9_6.src.rpm",
+        "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64&distro=rhel-9.6&package-id=cdd2d94a9c38f292&upstream=zstd-1.5.5-1.el9.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-37.el9?arch=x86_64&distro=rhel-9.6&package-id=dacf99b05b2295f6&upstream=rpm-4.16.1.3-37.el9.src.rpm",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&distro=rhel-9.6&package-id=16ca2392190fccfe&upstream=xz-5.2.5-8.el9_0.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=8db809343fa3fe29&upstream=gcc-11.5.0-5.el9_5.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=7512670668215a38&upstream=gcc-11.5.0-5.el9_5.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64&distro=rhel-9.6&package-id=f7f8d943bdae553f&upstream=libtasn1-4.16.0-9.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtool-ltdl@2.4.6-46.el9?arch=x86_64&distro=rhel-9.6&package-id=d97fb91fff35f4ca&upstream=libtool-2.4.6-46.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64&distro=rhel-9.6&package-id=615059ec73826c8d&upstream=libunistring-0.9.10-15.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64&distro=rhel-9.6&package-id=042b2ea74c010cf0&upstream=libusbx-1.0.26-1.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/systemd-libs@252-51.el9?arch=x86_64&distro=rhel-9.6&package-id=ab1fadc1d33a9f1e&upstream=systemd-252-51.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=fc13a0dc78469351&upstream=util-linux-2.37.4-21.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64&distro=rhel-9.6&package-id=644d34646f10f7ae&upstream=libverto-0.3.2-3.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&distro=rhel-9.6&package-id=d3709e4a8db9b6bc&upstream=libxcrypt-4.4.18-3.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxml2@2.9.13-9.el9_6?arch=x86_64&distro=rhel-9.6&package-id=142e0c5184768e72&upstream=libxml2-2.9.13-9.el9_6.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&distro=rhel-9.6&package-id=16ca2392190fccfe&upstream=xz-5.2.5-8.el9_0.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64&distro=rhel-9.6&package-id=9c63ee03e6e500ad&upstream=libyaml-0.2.5-7.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64&distro=rhel-9.6&package-id=cdd2d94a9c38f292&upstream=zstd-1.5.5-1.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/lksctp-tools@1.0.19-3.el9_4?arch=x86_64&distro=rhel-9.6&package-id=1bbb198e66b70e43&upstream=lksctp-tools-1.0.19-3.el9_4.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64&distro=rhel-9.6&package-id=0d89ff6591ed24aa&upstream=lua-5.4.4-4.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-posix@35.0-8.el9?arch=x86_64&distro=rhel-9.6&package-id=535d7017d3fa6879&upstream=lua-posix-35.0-8.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&distro=rhel-9.6&package-id=d3709e4a8db9b6bc&upstream=libxcrypt-4.4.18-3.el9.src.rpm",
+        "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64&distro=rhel-9.6&package-id=0d89ff6591ed24aa&upstream=lua-5.4.4-4.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua@5.4.4-4.el9?arch=x86_64&distro=rhel-9.6&package-id=44d71b9802b1a6c4&upstream=lua-5.4.4-4.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64&distro=rhel-9.6&package-id=0d89ff6591ed24aa&upstream=lua-5.4.4-4.el9.src.rpm",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=ef4d6a42c39b6034&upstream=readline-8.1-4.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64&distro=rhel-9.6&package-id=96b4cd464ad16cf1&upstream=lz4-1.9.3-5.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64&distro=rhel-9.6&package-id=fbf9bcecd48d49b1&upstream=microdnf-3.9.1-3.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/dnf-data@4.14.0-25.el9?arch=noarch&distro=rhel-9.6&package-id=9e2c17fe427676e7&upstream=dnf-4.14.0-25.el9.src.rpm",
+        "pkg:rpm/redhat/glib2@2.68.4-16.el9?arch=x86_64&distro=rhel-9.6&package-id=b153f7fb65cd8222&upstream=glib2-2.68.4-16.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libdnf@0.69.0-13.el9?arch=x86_64&distro=rhel-9.6&package-id=809fcd79847e161a&upstream=libdnf-0.69.0-13.el9.src.rpm",
+        "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=7512670668215a38&upstream=gcc-11.5.0-5.el9_5.src.rpm",
+        "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64&distro=rhel-9.6&package-id=2edcab74dc977b20&upstream=libpeas-1.30.0-4.el9.src.rpm",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=0edd82fc42eab4d9&upstream=util-linux-2.37.4-21.el9.src.rpm",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-37.el9?arch=x86_64&distro=rhel-9.6&package-id=dacf99b05b2295f6&upstream=rpm-4.16.1.3-37.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64&distro=rhel-9.6&package-id=f465e8751bc1071e&upstream=mpfr-4.1.0-7.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=e4c2cf4f6c98da18&upstream=gmp-6.2.0-13.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9?arch=x86_64&distro=rhel-9.6&package-id=4e4811efdca08c7d&upstream=ncurses-6.2-10.20210508.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9?arch=noarch&distro=rhel-9.6&package-id=a1613b552d5c15c8&upstream=ncurses-6.2-10.20210508.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/nettle@3.10.1-1.el9?arch=x86_64&distro=rhel-9.6&package-id=4c77a55779264dcf&upstream=nettle-3.10.1-1.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64&distro=rhel-9.6&package-id=30469a89d3a6f339&upstream=npth-1.6-8.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/nspr@4.35.0-17.el9_2?arch=x86_64&distro=rhel-9.6&package-id=26c308145aa5c3e3&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-softokn-freebl@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=6a79f4bde0e99cf0&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/nspr@4.35.0-17.el9_2?arch=x86_64&distro=rhel-9.6&package-id=26c308145aa5c3e3&upstream=nss-3.101.0-10.el9_2.src.rpm",
+        "pkg:rpm/redhat/nss-util@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=406e16374f3b021f&upstream=nss-3.101.0-10.el9_2.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-softokn@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=686e1510063b263e&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/nspr@4.35.0-17.el9_2?arch=x86_64&distro=rhel-9.6&package-id=26c308145aa5c3e3&upstream=nss-3.101.0-10.el9_2.src.rpm",
+        "pkg:rpm/redhat/nss-softokn-freebl@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=6a79f4bde0e99cf0&upstream=nss-3.101.0-10.el9_2.src.rpm",
+        "pkg:rpm/redhat/nss-util@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=406e16374f3b021f&upstream=nss-3.101.0-10.el9_2.src.rpm",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_3?arch=x86_64&distro=rhel-9.6&package-id=892e1356fdb52665&upstream=sqlite-3.34.1-7.el9_3.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-sysinit@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=f1fb560bb7aa6723&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64&distro=rhel-9.6&package-id=f58fd0c56048619d&upstream=coreutils-8.32-39.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/nspr@4.35.0-17.el9_2?arch=x86_64&distro=rhel-9.6&package-id=26c308145aa5c3e3&upstream=nss-3.101.0-10.el9_2.src.rpm",
+        "pkg:rpm/redhat/nss-util@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=406e16374f3b021f&upstream=nss-3.101.0-10.el9_2.src.rpm",
+        "pkg:rpm/redhat/nss@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=06626f8f3944db6c&upstream=nss-3.101.0-10.el9_2.src.rpm",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=da6ad46252374ced&upstream=sed-4.8-9.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-util@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=406e16374f3b021f&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/nspr@4.35.0-17.el9_2?arch=x86_64&distro=rhel-9.6&package-id=26c308145aa5c3e3&upstream=nss-3.101.0-10.el9_2.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=06626f8f3944db6c&upstream=nss-3.101.0-10.el9_2.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/crypto-policies-scripts@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&package-id=464ea69fc556f4ad&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+        "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&package-id=64df59775f05049c&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/nspr@4.35.0-17.el9_2?arch=x86_64&distro=rhel-9.6&package-id=26c308145aa5c3e3&upstream=nss-3.101.0-10.el9_2.src.rpm",
+        "pkg:rpm/redhat/nss-softokn@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=686e1510063b263e&upstream=nss-3.101.0-10.el9_2.src.rpm",
+        "pkg:rpm/redhat/nss-sysinit@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=f1fb560bb7aa6723&upstream=nss-3.101.0-10.el9_2.src.rpm",
+        "pkg:rpm/redhat/nss-util@3.101.0-10.el9_2?arch=x86_64&distro=rhel-9.6&package-id=406e16374f3b021f&upstream=nss-3.101.0-10.el9_2.src.rpm",
+        "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64&distro=rhel-9.6&package-id=3deb984e0c342d5f&upstream=p11-kit-0.25.3-3.el9_5.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/openldap@2.6.8-4.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8d626f8fe6c707&upstream=openldap-2.6.8-4.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64&distro=rhel-9.6&package-id=d55618a97ad843dd&upstream=cyrus-sasl-2.1.27-21.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64&distro=rhel-9.6&package-id=57ef373f1974e156&upstream=libevent-2.1.12-8.el9_4.src.rpm",
+        "pkg:rpm/redhat/libtool-ltdl@2.4.6-46.el9?arch=x86_64&distro=rhel-9.6&package-id=d97fb91fff35f4ca&upstream=libtool-2.4.6-46.el9.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm",
+        "pkg:rpm/redhat/shadow-utils@4.9-12.el9?arch=x86_64&distro=rhel-9.6&epoch=2&package-id=6c28440cd547a15f&upstream=shadow-utils-4.9-12.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-6.el9_5?arch=x86_64&distro=rhel-9.6&package-id=bcbb7401c1be39ef&upstream=openssl-fips-provider-3.0.7-6.el9_5.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64&distro=rhel-9.6&package-id=f58fd0c56048619d&upstream=coreutils-8.32-39.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-6.el9_5?arch=x86_64&distro=rhel-9.6&package-id=42a7b60cc274a3e4&upstream=openssl-fips-provider-3.0.7-6.el9_5.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-6.el9_5?arch=x86_64&distro=rhel-9.6&package-id=bcbb7401c1be39ef&upstream=openssl-fips-provider-3.0.7-6.el9_5.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch&distro=rhel-9.6&package-id=5bd0ac95528d06e7&upstream=ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.src.rpm",
+        "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch&distro=rhel-9.6&package-id=64df59775f05049c&upstream=crypto-policies-20250128-1.git5269e22.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/openssl-fips-provider@3.0.7-6.el9_5?arch=x86_64&distro=rhel-9.6&package-id=42a7b60cc274a3e4&upstream=openssl-fips-provider-3.0.7-6.el9_5.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64&distro=rhel-9.6&package-id=3deb984e0c342d5f&upstream=p11-kit-0.25.3-3.el9_5.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64&distro=rhel-9.6&package-id=1d92a866b3c8fee3&upstream=chkconfig-1.24-2.el9.src.rpm",
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64&distro=rhel-9.6&package-id=f7f8d943bdae553f&upstream=libtasn1-4.16.0-9.el9.src.rpm",
+        "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64&distro=rhel-9.6&package-id=a9586bae56dbbae8&upstream=p11-kit-0.25.3-3.el9_5.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64&distro=rhel-9.6&package-id=a9586bae56dbbae8&upstream=p11-kit-0.25.3-3.el9_5.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64&distro=rhel-9.6&package-id=2dc370039d6ee9af&upstream=libffi-3.4.2-8.el9.src.rpm",
+        "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64&distro=rhel-9.6&package-id=f7f8d943bdae553f&upstream=libtasn1-4.16.0-9.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64&distro=rhel-9.6&package-id=b35dca0d876967e5&upstream=pcre2-10.40-6.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch&distro=rhel-9.6&package-id=6f41357881f43a79&upstream=pcre2-10.40-6.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64&distro=rhel-9.6&package-id=73518a205b7179dc&upstream=pcre-8.44-4.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64&distro=rhel-9.6&package-id=aece279b92ad1633&upstream=popt-1.18-8.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libs@3.9.21-2.el9?arch=x86_64&distro=rhel-9.6&package-id=372f3aac35f4501e&upstream=python3.9-3.9.21-2.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64&distro=rhel-9.6&package-id=6e824ef360f5dc6e&upstream=bzip2-1.0.8-10.el9_5.src.rpm",
+        "pkg:rpm/redhat/expat@2.5.0-5.el9_6?arch=x86_64&distro=rhel-9.6&package-id=66e9bceb48b8d8cb&upstream=expat-2.5.0-5.el9_6.src.rpm",
+        "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=aefb88b0150eda0f&upstream=gdbm-1.23-1.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64&distro=rhel-9.6&package-id=2dc370039d6ee9af&upstream=libffi-3.4.2-8.el9.src.rpm",
+        "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64&distro=rhel-9.6&package-id=fc13a0dc78469351&upstream=util-linux-2.37.4-21.el9.src.rpm",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&distro=rhel-9.6&package-id=d3709e4a8db9b6bc&upstream=libxcrypt-4.4.18-3.el9.src.rpm",
+        "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9?arch=x86_64&distro=rhel-9.6&package-id=4e4811efdca08c7d&upstream=ncurses-6.2-10.20210508.el9.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm",
+        "pkg:rpm/redhat/python3-pip-wheel@21.3.1-1.el9?arch=noarch&distro=rhel-9.6&package-id=17815ed06966e551&upstream=python-pip-21.3.1-1.el9.src.rpm",
+        "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-13.el9?arch=noarch&distro=rhel-9.6&package-id=b2df5204eb3d0deb&upstream=python-setuptools-53.0.0-13.el9.src.rpm",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=ef4d6a42c39b6034&upstream=readline-8.1-4.el9.src.rpm",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_3?arch=x86_64&distro=rhel-9.6&package-id=892e1356fdb52665&upstream=sqlite-3.34.1-7.el9_3.src.rpm",
+        "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch&distro=rhel-9.6&package-id=dda8022ed5c64e66&upstream=tzdata-2025b-1.el9.src.rpm",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&distro=rhel-9.6&package-id=16ca2392190fccfe&upstream=xz-5.2.5-8.el9_0.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pip-wheel@21.3.1-1.el9?arch=noarch&distro=rhel-9.6&package-id=17815ed06966e551&upstream=python-pip-21.3.1-1.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch&distro=rhel-9.6&package-id=5bd0ac95528d06e7&upstream=ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3@3.9.21-2.el9?arch=x86_64&distro=rhel-9.6&package-id=b4c5c33a2372a96a&upstream=python3.9-3.9.21-2.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/python3-libs@3.9.21-2.el9?arch=x86_64&distro=rhel-9.6&package-id=372f3aac35f4501e&upstream=python3.9-3.9.21-2.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=ef4d6a42c39b6034&upstream=readline-8.1-4.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9?arch=x86_64&distro=rhel-9.6&package-id=4e4811efdca08c7d&upstream=ncurses-6.2-10.20210508.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/rootfiles@8.1-34.el9?arch=noarch&distro=rhel-9.6&package-id=c3e23175e7c73167&upstream=rootfiles-8.1-34.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-37.el9?arch=x86_64&distro=rhel-9.6&package-id=dacf99b05b2295f6&upstream=rpm-4.16.1.3-37.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/audit-libs@3.1.5-4.el9?arch=x86_64&distro=rhel-9.6&package-id=ec77664bfe6dc2c0&upstream=audit-3.1.5-4.el9.src.rpm",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64&distro=rhel-9.6&package-id=6e824ef360f5dc6e&upstream=bzip2-1.0.8-10.el9_5.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=5bd7c806cb0b843c&upstream=acl-2.3.1-4.el9.src.rpm",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&distro=rhel-9.6&package-id=f7699c7a69eaad5a&upstream=libcap-2.48-9.el9_2.src.rpm",
+        "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64&distro=rhel-9.6&package-id=cdd2d94a9c38f292&upstream=zstd-1.5.5-1.el9.src.rpm",
+        "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64&distro=rhel-9.6&package-id=0d89ff6591ed24aa&upstream=lua-5.4.4-4.el9.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64&distro=rhel-9.6&package-id=aece279b92ad1633&upstream=popt-1.18-8.el9.src.rpm",
+        "pkg:rpm/redhat/rpm@4.16.1.3-37.el9?arch=x86_64&distro=rhel-9.6&package-id=afe7d85639239102&upstream=rpm-4.16.1.3-37.el9.src.rpm",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_3?arch=x86_64&distro=rhel-9.6&package-id=892e1356fdb52665&upstream=sqlite-3.34.1-7.el9_3.src.rpm",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&distro=rhel-9.6&package-id=16ca2392190fccfe&upstream=xz-5.2.5-8.el9_0.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm@4.16.1.3-37.el9?arch=x86_64&distro=rhel-9.6&package-id=afe7d85639239102&upstream=rpm-4.16.1.3-37.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64&distro=rhel-9.6&package-id=f58fd0c56048619d&upstream=coreutils-8.32-39.el9.src.rpm",
+        "pkg:rpm/redhat/curl-minimal@7.76.1-31.el9?arch=x86_64&distro=rhel-9.6&package-id=f509087c83d84120&upstream=curl-7.76.1-31.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libarchive@3.5.3-4.el9?arch=x86_64&distro=rhel-9.6&package-id=d8ddf54736613a1b&upstream=libarchive-3.5.3-4.el9.src.rpm",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64&distro=rhel-9.6&package-id=aece279b92ad1633&upstream=popt-1.18-8.el9.src.rpm",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-37.el9?arch=x86_64&distro=rhel-9.6&package-id=dacf99b05b2295f6&upstream=rpm-4.16.1.3-37.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=da6ad46252374ced&upstream=sed-4.8-9.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=5bd7c806cb0b843c&upstream=acl-2.3.1-4.el9.src.rpm",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch&distro=rhel-9.6&package-id=7ce0aa004f15fb1c&upstream=setup-2.13.7-10.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/redhat-release@9.6-0.1.el9?arch=x86_64&distro=rhel-9.6&package-id=a37845ef28f958fe&upstream=redhat-release-9.6-0.1.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/shadow-utils@4.9-12.el9?arch=x86_64&distro=rhel-9.6&epoch=2&package-id=6c28440cd547a15f&upstream=shadow-utils-4.9-12.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/audit-libs@3.1.5-4.el9?arch=x86_64&distro=rhel-9.6&package-id=ec77664bfe6dc2c0&upstream=audit-3.1.5-4.el9.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=5bd7c806cb0b843c&upstream=acl-2.3.1-4.el9.src.rpm",
+        "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64&distro=rhel-9.6&package-id=3677ea600c46b6c8&upstream=attr-2.5.1-3.el9.src.rpm",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm",
+        "pkg:rpm/redhat/libsemanage@3.6-5.el9_6?arch=x86_64&distro=rhel-9.6&package-id=0540d4b49021576a&upstream=libsemanage-3.6-5.el9_6.src.rpm",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&distro=rhel-9.6&package-id=d3709e4a8db9b6bc&upstream=libxcrypt-4.4.18-3.el9.src.rpm",
+        "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch&distro=rhel-9.6&package-id=7ce0aa004f15fb1c&upstream=setup-2.13.7-10.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_3?arch=x86_64&distro=rhel-9.6&package-id=892e1356fdb52665&upstream=sqlite-3.34.1-7.el9_3.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-libs@252-51.el9?arch=x86_64&distro=rhel-9.6&package-id=ab1fadc1d33a9f1e&upstream=systemd-252-51.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=b2aff486b06c7f3e&upstream=bash-5.1.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64&distro=rhel-9.6&package-id=f58fd0c56048619d&upstream=coreutils-8.32-39.el9.src.rpm",
+        "pkg:rpm/redhat/glibc-common@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=26690b7b770c59f8&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&distro=rhel-9.6&package-id=cb09cd721d5a9f23&upstream=grep-3.6-5.el9.src.rpm",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&distro=rhel-9.6&package-id=f7699c7a69eaad5a&upstream=libcap-2.48-9.el9_2.src.rpm",
+        "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64&distro=rhel-9.6&package-id=7512670668215a38&upstream=gcc-11.5.0-5.el9_5.src.rpm",
+        "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64&distro=rhel-9.6&package-id=4365797aed5f61b4&upstream=libgcrypt-1.10.0-11.el9.src.rpm",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&distro=rhel-9.6&package-id=d3709e4a8db9b6bc&upstream=libxcrypt-4.4.18-3.el9.src.rpm",
+        "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64&distro=rhel-9.6&package-id=cdd2d94a9c38f292&upstream=zstd-1.5.5-1.el9.src.rpm",
+        "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64&distro=rhel-9.6&package-id=96b4cd464ad16cf1&upstream=lz4-1.9.3-5.el9.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&distro=rhel-9.6&epoch=1&package-id=234def9f682f4d22&upstream=openssl-3.2.2-6.el9_5.1.src.rpm",
+        "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64&distro=rhel-9.6&package-id=a9586bae56dbbae8&upstream=p11-kit-0.25.3-3.el9_5.src.rpm",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&distro=rhel-9.6&package-id=da6ad46252374ced&upstream=sed-4.8-9.el9.src.rpm",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&distro=rhel-9.6&package-id=16ca2392190fccfe&upstream=xz-5.2.5-8.el9_0.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/tar@1.34-7.el9?arch=x86_64&distro=rhel-9.6&epoch=2&package-id=58ae95ba550bdd36&upstream=tar-1.34-7.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64&distro=rhel-9.6&package-id=5bd7c806cb0b843c&upstream=acl-2.3.1-4.el9.src.rpm",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64&distro=rhel-9.6&package-id=115d4f352434e018&upstream=libselinux-3.6-3.el9.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&distro=rhel-9.6&package-id=16ca2392190fccfe&upstream=xz-5.2.5-8.el9_0.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=rhel-9.6&package-id=6f8bcc0080c3f214&upstream=zlib-1.2.11-40.el9.src.rpm",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.14?arch=x86_64&distro=rhel-9.6&package-id=fc14e651c1f3ca85&upstream=glibc-2.34-168.el9_6.14.src.rpm"
+      ]
+    }
+  ]
+}
+  

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -25,6 +25,7 @@ mod m0001040_alter_pythonver_cmp;
 mod m0001050_foreign_key_cascade;
 mod m0001060_advisory_vulnerability_indexes;
 mod m0001070_vulnerability_scores;
+mod m0001080_sbom_add_versions;
 mod m0001100_remove_get_purl;
 
 pub struct Migrator;
@@ -54,6 +55,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001050_foreign_key_cascade::Migration),
             Box::new(m0001060_advisory_vulnerability_indexes::Migration),
             Box::new(m0001070_vulnerability_scores::Migration),
+            Box::new(m0001080_sbom_add_versions::Migration),
             Box::new(m0001100_remove_get_purl::Migration),
         ]
     }

--- a/migration/src/m0001080_sbom_add_versions.rs
+++ b/migration/src/m0001080_sbom_add_versions.rs
@@ -1,0 +1,43 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Sbom::Table)
+                    .add_column(
+                        ColumnDef::new(Sbom::Versions)
+                            .array(ColumnType::Text)
+                            .not_null()
+                            .default("{}"),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Sbom::Table)
+                    .drop_column(Sbom::Versions)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Sbom {
+    Table,
+    Versions,
+}

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1287,6 +1287,7 @@ async fn query_sboms_by_array_values(ctx: &TrustifyContext) -> Result<(), anyhow
     ctx.ingest_documents([
         "quarkus-bom-2.13.8.Final-redhat-00004.json",
         "spdx/rhelai1_binary.json",
+        "cyclonedx/container.json",
     ])
     .await?;
 
@@ -1309,6 +1310,25 @@ async fn query_sboms_by_array_values(ctx: &TrustifyContext) -> Result<(), anyhow
     query(2, "authors>ZZZ").await;
     query(2, "organization").await;
     query(1, "tool: syft").await;
+    query(1, "versions=2.13.8.Final-redhat-00004").await;
+    query(1, "versions~2.13.8").await;
+    query(1, "version~2.13.8").await;
+    query(1, "2.13.8.Final-redhat-00004").await;
+    query(1, ".8.Final-redhat").await;
+    query(
+        1,
+        "versions=sha256:fbf470d8b5b84606f797d78775b9de88e14fdb43cc47b2db6ff3747b46df323e",
+    )
+    .await;
+    query(1, "versions~fbf470d8b5").await;
+    query(1, "version~fbf470d8b5").await;
+    query(
+        1,
+        "sha256:fbf470d8b5b84606f797d78775b9de88e14fdb43cc47b2db6ff3747b46df323e",
+    )
+    .await;
+    query(1, "fbf470d8b5").await;
+    query(3, "").await;
 
     Ok(())
 }

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -141,6 +141,10 @@ impl SbomService {
                     .alias("sbom_node", "r0")
                     .translator(|f, op, v| match f.split_once(':') {
                         Some(("label", key)) => Some(format!("labels:{key}{op}{v}")),
+                        None => match f {
+                            "version" => Some(format!("versions{op}{v}")),
+                            _ => None,
+                        },
                         _ => None,
                     }),
             )?

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -195,6 +195,7 @@ impl VulnerabilityAdvisorySummary {
                 "sbom"."data_licenses" AS "sbom$data_licenses",
                 "sbom"."source_document_id" AS "sbom$source_document_id",
                 "sbom"."labels" AS "sbom$labels",
+                "sbom"."versions" AS "sbom$versions",
                 "sbom_package"."sbom_id" AS "sbom_package$sbom_id",
                 "sbom_package"."node_id" AS "sbom_package$node_id",
                 "sbom_package"."version" AS "sbom_package$version",

--- a/modules/graphql/src/sbom.rs
+++ b/modules/graphql/src/sbom.rs
@@ -26,6 +26,7 @@ impl SbomQuery {
                 suppliers: sbom_context.sbom.suppliers,
                 source_document_id: sbom_context.sbom.source_document_id,
                 data_licenses: sbom_context.sbom.data_licenses,
+                versions: sbom_context.sbom.versions,
             }),
             Ok(None) => Err(FieldError::new("SBOM not found")),
             Err(err) => Err(FieldError::from(err)),
@@ -68,6 +69,7 @@ impl SbomQuery {
                     suppliers: sbom.sbom.suppliers,
                     source_document_id: sbom.sbom.source_document_id,
                     data_licenses: sbom.sbom.data_licenses,
+                    versions: sbom.sbom.versions,
                 })
             })
             .collect()

--- a/modules/ingestor/src/graph/sbom/clearly_defined.rs
+++ b/modules/ingestor/src/graph/sbom/clearly_defined.rs
@@ -88,6 +88,7 @@ impl Into<SbomInformation> for &Curation {
             authors: vec!["ClearlyDefined: Community-Curated".to_string()],
             suppliers: vec![],
             data_licenses: vec![],
+            versions: vec![],
         }
     }
 }

--- a/modules/ingestor/src/graph/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/graph/sbom/cyclonedx.rs
@@ -121,6 +121,15 @@ impl<'a> From<Information<'a>> for SbomInformation {
             })
             .collect();
 
+        let versions = sbom
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.component.as_ref())
+            .and_then(|component| component.version.as_ref())
+            .into_iter()
+            .map(|v| v.to_string())
+            .collect();
+
         Self {
             node_id: CYCLONEDX_DOC_REF.to_string(),
             name,
@@ -128,6 +137,7 @@ impl<'a> From<Information<'a>> for SbomInformation {
             authors,
             suppliers,
             data_licenses,
+            versions,
         }
     }
 }

--- a/modules/ingestor/src/graph/sbom/mod.rs
+++ b/modules/ingestor/src/graph/sbom/mod.rs
@@ -50,6 +50,8 @@ pub struct SbomInformation {
     pub suppliers: Vec<String>,
     /// The licenses of the data itself, if known.
     pub data_licenses: Vec<String>,
+    /// The many versions of the described_by field
+    pub versions: Vec<String>,
 }
 
 impl From<()> for SbomInformation {
@@ -110,6 +112,7 @@ impl Graph {
             authors,
             suppliers,
             data_licenses,
+            versions,
         } = info.into();
 
         let new_id = match self
@@ -137,6 +140,7 @@ impl Graph {
             source_document_id: Set(Some(new_id)),
             labels: Set(labels.into().validate()?),
             data_licenses: Set(data_licenses),
+            versions: Set(versions),
         };
 
         let node_model = sbom_node::ActiveModel {

--- a/modules/ingestor/src/graph/sbom/spdx.rs
+++ b/modules/ingestor/src/graph/sbom/spdx.rs
@@ -72,6 +72,23 @@ fn suppliers(sbom: &SPDX) -> Vec<String> {
     Vec::from_iter(result)
 }
 
+/// Extract versions for a SPDX SBOM by collecting versions of describing packages
+fn versions(sbom: &SPDX) -> Vec<String> {
+    // packages describing the SBOM
+    let describing = describing_packages(sbom);
+
+    // collect versions for matching packages
+    let mut result = HashSet::new();
+    for p in &sbom.package_information {
+        if !describing.contains(p.package_spdx_identifier.as_str()) {
+            continue;
+        }
+        result.extend(p.package_version.clone());
+    }
+
+    Vec::from_iter(result)
+}
+
 impl<'a> From<Information<'a>> for SbomInformation {
     fn from(value: Information<'a>) -> Self {
         let sbom = value.0;
@@ -96,6 +113,7 @@ impl<'a> From<Information<'a>> for SbomInformation {
                 .clone(),
             suppliers: suppliers(sbom),
             data_licenses: vec![value.0.document_creation_information.data_license.clone()],
+            versions: versions(sbom),
         }
     }
 }

--- a/modules/ingestor/src/service/sbom/clearly_defined.rs
+++ b/modules/ingestor/src/service/sbom/clearly_defined.rs
@@ -66,6 +66,7 @@ impl<'g> ClearlyDefinedLoader<'g> {
                         authors: vec!["ClearlyDefined Definitions".to_string()],
                         suppliers: vec![],
                         data_licenses: vec![],
+                        versions: vec![],
                     },
                     &tx,
                 )


### PR DESCRIPTION
Along with https://github.com/trustification/trustify/pull/1749, this PR is partially fixing https://issues.redhat.com/browse/TC-2564 which is about using full text search to find information about version.

To be able to search versions data requires to have a `versions` column added to sbom table.
That's the main purpose of this PR. 
This will also allow to specifically search `versions` which is different than full text search across the sbom.

## Summary by Sourcery

Add a new "versions" field to SBOM entities and enable version-specific filtering

New Features:
- Persist a versions column in the SBOM database table with a migration
- Expose SBOM.versions in GraphQL queries and vulnerability advisory summaries

Enhancements:
- Populate the new versions field when ingesting SPDX, CycloneDX, and ClearlyDefined SBOMs
- Extend the SBOM search translator to support exact and substring matches on versions

Build:
- Add migration m0001080_sbom_add_versions to add and remove the versions column

Tests:
- Add integration tests for querying SBOMs by version filters