### PR TITLE
Add some logging around garbage collection and default rate to 1h

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -41,7 +41,7 @@
 | `TRUSTD_DB_PASSWORD`                     | Database password                                                                   | `trustify`                              |
 | `TRUSTD_DB_PORT`                         | Database port                                                                       | `5432`                                  |
 | `TRUSTD_DB_USER`                         | Database username                                                                   | `postgres`                              |
-| `TRUSTD_GC_FREQ`                         | How often database garbage collection runs (humantime)                              | `5m`                                    |
+| `TRUSTD_GC_FREQ`                         | How often database garbage collection runs (humantime)                              | `1h`                                    |
 | `TRUSTD_ISSUER_URL`                      | Issuer URL for `--devmode`                                                          | `http://localhost:8090/realms/trustify` |
 | `TRUSTD_MAX_CACHE_SIZE`                  | Maximum size of the graph cache.                                                    | `200 MiB`                               |
 | `TRUSTD_S3_ACCESS_KEY`                   | S3 access key                                                                       |                                         |


### PR DESCRIPTION
Also changed type of default for more clarity logging durations

## Summary by Sourcery

Update GC scheduling to use Duration, default frequency to one hour, and add detailed logging around garbage collection.

Enhancements:
- Change GC_FREQ constant to a Duration of one hour
- Use humantime::parse_duration for parsing TRUSTD_GC_FREQ environment variable
- Log the configured GC frequency with a human-readable duration
- Measure and log the execution time of each garbage collection run

Documentation:
- Update TRUSTD_GC_FREQ default to 1h in the environment variables documentation