### PR TITLE
feat: disable GC for orphaned packages by default

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -41,7 +41,7 @@
 | `TRUSTD_DB_PASSWORD`                     | Database password                                                                   | `trustify`                              |
 | `TRUSTD_DB_PORT`                         | Database port                                                                       | `5432`                                  |
 | `TRUSTD_DB_USER`                         | Database username                                                                   | `postgres`                              |
-| `TRUSTD_GC_FREQ`                         | How often database garbage collection runs (humantime)                              | `1h`                                    |
+| `TRUSTD_GC_FREQ`                         | Database garbage collection frequency [disabled by default] (humantime)             | `0s`                                    |
 | `TRUSTD_ISSUER_URL`                      | Issuer URL for `--devmode`                                                          | `http://localhost:8090/realms/trustify` |
 | `TRUSTD_MAX_CACHE_SIZE`                  | Maximum size of the graph cache.                                                    | `200 MiB`                               |
 | `TRUSTD_S3_ACCESS_KEY`                   | S3 access key                                                                       |                                         |

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -38,7 +38,7 @@ use trustify_module_storage::{
 use trustify_module_ui::{UI, endpoints::UiResources};
 use utoipa::openapi::{Info, License};
 
-const GC_FREQ: Duration = Duration::from_secs(60 * 60);
+const GC_FREQ: Duration = Duration::from_secs(0);
 const ENV_GC_FREQ: &str = "TRUSTD_GC_FREQ";
 
 /// Run the API server
@@ -379,7 +379,7 @@ fn schedule_db_tasks(db: db::Database) {
         _ => GC_FREQ,
     };
     if freq < Duration::from_secs(1) {
-        log::warn!("GC is disabled; to enable, set {ENV_GC_FREQ} to at least 1s");
+        log::warn!("Garbage collection is disabled; to enable, set {ENV_GC_FREQ} to at least 1s");
         return;
     }
     log::info!("GC frequency set to {}", humantime::Duration::from(freq));


### PR DESCRIPTION
Downstream issue: https://issues.redhat.com/browse/TC-2958

## Summary by Sourcery

Disable automatic garbage collection for orphaned packages by default by setting the GC frequency to zero and updating related logging and documentation

New Features:
- Disable automatic database garbage collection by default

Enhancements:
- Change default GC frequency constant to zero seconds
- Update warning log message to reflect disabled GC state

Documentation:
- Document that TRUSTD_GC_FREQ is disabled by default with a default value of 0s