### PR TITLE
[backport][0.3.z] TC-2826 Packages List API - Add licenses array 

### DIFF
--- a/entity/src/sbom_package_license.rs
+++ b/entity/src/sbom_package_license.rs
@@ -68,3 +68,21 @@ impl Related<super::license::Entity> for Entity {
 }
 
 impl ActiveModelBehavior for ActiveModel {}
+
+impl LicenseCategory {
+    /// Returns the string representation of the license category
+    ///
+    /// # Examples
+    /// ```
+    /// use trustify_entity::sbom_package_license::LicenseCategory;
+    ///
+    /// assert_eq!(LicenseCategory::Declared.show(), "Declared");
+    /// assert_eq!(LicenseCategory::Concluded.show(), "Concluded");
+    /// ```
+    pub fn show(&self) -> &'static str {
+        match self {
+            LicenseCategory::Declared => "Declared",
+            LicenseCategory::Concluded => "Concluded",
+        }
+    }
+}

--- a/entity/src/sbom_package_license.rs
+++ b/entity/src/sbom_package_license.rs
@@ -68,21 +68,3 @@ impl Related<super::license::Entity> for Entity {
 }
 
 impl ActiveModelBehavior for ActiveModel {}
-
-impl LicenseCategory {
-    /// Returns the string representation of the license category
-    ///
-    /// # Examples
-    /// ```
-    /// use trustify_entity::sbom_package_license::LicenseCategory;
-    ///
-    /// assert_eq!(LicenseCategory::Declared.show(), "Declared");
-    /// assert_eq!(LicenseCategory::Concluded.show(), "Concluded");
-    /// ```
-    pub fn show(&self) -> &'static str {
-        match self {
-            LicenseCategory::Declared => "Declared",
-            LicenseCategory::Concluded => "Concluded",
-        }
-    }
-}

--- a/modules/fundamental/src/common/mod.rs
+++ b/modules/fundamental/src/common/mod.rs
@@ -1,1 +1,11 @@
+use sea_orm::FromQueryResult;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
 pub mod service;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, FromQueryResult)]
+pub struct LicenseRefMapping {
+    pub license_id: String,
+    pub license_name: String,
+}

--- a/modules/fundamental/src/common/mod.rs
+++ b/modules/fundamental/src/common/mod.rs
@@ -1,5 +1,8 @@
+use crate::sbom::service::sbom::LicenseBasicInfo;
 use sea_orm::FromQueryResult;
+use sea_query::FromValueTuple;
 use serde::{Deserialize, Serialize};
+use trustify_entity::sbom_package_license::LicenseCategory;
 use utoipa::ToSchema;
 
 pub mod service;
