### PR TITLE
Revert "feat: adding gc endpoint"

### DIFF
--- a/modules/fundamental/src/purl/endpoints/mod.rs
+++ b/modules/fundamental/src/purl/endpoints/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 use actix_web::{HttpResponse, Responder, get, web};
 use sea_orm::prelude::Uuid;
 use std::str::FromStr;
-use trustify_auth::{DeleteSbom, ReadSbom, authorizer::Require};
+use trustify_auth::{ReadSbom, authorizer::Require};
 use trustify_common::{
     db::Database, db::query::Query, id::IdError, model::Paginated, model::PaginatedResults,
     purl::Purl,
@@ -25,7 +25,6 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         .app_data(web::Data::new(purl_service))
         .service(base::get_base_purl)
         .service(base::all_base_purls)
-        .service(gc)
         .service(get)
         .service(all);
 }
@@ -80,23 +79,6 @@ pub async fn all(
     _: Require<ReadSbom>,
 ) -> actix_web::Result<impl Responder> {
     Ok(HttpResponse::Ok().json(service.purls(search, paginated, db.as_ref()).await?))
-}
-
-#[utoipa::path(
-    operation_id = "garbageCollect",
-    tag = "purl",
-    responses(
-        (status = 200, description = "Performs garbage collection for orphaned packages", body = String),
-    ),
-)]
-#[get("/v2/purl/gc")]
-pub async fn gc(
-    service: web::Data<PurlService>,
-    db: web::Data<Database>,
-    _: Require<DeleteSbom>,
-) -> actix_web::Result<impl Responder> {
-    let result = service.gc_purls(db.as_ref()).await?;
-    Ok(HttpResponse::Ok().body(result.to_string()))
 }
 
 #[cfg(test)]

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -2,7 +2,6 @@ use crate::purl::model::details::base_purl::BasePurlDetails;
 use crate::purl::model::summary::base_purl::BasePurlSummary;
 use crate::purl::model::summary::purl::PurlSummary;
 use crate::test::caller;
-use actix_web::http::StatusCode;
 use actix_web::test::TestRequest;
 use serde_json::{Value, json};
 use std::str::FromStr;
@@ -292,24 +291,5 @@ async fn test_purl_license_details(ctx: &TrustifyContext) -> Result<(), anyhow::
       "licenses_ref_mapping": []
     });
     assert!(expected_result.contains_subset(response.clone()));
-    Ok(())
-}
-
-#[test_context(TrustifyContext)]
-#[test(actix_web::test)]
-async fn garbage_collect(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.db, &ctx.graph).await?;
-    let app = caller(ctx).await?;
-
-    let uri = "/api/v2/purl/gc";
-    let request = TestRequest::get().uri(uri).to_request();
-    let response = app.call_service(request).await;
-
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body_bytes = actix_web::test::read_body(response).await;
-    let body_str = std::str::from_utf8(&body_bytes)?;
-    assert_eq!(body_str, "8");
-
     Ok(())
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2057,18 +2057,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasePurlDetails'
-  /api/v2/purl/gc:
-    get:
-      tags:
-      - purl
-      operationId: garbageCollect
-      responses:
-        '200':
-          description: Performs garbage collection for orphaned packages
-          content:
-            text/plain:
-              schema:
-                type: string
   /api/v2/purl/{key}:
     get:
       tags:


### PR DESCRIPTION
This reverts commit 9d0f3ac52b6560ff412cd1a945d991446a85a457.

A summary of the discussions we had in meetings and chats: the `/v2/purl/gc` endpoint requires quite some resources to run and, in fact, the automatic GC has been disabled in https://github.com/guacsec/trustify/pull/2009.
Consistently the endpoint will be removed in order to prevent impact on performance if it gets invoked.

Fixes #2023

## Summary by Sourcery

Revert the garbage collection endpoint for purls by removing its service registration, handler, test, and OpenAPI documentation to prevent performance impact

Bug Fixes:
- Remove the /api/v2/purl/gc endpoint and its handler implementation

Documentation:
- Remove the garbage collection path from the OpenAPI specification

Tests:
- Remove the associated garbage_collect integration test