### PR TITLE
chore: remove e2e tests from release workflow

### DIFF
--- a/.github/workflows/latest-release.yaml
+++ b/.github/workflows/latest-release.yaml
@@ -113,20 +113,11 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-  e2e-test:
-    needs: publish
-    uses: trustification/trustify-ci/.github/workflows/global-ci.yml@main
-    with:
-      server_image: ${{ needs.publish.outputs.image }}
-      run_api_tests: true
-      run_ui_tests: true
-
   deploy:
     if: ${{ (github.repository == 'trustification/trustify') && (needs.init.outputs.version == 'main') }}
     runs-on: ubuntu-24.04
     needs:
       - publish
-      - e2e-test
 
     steps:
 


### PR DESCRIPTION
e2e tests are already ran in the UI, so no need to run them here as well.

(cherry picked from commit ebda0ef4482ce1fb5f4d2d98f51ffdd2df439773)

## Summary by Sourcery

Remove the redundant e2e-test job and its references from the latest-release GitHub Actions workflow

CI:
- Drop the e2e-test job from latest-release.yaml
- Remove the e2e-test dependency from the deploy job