### PR TITLE
fix: Exclude labels with key 'file' from fetch_labels query

### DIFF
--- a/modules/fundamental/src/common/service.rs
+++ b/modules/fundamental/src/common/service.rs
@@ -13,6 +13,8 @@ pub enum DocumentType {
 /// Fetch all unique key/value labels matching the `filter_text` for all the `r#type` entities, i.e. `DocumentType::Advisory` or `DocumentType::Sbom`
 ///
 /// If limit=0 then all data will be fetched
+///
+/// Labels with the key `file` are excluded from the results.
 pub async fn fetch_labels<C: ConnectionTrait>(
     r#type: DocumentType,
     filter_text: String,
@@ -34,6 +36,7 @@ WHERE
         WHEN kv.value IS NULL THEN kv.key
         ELSE kv.key || '=' || kv.value
     END ILIKE $1 ESCAPE '\'
+    AND kv.key <> 'file'
 ORDER BY
     kv.key, kv.value
 "#,


### PR DESCRIPTION
Signed-off-by: Helio Frota <00hf11@gmail.com>

Issue described by @mrrajan:

```
Advisories added with default "file" label, making label recommendation
and filtering drop downs less effective.

For each Advisories, the label "file" added with unique value which
listed out under label recommendation and filtering condition.
```

## Summary by Sourcery

Filter out labels with the key 'file' in the fetch_labels SQL query and update its documentation accordingly

Bug Fixes:
- Exclude labels with key 'file' from the fetch_labels query results

Enhancements:
- Update the fetch_labels function documentation to mention exclusion of 'file' labels