### PR TITLE
chore: remove e2e tests from release workflow

### DIFF
--- a/.github/workflows/latest-release.yaml
+++ b/.github/workflows/latest-release.yaml
@@ -113,20 +113,11 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-  e2e-test:
-    needs: publish
-    uses: trustification/trustify-ci/.github/workflows/global-ci.yml@main
-    with:
-      server_image: ${{ needs.publish.outputs.image }}
-      run_api_tests: true
-      run_ui_tests: true
-
   deploy:
     if: ${{ (github.repository == 'guacsec/trustify') && (needs.init.outputs.version == 'main') }}
     runs-on: ubuntu-24.04
     needs:
       - publish
-      - e2e-test
 
     steps:
 


### PR DESCRIPTION
e2e tests are already ran in the UI, so no need to run them here as well.

## Summary by Sourcery

CI:
- Remove redundant e2e-test job and its deploy dependency from the release workflow