### PR TITLE
feat: add licence filter for PURLs (TC-2831)

### DIFF
--- a/common/src/db/func.rs
+++ b/common/src/db/func.rs
@@ -76,3 +76,14 @@ impl UpdateDeprecatedAdvisory {
         db.execute(stmt).await
     }
 }
+
+/// The function expanding the license replacing all 'LicenseRef-' instances
+/// with the actual license they refer to.
+pub struct ExpandLicenseExpression;
+
+impl Iden for ExpandLicenseExpression {
+    #[allow(clippy::unwrap_used)]
+    fn unquoted(&self, s: &mut dyn Write) {
+        write!(s, "expand_license_expression").unwrap()
+    }
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -25,6 +25,7 @@ mod m0001100_remove_get_purl;
 mod m0001110_sbom_node_checksum_indexes;
 mod m0001120_sbom_external_node_indexes;
 mod m0001130_gover_cmp;
+mod m0001140_expand_spdx_licenses_function;
 
 pub struct Migrator;
 
@@ -57,6 +58,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001110_sbom_node_checksum_indexes::Migration),
             Box::new(m0001120_sbom_external_node_indexes::Migration),
             Box::new(m0001130_gover_cmp::Migration),
+            Box::new(m0001140_expand_spdx_licenses_function::Migration),
         ]
     }
 }

