### PR TITLE
feat: license list endpoint with filtering (TC-2922)

### DIFF
--- a/common/src/db/func.rs
+++ b/common/src/db/func.rs
@@ -87,3 +87,14 @@ impl Iden for ExpandLicenseExpression {
         write!(s, "expand_license_expression").unwrap()
     }
 }
+
+/// The function returns the final license, no matter if it's coming from a CycloneDx of SPDX
+/// license data stored in the DB.
+pub struct CaseLicenseTextSbomId;
+
+impl Iden for CaseLicenseTextSbomId {
+    #[allow(clippy::unwrap_used)]
+    fn unquoted(&self, s: &mut dyn Write) {
+        write!(s, "case_license_text_sbom_id").unwrap()
+    }
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -26,6 +26,7 @@ mod m0001110_sbom_node_checksum_indexes;
 mod m0001120_sbom_external_node_indexes;
 mod m0001130_gover_cmp;
 mod m0001140_expand_spdx_licenses_function;
+mod m0001150_case_license_text_sbom_id_function;
 
 pub struct Migrator;
 
@@ -59,6 +60,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001120_sbom_external_node_indexes::Migration),
             Box::new(m0001130_gover_cmp::Migration),
             Box::new(m0001140_expand_spdx_licenses_function::Migration),
+            Box::new(m0001150_case_license_text_sbom_id_function::Migration),
         ]
     }
 }

--- a/migration/src/m0001150_case_license_text_sbom_id_function.rs
+++ b/migration/src/m0001150_case_license_text_sbom_id_function.rs
@@ -1,0 +1,29 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0001150_case_license_text_sbom_id_function/function_up.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("DROP FUNCTION IF EXISTS case_license_text_sbom_id(TEXT, UUID);")
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m0001150_case_license_text_sbom_id_function/function_up.sql
+++ b/migration/src/m0001150_case_license_text_sbom_id_function/function_up.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION case_license_text_sbom_id(
+    license_text TEXT,
+    sbom_id UUID
+) RETURNS TEXT AS $$
+BEGIN
+RETURN CASE WHEN sbom_id IS NULL
+        THEN license_text
+        ELSE expand_license_expression(license_text, sbom_id)
+    END CASE;
+END;
+$$ LANGUAGE plpgsql STABLE PARALLEL SAFE;

--- a/modules/fundamental/src/endpoints.rs
+++ b/modules/fundamental/src/endpoints.rs
@@ -23,7 +23,7 @@ pub fn configure(
     svc.app_data(web::Data::new(ingestor_service));
 
     crate::advisory::endpoints::configure(svc, db.clone(), config.advisory_upload_limit);
-    crate::license::endpoints::configure(svc);
+    crate::license::endpoints::configure(svc, db.clone());
     crate::organization::endpoints::configure(svc, db.clone());
     crate::purl::endpoints::configure(svc, db.clone());
     crate::product::endpoints::configure(svc, db.clone());

--- a/modules/fundamental/src/license/endpoints/mod.rs
+++ b/modules/fundamental/src/license/endpoints/mod.rs
@@ -1,18 +1,55 @@
 use crate::license::{
     endpoints::spdx::{get_spdx_license, list_spdx_licenses},
-    service::LicenseService,
+    service::{LicenseService, LicenseText},
 };
-use actix_web::web;
+use actix_web::{HttpResponse, Responder, get, web};
+use trustify_auth::{ReadSbom, authorizer::Require};
+use trustify_common::{
+    db::{Database, query::Query},
+    model::{Paginated, PaginatedResults},
+};
+use trustify_query::TrustifyQuery;
+use trustify_query_derive::Query;
 
 pub mod spdx;
 
-pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig) {
+pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, db: Database) {
     let license_service = LicenseService::new();
 
     config
+        .app_data(web::Data::new(db))
         .app_data(web::Data::new(license_service))
         .service(list_spdx_licenses)
-        .service(get_spdx_license);
+        .service(get_spdx_license)
+        .service(list_licenses);
+}
+
+#[allow(dead_code)]
+#[derive(Query)]
+struct LicenseQuery {
+    license: String,
+}
+/// List all licenses from SBOMs
+#[utoipa::path(
+    operation_id = "listLicenses",
+    tag = "license",
+    params(
+        TrustifyQuery<LicenseQuery>,
+        Paginated,
+    ),
+    responses(
+        (status = 200, description = "Matching licenses", body = PaginatedResults<LicenseText>),
+    ),
+)]
+#[get("/v2/license")]
+pub async fn list_licenses(
+    service: web::Data<LicenseService>,
+    db: web::Data<Database>,
+    web::Query(search): web::Query<Query>,
+    web::Query(paginated): web::Query<Paginated>,
+    _: Require<ReadSbom>,
+) -> actix_web::Result<impl Responder> {
+    Ok(HttpResponse::Ok().json(service.licenses(search, paginated, db.as_ref()).await?))
 }
 
 #[cfg(test)]

