### PR TITLE
chore: rename adr another adr with same number was added

### DIFF
--- a/docs/adrs/00010-version-range-in-responses.md
+++ b/docs/adrs/00010-version-range-in-responses.md
@@ -1,8 +1,8 @@
-# 00009. Add Version Range to purl status responses
+# 00010. Add Version Range to purl status responses
 
 ## Status
 
-PROPOSED
+APPROVED
 
 ## Context
 


### PR DESCRIPTION
## Summary by Sourcery

Rename ADR and mark it as approved

Documentation:
- Rename ADR file and internal heading from 00009 to 00010 to avoid duplicate numbering
- Update ADR status from PROPOSED to APPROVED