### PR TITLE
perf: license filtering with CTEs (TC-3006)

### DIFF
--- a/common/src/db/func.rs
+++ b/common/src/db/func.rs
@@ -98,3 +98,9 @@ impl Iden for CaseLicenseTextSbomId {
         write!(s, "case_license_text_sbom_id").unwrap()
     }
 }
+
+#[derive(Iden)]
+pub enum CustomFunc {
+    #[iden = "expand_license_expression_with_mappings"]
+    ExpandLicenseExpressionWithMappings,
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -29,6 +29,7 @@ mod m0001140_expand_spdx_licenses_function;
 mod m0001150_case_license_text_sbom_id_function;
 mod m0001160_improve_expand_spdx_licenses_function;
 mod m0001170_non_null_source_document_id;
+mod m0001180_expand_spdx_licenses_with_mappings_function;
 
 pub struct Migrator;
 
@@ -65,6 +66,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001150_case_license_text_sbom_id_function::Migration),
             Box::new(m0001160_improve_expand_spdx_licenses_function::Migration),
             Box::new(m0001170_non_null_source_document_id::Migration),
+            Box::new(m0001180_expand_spdx_licenses_with_mappings_function::Migration),
         ]
     }
 }

--- a/migration/src/m0001180_expand_spdx_licenses_with_mappings_function.rs
+++ b/migration/src/m0001180_expand_spdx_licenses_with_mappings_function.rs
@@ -1,0 +1,31 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0001180_expand_spdx_licenses_with_mappings_function/up.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0001180_expand_spdx_licenses_with_mappings_function/down.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m0001180_expand_spdx_licenses_with_mappings_function/down.sql
+++ b/migration/src/m0001180_expand_spdx_licenses_with_mappings_function/down.sql
@@ -1,0 +1,8 @@
+-- Rollback the license expansion optimization
+-- This restores the original UUID-based function signatures
+
+-- Drop the optimized functions
+DROP FUNCTION IF EXISTS expand_license_expression_with_mappings(TEXT, license_mapping[]);
+
+-- Drop the composite type
+DROP TYPE IF EXISTS license_mapping CASCADE;

--- a/migration/src/m0001180_expand_spdx_licenses_with_mappings_function/up.sql
+++ b/migration/src/m0001180_expand_spdx_licenses_with_mappings_function/up.sql
@@ -1,0 +1,40 @@
+-- Performance optimization for license expansion functions
+-- This migration replaces the functions to accept license mappings as arrays
+-- instead of querying the database per row, significantly improving performance
+
+-- Create a composite type to hold license mappings
+CREATE TYPE license_mapping AS (
+    license_id TEXT,
+    name TEXT
+);
+
+CREATE OR REPLACE FUNCTION expand_license_expression_with_mappings(
+    license_text TEXT,
+    license_mappings license_mapping[]
+) RETURNS TEXT AS $$
+DECLARE
+    result_text TEXT := license_text;
+    mapping license_mapping;
+BEGIN
+    -- Return early if no mappings provided or license_text is NULL
+    IF license_mappings IS NULL OR array_length(license_mappings, 1) IS NULL OR license_text IS NULL THEN
+        RETURN license_text;
+    END IF;
+
+    -- Replace each license reference with its corresponding name
+    FOREACH mapping IN ARRAY license_mappings
+    LOOP
+        -- Exit early if no more LicenseRef- patterns exist in the text
+        IF result_text !~ 'LicenseRef-' THEN
+            EXIT;
+        END IF;
+
+        -- Replace the license_id with the license name in the expression
+        -- This handles exact matches and license references within expressions
+        -- \m and \M are word boundary anchors to match whole words only
+        result_text := regexp_replace(result_text, '\m' || mapping.license_id || '\M', mapping.name, 'g');
+    END LOOP;
+
+    RETURN result_text;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;

