### PR TITLE
refactor: rename default OIDC resources to trustify

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cargo install oidc-cli
 Then, set up an initial client (needs to be done every time the client/keycloak instance is re-created):
 
 ```bash
-oidc create confidential trusty --issuer http://localhost:8090/realms/chicken --client-id walker --client-secret ZVzq9AMOVUdMY1lSohpx1jI3aW56QDPS
+oidc create confidential trusty --issuer http://localhost:8090/realms/trustify --client-id walker --client-secret ZVzq9AMOVUdMY1lSohpx1jI3aW56QDPS
 ```
 
 Then one can perform `http` request using HTTPie like this:

--- a/etc/deploy/compose/compose-sso.yaml
+++ b/etc/deploy/compose/compose-sso.yaml
@@ -34,8 +34,8 @@ services:
       - KEYCLOAK_ADMIN_PASSWORD=admin123456
       - REALM=trustify
       - INIT_DATA=/init-sso/data
-      - CHICKEN_ADMIN=admin
-      - CHICKEN_ADMIN_PASSWORD=admin123456
+      - TRUSTIFY_ADMIN=admin
+      - TRUSTIFY_ADMIN_PASSWORD=admin123456
       - REDIRECT_URIS=["http://localhost:*"]
       - WALKER_SECRET=ZVzq9AMOVUdMY1lSohpx1jI3aW56QDPS
       # The internal name (between containers) is "keycloak". However, from the host it reachable as "localhost:8090".

--- a/etc/deploy/compose/config/init-sso/data/there-is-more.sh
+++ b/etc/deploy/compose/config/init-sso/data/there-is-more.sh
@@ -12,10 +12,10 @@ kcadm create clients -r "${REALM}" -f "${INIT_DATA}/client-testing-user.json" "$
 kcadm create clients -r "${REALM}" -f "${INIT_DATA}/client-testing-manager.json" "${CLIENT_OPTS[@]}"
 
 # default role for service account of services
-kcadm add-roles -r "${REALM}" --uusername service-account-testing-manager --rolename chicken-manager
+kcadm add-roles -r "${REALM}" --uusername service-account-testing-manager --rolename trustify-manager
 
 # create a non-admin user
 kcadm create users -r "${REALM}" -s "username=user" -s enabled=true
-kcadm add-roles -r "${REALM}" --uusername "user" --rolename chicken-user
+kcadm add-roles -r "${REALM}" --uusername "user" --rolename trustify-user
 ID=$(kcadm get users -r "${REALM}" --query exact=true --query "username=user" --fields id --format csv --noquotes)
 kcadm update "users/${ID}/reset-password" -r "${REALM}" -s type=password -s "value=user123456" -s temporary=false -n

--- a/etc/deploy/compose/config/init-sso/init.sh
+++ b/etc/deploy/compose/config/init-sso/init.sh
@@ -71,13 +71,13 @@ else
 fi
 
 # create realm roles
-kcadm create roles -r "${REALM}" -s name=chicken-user || true
-kcadm create roles -r "${REALM}" -s name=chicken-manager || true
-kcadm create roles -r "${REALM}" -s name=chicken-admin || true
-# add chicken-user as default role
-kcadm add-roles -r "${REALM}" --rname "default-roles-${REALM}" --rolename chicken-user
+kcadm create roles -r "${REALM}" -s name=trustify-user || true
+kcadm create roles -r "${REALM}" -s name=trustify-manager || true
+kcadm create roles -r "${REALM}" -s name=trustify-admin || true
+# add trustify-user as default role
+kcadm add-roles -r "${REALM}" --rname "default-roles-${REALM}" --rolename trustify-user
 
-MANAGER_ID=$(kcadm get roles -r "${REALM}" --fields id,name --format csv --noquotes | grep ",chicken-manager" | cut -d ',' -f 1)
+MANAGER_ID=$(kcadm get roles -r "${REALM}" --fields id,name --format csv --noquotes | grep ",trustify-manager" | cut -d ',' -f 1)
 
 # create scopes
 # shellcheck disable=SC2043
