### PR TITLE
chore: change analysis status permission

### DIFF
--- a/common/auth/src/authenticator/default.rs
+++ b/common/auth/src/authenticator/default.rs
@@ -27,6 +27,7 @@ pub const DEFAULT_SCOPE_MAPPINGS: &[(&str, &[&str])] = &[
             "read.metadata",
             "read.sbom",
             "read.weakness",
+            "read.systemInformation",
         ],
     ),
     (

--- a/common/auth/src/permission.rs
+++ b/common/auth/src/permission.rs
@@ -103,6 +103,9 @@ permission! {
         #[strum(serialize = "upload.dataset")]
         UploadDataset,
 
+        #[strum(serialize = "read.systemInformation")]
+        ReadSystemInformation,
+
         #[strum(serialize = "ai")]
         Ai,
     }

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -93,7 +93,8 @@ The CLI alternative provides predefined scope mappings that cannot be customized
             "read.importer",
             "read.metadata",
             "read.sbom",
-            "read.weakness"
+            "read.weakness",
+            "read.systemInformation",
           ],
           "update:document": [
             "update.advisory",

--- a/modules/analysis/src/endpoints/mod.rs
+++ b/modules/analysis/src/endpoints/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 use actix_web::{HttpResponse, Responder, get, web};
 use serde_json::json;
 use trustify_auth::{
-    Permission, ReadSbom,
+    Permission, ReadSbom, ReadSystemInformation,
     authenticator::user::UserInformation,
     authorizer::{Authorizer, Require},
     utoipa::AuthResponse,
@@ -60,10 +60,9 @@ pub async fn analysis_status(
     user: UserInformation,
     authorizer: web::Data<Authorizer>,
     web::Query(StatusQuery { details }): web::Query<StatusQuery>,
-    _: Require<ReadSbom>,
+    _: Require<ReadSystemInformation>,
 ) -> actix_web::Result<impl Responder> {
-    // TODO: Replace with a more "admin" style permission when revisiting the permission system
-    authorizer.require(&user, Permission::CreateSbom)?;
+    authorizer.require(&user, Permission::ReadSystemInformation)?;
     Ok(HttpResponse::Ok().json(service.status(db.as_ref(), details).await?))
 }
 


### PR DESCRIPTION
logged as `user`:

<img width="1571" height="169" alt="2025-10-23_09-37" src="https://github.com/user-attachments/assets/72cc4d1a-caf5-4422-a764-5122f43bc419" />

```console
➜  ~ http localhost:8080/api/v2/analysis/status Authorization:$(oidc token trusty -b)
HTTP/1.1 200 OK
access-control-allow-credentials: true
access-control-expose-headers: content-type
content-encoding: br
content-type: application/json
date: Thu, 23 Oct 2025 12:36:00 GMT
transfer-encoding: chunked
vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
vary: accept-encoding

{
    "graph_count": 0,
    "graph_max_memory": 209715200,
    "graph_memory": 0,
    "loading_operations": 0,
    "sbom_count": 0
}
```

## Summary by Sourcery

Add a dedicated GetStatus permission and apply it to the analysis status endpoint, updating scope mappings and documentation accordingly.

New Features:
- Introduce a new GetStatus permission

Enhancements:
- Require GetStatus instead of CreateSbom for the analysis status endpoint
- Add "get.status" to the default OIDC scope mappings

Documentation:
- Document the "get.status" scope in the OIDC guide