### PR TITLE
Revert https://github.com/guacsec/trustify/pull/1921 [Backport release/0.3.z]

### DIFF
--- a/modules/analysis/src/service/test.rs
+++ b/modules/analysis/src/service/test.rs
@@ -298,13 +298,18 @@ async fn test_quarkus_analysis_service(ctx: &TrustifyContext) -> Result<(), anyh
     log::debug!("After: {analysis_graph:#?}");
 
     assert_root_traces(&analysis_graph.items, |traces| {
-        assert!(traces.contains(&[
+        assert!(
+            matches!(
+                traces,
+                [
+                    [..],
+                    [
                         Node {
                             id: "SPDXRef-e24fec28-1001-499c-827f-2e2e5f2671b5",
                             name: "quarkus-bom",
                             version: "3.2.12.Final-redhat-00002",
-                            cpes: &["cpe:/a:redhat:quarkus:3.2:*:el8:*",],
-                            purls: &[
+                            cpes: ["cpe:/a:redhat:quarkus:3.2:*:el8:*",],
+                            purls: [
                                 "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.12.Final-redhat-00002?repository_url=https://maven.repository.redhat.com/ga/&type=pom"
                             ],
                         },
@@ -312,10 +317,10 @@ async fn test_quarkus_analysis_service(ctx: &TrustifyContext) -> Result<(), anyh
                             id: "SPDXRef-DOCUMENT",
                             name: "quarkus-bom-3.2.12.Final-redhat-00002",
                             version: "",
-                            cpes: &[],
-                            purls: &[],
+                            ..
                         },
-                    ].as_slice()
+                    ]
+                ]
             ),
             "doesn't match: {traces:#?}"
         );

--- a/modules/importer/schema/importer.json
+++ b/modules/importer/schema/importer.json
@@ -533,15 +533,6 @@
               "type": "null"
             }
           ]
-        },
-        "concurrency": {
-          "description": "The maximum concurrent repository fetches",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 0
         }
       },
       "required": [

--- a/modules/importer/src/model/quay.rs
+++ b/modules/importer/src/model/quay.rs
@@ -33,10 +33,6 @@ pub struct QuayImporter {
     /// The max size of the ingested SBOM's (None is unlimited)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub size_limit: Option<BinaryByteSize>,
-
-    /// The maximum concurrent repository fetches
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub concurrency: Option<usize>,
 }
 
 pub const DEFAULT_SOURCE_QUAY: &str = "quay.io";

--- a/modules/importer/src/runner/quay/walker.rs
+++ b/modules/importer/src/runner/quay/walker.rs
@@ -1,27 +1,23 @@
 use super::oci::Reference;
-use crate::{
-    model::QuayImporter,
-    runner::{
-        common::Error,
-        context::RunContext,
-        progress::{Progress, ProgressInstance},
-        quay::oci,
-        report::{Message, Phase, ReportBuilder},
-    },
-};
-use anyhow::anyhow;
+use crate::model::QuayImporter;
+use crate::runner::common::Error;
+use crate::runner::context::RunContext;
+use crate::runner::progress::{Progress, ProgressInstance};
+use crate::runner::quay::oci;
+use crate::runner::report::{Message, Phase, ReportBuilder};
 use futures::{Stream, TryStreamExt, stream};
 use reqwest::header;
 use serde::Deserialize;
-use std::{collections::HashMap, future, sync::Arc};
+use std::future;
+use std::{collections::HashMap, sync::Arc};
 use time::OffsetDateTime;
 use tokio::sync::Mutex;
 use tracing::instrument;
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::service::{Cache, Format, IngestorService};
 
-/// Max number of concurrent repository fetches
-const DEFAULT_CONCURRENCY: usize = 32;
+// Max number of concurrent repository queries
+const CONCURRENCY: usize = 32;
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct LastModified(Option<i64>);
@@ -149,9 +145,9 @@ impl<C: RunContext> QuayWalker<C> {
 
     async fn sboms(&self) -> Result<Vec<Reference>, Error> {
         self.repositories(Some(String::new()))
-            .try_filter(|repo| future::ready(self.ingestible(repo)))
-            .map_ok(|repo| self.repository_details(repo))
-            .try_buffer_unordered(self.importer.concurrency.unwrap_or(DEFAULT_CONCURRENCY))
+            .try_filter(|v| future::ready(v.is_public && self.modified_since(v.last_modified)))
+            .map_ok(|v| self.repository(v.namespace, v.name))
+            .try_buffer_unordered(CONCURRENCY)
             .map_ok(|repo| {
                 stream::iter(
                     repo.sboms(&self.importer.source)
@@ -171,7 +167,6 @@ impl<C: RunContext> QuayWalker<C> {
                 if self.context.is_canceled().await {
                     return Err(Error::Canceled);
                 }
-                log::debug!("Fetching batch {page:?}");
                 let batch: Batch = self
                     .client
                     .get(self.importer.repositories_url(&page))
@@ -189,27 +184,15 @@ impl<C: RunContext> QuayWalker<C> {
         .try_flatten()
     }
 
-    async fn repository_details(&self, repo: Repository) -> Result<Repository, Error> {
-        if self.context.is_canceled().await {
-            return Err(Error::Canceled);
-        }
-        match (repo.namespace, repo.name) {
-            (Some(namespace), Some(name)) => {
-                let url = self.importer.repository_url(&namespace, &name);
-                log::debug!("Fetching {url}");
-                Ok(self.client.get(url).send().await?.json().await?)
-            }
-            _ => Err(Error::Processing(anyhow!(
-                "Repository name and namespace are required"
-            ))),
-        }
-    }
-
-    fn ingestible(&self, repo: &Repository) -> bool {
-        repo.namespace.is_some()
-            && repo.name.is_some()
-            && repo.is_public.is_some_and(|x| x)
-            && self.modified_since(repo.last_modified)
+    async fn repository(&self, namespace: String, name: String) -> Result<Repository, Error> {
+        log::debug!("Fetching {}/{namespace}/{name}", self.importer.source);
+        Ok(self
+            .client
+            .get(self.importer.repository_url(&namespace, &name))
+            .send()
+            .await?
+            .json()
+            .await?)
     }
 
     fn modified_since(&self, last_modified: Option<i64>) -> bool {
@@ -243,9 +226,9 @@ fn authorized_client(token: &str) -> Result<reqwest::Client, Error> {
 
 #[derive(Debug, Deserialize)]
 struct Repository {
-    namespace: Option<String>,
-    name: Option<String>,
-    is_public: Option<bool>,
+    namespace: String,
+    name: String,
+    is_public: bool,
     last_modified: Option<i64>,
     tags: Option<HashMap<String, Tag>>,
 }
@@ -259,11 +242,7 @@ impl Repository {
                 .map(|t| Sbom {
                     reference: Reference::with_tag(
                         registry.to_string(),
-                        format!(
-                            "{}/{}",
-                            self.namespace.clone().unwrap_or_default(),
-                            self.name.clone().unwrap_or_default()
-                        ),
+                        format!("{}/{}", self.namespace, self.name),
                         t.name.clone(),
                     ),
                     size: t.size.unwrap_or(u64::MAX),

--- a/modules/importer/src/runner/quay/walker.rs
+++ b/modules/importer/src/runner/quay/walker.rs
@@ -5,10 +5,9 @@ use crate::runner::context::RunContext;
 use crate::runner::progress::{Progress, ProgressInstance};
 use crate::runner::quay::oci;
 use crate::runner::report::{Message, Phase, ReportBuilder};
-use futures::{Stream, TryStreamExt, stream};
+use futures::{Stream, StreamExt, TryStreamExt, stream};
 use reqwest::header;
 use serde::Deserialize;
-use std::future;
 use std::{collections::HashMap, sync::Arc};
 use time::OffsetDateTime;
 use tokio::sync::Mutex;
@@ -141,21 +140,42 @@ impl<C: RunContext> QuayWalker<C> {
     }
 
     async fn sboms(&self) -> Result<Vec<Reference>, Error> {
-        self.repositories(Some(String::new()))
-            .try_filter(|v| future::ready(v.is_public && self.modified_since(v.last_modified)))
-            .map_ok(|v| self.repository(v.namespace, v.name))
-            .try_buffer_unordered(32)
-            .map_ok(|repo| {
-                stream::iter(
-                    repo.sboms(&self.importer.source)
-                        .into_iter()
-                        .map(Ok::<_, Error>), // try_flatten expects Results
-                )
+        let repositories = self
+            .repositories(Some(String::new()))
+            .try_fold(vec![], |mut acc, repo| async move {
+                if repo.is_public && self.modified_since(repo.last_modified) {
+                    acc.push(self.repository(repo.namespace, repo.name));
+                }
+                Ok(acc)
             })
-            .try_flatten()
-            .try_filter_map(|sbom| future::ready(Ok(self.valid(&sbom).then_some(sbom.reference))))
-            .try_collect()
-            .await
+            .await?;
+        let tags: Vec<(Reference, u64)> = stream::iter(repositories)
+            .buffer_unordered(32) // TODO: make configurable
+            .filter_map(|repo_result| async move {
+                match repo_result {
+                    Ok(repo) => repo.sboms(&self.importer.source),
+                    Err(e) => {
+                        log::warn!("Error retrieving repository: {e}");
+                        let mut report = self.report.lock().await;
+                        report.add_error(Phase::Retrieval, "repository", e.to_string());
+                        None
+                    }
+                }
+            })
+            .map(stream::iter)
+            .flatten()
+            .collect()
+            .await;
+        Ok(tags
+            .into_iter()
+            .filter_map(|(reference, size)| {
+                if self.too_big(size) {
+                    None
+                } else {
+                    Some(reference)
+                }
+            })
+            .collect())
     }
 
     fn repositories(&self, page: Option<String>) -> impl Stream<Item = Result<Repository, Error>> {
@@ -202,10 +222,10 @@ impl<C: RunContext> QuayWalker<C> {
         }
     }
 
-    fn valid(&self, sbom: &SBOM) -> bool {
+    fn too_big(&self, size: u64) -> bool {
         match self.importer.size_limit {
-            None => true,
-            Some(max) => sbom.size <= max.as_u64(),
+            None => false,
+            Some(max) => size > max.as_u64(),
         }
     }
 }
@@ -231,22 +251,22 @@ struct Repository {
 }
 
 impl Repository {
-    fn sboms(&self, registry: &str) -> Vec<SBOM> {
-        match &self.tags {
-            Some(tags) => tags
-                .values()
+    fn sboms(&self, registry: &str) -> Option<Vec<(Reference, u64)>> {
+        self.tags.as_ref().map(|tags| {
+            tags.values()
                 .filter(|t| t.name.ends_with(".sbom"))
-                .map(|t| SBOM {
-                    reference: Reference::with_tag(
-                        registry.to_string(),
-                        format!("{}/{}", self.namespace, self.name),
-                        t.name.clone(),
-                    ),
-                    size: t.size.unwrap_or(u64::MAX),
+                .map(|t| {
+                    (
+                        Reference::with_tag(
+                            registry.to_string(),
+                            format!("{}/{}", self.namespace, self.name),
+                            t.name.clone(),
+                        ),
+                        t.size.unwrap_or(u64::MAX),
+                    )
                 })
-                .collect(),
-            None => vec![],
-        }
+                .collect()
+        })
     }
 }
 
@@ -260,12 +280,6 @@ struct Batch {
 struct Tag {
     name: String,
     size: Option<u64>,
-}
-
-#[derive(Debug)]
-struct SBOM {
-    reference: Reference,
-    size: u64,
 }
 
 #[cfg(test)]
@@ -283,7 +297,7 @@ mod test {
             QuayImporter {
                 source: "quay.io".into(),
                 namespace: Some("redhat-user-workloads".into()),
-                size_limit: Some(ByteSize::kib(5).into()),
+                size_limit: Some(ByteSize::kib(3).into()),
                 ..Default::default()
             },
             ctx.ingestor.clone(),

--- a/modules/importer/src/runner/quay/walker.rs
+++ b/modules/importer/src/runner/quay/walker.rs
@@ -5,7 +5,7 @@ use crate::runner::context::RunContext;
 use crate::runner::progress::{Progress, ProgressInstance};
 use crate::runner::quay::oci;
 use crate::runner::report::{Message, Phase, ReportBuilder};
-use futures::{Stream, StreamExt, TryStreamExt, stream};
+use futures::{Stream, StreamExt, TryStreamExt, future, stream};
 use reqwest::header;
 use serde::Deserialize;
 use std::{collections::HashMap, sync::Arc};
@@ -151,17 +151,7 @@ impl<C: RunContext> QuayWalker<C> {
             .await?;
         let tags: Vec<(Reference, u64)> = stream::iter(repositories)
             .buffer_unordered(32) // TODO: make configurable
-            .filter_map(|repo_result| async move {
-                match repo_result {
-                    Ok(repo) => repo.sboms(&self.importer.source),
-                    Err(e) => {
-                        log::warn!("Error retrieving repository: {e}");
-                        let mut report = self.report.lock().await;
-                        report.add_error(Phase::Retrieval, "repository", e.to_string());
-                        None
-                    }
-                }
-            })
+            .filter_map(|repo| future::ready(repo.unwrap_or_default().sboms(&self.importer.source)))
             .map(stream::iter)
             .flatten()
             .collect()
@@ -241,7 +231,7 @@ fn authorized_client(token: &str) -> Result<reqwest::Client, Error> {
         .build()?)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 struct Repository {
     namespace: String,
     name: String,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4755,12 +4755,6 @@ components:
             - string
             - 'null'
             description: The API token authorizing access to the quay registry
-          concurrency:
-            type:
-            - integer
-            - 'null'
-            description: The maximum concurrent repository fetches
-            minimum: 0
           namespace:
             type:
             - string

--- a/server/src/sample_data.rs
+++ b/server/src/sample_data.rs
@@ -165,7 +165,7 @@ async fn add_quay(
             source: DEFAULT_SOURCE_QUAY.into(),
             namespace: Some(namespace.into()),
             size_limit: Some(ByteSize::mib(1).into()),
-            ..Default::default()
+            api_token: None,
         }),
     )
     .await

--- a/xtask/schema/generate-dump.json
+++ b/xtask/schema/generate-dump.json
@@ -547,15 +547,6 @@
               "type": "null"
             }
           ]
-        },
-        "concurrency": {
-          "description": "The maximum concurrent repository fetches",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 0
         }
       },
       "required": [


### PR DESCRIPTION
Reverts the eight commits in https://github.com/guacsec/trustify/pull/1921 as evaluated not in scope for the very next upstream release but deferred to a later one.