@@ -88,8 +88,8 @@ done
 for i in create:document delete:document; do
 kcadm create client-scopes -r "${REALM}" -s "name=$i" -s protocol=openid-connect || true
 ID=$(kcadm get client-scopes -r "${REALM}" --fields id,name --format csv --noquotes | grep ",${i}" | cut -d ',' -f 1)
-# add all scopes to the chicken-manager
-kcadm create "client-scopes/${ID}/scope-mappings/realm" -r "${REALM}" -b '[{"name":"chicken-manager", "id":"'"${MANAGER_ID}"'"}]' || true
+# add all scopes to the trustify-manager
+kcadm create "client-scopes/${ID}/scope-mappings/realm" -r "${REALM}" -b '[{"name":"trustify-manager", "id":"'"${MANAGER_ID}"'"}]' || true
 done
 
 # create clients - frontend
@@ -116,26 +116,26 @@ if [[ -n "$ID" ]]; then
 else
   kcadm create clients -r "${REALM}" -f "${INIT_DATA}/client-walker.json" "${CLIENT_OPTS[@]}"
 fi
-kcadm add-roles -r "${REALM}" --uusername service-account-walker --rolename chicken-manager
+kcadm add-roles -r "${REALM}" --uusername service-account-walker --rolename trustify-manager
 # now set the client-secret
 ID=$(kcadm get clients -r "${REALM}" --query exact=true --query "clientId=walker" --fields id --format csv --noquotes)
 kcadm update "clients/${ID}" -r "${REALM}" -s "secret=${WALKER_SECRET}"
 
 # create user
-ID=$(kcadm get users -r "${REALM}" --query exact=true --query "username=${CHICKEN_ADMIN}" --fields id --format csv --noquotes)
+ID=$(kcadm get users -r "${REALM}" --query exact=true --query "username=${TRUSTIFY_ADMIN}" --fields id --format csv --noquotes)
 if [[ -n "$ID" ]]; then
   kcadm update "users/$ID" -r "${REALM}" -s enabled=true
 else
-  kcadm create users -r "${REALM}" -s "username=${CHICKEN_ADMIN}" -s enabled=true
+  kcadm create users -r "${REALM}" -s "username=${TRUSTIFY_ADMIN}" -s enabled=true
 fi
 
 # set role
-kcadm add-roles -r "${REALM}" --uusername "${CHICKEN_ADMIN}" --rolename chicken-admin
-kcadm add-roles -r "${REALM}" --uusername "${CHICKEN_ADMIN}" --rolename chicken-manager
+kcadm add-roles -r "${REALM}" --uusername "${TRUSTIFY_ADMIN}" --rolename trustify-admin
+kcadm add-roles -r "${REALM}" --uusername "${TRUSTIFY_ADMIN}" --rolename trustify-manager
 
 # set password
-ID=$(kcadm get users -r "${REALM}" --query exact=true --query "username=${CHICKEN_ADMIN}" --fields id --format csv --noquotes)
-kcadm update "users/${ID}/reset-password" -r "${REALM}" -s type=password -s "value=${CHICKEN_ADMIN_PASSWORD}" -s temporary=false -n
+ID=$(kcadm get users -r "${REALM}" --query exact=true --query "username=${TRUSTIFY_ADMIN}" --fields id --format csv --noquotes)
+kcadm update "users/${ID}/reset-password" -r "${REALM}" -s type=password -s "value=${TRUSTIFY_ADMIN_PASSWORD}" -s temporary=false -n
 
 if [[ -f "${INIT_DATA}/there-is-more.sh" ]]; then
   echo Performing additional setup


### PR DESCRIPTION
## Summary by Sourcery

Rename default OIDC realm resources, roles, environment variables, and documentation references from "chicken" to "trustify".

Enhancements:
- Replace chicken-user, chicken-manager, and chicken-admin roles with trustify-user, trustify-manager, and trustify-admin in initialization scripts
- Update environment variables CHICKEN_ADMIN and CHICKEN_ADMIN_PASSWORD to TRUSTIFY_ADMIN and TRUSTIFY_ADMIN_PASSWORD in Docker Compose configuration
- Adjust client scope assignments, user and service-account role mappings, and initialization data scripts to use the new trustify prefixes
- Revise README examples to reference the trustify realm and issuer URLs