### PR TITLE
fix: source document id must be non-null

### DIFF
--- a/entity/src/advisory.rs
+++ b/entity/src/advisory.rs
@@ -31,7 +31,7 @@ pub struct Model {
     pub withdrawn: Option<OffsetDateTime>,
     pub title: Option<String>,
     pub labels: Labels,
-    pub source_document_id: Option<Uuid>,
+    pub source_document_id: Uuid,
 }
 
 #[cfg(feature = "async-graphql")]

--- a/entity/src/sbom.rs
+++ b/entity/src/sbom.rs
@@ -19,7 +19,7 @@ pub struct Model {
     pub suppliers: Vec<String>,
     pub data_licenses: Vec<String>,
 
-    pub source_document_id: Option<Uuid>,
+    pub source_document_id: Uuid,
 
     #[cfg_attr(
         feature = "async-graphql",

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -28,6 +28,7 @@ mod m0001130_gover_cmp;
 mod m0001140_expand_spdx_licenses_function;
 mod m0001150_case_license_text_sbom_id_function;
 mod m0001160_improve_expand_spdx_licenses_function;
+mod m0001170_non_null_source_document_id;
 
 pub struct Migrator;
 
@@ -63,6 +64,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001140_expand_spdx_licenses_function::Migration),
             Box::new(m0001150_case_license_text_sbom_id_function::Migration),
             Box::new(m0001160_improve_expand_spdx_licenses_function::Migration),
+            Box::new(m0001170_non_null_source_document_id::Migration),
         ]
     }
 }

--- a/migration/src/m0001170_non_null_source_document_id.rs
+++ b/migration/src/m0001170_non_null_source_document_id.rs
@@ -1,0 +1,63 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Advisory::Table)
+                    .modify_column(ColumnDef::new(Advisory::SourceDocumentId).not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Sbom::Table)
+                    .modify_column(ColumnDef::new(Sbom::SourceDocumentId).not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Sbom::Table)
+                    .modify_column(ColumnDef::new(Sbom::SourceDocumentId).null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Advisory::Table)
+                    .modify_column(ColumnDef::new(Advisory::SourceDocumentId).null())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Iden)]
+enum Advisory {
+    Table,
+    SourceDocumentId,
+}
+
+#[derive(Iden)]
+enum Sbom {
+    Table,
+    SourceDocumentId,
+}

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -560,11 +560,7 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .call_and_read_body_json(TestRequest::get().uri("/api/v2/advisory").to_request())
         .await;
     assert_eq!(advisory_list.total, 1);
-    let key: StorageKey = advisory_list.items[0]
-        .source_document
-        .as_ref()
-        .expect("valid document")
-        .try_into()?;
+    let key: StorageKey = advisory_list.items[0].source_document.clone().try_into()?;
     assert!(storage.retrieve(key.clone()).await?.is_some());
 
     // first delete should succeed

