### PR TITLE
Update redhat-sboms importer source for 2.2

### DIFF
--- a/modules/importer/README.md
+++ b/modules/importer/README.md
@@ -38,7 +38,7 @@ http POST localhost:8080/api/v2/importer/osv-r osv[source]=https://github.com/RC
 Quarkus & RHEL 9 data:
 
 ```shell
-http POST localhost:8080/api/v2/importer/redhat-sbom sbom[source]=https://security.access.redhat.com/data/sbom/v1/spdx/ sbom[keys][]=https://security.access.redhat.com/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4 sbom[disabled]:=false sbom[onlyPatterns][]=quarkus sbom[onlyPatterns][]=rhel-9 sbom[period]=30s sbom[v3Signatures]:=true
+http POST localhost:8080/api/v2/importer/redhat-sbom sbom[source]=https://security.access.redhat.com/data/sbom/v1/ sbom[keys][]=https://security.access.redhat.com/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4 sbom[disabled]:=false sbom[onlyPatterns][]=quarkus sbom[onlyPatterns][]=rhel-9 sbom[period]=30s sbom[v3Signatures]:=true
 ```
 
 ### Get all importers

--- a/server/src/sample_data.rs
+++ b/server/src/sample_data.rs
@@ -180,7 +180,7 @@ pub async fn sample_data(db: trustify_common::db::Database) -> anyhow::Result<()
             description: Some("All Red Hat SBOMs".into()),
             labels: Default::default(),
         },
-        source: "https://security.access.redhat.com/data/sbom/v1/spdx/".to_string(),
+        source: "https://security.access.redhat.com/data/sbom/v1/".to_string(),
         keys: vec![
             Url::parse("https://security.access.redhat.com/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4")?
         ],

--- a/xtask/src/dataset.rs
+++ b/xtask/src/dataset.rs
@@ -81,7 +81,7 @@ impl GenerateDump {
                     }),
                     ImporterConfiguration::Sbom(SbomImporter {
                         common: default_common("All Red Hat SBOMs"),
-                        source: "https://security.access.redhat.com/data/sbom/v1/spdx/".to_string(),
+                        source: "https://security.access.redhat.com/data/sbom/v1/".to_string(),
                         keys: vec!["https://security.access.redhat.com/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4".parse()?],
                         v3_signatures: true,
                         only_patterns: vec![],


### PR DESCRIPTION
Old: "https://access.redhat.com/security/data/sbom/beta/"
New: "https://security.access.redhat.com/data/sbom/v1/"

Also updated the key, though the old link returns a 301 to the new

Old:
"https://access.redhat.com/security/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4" 
New:
"https://security.access.redhat.com/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4"

Downstream issue: https://issues.redhat.com/browse/TC-3086