--- a/migration/src/m0001140_expand_spdx_licenses_function.rs
+++ b/migration/src/m0001140_expand_spdx_licenses_function.rs
@@ -1,0 +1,84 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Indexes supporting the query on licensing_infos table added with the SQL script below
+        manager
+            .create_index(
+                Index::create()
+                    .table(LicensingInfos::Table)
+                    .name(Indexes::SbomIdIdx.to_string())
+                    .col(LicensingInfos::SbomId)
+                    .to_owned(),
+            )
+            .await?;
+        // Indexes supporting the sorting on licensing_infos table added with the SQL script below
+        manager
+            .create_index(
+                Index::create()
+                    .table(LicensingInfos::Table)
+                    .name(Indexes::LicenseIdIdx.to_string())
+                    .col(LicensingInfos::LicenseId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0001140_expand_spdx_licenses_function/expand_up.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("DROP FUNCTION IF EXISTS expand_license_expression(TEXT, UUID);")
+            .await
+            .map(|_| ())?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(LicensingInfos::Table)
+                    .name(Indexes::LicenseIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(LicensingInfos::Table)
+                    .name(Indexes::SbomIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+pub enum Indexes {
+    LicenseIdIdx,
+    SbomIdIdx,
+}
+
+#[derive(DeriveIden)]
+pub enum LicensingInfos {
+    Table,
+    LicenseId,
+    SbomId,
+}

--- a/migration/src/m0001140_expand_spdx_licenses_function.rs
+++ b/migration/src/m0001140_expand_spdx_licenses_function.rs
@@ -6,23 +6,13 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        // Indexes supporting the query on licensing_infos table added with the SQL script below
+        // Index supporting the query on licensing_infos table added with the SQL script below
         manager
             .create_index(
                 Index::create()
                     .table(LicensingInfos::Table)
                     .name(Indexes::SbomIdIdx.to_string())
                     .col(LicensingInfos::SbomId)
-                    .to_owned(),
-            )
-            .await?;
-        // Indexes supporting the sorting on licensing_infos table added with the SQL script below
-        manager
-            .create_index(
-                Index::create()
-                    .table(LicensingInfos::Table)
-                    .name(Indexes::LicenseIdIdx.to_string())
-                    .col(LicensingInfos::LicenseId)
                     .to_owned(),
             )
             .await?;
@@ -50,16 +40,6 @@ impl MigrationTrait for Migration {
                 Index::drop()
                     .if_exists()
                     .table(LicensingInfos::Table)
-                    .name(Indexes::LicenseIdIdx.to_string())
-                    .to_owned(),
-            )
-            .await?;
-
-        manager
-            .drop_index(
-                Index::drop()
-                    .if_exists()
-                    .table(LicensingInfos::Table)
                     .name(Indexes::SbomIdIdx.to_string())
                     .to_owned(),
             )
@@ -72,13 +52,11 @@ impl MigrationTrait for Migration {
 #[allow(clippy::enum_variant_names)]
 #[derive(DeriveIden)]
 pub enum Indexes {
-    LicenseIdIdx,
     SbomIdIdx,
 }
 
 #[derive(DeriveIden)]
 pub enum LicensingInfos {
     Table,
-    LicenseId,
     SbomId,
 }

--- a/migration/src/m0001140_expand_spdx_licenses_function.rs
+++ b/migration/src/m0001140_expand_spdx_licenses_function.rs
@@ -17,6 +17,17 @@ impl MigrationTrait for Migration {
             )
             .await?;
 
+        // Index supporting the query on licensing_infos table added with the SQL script below
+        manager
+            .create_index(
+                Index::create()
+                    .table(SbomPackageLicense::Table)
+                    .name(Indexes::LicenseIdIdx.to_string())
+                    .col(SbomPackageLicense::LicenseId)
+                    .to_owned(),
+            )
+            .await?;
+
         manager
             .get_connection()
             .execute_unprepared(include_str!(
@@ -39,6 +50,16 @@ impl MigrationTrait for Migration {
             .drop_index(
                 Index::drop()
                     .if_exists()
+                    .table(SbomPackageLicense::Table)
+                    .name(Indexes::LicenseIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
                     .table(LicensingInfos::Table)
                     .name(Indexes::SbomIdIdx.to_string())
                     .to_owned(),
@@ -53,10 +74,17 @@ impl MigrationTrait for Migration {
 #[derive(DeriveIden)]
 pub enum Indexes {
     SbomIdIdx,
+    LicenseIdIdx,
 }
 
 #[derive(DeriveIden)]
 pub enum LicensingInfos {
     Table,
     SbomId,
+}
+
+#[derive(DeriveIden)]
+pub enum SbomPackageLicense {
+    Table,
+    LicenseId,
 }

--- a/migration/src/m0001140_expand_spdx_licenses_function/expand_up.sql
+++ b/migration/src/m0001140_expand_spdx_licenses_function/expand_up.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE FUNCTION expand_license_expression(
+    license_text TEXT,
+    sbom_id_param UUID
+) RETURNS TEXT AS $$
+DECLARE
+    result_text TEXT := license_text;
+    license_mapping RECORD;
+BEGIN
+    -- Replace each license reference with its corresponding name
+    FOR license_mapping IN
+        SELECT license_id, name
+        FROM licensing_infos
+        WHERE sbom_id = sbom_id_param
+        ORDER BY LENGTH(license_id) DESC
+    LOOP
+        -- Replace the license_id with the license name in the expression
+        -- This handles exact matches and license references within expressions
+        result_text := REPLACE(result_text, license_mapping.license_id, license_mapping.name);
+END LOOP;
+
+RETURN result_text;
+END;
+$$ LANGUAGE plpgsql;

--- a/migration/src/m0001140_expand_spdx_licenses_function/expand_up.sql
+++ b/migration/src/m0001140_expand_spdx_licenses_function/expand_up.sql
@@ -14,7 +14,7 @@ BEGIN
     LOOP
         -- Replace the license_id with the license name in the expression
         -- This handles exact matches and license references within expressions
-        result_text := regexp_replace(result_text, '\m' || license_mapping.license_id || '\M', license_mapping.name);
+        result_text := regexp_replace(result_text, '\m' || license_mapping.license_id || '\M', license_mapping.name, 'g');
 END LOOP;
 
 RETURN result_text;

--- a/migration/src/m0001140_expand_spdx_licenses_function/expand_up.sql
+++ b/migration/src/m0001140_expand_spdx_licenses_function/expand_up.sql
@@ -19,4 +19,4 @@ END LOOP;
 
 RETURN result_text;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE PARALLEL SAFE;

--- a/migration/src/m0001140_expand_spdx_licenses_function/expand_up.sql
+++ b/migration/src/m0001140_expand_spdx_licenses_function/expand_up.sql
@@ -11,11 +11,10 @@ BEGIN
         SELECT license_id, name
         FROM licensing_infos
         WHERE sbom_id = sbom_id_param
-        ORDER BY LENGTH(license_id) DESC
     LOOP
         -- Replace the license_id with the license name in the expression
         -- This handles exact matches and license references within expressions
-        result_text := REPLACE(result_text, license_mapping.license_id, license_mapping.name);
+        result_text := regexp_replace(result_text, '\m' || license_mapping.license_id || '\M', license_mapping.name);
 END LOOP;
 
 RETURN result_text;

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -297,6 +297,7 @@ impl PurlService {
         paginated: Paginated,
         connection: &C,
     ) -> Result<PaginatedResults<PurlSummary>, Error> {
+        const LICENSE: &str = "license";
         let mut select = qualified_purl::Entity::find().filtering_with(
             query.clone(),
             qualified_purl::Entity
@@ -308,7 +309,7 @@ impl PurlService {
                     "purl" => Purl::translate(op, v),
                     // Add an empty condition (effectively TRUE) to the main SQL query
                     // since the real filtering by license happens in the license subqueries below
-                    "license" => Some("".to_string()),
+                    LICENSE => Some("".to_string()),
                     _ => None,
                 }),
         )?;
@@ -318,7 +319,7 @@ impl PurlService {
         // that will match the input query criteria must be among the one satisfying
         // the license values requested in the input query itself.
         if let Some(license_query) = query
-            .get_constraint_for_field("license")
+            .get_constraint_for_field(LICENSE)
             .map(|constraint| q(&format!("{constraint}")))
         {
             let mut select_packages_from_spdx =

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -11,19 +11,19 @@ use sea_orm::{
     ColumnTrait, ConnectionTrait, EntityTrait, FromQueryResult, IntoIdentity, QueryFilter,
     QueryOrder, QuerySelect, QueryTrait, RelationTrait, Select, prelude::Uuid,
 };
-use sea_query::extension::postgres::PgExpr;
-use sea_query::{ColumnType, Expr, Func, JoinType, Order, SelectStatement, SimpleExpr, UnionType};
+use sea_query::{
+    ColumnType, Expr, Func, JoinType, Order, SelectStatement, SimpleExpr, UnionType,
+    extension::postgres::PgExpr,
+};
 use tracing::instrument;
-use trustify_common::db::query::{Columns, q};
 use trustify_common::{
     db::{
         limiter::LimiterTrait,
-        query::{Filtering, IntoColumns, Query},
+        query::{Columns, Filtering, IntoColumns, Query, q},
     },
     model::{Paginated, PaginatedResults},
     purl::{Purl, PurlErr},
 };
-use trustify_entity::sbom_package_purl_ref::Entity;
 use trustify_entity::{
     base_purl, license,
     qualified_purl::{self, CanonicalPurl},
@@ -404,7 +404,7 @@ impl PurlService {
             .into_query())
     }
 
-    fn create_license_filtering_base_query() -> Select<Entity> {
+    fn create_license_filtering_base_query() -> Select<sbom_package_purl_ref::Entity> {
         sbom_package_purl_ref::Entity::find()
             .select_only()
             .column(sbom_package_purl_ref::Column::QualifiedPurlId)

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -653,6 +653,17 @@ async fn qualified_packages_filter_by_license(ctx: &TrustifyContext) -> Result<(
 
     let results = service
         .purls(
+            q("license=GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD|Apache License 2.0"),
+            Paginated::default(),
+            &ctx.db,
+        )
+        .await?;
+
+    log::debug!("{results:#?}");
+    assert_eq!(4, results.items.len());
+
+    let results = service
+        .purls(
             q("license=GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD&lib"),
             Paginated::default(),
             &ctx.db,
@@ -675,8 +686,6 @@ async fn qualified_packages_filter_by_license(ctx: &TrustifyContext) -> Result<(
     log::debug!("{results:#?}");
     assert_eq!(4, results.items.len());
 
-    ctx.ingest_document("cyclonedx/rh/latest_filters/container/quay_builder_qemu_rhcos_rhel8_2025-02-24/quay-builder-qemu-rhcos-rhel-8-amd64.json")
-        .await?;
     let results = service
         .purls(
             q("license=GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD&lib&version=8.5.0-22.el8_10"),

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -732,6 +732,22 @@ async fn qualified_packages_filter_by_license(ctx: &TrustifyContext) -> Result<(
     // Should return no items or handle gracefully
     assert_eq!(0, invalid_results.items.len());
 
+    // Pagination for just having the total count
+    let results = service
+        .purls(
+            q("license=GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"),
+            Paginated {
+                offset: 0,
+                limit: 1,
+            },
+            &ctx.db,
+        )
+        .await?;
+
+    log::debug!("{results:#?}");
+    assert_eq!(1, results.items.len());
+    assert_eq!(4, results.total);
+
     Ok(())
 }
 

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -699,6 +699,30 @@ async fn qualified_packages_filter_by_license(ctx: &TrustifyContext) -> Result<(
     log::debug!("{results:#?}");
     assert_eq!(0, results.items.len());
 
+    // Negative test: empty license query
+    let empty_results = service
+        .purls(q("license="), Paginated::default(), &ctx.db)
+        .await?;
+    log::debug!("Empty license query results: {empty_results:#?}");
+    // Should return no items or handle gracefully
+    assert_eq!(0, empty_results.items.len());
+
+    // Negative test: malformed license query
+    let malformed_results = service
+        .purls(q("license=!!!not_a_license"), Paginated::default(), &ctx.db)
+        .await?;
+    log::debug!("Malformed license query results: {malformed_results:#?}");
+    // Should return no items or handle gracefully
+    assert_eq!(0, malformed_results.items.len());
+
+    // Negative test: invalid license query
+    let invalid_results = service
+        .purls(q("license=INVALID_LICENSE"), Paginated::default(), &ctx.db)
+        .await?;
+    log::debug!("Invalid license query results: {invalid_results:#?}");
+    // Should return no items or handle gracefully
+    assert_eq!(0, invalid_results.items.len());
+
     Ok(())
 }
 

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -636,7 +636,7 @@ async fn qualified_packages_filter_by_license(ctx: &TrustifyContext) -> Result<(
         )
         .await?;
 
-    log::debug!("{results:#?}");
+    // log::debug!("{results:#?}");
     // MTV SBOM contains 2 packages with the specified license
     assert_eq!(2, results.items.len());
 
@@ -661,6 +661,26 @@ async fn qualified_packages_filter_by_license(ctx: &TrustifyContext) -> Result<(
 
     log::debug!("{results:#?}");
     assert_eq!(4, results.items.len());
+
+    let results = service
+        .purls(
+            q("license~GPLv3+ with exceptions|Apache"),
+            Paginated::default(),
+            &ctx.db,
+        )
+        .await?;
+
+    log::debug!("{results:#?}");
+    // 'GPLv3+ with exceptions' is used in:
+    // "LicenseRef-12" => used in 2 packages
+    // "LicenseRef-16" => used in 1 package
+    //
+    // 'Apache' is used in:
+    // "LicenseRef-0" => used in 2 packages
+    // "LicenseRef-Apache" => never used in any package
+    // + directly declared in 52 packages
+    // Total = used in 57 packages
+    assert_eq!(57, results.items.len());
 
     let results = service
         .purls(


### PR DESCRIPTION
Adds license-based filtering to PURL queries, enabling searches like `license=GPLv3+`.

**Changes**

  - Implemented two-phase filtering strategy:
    - SPDX: Uses `expand_license_expression()` for LicenseRef resolution
    - CycloneDX: Direct text matching on license field
    - Results combined via UNION DISTINCT and used to filter main query to filter by `WHERE id IN (...)`
  - Added PostgreSQL function `expand_license_expression()` to resolve SPDX LicenseRef references
  - Created performance indexes on `licensing_infos` table
  - Added `get_constraint_for_field()` for extracting license constraints

Relates to [TC-2831](https://issues.redhat.com/browse/TC-2831)

## Summary by Sourcery

Add license filtering support to the PURL service by extending the query builder to recognize a license field, implementing two-phase subqueries for SPDX and CycloneDX documents, introducing a PostgreSQL function to resolve license references, and ensuring coverage with integration tests.

New Features:
- Support license-based filtering in PURL queries using a two-phase approach (SPDX with expand_license_expression and CycloneDX direct matching)

Enhancements:
- Add Query.get_constraint_for_field to extract field-specific constraints for license filtering

Build:
- Introduce a new database migration to create the expand_license_expression function and add an index on licensing_infos.sbom_id

Tests:
- Add integration tests for PURL license filtering covering positive, empty, malformed, and invalid scenarios