### PR TITLE
chore: using custom bucket boundaries for http metrics

### DIFF
--- a/common/infrastructure/Cargo.toml
+++ b/common/infrastructure/Cargo.toml
@@ -21,7 +21,7 @@ mime = { workspace = true }
 openssl = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"] }
-opentelemetry_sdk = { workspace = true, features = ["metrics"] }
+opentelemetry_sdk = { workspace = true, features = ["metrics", "spec_unstable_metrics_views"] }
 opentelemetry-instrumentation-actix-web = { workspace = true, features = ["metrics"] }
 parking_lot = { workspace = true }
 reqwest = { workspace = true }


### PR DESCRIPTION
* This aligns with https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-metrics.md#metric-httpserverrequestduration
* This is related to https://github.com/trustification/trustify/issues/1898

## Summary by Sourcery

Configure custom histogram bucket boundaries for HTTP server duration metrics per OTEL conventions and enable metrics views support in the SDK.

Enhancements:
- Add a view for http.server.duration to use explicit bucket histogram boundaries and record min/max.
- Enable the spec_unstable_metrics_views feature in opentelemetry_sdk to support custom metric views.