### PR TITLE
fix(ui): prevent extract-purls endpoint from returning invalid purls

### DIFF
--- a/etc/test-data/cyclonedx/invalid-purl.json
+++ b/etc/test-data/cyclonedx/invalid-purl.json
@@ -1,0 +1,22 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "timestamp": "1970-01-01T13:30:00Z",
+    "component": {
+      "name": "simple",
+      "type": "application"
+    }
+  },
+  "components": [
+    {
+      "name": "A",
+      "version": "1",
+      "bom-ref": "a",
+      "purl": "invalid purl",
+      "type": "library"
+    }
+  ],
+  "dependencies": []
+}

--- a/modules/fundamental/src/vulnerability/model/analyze.rs
+++ b/modules/fundamental/src/vulnerability/model/analyze.rs
@@ -15,6 +15,12 @@ pub struct AnalysisRequest {
     pub purls: Vec<String>,
 }
 
+#[derive(Serialize, Deserialize, Debug, ToSchema, Default)]
+pub struct AnalysisResult {
+    pub details: Vec<AnalysisDetails>,
+    pub warnings: Vec<String>,
+}
+
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct AnalysisDetails {
     #[serde(flatten)]
@@ -97,10 +103,10 @@ pub struct Score {
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
-pub struct AnalysisResponse(pub BTreeMap<String, Vec<AnalysisDetails>>);
+pub struct AnalysisResponse(pub BTreeMap<String, AnalysisResult>);
 
 impl Deref for AnalysisResponse {
-    type Target = BTreeMap<String, Vec<AnalysisDetails>>;
+    type Target = BTreeMap<String, AnalysisResult>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod test;
 
+use crate::vulnerability::model::AnalysisResult;
 use crate::{
     Error,
     advisory::model::AdvisoryHead,
@@ -9,10 +10,11 @@ use crate::{
         VulnerabilityDetails, VulnerabilityHead, VulnerabilitySummary,
     },
 };
-use futures_util::{TryFutureExt, TryStreamExt};
+use futures_util::{TryFutureExt, TryStreamExt, future};
 use sea_orm::{
     EntityTrait, FromQueryResult, Statement, StreamTrait, TryGetableFromJson, prelude::*,
 };
+use std::collections::btree_map::Entry;
 use std::{
     collections::{BTreeMap, HashMap},
     str::FromStr,
@@ -25,7 +27,7 @@ use trustify_common::{
     },
     memo::Memo,
     model::{Paginated, PaginatedResults},
-    purl::{Purl, PurlErr},
+    purl::Purl,
 };
 use trustify_entity::{advisory, cvss3, vulnerability};
 use trustify_module_ingestor::common::Deprecation;
@@ -105,22 +107,40 @@ impl VulnerabilityService {
     where
         C: ConnectionTrait + StreamTrait,
     {
-        let query = Self::build_query(purls, connection)?;
+        let mut warnings = HashMap::new();
+        let query = Self::build_query(purls, connection, &mut warnings)?;
 
         let stmt = Statement::from_string(connection.get_database_backend(), query);
         log::debug!("Analyzing using: {stmt}");
         let result = connection.stream(stmt).map_err(Error::from).await?;
-        let result = result
+        let mut result = result
             .map_err(Error::from)
             .and_then(|row| Self::row_to_vuln(row, connection))
             .try_fold(
                 BTreeMap::new(),
-                |mut acc: BTreeMap<String, Vec<AnalysisDetails>>, (requested_purl, head)| async {
-                    acc.entry(requested_purl).or_default().push(head);
-                    Ok(acc)
+                |mut acc: BTreeMap<String, AnalysisResult>, (requested_purl, head)| {
+                    match acc.entry(requested_purl.clone()) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(AnalysisResult {
+                                details: vec![head],
+                                warnings: warnings.remove(&requested_purl).unwrap_or_default(),
+                            });
+                        }
+                        Entry::Occupied(mut entry) => {
+                            entry.get_mut().details.push(head);
+                        }
+                    };
+
+                    future::ok(acc)
                 },
             )
             .await?;
+
+        // add the remaining warnings
+
+        for (purl, warnings) in warnings {
+            result.entry(purl).or_default().warnings.extend(warnings);
+        }
 
         Ok(AnalysisResponse(result))
     }
@@ -129,12 +149,21 @@ impl VulnerabilityService {
     fn build_query(
         purls: impl IntoIterator<Item = impl AsRef<str>>,
         connection: &impl ConnectionTrait,
+        warnings: &mut HashMap<String, Vec<String>>,
     ) -> Result<String, Error> {
         let query = purls
             .into_iter()
             .map(|p| {
                 let p = p.as_ref();
                 let purl = Purl::from_str(p)?;
+
+                let Some(version) = purl.version else {
+                    warnings
+                        .entry(p.to_string())
+                        .or_default()
+                        .push("Unable to process: missing version component".to_string());
+                    return Ok(None);
+                };
 
                 let ns_condition = match &purl.namespace {
                     Some(namespace) => {
@@ -194,17 +223,12 @@ GROUP BY
                 let query = Statement::from_sql_and_values(
                     connection.get_database_backend(),
                     &sql,
-                    [
-                        p.into(),
-                        purl.name.into(),
-                        purl.ty.into(),
-                        purl.version
-                            .ok_or_else(|| PurlErr::MissingVersion(p.to_owned()))?
-                            .into(),
-                    ],
+                    [p.into(), purl.name.into(), purl.ty.into(), version.into()],
                 );
-                Ok(query.to_string())
+
+                Ok(Some(query.to_string()))
             })
+            .filter_map(Result::transpose)
             .collect::<Result<Vec<String>, Error>>()?
             .join(" UNION ALL ");
 

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -488,13 +488,32 @@ async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ])
     .await?;
 
-    let result = service.analyze_purls(Vec::<&str>::new(), &ctx.db).await?;
+    // test empty request
 
+    let result = service.analyze_purls(Vec::<&str>::new(), &ctx.db).await?;
     assert!(result.is_empty());
 
-    for purl in ["this is not valid", "pkg:npm/missing.version"].iter() {
+    // test some invalid PURLs
+
+    for purl in ["this is not valid"].iter() {
         let result = service.analyze_purls(vec![purl], &ctx.db).await;
         assert!(result.is_err());
+    }
+
+    // test some unsuitable PURLs
+
+    for purl in ["pkg:npm/missing.version"].iter() {
+        let result = service.analyze_purls(vec![purl], &ctx.db).await;
+        // must still be ok
+        assert!(result.is_ok(), "{purl} should not fail the request");
+        let result = result.unwrap();
+        // has exactly one entry
+        assert_eq!(result.len(), 1);
+        // which is the purl
+        let result = &result[*purl];
+        // and has one warning, but no details
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.details.is_empty());
     }
 
     let expected = [
@@ -533,18 +552,22 @@ async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test(tokio::test)]
 #[ignore = "Requires #1873"]
 async fn analyze_purls_no_score(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    const PURL: &str = "pkg:cargo/hyper@0.14.9";
+
     let service = VulnerabilityService::new();
 
     ctx.ingest_documents(["osv/RUSTSEC-2022-0022.json"]).await?;
 
-    let result = service
-        .analyze_purls(["pkg:cargo/hyper@0.14.9"], &ctx.db)
-        .await?;
+    let result = service.analyze_purls([PURL], &ctx.db).await?;
+
+    // ensure there is no warning
+
+    assert!(result[PURL].warnings.is_empty());
 
     // ensure we get an entry
 
     assert_eq!(result.len(), 1);
-    let advisory = &result["pkg:cargo/hyper@0.14.9"][0];
+    let advisory = &result[PURL].details[0];
     let status = &advisory.status["affected"][0];
 
     // the scores must be empty

--- a/modules/fundamental/tests/vuln/mod.rs
+++ b/modules/fundamental/tests/vuln/mod.rs
@@ -28,9 +28,14 @@ async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let entry = &result["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"];
 
+    // test for warnings (should be none)
+
+    assert!(entry.warnings.is_empty());
+
     // test for vulnerability IDs
 
     let ids = entry
+        .details
         .iter()
         .map(|vuln| &vuln.head.identifier)
         .sorted()
@@ -41,6 +46,7 @@ async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // now check advisories
 
     let vuln_entry = entry
+        .details
         .iter()
         .find(|e| e.head.identifier == "CVE-2024-28834")
         .expect("must find entry");

--- a/modules/ui/src/model.rs
+++ b/modules/ui/src/model.rs
@@ -8,6 +8,8 @@ pub struct ExtractResult {
     pub format: Format,
     /// packages of the SBOM
     pub packages: BTreeMap<String, ExtractPackage>,
+    /// warnings while parsing
+    pub warnings: Vec<String>,
 }
 
 /// Information extracted from a package

--- a/modules/ui/src/service.rs
+++ b/modules/ui/src/service.rs
@@ -4,14 +4,17 @@ use std::collections::BTreeMap;
 use trustify_common::purl::Purl;
 
 /// Extract PURLs from a SPDX file
-pub fn extract_spdx_purls(sbom: spdx_rs::models::SPDX) -> BTreeMap<String, ExtractPackage> {
+pub fn extract_spdx_purls(
+    sbom: spdx_rs::models::SPDX,
+    warnings: &mut Vec<String>,
+) -> BTreeMap<String, ExtractPackage> {
     let mut result = BTreeMap::<String, ExtractPackage>::new();
 
     for pkg in sbom.package_information {
         let mut purls = vec![];
         for er in pkg.external_reference {
             if er.reference_type == "purl" {
-                purls.extend(filter_purl(er.reference_locator));
+                purls.extend(filter_purl(er.reference_locator, warnings));
             }
         }
 
@@ -28,12 +31,17 @@ pub fn extract_spdx_purls(sbom: spdx_rs::models::SPDX) -> BTreeMap<String, Extra
 /// Extract PURLs from a CycloneDX file
 pub fn extract_cyclonedx_purls(
     sbom: serde_cyclonedx::cyclonedx::v_1_6::CycloneDx,
+    warnings: &mut Vec<String>,
 ) -> BTreeMap<String, ExtractPackage> {
     let mut result = BTreeMap::new();
 
-    fn scan_comps(result: &mut BTreeMap<String, ExtractPackage>, component: Component) {
+    fn scan_comps(
+        result: &mut BTreeMap<String, ExtractPackage>,
+        warnings: &mut Vec<String>,
+        component: Component,
+    ) {
         let mut purls = vec![];
-        if let Some(purl) = component.purl.and_then(filter_purl) {
+        if let Some(purl) = component.purl.and_then(|purl| filter_purl(purl, warnings)) {
             purls.push(purl);
         }
 
@@ -48,7 +56,7 @@ pub fn extract_cyclonedx_purls(
                 })
                 .filter(|id| id.field == "purl")
                 .flat_map(|id| id.concluded_value)
-                .flat_map(filter_purl),
+                .flat_map(|purl| filter_purl(purl, warnings)),
         );
 
         result
@@ -58,16 +66,16 @@ pub fn extract_cyclonedx_purls(
             .extend(purls);
 
         for comp in component.components.into_iter().flatten() {
-            scan_comps(result, comp);
+            scan_comps(result, warnings, comp);
         }
     }
 
     if let Some(component) = sbom.metadata.and_then(|md| md.component) {
-        scan_comps(&mut result, component);
+        scan_comps(&mut result, warnings, component);
     }
 
     for component in sbom.components.into_iter().flatten() {
-        scan_comps(&mut result, component);
+        scan_comps(&mut result, warnings, component);
     }
 
     result
@@ -76,25 +84,47 @@ pub fn extract_cyclonedx_purls(
 /// Filter out invalid PURLs
 ///
 /// If the PURL is valid, return the `Some(input)`, otherwise return `None`.
-fn filter_purl(purl: String) -> Option<String> {
-    Purl::try_from(purl.as_str()).ok().map(|_| purl)
+fn filter_purl(purl: String, warnings: &mut Vec<String>) -> Option<String> {
+    match Purl::try_from(purl.as_str()) {
+        Ok(_) => Some(purl),
+        Err(err) => {
+            warnings.push(format!("failed to parse purl: {err}"));
+            None
+        }
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
 
+    fn assert(purl: &str, error: Option<&str>) {
+        let mut warnings = vec![];
+        let result = filter_purl(String::from(purl), &mut warnings);
+
+        if let Some(error) = error {
+            assert!(result.is_none());
+            assert_eq!(warnings, vec![error.to_string()])
+        } else {
+            assert_eq!(result, Some(purl.into()));
+            assert!(warnings.is_empty());
+        }
+    }
+
     #[test]
     fn invalid() {
-        assert_eq!(filter_purl("".into()), None);
-        assert_eq!(filter_purl("pkg:".into()), None);
+        assert(
+            "",
+            Some("failed to parse purl: packageurl problem missing scheme"),
+        );
+        assert(
+            "pkg:",
+            Some("failed to parse purl: packageurl problem missing type"),
+        );
     }
 
     #[test]
     fn valid() {
-        assert_eq!(
-            filter_purl("pkg:golang/archive/tar".into()),
-            Some("pkg:golang/archive/tar".into())
-        );
+        assert("pkg:golang/archive/tar", None);
     }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3471,11 +3471,23 @@ components:
     AnalysisResponse:
       type: object
       additionalProperties:
-        type: array
-        items:
-          $ref: '#/components/schemas/AnalysisDetails'
+        $ref: '#/components/schemas/AnalysisResult'
       propertyNames:
         type: string
+    AnalysisResult:
+      type: object
+      required:
+      - details
+      - warnings
+      properties:
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/AnalysisDetails'
+        warnings:
+          type: array
+          items:
+            type: string
     AnalysisStatus:
       type: object
       required:
@@ -3804,6 +3816,7 @@ components:
       required:
       - format
       - packages
+      - warnings
       properties:
         format:
           $ref: '#/components/schemas/Format'
@@ -3815,6 +3828,11 @@ components:
             $ref: '#/components/schemas/ExtractPackage'
           propertyNames:
             type: string
+        warnings:
+          type: array
+          items:
+            type: string
+          description: warnings while parsing
     Format:
       type: string
       enum:


### PR DESCRIPTION
Closes: https://github.com/trustification/trustify/issues/1887

## Summary by Sourcery

Validate and filter PURLs in SPDX and CycloneDX extraction to prevent invalid PURLs from being returned

Bug Fixes:
- Filter out invalid PURLs from the extract-purls endpoints

Enhancements:
- Introduce filter_purl helper using Purl::try_from for validation
- Apply PURL validation in extract_spdx_purls and extract_cyclonedx_purls functions

Tests:
- Add unit tests for filter_purl to verify valid and invalid PURLs