### PR TITLE
prepare release 0.4.0-beta.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8310,7 +8310,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-auth"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8344,7 +8344,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-common"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8394,7 +8394,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-cvss"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "serde",
  "test-log",
@@ -8404,7 +8404,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-db"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "anyhow",
  "log",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-entity"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8444,7 +8444,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-infrastructure"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "actix-cors",
  "actix-tls",
@@ -8480,7 +8480,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-migration"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "anyhow",
  "sea-orm-migration",
@@ -8497,7 +8497,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-analysis"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-fundamental"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8622,7 +8622,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-graphql"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8645,7 +8645,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-importer"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8702,7 +8702,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ingestor"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-storage"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8787,7 +8787,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ui"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "actix-web",
  "actix-web-static-files",
@@ -8809,7 +8809,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-user"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8831,14 +8831,14 @@ dependencies = [
 
 [[package]]
 name = "trustify-query"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "utoipa",
 ]
 
 [[package]]
 name = "trustify-query-derive"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -8846,7 +8846,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-server"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8888,7 +8888,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-test-context"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-trustd"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -10033,7 +10033,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 edition = "2024"
 publish = false
 license = "Apache-2.0"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache License, Version 2.0
     identifier: Apache-2.0
-  version: 0.4.0-beta.1
+  version: 0.4.0-beta.2
 paths:
   /.well-known/trustify:
     get:


### PR DESCRIPTION
## Summary by Sourcery

Prepare for the 0.4.0-beta.2 release by updating project and API versions and redirecting the UI dependency to the corresponding release branch.

Enhancements:
- Bump workspace package version to 0.4.0-beta.2
- Update OpenAPI spec version to 0.4.0-beta.2
- Switch trustify-ui dependency to the publish/release/0.4.z branch