### PR TITLE
fix: properly filter cvss scores for the advisory

### DIFF
--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -85,7 +85,6 @@ impl VulnerabilityAdvisoryHead {
         }
     }
     pub async fn from_entities<C: ConnectionTrait>(
-        vulnerability: &vulnerability::Model,
         vuln_advisories: &[advisory::Model],
         vuln_cvss3s: &[cvss3::Model],
         tx: &C,
@@ -98,7 +97,7 @@ impl VulnerabilityAdvisoryHead {
             // filter all vulnerability cvss3 to those that pertain to only this advisory.
             let cvss3 = vuln_cvss3s
                 .iter()
-                .filter(|e| e.vulnerability_id == vulnerability.id)
+                .filter(|e| e.advisory_id == advisory.id)
                 .collect::<Vec<_>>();
 
             let score = if cvss3.is_empty() {

--- a/modules/fundamental/src/vulnerability/model/summary.rs
+++ b/modules/fundamental/src/vulnerability/model/summary.rs
@@ -70,13 +70,8 @@ impl VulnerabilitySummary {
                 .await?,
                 average_severity: vuln.base_severity.map(|s| s.into()),
                 average_score: vuln.base_score,
-                advisories: VulnerabilityAdvisoryHead::from_entities(
-                    vuln,
-                    advisories,
-                    vuln_cvss3s,
-                    tx,
-                )
-                .await?,
+                advisories: VulnerabilityAdvisoryHead::from_entities(advisories, vuln_cvss3s, tx)
+                    .await?,
             });
         }
 

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -457,6 +457,21 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     assert_eq!(vulns.items[0].average_score, Some(6.9));
     assert_eq!(vulns.items[0].average_severity, Some(Severity::Medium));
 
+    let vulns = service
+        .fetch_vulnerabilities(
+            q("CVE-2023-39325"),
+            Paginated::default(),
+            Default::default(),
+            &ctx.db,
+        )
+        .await?;
+    assert_eq!(1, vulns.items.len());
+    assert_eq!(2, vulns.items[0].advisories.len());
+    assert_eq!(vulns.items[0].advisories[0].score, Some(7.5));
+    assert_eq!(vulns.items[0].advisories[0].severity, Some(Severity::High));
+    assert_eq!(vulns.items[0].advisories[1].score, None);
+    assert_eq!(vulns.items[0].advisories[1].severity, None);
+
     Ok(())
 }
 


### PR DESCRIPTION
Currently the logic incorrectly filters CVSS scores based on the vulnerability ID instead of the advisory ID. This change ensures that only CVSS scores related to the specific advisory are included in the advisory summary.

## Summary by Sourcery

Fix CVSS filtering logic for advisory summaries to use advisory_id instead of vulnerability_id, update related invocation, and add validation tests

Bug Fixes:
- Filter CVSS scores by advisory_id in VulnerabilityAdvisoryHead instead of vulnerability_id
- Correct arguments passed to VulnerabilityAdvisoryHead::from_entities in vulnerability summary

Enhancements:
- Remove unused vulnerability parameter from VulnerabilityAdvisoryHead::from_entities signature

Tests:
- Add test verifying only advisory-specific CVSS scores are included in fetched vulnerabilities