### PR TITLE
chore: move (and rename) trustify-load-test-runs

### DIFF
--- a/.github/workflows/scale-test.yaml
+++ b/.github/workflows/scale-test.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: "trustification/trustify-load-test-runs"
+          repository: "guacsec/trustify-scale-test-runs"
 
       - run: |
           mkdir report
@@ -60,7 +60,7 @@ jobs:
         run: |
           cp publish/baseline.json baseline/
 
-      # 'rev' supports the PR number in https://github.com/trustification/trustify-load-test-runs/blob/main/Containerfile.trustify
+      # 'rev' supports the PR number in https://github.com/guacsec/trustify-scale-test-runs/blob/main/Containerfile.trustify
       # the PR number is stored in 'github.event.issue.number' when managing an 'issue_comment' event as reported in
       # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only
       - name: Build Containers

--- a/README.md
+++ b/README.md
@@ -267,11 +267,11 @@ CPE (Product?) and/or pURLs described by the SBOM
 ## Related Projects
 
 * [Trustify user interface](https://github.com/guacsec/trustify-ui)
-* [Helm charts used for the Trustify deployment](https://github.com/trustification/trustify-helm-charts)
+* [Helm charts used for the Trustify deployment](https://github.com/guacsec/trustify-helm-charts)
 * [OpenShift Operator used for the Trustify deployment](https://github.com/trustification/trustify-operator)
 * [Ansible playbooks used for the Trustify deployment](https://github.com/trustification/trustify-ansible)
 * [Trustify API & user interface test suite](https://github.com/trustification/trustify-tests)
-* [Trustify load tests runner](https://github.com/trustification/trustify-load-test-runs)
-* [Trustify load test suite](https://github.com/trustification/scale-testing)
+* [Trustify load tests runner](https://github.com/guacsec/trustify-scale-test-runs)
+* [Trustify load test suite](https://github.com/guacsec/scale-testing)
 * [Trustify GitHub CI helpers](https://github.com/trustification/trustify-ci)
 * [Trustify release tools](https://github.com/guacsec/trustify-release-tools)


### PR DESCRIPTION
The repo has been renamed to `trustify-scale-test-runs` in the process as it has more sense (being connected to `scale-testing` repo)