### PR TITLE
fix: set RUSTFLAGS for Windows binary build

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -118,6 +118,16 @@ jobs:
         run: |
           cargo binstall cross -y --force
 
+      # Workaround for https://github.com/actions/runner-images/issues/12432
+      # from https://github.com/rust-lang/rust/issues/141626#issuecomment-2919419236
+      # Visual Studio bug tracker https://developercommunity.visualstudio.com/t/Regression-from-1943:-linkexe-crashes/10912960
+      - name: Setup RUSTFLAGS (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('RUSTFLAGS', '-Csymbol-mangling-version=v0');
+
       - run: mkdir -p upload
 
       - name: Build | Build


### PR DESCRIPTION
fixes #1793 

Latest binary builds for Windows failed and it looks related to this issue https://github.com/actions/runner-images/issues/12432 which reports it as a consequence of https://github.com/rust-lang/rust/issues/141626.
From the last issue, I've applied the workaround of setting `-Csymbol-mangling-version=v0` in `RUSTFLAGS` when building on Windows.

To keep track of "everything", this is the Visual Studio bug reported to fix this https://developercommunity.visualstudio.com/t/Regression-from-1943:-linkexe-crashes/10912960 

CI won't really test this so merging it is fine in order to have the `latest-release` CI job to run it and check if it really works on GitHub Windows runner.