@@ -8,4 +11,19 @@ pub mod service;
 pub struct LicenseRefMapping {
     pub license_id: String,
     pub license_name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct LicenseInfo {
+    pub license_name: String,
+    pub license_type: LicenseCategory,
+}
+
+impl From<LicenseBasicInfo> for LicenseInfo {
+    fn from(license_basic_info: LicenseBasicInfo) -> Self {
+        LicenseInfo {
+            license_name: license_basic_info.license_name,
+            license_type: LicenseCategory::from_value_tuple(license_basic_info.license_type),
+        }
+    }
 }

--- a/modules/fundamental/src/license/service/mod.rs
+++ b/modules/fundamental/src/license/service/mod.rs
@@ -1,6 +1,6 @@
-use crate::sbom::model::LicenseRefMapping;
 use crate::{
     Error,
+    common::LicenseRefMapping,
     license::model::{
         SpdxLicenseDetails, SpdxLicenseSummary,
         sbom_license::{

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -288,7 +288,7 @@ async fn test_purl_license_details(ctx: &TrustifyContext) -> Result<(), anyhow::
           "license_type": "concluded"
         }
       ],
-      "license_ref_mapping": [
+      "licenses_ref_mapping": [
         {
           "license_id": "LicenseRef-Netscape",
           "license_name": "Netscape"

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -281,11 +281,11 @@ async fn test_purl_license_details(ctx: &TrustifyContext) -> Result<(), anyhow::
       "licenses": [
         {
           "license_name": "(LicenseRef-8 OR LicenseRef-0 OR LicenseRef-MPL) AND (LicenseRef-Netscape OR LicenseRef-0 OR LicenseRef-8)",
-          "license_type": "Declared"
+          "license_type": "declared"
         },
         {
           "license_name": "NOASSERTION",
-          "license_type": "Concluded"
+          "license_type": "concluded"
         }
       ],
       "license_ref_mapping": [

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -41,7 +41,7 @@ pub struct PurlDetails {
     pub base: BasePurlHead,
     pub advisories: Vec<PurlAdvisory>,
     pub licenses: Vec<LicenseInfo>,
-    pub license_ref_mapping: Vec<LicenseRefMapping>,
+    pub licenses_ref_mapping: Vec<LicenseRefMapping>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, FromQueryResult)]
@@ -149,7 +149,7 @@ impl PurlDetails {
             base: BasePurlHead::from_entity(&package),
             advisories: PurlAdvisory::from_entities(purl_statuses, product_statuses, tx).await?,
             licenses: purl_license_info,
-            license_ref_mapping,
+            licenses_ref_mapping: license_ref_mapping,
         })
     }
 }

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -9,7 +9,7 @@ pub use query::*;
 use crate::sbom::model::LicenseRefMapping;
 use crate::{
     Error,
-    common::service::delete_doc,
+    common::{LicenseRefMapping, service::delete_doc},
     license::{
         get_sanitize_filename,
         service::{LicenseService, license_export::LicenseExporter},

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -3,10 +3,10 @@ pub mod raw_sql;
 
 use super::service::SbomService;
 use crate::{
-    Error, purl::model::summary::purl::PurlSummary, sbom::service::sbom::LicenseBasicInfo,
-    source_document::model::SourceDocument,
+    Error, common::LicenseRefMapping, purl::model::summary::purl::PurlSummary,
+    sbom::service::sbom::LicenseBasicInfo, source_document::model::SourceDocument,
 };
-use sea_orm::{ConnectionTrait, FromQueryResult, ModelTrait, PaginatorTrait, prelude::Uuid};
+use sea_orm::{ConnectionTrait, ModelTrait, PaginatorTrait, prelude::Uuid};
 use sea_query::FromValueTuple;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -151,12 +151,6 @@ impl From<LicenseBasicInfo> for LicenseInfo {
             license_type: LicenseCategory::from_value_tuple(license_basic_info.license_type),
         }
     }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, FromQueryResult)]
-pub struct LicenseRefMapping {
-    pub license_id: String,
-    pub license_name: String,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -2,19 +2,18 @@ pub mod details;
 pub mod raw_sql;
 
 use super::service::SbomService;
+use crate::common::LicenseInfo;
 use crate::{
     Error, common::LicenseRefMapping, purl::model::summary::purl::PurlSummary,
-    sbom::service::sbom::LicenseBasicInfo, source_document::model::SourceDocument,
+    source_document::model::SourceDocument,
 };
 use sea_orm::{ConnectionTrait, ModelTrait, PaginatorTrait, prelude::Uuid};
-use sea_query::FromValueTuple;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use tracing::instrument;
 use trustify_common::{cpe::Cpe, model::Paginated, purl::Purl};
 use trustify_entity::{
-    labels::Labels, relationship::Relationship, sbom, sbom_node, sbom_package,
-    sbom_package_license::LicenseCategory, source_document,
+    labels::Labels, relationship::Relationship, sbom, sbom_node, sbom_package, source_document,
 };
 use utoipa::ToSchema;
 
@@ -136,21 +135,6 @@ pub struct SbomPackage {
     /// LicenseRef mappings
     #[cfg_attr(feature = "async-graphql", graphql(skip))]
     pub licenses_ref_mapping: Vec<LicenseRefMapping>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
-pub struct LicenseInfo {
-    pub license_name: String,
-    pub license_type: LicenseCategory,
-}
-
-impl From<LicenseBasicInfo> for LicenseInfo {
-    fn from(license_basic_info: LicenseBasicInfo) -> Self {
-        LicenseInfo {
-            license_name: license_basic_info.license_name,
-            license_type: LicenseCategory::from_value_tuple(license_basic_info.license_type),
-        }
-    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -1,7 +1,7 @@
 use super::SbomService;
-use crate::sbom::model::LicenseRefMapping;
 use crate::{
     Error,
+    common::LicenseRefMapping,
     sbom::model::{
         SbomExternalPackageReference, SbomNodeReference, SbomPackage, SbomPackageRelation,
         SbomSummary, Which, details::SbomDetails,
@@ -235,7 +235,8 @@ impl SbomService {
     }
 
     /// Get all the tuples License ID, License Name from the licensing_infos table for a single SBOM
-    async fn get_licensing_infos<C: ConnectionTrait>(
+    #[instrument(skip(connection), err(level=tracing::Level::INFO))]
+    pub async fn get_licensing_infos<C: ConnectionTrait>(
         connection: &C,
         sbom_id: Uuid,
     ) -> Result<BTreeMap<String, String>, Error> {
@@ -624,9 +625,9 @@ where
             JoinType::LeftJoin,
             sbom_package::Relation::PackageLicense.def(),
         ).join(
-            JoinType::LeftJoin,
-            sbom_package_license::Relation::License.def(),
-        )
+        JoinType::LeftJoin,
+        sbom_package_license::Relation::License.def(),
+    )
 }
 
 #[derive(FromQueryResult)]

--- a/modules/fundamental/tests/sbom/spdx/perf.rs
+++ b/modules/fundamental/tests/sbom/spdx/perf.rs
@@ -4,7 +4,7 @@ use test_log::test;
 use tracing::instrument;
 use trustify_common::model::Paginated;
 use trustify_entity::sbom_package_license::LicenseCategory;
-use trustify_module_fundamental::sbom::model::{LicenseInfo, SbomPackage};
+use trustify_module_fundamental::{common::LicenseInfo, sbom::model::SbomPackage};
 use trustify_test_context::TrustifyContext;
 
 #[test_context(TrustifyContext)]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4665,7 +4665,7 @@ components:
         - base
         - advisories
         - licenses
-        - license_ref_mapping
+        - licenses_ref_mapping
         properties:
           advisories:
             type: array
@@ -4673,14 +4673,14 @@ components:
               $ref: '#/components/schemas/PurlAdvisory'
           base:
             $ref: '#/components/schemas/BasePurlHead'
-          license_ref_mapping:
-            type: array
-            items:
-              $ref: '#/components/schemas/LicenseRefMapping'
           licenses:
             type: array
             items:
               $ref: '#/components/schemas/LicenseInfo'
+          licenses_ref_mapping:
+            type: array
+            items:
+              $ref: '#/components/schemas/LicenseRefMapping'
           version:
             $ref: '#/components/schemas/VersionedPurlHead'
     PurlHead:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4665,6 +4665,7 @@ components:
         - base
         - advisories
         - licenses
+        - license_ref_mapping
         properties:
           advisories:
             type: array
@@ -4672,10 +4673,14 @@ components:
               $ref: '#/components/schemas/PurlAdvisory'
           base:
             $ref: '#/components/schemas/BasePurlHead'
+          license_ref_mapping:
+            type: array
+            items:
+              $ref: '#/components/schemas/LicenseRefMapping'
           licenses:
             type: array
             items:
-              $ref: '#/components/schemas/PurlLicenseSummary'
+              $ref: '#/components/schemas/PurlLicenseInfo'
           version:
             $ref: '#/components/schemas/VersionedPurlHead'
     PurlHead:
@@ -4691,18 +4696,16 @@ components:
           type: string
           format: uuid
           description: The ID of the qualified PURL
-    PurlLicenseSummary:
+    PurlLicenseInfo:
       type: object
       required:
-      - sbom
-      - licenses
+      - license_name
+      - license_type
       properties:
-        licenses:
-          type: array
-          items:
-            type: string
-        sbom:
-          $ref: '#/components/schemas/SbomHead'
+        license_name:
+          type: string
+        license_type:
+          type: string
     PurlStatus:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4680,7 +4680,7 @@ components:
           licenses:
             type: array
             items:
-              $ref: '#/components/schemas/PurlLicenseInfo'
+              $ref: '#/components/schemas/LicenseInfo'
           version:
             $ref: '#/components/schemas/VersionedPurlHead'
     PurlHead:
@@ -4696,16 +4696,6 @@ components:
           type: string
           format: uuid
           description: The ID of the qualified PURL
-    PurlLicenseInfo:
-      type: object
-      required:
-      - license_name
-      - license_type
-      properties:
-        license_name:
-          type: string
-        license_type:
-          type: string
     PurlStatus:
       type: object
       required:


### PR DESCRIPTION
## Summary by Sourcery

Add structured license information to the PURL details endpoint by fetching SBOM license data, parsing SPDX expressions to build reference mappings, updating the API schema, and covering the new functionality with tests

New Features:
- Include licenses array and license reference mappings in the PurlDetails API

Enhancements:
- Implement extract_license_ref_mappings to parse SPDX expressions and populate LicenseRefMapping
- Move LicenseInfo and LicenseRefMapping types to a shared common module
- Expose and instrument SbomService.get_licensing_infos to retrieve licensing data

Documentation:
- Update OpenAPI spec to include licenses and licenses_ref_mapping fields

Tests:
- Add integration test for PURL license details endpoint