--- a/modules/fundamental/src/license/endpoints/test.rs
+++ b/modules/fundamental/src/license/endpoints/test.rs
@@ -240,6 +240,32 @@ async fn list_licenses_with_search_filter(ctx: &TrustifyContext) -> Result<(), a
 
     assert_eq!(0, response.total);
     assert_eq!(0, response.items.len());
+
+    // Test search filter for "ASL" (Apache Software License) and sorting (default asc)
+    let uri = "/api/v2/license?q=license~ASL&sort=license";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(response.total, 4);
+    // Verify licenses are sorted in ascending order
+    let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
+    let mut sorted_licenses = license_names.clone();
+    sorted_licenses.sort();
+    assert_eq!(license_names, sorted_licenses);
+
+    // Test full text search filter for "ASL" (Apache Software License) and sorting desc
+    let uri = "/api/v2/license?q=ASL&sort=license:desc";
+    let request = TestRequest::get().uri(uri).to_request();
+    let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
+
+    assert_eq!(response.total, 4);
+    // Verify licenses are sorted in descending order
+    let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
+    let mut sorted_licenses = license_names.clone();
+    sorted_licenses.sort();
+    sorted_licenses.reverse();
+    assert_eq!(license_names, sorted_licenses);
+
     Ok(())
 }
 


### PR DESCRIPTION
Some considerations based upon evaluation against the largest testing dataset, i.e. the scale test one.

## Optimization at high level

- CTE 1: Prepare license mappings
- CTE 2: Deduplicate input data
- CTE 3: Perform expensive operation on minimum set
- Final: Filter and return results

Each CTE ([Common Table Expressions](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH)) has a single, well-defined purpose.

## Benefits of Using CTEs for Minimum Dataset Execution

### Reduction in Expensive Operations
  - Before: 766,498 total rows → 255,000+ function calls to EXPAND_LICENSE_EXPRESSION
  - After: Deduplicate to 31,459 unique combinations → only 31,459 function calls
  - Result: 24x reduction in data volume, 8x reduction in function calls
  - Impact: ~4x performance improvement (25.5s → 6s)

### Exploit Data Invariants
  - Key insight: Same license text in same SBOM always expands identically
  - CTE benefit: DISTINCT in CTE enforces this invariant at SQL level
  - Avoids: Redundant computation of identical expansions

 ### Single Query Execution vs N+1 Pattern
  - Without CTE: Query → fetch → loop → call function N times → aggregate
  - With CTE: Single query executes everything in database engine
  - Benefit: Eliminates round-trips between application and database

### Database-Level Optimization
  - PostgreSQL can optimize each CTE independently
  - Query planner chooses optimal join order and indexes
  - Intermediate results can be materialized or inlined based on cost
  - Better use of database caching and buffer pools

## Further changes
- new way for expressing custom functions for SQL in `common/src/db/func.rs` (follow-up PR to migrate the existing ones once agreed upon applying it)
- added some more tests

Fixes [TC-3006](https://issues.redhat.com/browse/TC-3006)

## Summary by Sourcery

Streamline SPDX license filtering by moving deduplication and expression expansion into three database CTEs and a new PL/pgSQL function, updating service layers to use a single-query approach for significant performance gains, and adding the necessary migration and endpoint tests

New Features:
- Introduce CTE-based license filtering pipeline in license, SBOM, and PURL services to deduplicate and expand SPDX expressions entirely in SQL
- Add a new PL/pgSQL function `expand_license_expression_with_mappings` with a composite `license_mapping` type via migration m0001180
- Expose the new expand function in Rust through a `CustomFunc::ExpandLicenseExpressionWithMappings` enum variant

Enhancements:
- Refactor service queries to use `build_license_filtering_with_clause`, reducing redundant expansion calls and eliminating N+1 patterns
- Leverage distinct CTEs for mapping aggregation, unique license/SBOM pairs, and expression expansion, yielding ~4× performance improvement
- Integrate full-text search and sorting translations into the new CTE-based filtering logic

Build:
- Add migration m0001180 to create `license_mapping` composite type and optimized expansion function

Tests:
- Add endpoint tests to verify license search filtering and sorting order for the updated license API