### PR TITLE
test: set LC_COLLATE (TC-3070)

### DIFF
--- a/common/db/src/lib.rs
+++ b/common/db/src/lib.rs
@@ -55,7 +55,10 @@ impl<'a> Database<'a> {
 
         db.execute(Statement::from_string(
             db.get_database_backend(),
-            format!("CREATE DATABASE \"{}\";", database.name),
+            format!(
+                "CREATE DATABASE \"{}\" WITH LC_COLLATE 'C' TEMPLATE 'template0';",
+                database.name
+            ),
         ))
         .await?;
         db.close().await?;


### PR DESCRIPTION
Setting `LC_COLLATE="C"` in the embedded test database ensures the database sorting matches Rust's sorting behavior because both use byte-order comparison, making them compatible for test validation. 

I had to set the env var because:
  - `LC_COLLATE` is set during database cluster initialization (initdb)
  - PostgreSQL reads it from the environment when `initdb` runs
  - `postgresql_embedded` (v0.20.0) doesn't expose `initdb` parameter customization
  - `LC_COLLATE` cannot be changed after database creation

@jcrossley3 let me know if this works locally for you.

## Summary by Sourcery

Tests:
- Configure embedded test database with LC_COLLATE="C" to ensure deterministic byte-order sorting matching Rust's string comparisons