### PR TITLE
perf: improve 'expand_license_expression' PLSQL function

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -27,6 +27,7 @@ mod m0001120_sbom_external_node_indexes;
 mod m0001130_gover_cmp;
 mod m0001140_expand_spdx_licenses_function;
 mod m0001150_case_license_text_sbom_id_function;
+mod m0001160_improve_expand_spdx_licenses_function;
 
 pub struct Migrator;
 
@@ -61,6 +62,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001130_gover_cmp::Migration),
             Box::new(m0001140_expand_spdx_licenses_function::Migration),
             Box::new(m0001150_case_license_text_sbom_id_function::Migration),
+            Box::new(m0001160_improve_expand_spdx_licenses_function::Migration),
         ]
     }
 }

--- a/migration/src/m0001160_improve_expand_spdx_licenses_function.rs
+++ b/migration/src/m0001160_improve_expand_spdx_licenses_function.rs
@@ -1,0 +1,29 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0001160_improve_expand_spdx_licenses_function/improve_expand_up.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("DROP FUNCTION IF EXISTS expand_license_expression(TEXT, UUID);")
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m0001160_improve_expand_spdx_licenses_function/improve_expand_up.sql
+++ b/migration/src/m0001160_improve_expand_spdx_licenses_function/improve_expand_up.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE FUNCTION expand_license_expression(
+    license_text TEXT,
+    sbom_id_param UUID
+) RETURNS TEXT AS $$
+DECLARE
+    result_text TEXT := license_text;
+    license_mapping RECORD;
+BEGIN
+    -- Replace each license reference with its corresponding name
+    FOR license_mapping IN
+        SELECT license_id, name
+        FROM licensing_infos
+        WHERE sbom_id = sbom_id_param
+    LOOP
+        -- Exit early if no more LicenseRef- patterns exist in the text
+        IF result_text !~ 'LicenseRef-' THEN
+            EXIT;
+        END IF;
+        -- Replace the license_id with the license name in the expression
+        -- This handles exact matches and license references within expressions
+        result_text := regexp_replace(result_text, '\m' || license_mapping.license_id || '\M', license_mapping.name, 'g');
+END LOOP;
+
+RETURN result_text;
+END;
+$$ LANGUAGE plpgsql STABLE PARALLEL SAFE;


### PR DESCRIPTION
Compared to the current version of `expand_license_expression`, the one in this PR adds:
```sql
        -- Exit early if no more LicenseRef- patterns exist in the text
        IF result_text !~ 'LicenseRef-' THEN
            EXIT;
        END IF;
```
in order for the function to loop only as long as there's a `LicenseRef-` to replace and not, just like happening so far, looping through all the rows from `licensing_infos` every time.

This improves the performance recorded by the `get_sbom_license_ids` scale test (`-294115.66 ms` on average)

## Summary by Sourcery

Introduce a new migration to optimize the expand_license_expression PL/pgSQL function by adding an early exit when no LicenseRef- patterns remain and register this migration in the migration sequence.

Enhancements:
- Add early exit check in expand_license_expression to stop scanning licensing_infos once no more LicenseRef- patterns are found

Build:
- Include the new m0001160 migration in the Migrator struct to apply the optimized function change