### PR TITLE
fix: mark advisory average scores and severites deprecated

### DIFF
--- a/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
+++ b/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
@@ -72,6 +72,7 @@ impl AdvisoryVulnerabilityHead {
                 .filter(advisory_vulnerability::Column::VulnerabilityId.eq(&vuln.id))
                 .one(tx)
                 .await?;
+
             if let Some(advisory_vuln) = advisory_vuln {
                 let head = if vuln.title.is_some() {
                     VulnerabilityHead::from_vulnerability_entity(vuln, Memo::NotProvided, tx)

--- a/modules/fundamental/src/advisory/model/details/mod.rs
+++ b/modules/fundamental/src/advisory/model/details/mod.rs
@@ -24,14 +24,17 @@ pub struct AdvisoryDetails {
 
     /// Average (arithmetic mean) severity of the advisory aggregated from *all* related vulnerability assertions.
     #[schema(required)]
+    #[deprecated]
     pub average_severity: Option<Severity>,
 
     /// Average (arithmetic mean) score of the advisory aggregated from *all* related vulnerability assertions.
     #[schema(required)]
+    #[deprecated]
     pub average_score: Option<f64>,
 }
 
 impl AdvisoryDetails {
+    #[allow(deprecated)]
     pub async fn from_entity<C: ConnectionTrait>(
         advisory: &AdvisoryCatcher,
         tx: &C,
@@ -62,8 +65,8 @@ impl AdvisoryDetails {
                 .as_ref()
                 .map(SourceDocument::from_entity),
             vulnerabilities,
-            average_severity: advisory.average_severity.map(|sev| sev.into()),
-            average_score: advisory.average_score,
+            average_severity: None,
+            average_score: None,
         })
     }
 }

--- a/modules/fundamental/src/advisory/service/test.rs
+++ b/modules/fundamental/src/advisory/service/test.rs
@@ -8,7 +8,7 @@ use time::OffsetDateTime;
 use trustify_common::{db::query::q, hashing::Digests, model::Paginated, purl::Purl};
 use trustify_cvss::cvss3::{
     AttackComplexity, AttackVector, Availability, Confidentiality, Cvss3Base, Integrity,
-    PrivilegesRequired, Scope, UserInteraction, severity::Severity,
+    PrivilegesRequired, Scope, UserInteraction,
 };
 use trustify_entity::labels::Labels;
 use trustify_entity::version_scheme::VersionScheme;
@@ -88,54 +88,6 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn all_advisories_filtered_by_average_score(
-    ctx: &TrustifyContext,
-) -> Result<(), anyhow::Error> {
-    ingest_and_link_advisory(ctx).await?;
-
-    ingest_sample_advisory(ctx, "RHSA-2", "RHSA-2").await?;
-
-    let fetch = AdvisoryService::new(ctx.db.clone());
-    let fetched = fetch
-        .fetch_advisories(
-            q("average_score>8"),
-            Paginated::default(),
-            Default::default(),
-            &ctx.db,
-        )
-        .await?;
-
-    assert_eq!(fetched.total, 1);
-    Ok(())
-}
-
-#[test_context(TrustifyContext)]
-#[test(actix_web::test)]
-async fn all_advisories_filtered_by_average_severity(
-    ctx: &TrustifyContext,
-) -> Result<(), anyhow::Error> {
-    ingest_and_link_advisory(ctx).await?;
-
-    ingest_sample_advisory(ctx, "RHSA-2", "RHSA-2").await?;
-
-    let fetch = AdvisoryService::new(ctx.db.clone());
-    let fetched = fetch
-        .fetch_advisories(
-            q("average_severity>=critical"),
-            Paginated::default(),
-            Default::default(),
-            &ctx.db,
-        )
-        .await?;
-
-    log::debug!("{:#?}", fetched);
-
-    assert_eq!(fetched.total, 1);
-    Ok(())
-}
-
-#[test_context(TrustifyContext)]
-#[test(actix_web::test)]
 async fn single_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let digests = Digests::digest("RHSA-1");
 
@@ -206,11 +158,10 @@ async fn single_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 sha512,
                 ..
             }),
-            average_severity: Some(average_severity),
-
+            average_severity: None,
                 ..
             })
-        if sha256 == jenny256.to_string() && sha384 == jenny384.to_string() && sha512 == jenny512.to_string() && average_severity == Severity::Critical));
+        if sha256 == jenny256.to_string() && sha384 == jenny384.to_string() && sha512 == jenny512.to_string()));
 
     let fetched = fetch.fetch_advisory(id, &ctx.db).await?;
     assert!(matches!(
@@ -223,11 +174,11 @@ async fn single_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 sha512,
                 ..
             }),
-            average_severity: Some(average_severity),
+            average_severity: None,
 
                 ..
             })
-        if sha256 == jenny256.to_string() && sha384 == jenny384.to_string() && sha512 == jenny512.to_string() && average_severity == Severity::Critical));
+        if sha256 == jenny256.to_string() && sha384 == jenny384.to_string() && sha512 == jenny512.to_string()));
 
     Ok(())
 }

--- a/modules/fundamental/src/ai/service/tools/advisory_info.rs
+++ b/modules/fundamental/src/ai/service/tools/advisory_info.rs
@@ -50,6 +50,7 @@ Advisories have a UUID that uniquely identifies the advisory.
         input_description("UUID of the Advisory. Example: 2fd0d1b7-a908-4d63-9310-d57a7f77c6df")
     }
 
+    #[allow(deprecated)]
     async fn run(&self, input: Value) -> Result<String, Box<dyn Error>> {
         let service = &self.service;
 
@@ -174,8 +175,8 @@ mod tests {
   "identifier": "RHSA-1",
   "issuer": null,
   "title": "RHSA-1",
-  "score": 9.1,
-  "severity": "critical",
+  "score": null,
+  "severity": null,
   "vulnerabilities": [
     {
       "identifier": "CVE-123",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3286,6 +3286,7 @@ components:
             - 'null'
             format: double
             description: Average (arithmetic mean) score of the advisory aggregated from *all* related vulnerability assertions.
+            deprecated: true
           average_severity:
             oneOf:
             - type: 'null'
@@ -3369,11 +3370,13 @@ components:
             - 'null'
             format: double
             description: Average (arithmetic mean) score of the advisory aggregated from *all* related vulnerability assertions.
+            deprecated: true
           average_severity:
             type:
             - string
             - 'null'
             description: Average (arithmetic mean) severity of the advisory aggregated from *all* related vulnerability assertions.
+            deprecated: true
           vulnerabilities:
             type: array
             items:
@@ -4103,11 +4106,13 @@ components:
                   - 'null'
                   format: double
                   description: Average (arithmetic mean) score of the advisory aggregated from *all* related vulnerability assertions.
+                  deprecated: true
                 average_severity:
                   type:
                   - string
                   - 'null'
                   description: Average (arithmetic mean) severity of the advisory aggregated from *all* related vulnerability assertions.
+                  deprecated: true
                 vulnerabilities:
                   type: array
                   items:


### PR DESCRIPTION
According to adr https://github.com/trustification/trustify/blob/main/docs/adrs/00004-advisory-scores.md
we don't want to calculate average scores for advisories anymore.
The values like aggregated severity will be extracted from appropriate advisories
and stored as labels.
This commit deprecates average score and severity fields in models and modifies the query to
stop calculating these values.