### PR TITLE
fix: test for analysis latest endpoint that ensures the latest sbom from all `products` are being returned

### DIFF
--- a/modules/analysis/src/endpoints/tests/latest_filters.rs
+++ b/modules/analysis/src/endpoints/tests/latest_filters.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::test::caller;
 
 use actix_http::Request;
@@ -219,7 +221,16 @@ async fn resolve_rh_variant_latest_filter_middleware_cdx(
     );
     let request: Request = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(request).await;
-    assert_eq!(response["total"], 2);
+    assert_eq!(response["total"], 3);
+    let items = response["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|e| e["product_name"].as_str())
+        .collect::<HashSet<_>>();
+
+    assert!(items.contains("quarkus-camel-bom"));
+    assert!(items.contains("quarkus-cxf-bom"));
 
     // name exact search
     let uri: String = format!(


### PR DESCRIPTION
## Summary by Sourcery

Fix test for the analysis latest endpoint to ensure it checks for the new expected total and verifies that the latest SBOMs from all products are included.

Bug Fixes:
- Update expected total from 2 to 3 in the latest_filters test
- Add assertions to confirm the presence of quarkus-camel-bom and quarkus-cxf-bom in the returned items