### PR TITLE
feat: SBOM license filtering with refactoring for SBOM and PURL (TC-2832)

### DIFF
--- a/modules/fundamental/src/common/service.rs
+++ b/modules/fundamental/src/common/service.rs
@@ -1,8 +1,167 @@
 use crate::{Error, common::LicenseRefMapping, source_document::model::SourceDocument};
-use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, PaginatorTrait, Statement};
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, FromQueryResult, PaginatorTrait,
+    QueryFilter, QuerySelect, QueryTrait, RelationTrait, Select, Statement,
+};
+use sea_query::{
+    ColumnType, Condition, Expr, Func, JoinType, SelectStatement, SimpleExpr, UnionType,
+    extension::postgres::PgExpr,
+};
 use spdx_expression;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, future::Future};
+use trustify_common::db::{
+    ExpandLicenseExpression,
+    query::{Columns, Filtering, IntoColumns, Query, q},
+};
+use trustify_entity::{license, sbom_package, sbom_package_license, sbom_package_purl_ref};
 use trustify_module_storage::service::{StorageBackend, StorageKey, dispatch::DispatchBackend};
+
+pub const LICENSE: &str = "license";
+
+/// Builds a CycloneDX license query using direct text matching on license fields
+///
+/// # Arguments
+/// * `license_query` - The license query to filter by
+/// * `base_query` - The base query to apply license filtering to
+pub fn build_cyclonedx_license_query<E>(
+    license_query: Query,
+    base_query: Select<E>,
+) -> Result<SelectStatement, Error>
+where
+    E: EntityTrait,
+{
+    Ok(base_query
+        .filtering_with(
+            license_query,
+            license::Entity
+                .columns()
+                .translator(|field, operator, value| match field {
+                    LICENSE => Some(format!("text{operator}{value}")),
+                    _ => None,
+                }),
+        )?
+        .into_query())
+}
+
+/// Builds an SPDX license query using expand_license_expression() for LicenseRef resolution
+///
+/// # Arguments
+/// * `license_query` - The license query to filter by
+/// * `base_query` - The base query to apply license filtering to
+pub fn build_spdx_license_query<E>(
+    license_query: Query,
+    base_query: Select<E>,
+) -> Result<SelectStatement, Error>
+where
+    E: EntityTrait,
+{
+    const EXPANDED_LICENSE: &str = "expanded_license";
+    Ok(base_query
+        .filtering_with(
+            license_query,
+            Columns::default()
+                .add_expr(
+                    EXPANDED_LICENSE,
+                    SimpleExpr::FunctionCall(
+                        Func::cust(ExpandLicenseExpression)
+                            .arg(Expr::col(license::Column::Text))
+                            .arg(Expr::col((
+                                sbom_package_license::Entity,
+                                sbom_package_license::Column::SbomId,
+                            ))),
+                    ),
+                    ColumnType::Text,
+                )
+                .translator(|field, operator, value| match field {
+                    LICENSE => Some(format!("{EXPANDED_LICENSE}{operator}{value}")),
+                    _ => None,
+                }),
+        )?
+        .filter(Expr::col(license::Column::Text).ilike("%LicenseRef-%"))
+        .into_query())
+}
+
+/// Creates a base query for PURL license filtering (targeting qualified_purl_id)
+pub fn create_purl_license_filtering_base_query() -> Select<sbom_package_purl_ref::Entity> {
+    sbom_package_purl_ref::Entity::find()
+        .select_only()
+        .column(sbom_package_purl_ref::Column::QualifiedPurlId)
+        .join(
+            JoinType::Join,
+            sbom_package_purl_ref::Relation::Package.def(),
+        )
+        .join(JoinType::Join, sbom_package::Relation::PackageLicense.def())
+        .join(
+            JoinType::Join,
+            sbom_package_license::Relation::License.def(),
+        )
+}
+
+/// Creates a base query for SBOM license filtering (targeting sbom_id)
+pub fn create_sbom_license_filtering_base_query() -> Select<sbom_package_license::Entity> {
+    sbom_package_license::Entity::find()
+        .select_only()
+        .column(sbom_package_license::Column::SbomId)
+        .join(
+            JoinType::Join,
+            sbom_package_license::Relation::License.def(),
+        )
+}
+
+/// Applies license filtering to a query using a two-phase SPDX/CycloneDX approach
+///
+/// This function encapsulates the complete license filtering pattern used by both
+/// PURL and SBOM services, eliminating code duplication.
+///
+/// # Arguments
+/// * `main_query` - The main query to apply license filtering to
+/// * `search_query` - The full search query that may contain license constraints
+/// * `base_query_fn` - Function that creates the base query for license filtering
+/// * `target_column` - The column to use in the subquery (e.g., qualified_purl::Column::Id or sbom::Column::SbomId)
+///
+/// # Returns
+/// The modified main query with license filtering applied (if license constraints exist)
+pub fn apply_license_filtering<E, BE, F, C>(
+    main_query: Select<E>,
+    search_query: &Query,
+    base_query_fn: F,
+    target_column: C,
+) -> Result<Select<E>, Error>
+where
+    E: EntityTrait,
+    BE: EntityTrait,
+    F: Fn() -> Select<BE>,
+    C: ColumnTrait,
+{
+    // since different fields conditions in input query are AND'd when translating them
+    // into DB query, if the `license` field is in the input query then qualified_purl
+    // that will match the input query criteria must be among the one satisfying
+    // the license values requested in the input query itself.
+    if let Some(license_query) = search_query
+        .get_constraint_for_field(LICENSE)
+        .map(|constraint| q(&format!("{constraint}")))
+    {
+        let license_filtering_base_query = base_query_fn();
+        let mut select_from_spdx =
+            build_spdx_license_query(license_query.clone(), license_filtering_base_query.clone())?;
+        let select_from_cyclonedx =
+            build_cyclonedx_license_query(license_query, license_filtering_base_query)?;
+
+        // Filters using a two-phase approach:
+        // 1. SPDX documents: Uses expand_license_expression() for LicenseRef resolution
+        // 2. CycloneDX documents: Direct text matching on license field
+        // The results are UNIONed and used to filter the main query.
+        let select_filtering_by_license =
+            select_from_spdx.union(UnionType::Distinct, select_from_cyclonedx);
+
+        Ok(main_query.filter(
+            Condition::all().add(target_column.in_subquery(select_filtering_by_license.clone())),
+        ))
+    } else {
+        // No license filtering needed, return the query unchanged
+        Ok(main_query)
+    }
+}
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum DocumentType {

--- a/modules/fundamental/src/sbom/service/test.rs
+++ b/modules/fundamental/src/sbom/service/test.rs
@@ -4,7 +4,12 @@ use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::cpe::Cpe;
-use trustify_common::{id::Id, purl::Purl};
+use trustify_common::{
+    db::query::{Query, q},
+    id::Id,
+    model::Paginated,
+    purl::Purl,
+};
 use trustify_entity::labels::Labels;
 use trustify_test_context::TrustifyContext;
 
@@ -167,6 +172,157 @@ async fn sbom_update_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
         details.summary.head.labels.0.get("label_2"),
         Some("Label no 2".to_string()).as_ref()
     );
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let service = SbomService::new(ctx.db.clone());
+
+    // Ingest SBOMs with license information
+    ctx.ingest_document("spdx/mtv-2.6.json").await?;
+    ctx.ingest_document("cyclonedx/rh/latest_filters/container/quay_builder_qemu_rhcos_rhel8_2025-02-24/quay-builder-qemu-rhcos-rhel-8-amd64.json").await?;
+
+    // Test 1: Filter by specific license found in SPDX documents
+    let results = service
+        .fetch_sboms(
+            q("license=GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"),
+            Paginated::default(),
+            (),
+            &ctx.db,
+        )
+        .await?;
+
+    log::debug!("License filter results: {results:#?}");
+    // Both SBOMs contain packages with this license combination
+    assert_eq!(results.total, 2);
+    assert_eq!(results.items.len(), 2);
+
+    // Test 2: Filter by partial license match
+    let results = service
+        .fetch_sboms(
+            q("license~GPLv3+ with exceptions"),
+            Paginated::default(),
+            (),
+            &ctx.db,
+        )
+        .await?;
+
+    log::debug!("Partial license filter results: {results:#?}");
+    // Both SBOMs contain packages with 'GPLv3+ with exceptions' license
+    assert_eq!(results.total, 2);
+    assert_eq!(results.items.len(), 2);
+
+    // Test 3: Filter by license found in single SBOMs
+    let results = service
+        .fetch_sboms(q("license~OFL"), Paginated::default(), (), &ctx.db)
+        .await?;
+
+    log::debug!("OFL license filter results: {results:#?}");
+    // Only SPDX SBOMs contain packages with OFL license
+    assert_eq!(results.total, 1);
+    assert_eq!(results.items[0].head.name, "MTV-2.6");
+
+    let results = service
+        .fetch_sboms(q("license=Apache 2.0"), Paginated::default(), (), &ctx.db)
+        .await?;
+
+    log::debug!("Apache 2.0 license filter results: {results:#?}");
+    // Only CycloneDX SBOM has Apache 2.0
+    assert_eq!(results.total, 1);
+    assert_eq!(
+        results.items[0].head.name,
+        "quay/quay-builder-qemu-rhcos-rhel8"
+    );
+
+    // Test 4: Test OR operation for multiple licenses
+    let results = service
+        .fetch_sboms(
+            q("license=OFL|Apache 2.0"),
+            Paginated::default(),
+            (),
+            &ctx.db,
+        )
+        .await?;
+
+    log::debug!("Multiple license OR filter results: {results:#?}");
+    // Both SBOMs contain packages with these licenses
+    assert_eq!(results.total, 2);
+    assert_eq!(results.items.len(), 2);
+
+    // Test 5: Negative test - license that doesn't exist
+    let results = service
+        .fetch_sboms(
+            q("license=NONEXISTENT_LICENSE"),
+            Paginated::default(),
+            (),
+            &ctx.db,
+        )
+        .await?;
+
+    log::debug!("Nonexistent license filter results: {results:#?}");
+    // Should return no SBOMs
+    assert_eq!(results.total, 0);
+    assert!(results.items.is_empty());
+
+    // Test 6: Empty license query
+    let results = service
+        .fetch_sboms(q("license="), Paginated::default(), (), &ctx.db)
+        .await?;
+
+    log::debug!("Empty license query results: {results:#?}");
+    // Should return no SBOMs or handle gracefully
+    assert_eq!(results.total, 0);
+    assert!(results.items.is_empty());
+
+    // Test 7: Combine license filter with other filters (should work together)
+    let results = service
+        .fetch_sboms(
+            q("license~Apache&name~quay"),
+            Paginated::default(),
+            (),
+            &ctx.db,
+        )
+        .await?;
+
+    log::debug!("Combined license + name filter results: {results:#?}");
+    // Should find SBOMs that have both Apache license and name containing "quay"
+    // CycloneDX SBOM has Apache license and "quay" in name
+    assert_eq!(results.total, 1);
+    assert_eq!(
+        results.items[0].head.name,
+        "quay/quay-builder-qemu-rhcos-rhel8"
+    );
+
+    // Test 8: Pagination with license filtering
+    let results = service
+        .fetch_sboms(
+            q("license~GPL"),
+            Paginated {
+                offset: 0,
+                limit: 1,
+            },
+            (),
+            &ctx.db,
+        )
+        .await?;
+
+    log::debug!("Paginated license filter results: {results:#?}");
+    // Should return at most 1 item but show total count
+    // Both SBOMs contain GPL licenses, but limit to 1
+    assert_eq!(results.items.len(), 1);
+    assert_eq!(results.total, 2);
+
+    // Test 9: Verify that SBOMs without license filters still work
+    let all_results = service
+        .fetch_sboms(Query::default(), Paginated::default(), (), &ctx.db)
+        .await?;
+
+    log::debug!("All SBOMs results: {all_results:#?}");
+    // Should return all SBOMs
+    assert_eq!(all_results.total, 2); // We ingested exactly 2 SBOMs
 
     Ok(())
 }


### PR DESCRIPTION
This PR implements license filtering functionality for the SBOM service and refactors duplicate code patterns between SBOM and PURL services to improve maintainability.

Changes

1. Added License Filtering to SBOM Service: Implemented the same two-phase license filtering approach used in PURL service
2. Code Refactoring and Deduplication: within `modules/fundamental/src/` moved to common module `common/service.rs` some functions from `purl/service/mod.rs` to be reused in `sbom/service/sbom.rs`

Relates to [TC-2832](https://issues.redhat.com/browse/TC-2832)

Assisted-by: Claude Code