--- a/modules/fundamental/src/license/endpoints/test.rs
+++ b/modules/fundamental/src/license/endpoints/test.rs
@@ -1,4 +1,5 @@
 use crate::license::model::{SpdxLicenseDetails, SpdxLicenseSummary};
+use crate::license::service::LicenseText;
 use crate::test::caller;
 use actix_web::test::TestRequest;
 use test_context::test_context;
@@ -36,6 +37,285 @@ async fn get_spdx_license(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let request = TestRequest::get().uri(uri).to_request();
     let response: SpdxLicenseDetails = app.call_and_read_body_json(request).await;
     assert_eq!(response.summary.id, "GLWTPL");
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn list_licenses_no_data(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    let uri = "/api/v2/license";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    // Should have the preloaded licenses from DB init when no SBOMs are loaded
+    assert_eq!(response.items.len(), 25);
+    assert_eq!(response.total, 652);
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn list_licenses_with_spdx_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    // Ingest an SPDX SBOM that has LicenseRef mappings
+    ctx.ingest_document("spdx/OCP-TOOLS-4.11-RHEL-8.json")
+        .await?;
+
+    let uri = "/api/v2/license?sort=license:asc";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(response.items.len(), 25); // 25 is the default for pagination
+    assert_eq!(response.total, 732);
+
+    // Check that we have some expected licenses from the SPDX SBOM
+    let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
+
+    // Basic checks for licenses that should be in this SPDX SBOM
+    assert!(license_names.iter().any(|l| l.contains("ASL 2.0"))); // Apache Software License 2.0
+    assert!(license_names.iter().any(|l| l.contains("BSD"))); // BSD licenses
+    assert!(license_names.iter().any(|l| l.contains("MIT"))); // MIT license
+    // Expended license for LicenseRef-13
+    assert!(license_names.iter().any(|l| l.contains(
+        "(FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement"
+    )));
+    // Expanded license from (LicenseRef-4 OR LicenseRef-Artistic) AND LicenseRef-5 AND LicenseRef-UCD
+    assert!(
+        license_names
+            .iter()
+            .any(|l| l.contains("(GPL+ OR Artistic) AND Artistic 2.0 AND UCD"))
+    );
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn list_licenses_no_license_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    // Ingest an SPDX SBOM that has LicenseRef mappings
+    ctx.ingest_document("spdx/OCP-TOOLS-4.11-RHEL-8.json")
+        .await?;
+
+    let uri = "/api/v2/license?sort=license:asc&limit=733";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(response.items.len(), 732);
+    assert_eq!(response.total, 732);
+
+    // Check that we have some expected licenses from the SPDX SBOM
+    let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
+
+    // Verify that we don't have raw LicenseRef- values in the output
+    // (they should all be expanded to their actual license names)
+    let license_ref_found = license_names
+        .into_iter()
+        .filter(|l| l.contains("LicenseRef-"))
+        .collect::<Vec<String>>();
+    assert_eq!(
+        license_ref_found.len(),
+        0,
+        "No 'LicenseRef-' should exist but {:?} have been found",
+        license_ref_found
+    );
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn list_licenses_with_cyclonedx_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    // Ingest a CycloneDX SBOM
+    ctx.ingest_document("zookeeper-3.9.2-cyclonedx.json")
+        .await?;
+
+    let uri = "/api/v2/license?sort=license:asc";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(response.items.len(), 25);
+    assert_eq!(response.total, 659);
+
+    // Check that we have some expected licenses from the CycloneDX SBOM
+    let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
+
+    assert!(
+        license_names
+            .iter()
+            .any(|l| l.contains("(CDDL-1.0 OR GPL-2.0-with-classpath-exception)"))
+    );
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn list_licenses_with_mixed_sboms(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    // Ingest both SPDX and CycloneDX SBOMs
+    ctx.ingest_documents([
+        "spdx/OCP-TOOLS-4.11-RHEL-8.json",
+        "zookeeper-3.9.2-cyclonedx.json",
+    ])
+    .await?;
+
+    let uri = "/api/v2/license?sort=license:asc";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(response.total, 736);
+    assert_eq!(response.items.len(), 25);
+
+    let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
+
+    // Should have licenses from both SPDX and CycloneDX
+    assert!(
+        license_names
+            .iter()
+            .any(|l| l.contains("(GPL+ OR Artistic) AND Artistic 2.0 AND UCD"))
+    ); // Expanded license from (LicenseRef-4 OR LicenseRef-Artistic) AND LicenseRef-5 AND LicenseRef-UCD
+    assert!(
+        license_names
+            .iter()
+            .any(|l| l.contains("(CDDL-1.0 OR GPL-2.0-with-classpath-exception)"))
+    );
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn list_licenses_with_search_filter(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    // Ingest SBOMs with various licenses
+    ctx.ingest_documents([
+        "spdx/OCP-TOOLS-4.11-RHEL-8.json",
+        "zookeeper-3.9.2-cyclonedx.json",
+    ])
+    .await?;
+
+    // Test search filter for "ASL" (Apache Software License)
+    let uri = "/api/v2/license?q=license~ASL";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(response.total, 4);
+
+    // Test full text search filter for "ASL" (Apache Software License)
+    let uri = "/api/v2/license?q=ASL";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(response.total, 4);
+
+    // Test case-insensitive search filter for "asl"
+    let uri = "/api/v2/license?q=asl";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(response.total, 4);
+
+    // Test case-insensitive search filter for "AsL"
+    let uri = "/api/v2/license?q=AsL";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(response.total, 4);
+
+    // Test for non-existent license
+    let uri = "/api/v2/license?q=NonExistentLicense";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(0, response.total);
+    assert_eq!(0, response.items.len());
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn list_licenses_with_pagination(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    // Test pagination - first page
+    let uri = "/api/v2/license?limit=5&offset=0";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    let total_licenses = response.total;
+    assert!(total_licenses > 0);
+
+    if total_licenses > 5 {
+        assert_eq!(5, response.items.len());
+    } else {
+        assert_eq!(total_licenses as usize, response.items.len());
+    }
+
+    // Test pagination - second page (if there are enough items)
+    if total_licenses > 5 {
+        let uri = "/api/v2/license?limit=5&offset=5";
+        let request = TestRequest::get().uri(uri).to_request();
+        let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+        assert_eq!(total_licenses, response.total); // Total should remain the same
+
+        if total_licenses > 10 {
+            assert_eq!(5, response.items.len());
+        } else {
+            assert_eq!((total_licenses - 5) as usize, response.items.len());
+        }
+    }
+
+    // Test pagination with offset beyond available items
+    let uri = format!("/api/v2/license?limit=5&offset={}", total_licenses + 10);
+    let request = TestRequest::get().uri(&uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(total_licenses, response.total); // Total should remain the same
+    assert_eq!(0, response.items.len()); // No items should be returned
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn list_licenses_sorting(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    // Ingest an SPDX SBOM that has LicenseRef mappings
+    ctx.ingest_document("spdx/OCP-TOOLS-4.11-RHEL-8.json")
+        .await?;
+
+    let uri = "/api/v2/license?sort=license:asc&limit=733";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(response.items.len(), 732);
+    assert_eq!(response.total, 732);
+
+    // Verify licenses are sorted
+    let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
+    let mut sorted_licenses = license_names.clone();
+    sorted_licenses.sort();
+    assert_eq!(license_names, sorted_licenses);
+
+    let uri = "/api/v2/license?sort=license:desc&limit=733";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+    let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
+    sorted_licenses.reverse();
+    assert_eq!(license_names, sorted_licenses);
 
     Ok(())
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1322,6 +1322,87 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_ImporterReport'
+  /api/v2/license:
+    get:
+      tags:
+      - license
+      summary: List all licenses from SBOMs
+      operationId: listLicenses
+      parameters:
+      - name: q
+        in: query
+        description: |-
+          Query for advisories defined using the following EBNF grammar (ISO/IEC 14977):
+          (* Query Grammar - EBNF Compliant *)
+          query = ( values | filter ) , { "&" , query } ;
+          values = value , { "|" , value } ;
+          filter = field , operator , values ;
+          operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<" ;
+          field = ("license")
+          value = { value_char } ;
+          value_char = escaped_char | normal_char ;
+          escaped_char = "\" , special_char ;
+          normal_char = ? any character except '&', '|', '=', '!', '~', '>', '<', '\' ? ;
+          special_char = "&" | "|" | "=" | "!" | "~" | ">" | "<" | "\" ;
+          (* Examples:
+              - Simple filter: title=example
+              - Multiple values filter: title=foo|bar|baz
+              - Complex filter: modified>2024-01-01
+              - Combined query: title=foo&average_severity=high
+              - Escaped characters: title=foo\&bar
+          *)
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        description: |-
+          EBNF grammar for the _sort_ parameter:
+          ```text
+              sort = field [ ':', order ] { ',' sort }
+              order = ( "asc" | "desc" )
+              field = ("license")
+          ```
+          The optional _order_ should be one of "asc" or "desc". If
+          omitted, the order defaults to "asc".
+
+          Each _field_ name must correspond to one of the columns of the
+          table holding the entities being queried. Those corresponding
+          to JSON objects in the database may use a ':' to delimit the
+          column name and the object key,
+          e.g. `purl:qualifiers:type:desc`
+        required: false
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: |-
+          The first item to return, skipping all that come before it.
+
+          NOTE: The order of items is defined by the API being called.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: limit
+        in: query
+        description: |-
+          The maximum number of entries to return.
+
+          Zero means: no limit
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      responses:
+        '200':
+          description: Matching licenses
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResults_LicenseText'
   /api/v2/license/spdx/license:
     get:
       tags:
@@ -3991,6 +4072,13 @@ components:
           type: array
           items:
             type: string
+    LicenseText:
+      type: object
+      required:
+      - license
+      properties:
+        license:
+          type: string
     Message:
       type: object
       required:
@@ -4233,6 +4321,25 @@ components:
                 type: array
                 items:
                   type: string
+        total:
+          type: integer
+          format: int64
+          minimum: 0
+    PaginatedResults_LicenseText:
+      type: object
+      required:
+      - items
+      - total
+      properties:
+        items:
+          type: array
+          items:
+            type: object
+            required:
+            - license
+            properties:
+              license:
+                type: string
         total:
           type: integer
           format: int64


### PR DESCRIPTION
Changes:

- add the `/v2/license` endpoint with `license` filter and usual pagination
- Implement license text resolution for both SPDX and CycloneDX SBOM formats with proper LicenseRef expansion

Relates to [TC-2922](https://issues.redhat.com/browse/TC-2922)

## Summary by Sourcery

Add a new GET /v2/license endpoint to list and filter licenses extracted from SBOMs with pagination and sorting, and implement dynamic license text resolution with expanded LicenseRef support for both SPDX and CycloneDX formats.

New Features:
- Introduce /v2/license endpoint with query filter, pagination, and sorting support
- Implement license text resolution with LicenseRef expansion for SPDX and CycloneDX SBOMs

Enhancements:
- Add case_license_text_sbom_id database function and SeaORM integration to handle conditional license text resolution
- Define LicenseText model and integrate TrustifyQuery and PaginatedResults for streamlined querying

Build:
- Add new migration for case_license_text_sbom_id database function

Documentation:
- Extend OpenAPI spec with /v2/license path, request parameters, and LicenseText/PaginatedResults schemas

Tests:
- Add comprehensive integration tests covering empty dataset, SPDX, CycloneDX, mixed SBOMs, search filtering, pagination, and sorting scenarios