### PR TITLE
[TC-3060] gensbom: Support TPA with certs

### DIFF
--- a/etc/gensbom/Containerfile
+++ b/etc/gensbom/Containerfile
@@ -1,6 +1,6 @@
 ARG SYFT_REGISTRY=ghcr.io/anchore
 ARG SYFT_IMAGE=syft
-ARG SYFT_TAG=latest
+ARG SYFT_TAG=v1.36.0
 
 FROM registry.access.redhat.com/ubi9/ubi:latest
 

--- a/etc/gensbom/README.md
+++ b/etc/gensbom/README.md
@@ -7,6 +7,8 @@
 * `podman`
 * [`config.json`](https://github.com/google/go-containerregistry/tree/main/pkg/authn#docker-config-auth)
   in the current working directory
+* `trust.crt` (optional custom trust anchors) in the current working directory
+  if the running TPA service uses a certificate signed by these trust anchors
 * `TPA_SERVICE_URL`, holding the URL to the running TPA service, e.g.
   `my.tpa.instance.abc:8765`
 * `TPA_AUTH_TOKEN`, holding the valid authorization token, e.g.
@@ -90,7 +92,7 @@ The `Containerfile` build arguments:
 * `SYFT_REGISTRY`, holding the container registry from which the `syft`
   container is pulled (default: `ghcr.io/anchore`)
 * `SYFT_IMAGE`, holding the `syft` container image name (default: `syft`)
-* `SYFT_TAG`, holding the `syft` container image tag (default: `latest`)
+* `SYFT_TAG`, holding the `syft` container image tag (default: `v1.36.0`)
 
 ## References
 


### PR DESCRIPTION
~~Add `-k` flag to `curl` in case TPA is configured with SSL certificates.~~
Detect provided trust anchors and ~~install it on the container~~ pass them to `curl`.

## Summary by Sourcery

Add the insecure (-k) flag to curl invocations in the gensbom.sh script to allow interactions with TPA services using custom or self-signed SSL certificates

Enhancements:
- Add the -k option to curl download check to skip SSL verification
- Add the -k option to curl POST operations to skip SSL verification