### PR TITLE
ci: create a vendor archive during release builds

### DIFF
--- a/.github/scripts/vendor.sh
+++ b/.github/scripts/vendor.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# must be called from the root of the repository
+
+set -e
+set -x
+
+VERSION=${1:-5.27.0}
+shift || true
+
+cargo vendor > vendor.toml
+
+curl -sSL "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v${VERSION}.zip" -o vendor/swagger-ui.zip
+
+pushd vendor/trustify-ui/res
+npm ci --ignore-scripts
+popd

--- a/.github/scripts/vendor.sh
+++ b/.github/scripts/vendor.sh
@@ -5,12 +5,18 @@
 set -e
 set -x
 
-VERSION=${1:-5.27.0}
+VERSION=${1:-5.27.1}
+shift || true
+SHA256=${1:-15f1dc8c80663e5f2926818c1d8cf8ca5f97c4cbd494a90145c1e213d2c76dc3}
 shift || true
 
 cargo vendor > vendor.toml
 
 curl -sSL "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v${VERSION}.zip" -o vendor/swagger-ui.zip
+
+if [[ -n "$SHA256" ]]; then
+  echo "$SHA256" vendor/swagger-ui.zip | sha256sum --check
+fi
 
 pushd vendor/trustify-ui/res
 npm ci --ignore-scripts

--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -9,6 +9,29 @@ on:
 
 jobs:
 
+  vendor:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create vendor archive
+        run: |
+          .github/scripts/vendor.sh
+
+      - name: Stage vendor archive
+        run: |
+          tar caf vendor.tar.xz vendor
+
+      - name: Upload vendor archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: vendor
+          path: |
+            vendor.tar.xz
+            vendor.toml
+          if-no-files-found: error
+
   build:
     name: Build
     runs-on: ${{ matrix.os }}
@@ -109,6 +132,8 @@ jobs:
             core.exportVariable('RUSTFLAGS', '-Csymbol-mangling-version=v0');
 
       - run: mkdir -p upload
+
+      - run: npm --version
 
       - name: Build | Build
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@
 /dump.sql
 .ai_history.txt
 /vendor/
-/.vendor.toml
+/vendor.toml

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 /perf.data*
 /dump.sql
 .ai_history.txt
+/vendor/
+/.vendor.toml


### PR DESCRIPTION
In order to create a release build (downstream), we create a vendored archive with each release.

## Summary by Sourcery

Generate a vendored dependencies archive in CI for release builds by adding a dedicated vendor job and vendor.sh script, and streamline the build workflow by dropping cross compilation setup and cleaning up obsolete config

New Features:
- Introduce a vendor CI job to package and upload vendored dependencies (Rust and frontend) as an artifact
- Add vendor.sh script to vendor Rust crates, download Swagger UI, and install frontend modules

Enhancements:
- Simplify build-binary workflow by removing cross compilation setup, adjusting matrix targets, and adding an npm version check

CI:
- Create and upload vendor.tar.xz and vendor.toml artifacts in the release CI pipeline
- Remove obsolete cross setup step and related configuration in CI

Chores:
- Remove Cross.toml file