--- a/modules/fundamental/src/advisory/model/details/mod.rs
+++ b/modules/fundamental/src/advisory/model/details/mod.rs
@@ -17,7 +17,7 @@ pub struct AdvisoryDetails {
     pub head: AdvisoryHead,
 
     #[serde(flatten)]
-    pub source_document: Option<SourceDocument>,
+    pub source_document: SourceDocument,
 
     /// Vulnerabilities addressed within this advisory.
     pub vulnerabilities: Vec<AdvisoryVulnerabilitySummary>,
@@ -60,10 +60,7 @@ impl AdvisoryDetails {
                 tx,
             )
             .await?,
-            source_document: advisory
-                .source_document
-                .as_ref()
-                .map(SourceDocument::from_entity),
+            source_document: SourceDocument::from_entity(&advisory.source_document),
             vulnerabilities,
             average_severity: None,
             average_score: None,

--- a/modules/fundamental/src/advisory/model/summary.rs
+++ b/modules/fundamental/src/advisory/model/summary.rs
@@ -17,7 +17,7 @@ pub struct AdvisorySummary {
 
     /// Information pertaning to the underlying source document, if any.
     #[serde(flatten)]
-    pub source_document: Option<SourceDocument>,
+    pub source_document: SourceDocument,
 
     /// Average (arithmetic mean) severity of the advisory aggregated from *all* related vulnerability assertions.
     #[schema(required)]
@@ -69,10 +69,7 @@ impl AdvisorySummary {
                     tx,
                 )
                 .await?,
-                source_document: each
-                    .source_document
-                    .as_ref()
-                    .map(SourceDocument::from_entity),
+                source_document: SourceDocument::from_entity(&each.source_document),
                 average_severity: None,
                 average_score: None,
                 vulnerabilities,

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -199,7 +199,7 @@ impl AdvisoryService {
 
 #[derive(Debug)]
 pub struct AdvisoryCatcher {
-    pub source_document: Option<source_document::Model>,
+    pub source_document: source_document::Model,
     pub advisory: advisory::Model,
     pub issuer: Option<organization::Model>,
 }
@@ -211,7 +211,8 @@ impl FromQueryResult for AdvisoryCatcher {
                 res,
                 "",
                 source_document::Entity,
-            )?,
+            )?
+            .ok_or_else(|| DbErr::Custom("Missing source document".to_string()))?,
             advisory: Self::from_query_result_multi_model(res, "", advisory::Entity)?,
             issuer: Self::from_query_result_multi_model_optional(res, "", organization::Entity)?,
         })

--- a/modules/fundamental/src/advisory/service/test.rs
+++ b/modules/fundamental/src/advisory/service/test.rs
@@ -152,12 +152,12 @@ async fn single_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             fetched,
             Some(AdvisoryDetails {
                 head: AdvisoryHead { .. },
-            source_document: Some(SourceDocument {
+            source_document: SourceDocument {
                 sha256,
                 sha384,
                 sha512,
                 ..
-            }),
+            },
             average_severity: None,
                 ..
             })
@@ -168,14 +168,13 @@ async fn single_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             fetched,
             Some(AdvisoryDetails {
                 head: AdvisoryHead { .. },
-            source_document: Some(SourceDocument {
+            source_document: SourceDocument {
                 sha256,
                 sha384,
                 sha512,
                 ..
-            }),
+            },
             average_severity: None,
-
                 ..
             })
         if sha256 == jenny256.to_string() && sha384 == jenny384.to_string() && sha512 == jenny512.to_string()));

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1181,8 +1181,7 @@ async fn download_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let sbom = app.call_and_read_body_json::<SbomSummary>(req).await;
     assert_eq!(Id::Uuid(sbom.head.id), result.id);
 
-    assert!(sbom.source_document.is_some());
-    let doc = sbom.source_document.unwrap();
+    let doc = sbom.source_document;
 
     let hashes = vec![doc.sha256, doc.sha384, doc.sha512];
 

