### PR TITLE
feat(fundamental): return all scores in addition for sbom advisories

### DIFF
--- a/modules/fundamental/src/common/mod.rs
+++ b/modules/fundamental/src/common/mod.rs
@@ -6,6 +6,7 @@ use trustify_entity::sbom_package_license::LicenseCategory;
 use utoipa::ToSchema;
 
 pub mod license_filtering;
+pub mod model;
 pub mod service;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, FromQueryResult)]

--- a/modules/fundamental/src/common/model/mod.rs
+++ b/modules/fundamental/src/common/model/mod.rs
@@ -1,0 +1,2 @@
+mod score;
+pub use score::*;

--- a/modules/fundamental/src/common/model/score.rs
+++ b/modules/fundamental/src/common/model/score.rs
@@ -1,0 +1,134 @@
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use trustify_cvss::cvss3::severity::Severity;
+use trustify_entity::cvss3;
+use utoipa::{
+    PartialSchema, ToSchema,
+    openapi::{
+        ObjectBuilder, RefOr, Schema, Type, extensions::ExtensionsBuilder, schema::SchemaType,
+    },
+};
+
+/// The type of score, indicating the scoring system and version used.
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq, strum::VariantArray)]
+pub enum ScoreType {
+    /// CVSS v2.0 score
+    #[serde(rename = "2.0")]
+    V2,
+    /// CVSS v3.0 score
+    #[serde(rename = "3.0")]
+    V3,
+    /// CVSS v3.1 score
+    #[serde(rename = "3.1")]
+    V3_1,
+    /// CVSS v4.0 score
+    #[serde(rename = "4.0")]
+    V4,
+}
+
+impl PartialSchema for ScoreType {
+    fn schema() -> RefOr<Schema> {
+        Schema::Object(
+            ObjectBuilder::new()
+                .schema_type(SchemaType::Type(Type::String))
+                .description(Some(
+                    "The type of score, indicating the scoring system and version used.",
+                ))
+                .enum_values(Some(["2.0", "3.0", "3.1", "4.0"]))
+                .extensions(Some(
+                    ExtensionsBuilder::new()
+                        .add(
+                            "x-enum-descriptions",
+                            json!([
+                                "CVSS v2.0 score",
+                                "CVSS v3.0 score",
+                                "CVSS v3.1 score",
+                                "CVSS v4.0 score",
+                            ]),
+                        )
+                        .build(),
+                ))
+                .build(),
+        )
+        .into()
+    }
+}
+
+impl ToSchema for ScoreType {}
+
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, ToSchema, PartialEq)]
+pub struct Score {
+    /// The score type
+    pub r#type: ScoreType,
+    /// The actual value
+    pub value: f64,
+    /// The derived severity
+    pub severity: Severity,
+}
+
+impl TryFrom<cvss3::Model> for Score {
+    type Error = ();
+
+    fn try_from(row: cvss3::Model) -> Result<Self, Self::Error> {
+        // map to V3* type
+        let r#type = match row.minor_version {
+            0 => ScoreType::V3,
+            1 => ScoreType::V3_1,
+            _ => return Err(()),
+        };
+
+        Ok(Score {
+            r#type,
+            value: row.score,
+            severity: row.score.into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use strum::VariantArray;
+
+    #[test]
+    fn ensure_schema_variants() {
+        let RefOr::T(Schema::Object(schema)) = ScoreType::schema() else {
+            panic!("must but a concrete object");
+        };
+
+        // ensure the base type is a string
+
+        assert!(matches!(schema.schema_type, SchemaType::Type(Type::String)));
+
+        // ensure we have as many enum variants as in our Rust type, and that they match
+
+        assert_eq!(
+            schema.enum_values,
+            Some(
+                ScoreType::VARIANTS
+                    .iter()
+                    .map(|v| json!(v))
+                    .collect::<Vec<_>>()
+            )
+        );
+
+        // ensure that we have the same entries in the extension description
+
+        let ext = &schema.extensions.unwrap()["x-enum-descriptions"];
+        let serde_json::Value::Array(items) = ext else {
+            panic!("must be an array")
+        };
+
+        assert_eq!(
+            items,
+            &ScoreType::VARIANTS
+                .iter()
+                .map(|v| {
+                    let v = json!(v).to_string();
+                    let v = v.trim_matches('\"');
+                    format!("CVSS v{v} score")
+                })
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1126,6 +1126,9 @@ async fn get_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // assert expected fields
     assert_eq!(v[0]["identifier"], "https://www.redhat.com/#CVE-2023-0044");
     assert_eq!(v[0]["status"][0]["average_severity"], "medium");
+    assert_eq!(v[0]["status"][0]["scores"][0]["type"], "3.1");
+    assert_eq!(v[0]["status"][0]["scores"][0]["value"], 5.3);
+    assert_eq!(v[0]["status"][0]["scores"][0]["severity"], "medium");
 
     Ok(())
 }

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -241,7 +241,9 @@ impl SbomAdvisory {
 pub struct SbomStatus {
     #[serde(flatten)]
     pub vulnerability: VulnerabilityHead,
+    #[deprecated(since = "0.4.0", note = "Please use `scores` instead")]
     pub average_severity: Severity,
+    #[deprecated(since = "0.4.0", note = "Please use `scores` instead")]
     pub average_score: f64,
     pub status: String,
     pub context: Option<StatusContext>,
@@ -280,7 +282,9 @@ impl SbomStatus {
                 vulnerability,
             ),
             context: cpe.as_ref().map(|e| StatusContext::Cpe(e.to_string())),
+            #[allow(deprecated)]
             average_severity: average.severity(),
+            #[allow(deprecated)]
             average_score: average.value(),
             status,
             packages,

--- a/modules/fundamental/src/vulnerability/model/analyze.rs
+++ b/modules/fundamental/src/vulnerability/model/analyze.rs
@@ -1,14 +1,9 @@
-use crate::{advisory::model::AdvisoryHead, vulnerability::model::VulnerabilityHead};
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-use std::{collections::BTreeMap, ops::Deref};
-use trustify_cvss::cvss3::severity::Severity;
-use utoipa::{
-    PartialSchema, ToSchema,
-    openapi::{
-        ObjectBuilder, RefOr, Schema, Type, extensions::ExtensionsBuilder, schema::SchemaType,
-    },
+use crate::{
+    advisory::model::AdvisoryHead, common::model::Score, vulnerability::model::VulnerabilityHead,
 };
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, ops::Deref};
+use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct AnalysisRequest {
@@ -45,63 +40,6 @@ pub struct AnalysisAdvisory {
     pub scores: Vec<Score>,
 }
 
-/// The type of score, indicating the scoring system and version used.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq, strum::VariantArray)]
-pub enum ScoreType {
-    /// CVSS v2.0 score
-    #[serde(rename = "2.0")]
-    V2,
-    /// CVSS v3.0 score
-    #[serde(rename = "3.0")]
-    V3,
-    /// CVSS v3.1 score
-    #[serde(rename = "3.1")]
-    V3_1,
-    /// CVSS v4.0 score
-    #[serde(rename = "4.0")]
-    V4,
-}
-
-impl PartialSchema for ScoreType {
-    fn schema() -> RefOr<Schema> {
-        Schema::Object(
-            ObjectBuilder::new()
-                .schema_type(SchemaType::Type(Type::String))
-                .description(Some(
-                    "The type of score, indicating the scoring system and version used.",
-                ))
-                .enum_values(Some(["2.0", "3.0", "3.1", "4.0"]))
-                .extensions(Some(
-                    ExtensionsBuilder::new()
-                        .add(
-                            "x-enum-descriptions",
-                            json!([
-                                "CVSS v2.0 score",
-                                "CVSS v3.0 score",
-                                "CVSS v3.1 score",
-                                "CVSS v4.0 score",
-                            ]),
-                        )
-                        .build(),
-                ))
-                .build(),
-        )
-        .into()
-    }
-}
-
-impl ToSchema for ScoreType {}
-
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, ToSchema, PartialEq)]
-pub struct Score {
-    /// The score type
-    pub r#type: ScoreType,
-    /// The actual value
-    pub value: f64,
-    /// The derived severity
-    pub severity: Severity,
-}
-
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct AnalysisResponse(pub BTreeMap<String, AnalysisResult>);
 
@@ -110,53 +48,5 @@ impl Deref for AnalysisResponse {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use strum::VariantArray;
-
-    #[test]
-    fn ensure_schema_variants() {
-        let RefOr::T(Schema::Object(schema)) = ScoreType::schema() else {
-            panic!("must but a concrete object");
-        };
-
-        // ensure the base type is a string
-
-        assert!(matches!(schema.schema_type, SchemaType::Type(Type::String)));
-
-        // ensure we have as many enum variants as in our Rust type, and that they match
-
-        assert_eq!(
-            schema.enum_values,
-            Some(
-                ScoreType::VARIANTS
-                    .iter()
-                    .map(|v| json!(v))
-                    .collect::<Vec<_>>()
-            )
-        );
-
-        // ensure that we have the same entries in the extension description
-
-        let ext = &schema.extensions.unwrap()["x-enum-descriptions"];
-        let serde_json::Value::Array(items) = ext else {
-            panic!("must be an array")
-        };
-
-        assert_eq!(
-            items,
-            &ScoreType::VARIANTS
-                .iter()
-                .map(|v| {
-                    let v = json!(v).to_string();
-                    let v = v.trim_matches('\"');
-                    format!("CVSS v{v} score")
-                })
-                .collect::<Vec<_>>()
-        );
     }
 }

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -1,22 +1,21 @@
 #[cfg(test)]
 mod test;
 
-use crate::vulnerability::model::AnalysisResult;
 use crate::{
     Error,
     advisory::model::AdvisoryHead,
+    common::model::Score,
     vulnerability::model::{
-        AnalysisAdvisory, AnalysisDetails, AnalysisResponse, Score, ScoreType,
-        VulnerabilityDetails, VulnerabilityHead, VulnerabilitySummary,
+        AnalysisAdvisory, AnalysisDetails, AnalysisResponse, AnalysisResult, VulnerabilityDetails,
+        VulnerabilityHead, VulnerabilitySummary,
     },
 };
 use futures_util::{TryFutureExt, TryStreamExt, future};
 use sea_orm::{
     EntityTrait, FromQueryResult, Statement, StreamTrait, TryGetableFromJson, prelude::*,
 };
-use std::collections::btree_map::Entry;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, btree_map::Entry},
     str::FromStr,
 };
 use tracing::instrument;
@@ -300,21 +299,8 @@ GROUP BY
             .await?
             .map_err(Error::from)
             .try_filter_map(async |row| {
-                // map to V3* type
-                let r#type = match row.minor_version {
-                    0 => ScoreType::V3,
-                    1 => ScoreType::V3_1,
-                    _ => return Ok(None),
-                };
-
-                Ok(Some((
-                    row.advisory_id,
-                    Score {
-                        r#type,
-                        value: row.score,
-                        severity: row.score.into(),
-                    },
-                )))
+                let advisory_id = row.advisory_id;
+                Ok(Score::try_from(row).ok().map(|score| (advisory_id, score)))
             })
             .try_fold(
                 HashMap::<Uuid, Vec<Score>>::new(),

--- a/modules/fundamental/tests/sbom/details.rs
+++ b/modules/fundamental/tests/sbom/details.rs
@@ -152,6 +152,7 @@ async fn sbom_details_cyclonedx_osv(ctx: &TrustifyContext) -> Result<(), anyhow:
     Ok(())
 }
 
+#[allow(deprecated)]
 fn check_advisory(
     sbom: &SbomDetails,
     advisory_id: &str,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5087,6 +5087,7 @@ components:
         - average_score
         - status
         - packages
+        - scores
         properties:
           average_score:
             type: number
@@ -5101,6 +5102,10 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/SbomPackage'
+          scores:
+            type: array
+            items:
+              $ref: '#/components/schemas/Score'
           status:
             type: string
     SbomSummary:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5092,6 +5092,7 @@ components:
           average_score:
             type: number
             format: double
+            deprecated: true
           average_severity:
             $ref: '#/components/schemas/Severity'
           context:


### PR DESCRIPTION
## Summary by Sourcery

Consolidate CVSS scoring into a shared Score model and include full score lists in SBOM and advisory analyses

New Features:
- Expose a vector of all advisory scores in AnalysisAdvisory responses
- Include a vector of all CVSS scores in SbomStatus

Enhancements:
- Extract ScoreType and Score definitions into a common model to eliminate duplication
- Refactor vulnerability service and SbomStatus to use the shared Score::try_from conversion
- Remove legacy score schema and conversion code from individual modules

Tests:
- Add a schema validation test for ScoreType enum variants in the common model