### PR TITLE
fix: VersionedPurlStatus doesn't find the status

### DIFF
--- a/modules/fundamental/src/purl/model/details/versioned_purl.rs
+++ b/modules/fundamental/src/purl/model/details/versioned_purl.rs
@@ -139,7 +139,9 @@ impl VersionedPurlStatus {
         package_status: &purl_status::Model,
         tx: &C,
     ) -> Result<Self, Error> {
-        let status = package_status.find_related(status::Entity).one(tx).await?;
+        let status = status::Entity::find_by_id(package_status.status_id)
+            .one(tx)
+            .await?;
 
         let status = status.map(|e| e.slug).unwrap_or("unknown".to_string());
 

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -840,12 +840,33 @@ async fn contextual_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     assert!( advisory.status.iter().any(|status| {
         matches!( &status.context , Some(StatusContext::Cpe(cpe)) if cpe == "cpe:/a:redhat:enterprise_linux:8:*:appstream:*")
-        && status.vulnerability.identifier == "CVE-2024-24549"
+        && status.vulnerability.identifier == "CVE-2024-24549" && status.status == "fixed"
     }));
 
     assert!( advisory.status.iter().any(|status| {
         matches!( &status.context , Some(StatusContext::Cpe(cpe)) if cpe == "cpe:/a:redhat:enterprise_linux:8:*:appstream:*")
-            && status.vulnerability.identifier == "CVE-2024-23672"
+            && status.vulnerability.identifier == "CVE-2024-23672" && status.status == "fixed"
+    }));
+
+    let versioned = service
+        .versioned_purl_by_uuid(&tomcat_jsp.version.uuid, &ctx.db)
+        .await?
+        .unwrap();
+
+    assert_eq!(1, versioned.advisories.len());
+
+    let advisory = &versioned.advisories[0];
+
+    log::debug!("{advisory:#?}");
+
+    assert_eq!(2, advisory.status.len());
+
+    assert!(advisory.status.iter().any(|status| {
+        status.vulnerability.identifier == "CVE-2024-24549" && status.status == "fixed"
+    }));
+
+    assert!(advisory.status.iter().any(|status| {
+        status.vulnerability.identifier == "CVE-2024-23672" && status.status == "fixed"
     }));
 
     Ok(())


### PR DESCRIPTION
The status is always "unknown" even if there are proper statuses in the database as wrong find function is used.

## Summary by Sourcery

Fix incorrect status lookup for versioned PURLs and enhance tests to validate actual status resolution

Bug Fixes:
- Use find_by_id instead of find_related when retrieving status to avoid always returning "unknown"

Tests:
- Extend purl service tests to assert proper "fixed" statuses for advisories in versioned PURLs