### PR TITLE
build: upgrade to Rust 1.90.0

### DIFF
--- a/common/src/db/query.rs
+++ b/common/src/db/query.rs
@@ -86,7 +86,7 @@ impl Query {
         const RE: &str = r"^(?<field>[^\\]+?)(?<op>=|!=|~|!~|>=|>|<=|<)(?<value>.*)$";
         static LOCK: OnceLock<Regex> = OnceLock::new();
         #[allow(clippy::unwrap_used)]
-        let regex = LOCK.get_or_init(|| (Regex::new(RE).unwrap()));
+        let regex = LOCK.get_or_init(|| Regex::new(RE).unwrap());
 
         fn encode(s: &str) -> String {
             s.replace(r"\&", "\x07").replace(r"\|", "\x08")

--- a/cvss/src/cvss3/score.rs
+++ b/cvss/src/cvss3/score.rs
@@ -27,7 +27,7 @@ impl Score {
     pub fn roundup(self) -> Score {
         let score_int = (self.0 * 100_000.0) as u64;
 
-        if score_int % 10000 == 0 {
+        if score_int.is_multiple_of(10000) {
             Score((score_int as f64) / 100_000.0)
         } else {
             let score_floor = ((score_int as f64) / 10_000.0).floor();

--- a/modules/fundamental/tests/sbom/cyclonedx/reingest.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/reingest.rs
@@ -36,7 +36,7 @@ async fn reingest(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             packages
                 .items
                 .iter()
-                .map(|p| (p.name.clone()))
+                .map(|p| p.name.clone())
                 .collect::<Vec<_>>(),
             vec!["simple".to_string()]
         );

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
The downstream build will use 1.90.0. So we can (and should) switch to 1.90.0 upstream.