### PR TITLE
chore: improves OTEL docs a bit

### DIFF
--- a/docs/otel.md
+++ b/docs/otel.md
@@ -19,7 +19,7 @@ while DevOps manage its configuration, deployment, and backend integration.
 
 We are focusing on the signals: **traces** and **metrics**.
 
-## To enable traces, follow the instructions below
+## Enabling Traces
 
 * Clone Trustify
 * Open a terminal and run the command below to start OTEL Collector, Tempo, Prometheus, and Grafana:
@@ -36,9 +36,9 @@ RUST_LOG=info OTEL_TRACES_SAMPLER_ARG=1 cargo run --bin trustd api --devmode --d
 
 >[!NOTE]
 > You can select `traces` or `metrics` individually, or both, as shown in the command above.
-> For `metrics` only, the extra environment variables `RUST_LOG=info` and `OTEL_TRACES_SAMPLER_ARG=1` are not needed.
+> When using `metrics` only, the extra environment variables `RUST_LOG=info` and `OTEL_TRACES_SAMPLER_ARG=1` are not required.
 
-* For the importer use the command below to enable traces:
+* To enable traces for the importer, use the command below:
 
 ```shell
 RUST_LOG=info OTEL_TRACES_SAMPLER_ARG=1 cargo run --bin trustd importer --db-port 5432 --tracing enabled
@@ -54,7 +54,7 @@ To view Trustify's metrics in the Prometheus expression browser, use the followi
 
 ## Diagrams
 
-The diagrams below reflect the **current state** of both Trustify and [Trustify Helm Charts](https://github.com/trustification/trustify-helm-charts)
+The diagrams below reflect the **current state** of both Trustify and the [Trustify Helm Charts](https://github.com/trustification/trustify-helm-charts).
 
 ### Scenarios
 


### PR DESCRIPTION
Assisted-by: Claude Code

## Summary by Sourcery

Refine and clarify the OpenTelemetry documentation by updating section headings, rephrasing instructions, and improving link wording for better readability.

Enhancements:
- Update the traces section header to ‘Enabling Traces’ for consistency
- Rephrase note about metrics-only usage to improve clarity
- Clarify the importer command bullet to explicitly mention enabling traces
- Adjust link wording to include 'the' before Trustify Helm Charts

Documentation:
- Improve grammar and style in docs/otel.md