### PR TITLE
chore: change analysis status permission to `read`

### DIFF
--- a/modules/analysis/src/endpoints/mod.rs
+++ b/modules/analysis/src/endpoints/mod.rs
@@ -63,7 +63,7 @@ pub async fn analysis_status(
     _: Require<ReadSbom>,
 ) -> actix_web::Result<impl Responder> {
     // TODO: Replace with a more "admin" style permission when revisiting the permission system
-    authorizer.require(&user, Permission::CreateSbom)?;
+    authorizer.require(&user, Permission::ReadMetadata)?;
     Ok(HttpResponse::Ok().json(service.status(db.as_ref(), details).await?))
 }
 


### PR DESCRIPTION
see: https://issues.redhat.com/browse/TC-2550

Changed to ReadMetadata which apparently makes more sense as the expected result is some side graph information related:

```
{
    "graph_count": 0,
    "graph_max_memory": 209715200,
    "graph_memory": 0,
    "loading_operations": 0,
    "sbom_count": 0
}
```

For the testing-user this permission falls into `read:document` scope

Before:
```console
http localhost:8080/api/v2/analysis/status Authorization:$(oidc token trusty2 -b)
HTTP/1.1 403 Forbidden
access-control-allow-credentials: true
access-control-expose-headers: content-type
content-encoding: br
content-type: application/json
date: Tue, 26 Aug 2025 12:53:33 GMT
transfer-encoding: chunked
vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
vary: accept-encoding

{
    "error": "Forbidden",
    "message": "Authorization failed"
}
```

After:
```console
http localhost:8080/api/v2/analysis/status Authorization:$(oidc token trusty2 -b)
HTTP/1.1 200 OK
access-control-allow-credentials: true
access-control-expose-headers: content-type
content-encoding: br
content-type: application/json
date: Tue, 26 Aug 2025 12:55:04 GMT
transfer-encoding: chunked
vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
vary: accept-encoding

{
    "graph_count": 0,
    "graph_max_memory": 209715200,
    "graph_memory": 0,
    "loading_operations": 0,
    "sbom_count": 0
}
```

## Summary by Sourcery

Chores:
- Require ReadMetadata permission for analysis status endpoint instead of CreateSbom