--- a/modules/fundamental/tests/dataset.rs
+++ b/modules/fundamental/tests/dataset.rs
@@ -48,10 +48,6 @@ async fn ingest(ctx: TrustifyContext) -> anyhow::Result<()> {
 
     let source_doc = sbom_summary.source_document;
 
-    assert!(source_doc.is_some());
-
-    let source_doc = source_doc.unwrap();
-
     let storage_key = (&source_doc).try_into()?;
 
     let stream = storage.retrieve(storage_key).await?;

--- a/modules/fundamental/tests/sbom/spdx.rs
+++ b/modules/fundamental/tests/sbom/spdx.rs
@@ -181,10 +181,7 @@ async fn ingested_timestamp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
                 .await?
                 .expect("must find the document");
 
-            let ingested = sbom
-                .source_document
-                .expect("must have a source document")
-                .ingested;
+            let ingested = sbom.source_document.ingested;
             let now = OffsetDateTime::now_utc();
             assert!(ingested > start && ingested < now);
 

--- a/modules/fundamental/tests/sbom/spdx/corner_cases.rs
+++ b/modules/fundamental/tests/sbom/spdx/corner_cases.rs
@@ -222,12 +222,7 @@ async fn special_char(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let stream = ctx
         .storage
-        .retrieve(
-            sbom.source_document
-                .expect("must be found")
-                .try_into()
-                .expect("must be converted"),
-        )
+        .retrieve(sbom.source_document.try_into().expect("must be converted"))
         .await?
         .expect("must be found");
     let data: BytesMut = stream.try_collect().await?;

--- a/modules/ingestor/src/graph/advisory/mod.rs
+++ b/modules/ingestor/src/graph/advisory/mod.rs
@@ -164,7 +164,7 @@ impl Graph {
             modified: Set(modified),
             withdrawn: Set(withdrawn),
             labels: Set(labels.validate()?),
-            source_document_id: Set(Some(new_id)),
+            source_document_id: Set(new_id),
         };
 
         let result = model.insert(connection).await?;

--- a/modules/ingestor/src/graph/sbom/mod.rs
+++ b/modules/ingestor/src/graph/sbom/mod.rs
@@ -134,7 +134,7 @@ impl Graph {
             authors: Set(authors),
             suppliers: Set(suppliers),
 
-            source_document_id: Set(Some(new_id)),
+            source_document_id: Set(new_id),
             labels: Set(labels.into().validate()?),
             data_licenses: Set(data_licenses),
         };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3278,9 +3278,7 @@ components:
     AdvisoryDetails:
       allOf:
       - $ref: '#/components/schemas/AdvisoryHead'
-      - oneOf:
-        - type: 'null'
-        - $ref: '#/components/schemas/SourceDocument'
+      - $ref: '#/components/schemas/SourceDocument'
       - type: object
         required:
         - vulnerabilities
@@ -3361,10 +3359,8 @@ components:
     AdvisorySummary:
       allOf:
       - $ref: '#/components/schemas/AdvisoryHead'
-      - oneOf:
-        - type: 'null'
-        - $ref: '#/components/schemas/SourceDocument'
-          description: Information pertaning to the underlying source document, if any.
+      - $ref: '#/components/schemas/SourceDocument'
+        description: Information pertaning to the underlying source document, if any.
       - type: object
         required:
         - average_severity
@@ -4190,10 +4186,8 @@ components:
           items:
             allOf:
             - $ref: '#/components/schemas/AdvisoryHead'
-            - oneOf:
-              - type: 'null'
-              - $ref: '#/components/schemas/SourceDocument'
-                description: Information pertaning to the underlying source document, if any.
+            - $ref: '#/components/schemas/SourceDocument'
+              description: Information pertaning to the underlying source document, if any.
             - type: object
               required:
               - average_severity
@@ -4519,9 +4513,7 @@ components:
           items:
             allOf:
             - $ref: '#/components/schemas/SbomHead'
-            - oneOf:
-              - type: 'null'
-              - $ref: '#/components/schemas/SourceDocument'
+            - $ref: '#/components/schemas/SourceDocument'
             - type: object
               required:
               - described_by
@@ -5101,9 +5093,7 @@ components:
     SbomSummary:
       allOf:
       - $ref: '#/components/schemas/SbomHead'
-      - oneOf:
-        - type: 'null'
-        - $ref: '#/components/schemas/SourceDocument'
+      - $ref: '#/components/schemas/SourceDocument'
       - type: object
         required:
         - described_by


### PR DESCRIPTION
I ran across this when working on the ADR PoC for re-ingesting documents.

It's never null. It is actually required. But we don't enforce this and neither reflect this in our data model. Which makes things more complicated.

## Summary by Sourcery

Enforce non-null constraint for source_document_id across entity models, ingestion logic, and database schema

Enhancements:
- Change source_document_id from Option<Uuid> to required Uuid in advisory and SBOM entity models
- Update ingestion Graph implementations to set source_document_id directly without wrapping in Option

Build:
- Add migration m0001170 to alter source_document_id columns to NOT NULL in advisory and SBOM tables and register it in the migrator