### PR TITLE
test: fix up oom test

### DIFF
--- a/etc/deploy/compose/compose.yaml
+++ b/etc/deploy/compose/compose.yaml
@@ -10,3 +10,5 @@ services:
     shm_size: '1g'
     command: >
       postgres -c random_page_cost=1.1 -c max_parallel_workers_per_gather=4 -c shared_preload_libraries='pg_stat_statements'
+#    volumes:
+#      - <base>/dump.sql.gz:/docker-entrypoint-initdb.d/dump.sql.gz:Z

--- a/modules/fundamental/tests/issues/oom.rs
+++ b/modules/fundamental/tests/issues/oom.rs
@@ -2,22 +2,47 @@
 
 use std::str::FromStr;
 use test_context::test_context;
+use test_log::test;
 use trustify_common::id::Id;
 use trustify_module_fundamental::sbom::service::SbomService;
-use trustify_test_context::{TrustifyContext, flame::setup_global_subscriber};
+use trustify_test_context::TrustifyContext;
 
-#[test_context(TrustifyContext, skip_teardown)]
-#[tokio::test]
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
 #[ignore = "Only works with a pre-existing database and a specific dump"]
-async fn fetch(ctx: TrustifyContext) -> anyhow::Result<()> {
-    let _guard = setup_global_subscriber();
-
+/// This test will not fail, but running with `--test-threads=1` it will show the amount of memory
+/// used, using [`TrustifyTestContext::teardown`].
+async fn fetch(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // this requires an imported dataset
 
     let service = SbomService::new(ctx.db.clone());
     // update this digest to point to a "large SBOM"
+    // the following statement can be used"
+    /*
+    select
+        e.sha256
+    from
+        sbom_package_purl_ref a
+            join qualified_purl b on b.id = a.qualified_purl_id
+            join versioned_purl c on c.id = b.versioned_purl_id
+            join sbom d on d.sbom_id = a.sbom_id
+            join source_document e on d.source_document_id = e.id
+    where
+        c.base_purl_id = (
+            select a.base_purl_id
+            from purl_status a
+            group by a.base_purl_id
+            order by count(*) desc
+            limit 1
+        )
+    group by
+        e.sha256
+    order by
+        count(*) desc
+    limit 1;
+         */
     let id =
-        Id::from_str("sha256:f293eb898192085804419f9dd40a738f20d67dd81846e88c6720f692ec5f3081")?;
+        Id::from_str("sha256:a08f4d8723d3f2e1e12ba4a8961c6ebccfd603577d784b24576c09be8925af40")?;
     let statuses: Vec<String> = vec!["affected".to_string()];
 
     let result = service.fetch_sbom_details(id, statuses, &ctx.db).await?;


### PR DESCRIPTION
First we need to ensure `teardown` is being run. This can be done by dropping the `skip_teardown` attribute.

Second, we need to refresh the ID. Adding the SQL statement used for future reference.

Third, add some more explanation about the expectation towards the test.

## Summary by Sourcery

Refine the OOM test by restoring teardown execution, migrating to test_log's test attribute, updating the SBOM ID, and enhancing documentation with an SQL snippet and usage explanation.

Bug Fixes:
- Restore test teardown by removing the skip_teardown attribute

Enhancements:
- Switch from tokio::test to test_log::test for better logging integration
- Remove obsolete global subscriber setup
- Change the test signature to accept a reference to TrustifyContext

Tests:
- Refresh the SBOM ID used in the test
- Embed the SQL query used to derive the SBOM ID for future reference
- Add a doc comment explaining memory usage expectations under --test-threads=1