### PR TITLE
fix: PurlCreator::create race condition

### DIFF
--- a/modules/ingestor/src/graph/purl/creator.rs
+++ b/modules/ingestor/src/graph/purl/creator.rs
@@ -75,13 +75,9 @@ impl PurlCreator {
 
         for batch in &packages.into_values().chunked() {
             base_purl::Entity::insert_many(batch)
-                .on_conflict(
-                    OnConflict::columns([base_purl::Column::Id])
-                        .do_nothing()
-                        .to_owned(),
-                )
+                .on_conflict(OnConflict::new().do_nothing().to_owned())
                 .do_nothing()
-                .exec(db)
+                .exec_without_returning(db)
                 .await?;
         }
 
@@ -89,13 +85,9 @@ impl PurlCreator {
 
         for batch in &versions.into_values().chunked() {
             versioned_purl::Entity::insert_many(batch)
-                .on_conflict(
-                    OnConflict::columns([versioned_purl::Column::Id])
-                        .do_nothing()
-                        .to_owned(),
-                )
+                .on_conflict(OnConflict::new().do_nothing().to_owned())
                 .do_nothing()
-                .exec(db)
+                .exec_without_returning(db)
                 .await?;
         }
 
@@ -103,13 +95,9 @@ impl PurlCreator {
 
         for batch in &qualifieds.into_values().chunked() {
             qualified_purl::Entity::insert_many(batch)
-                .on_conflict(
-                    OnConflict::columns([qualified_purl::Column::Id])
-                        .do_nothing()
-                        .to_owned(),
-                )
+                .on_conflict(OnConflict::new().do_nothing().to_owned())
                 .do_nothing()
-                .exec(db)
+                .exec_without_returning(db)
                 .await?;
         }
 

--- a/modules/ingestor/tests/parallel.rs
+++ b/modules/ingestor/tests/parallel.rs
@@ -151,7 +151,6 @@ async fn csaf_parallel(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[instrument]
 #[test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
-#[ignore = "Enable once the PURL database structure has been refactored"]
 async fn purl_creator(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     const NUM: usize = 25;
     const ITEMS: usize = 25;


### PR DESCRIPTION
Concurrent advisory ingestion was causing duplicate key violations due to race conditions in PURL creation.
The issue occurred because:
  1. Multiple threads attempted to INSERT the same PURLs simultaneously
  2. Tables have both a primary key (id) AND unique constraints (e.g., `by_pid_v` on `(base_purl_id, version)`)
  3. `ON CONFLICT` was specified on only the `id` column, which doesn't catch conflicts on other unique constraints

Fix:
  - Changed to `OnConflict::new().do_nothing()` because specifying no columns allows PostgreSQL to check ALL unique constraints
 
Improvement:
  - Changed from `.exec()` to `.exec_without_returning()` for eliminating unnecessary `RETURNING` clause since batch operations don't need anything returned

## Summary by Sourcery

Prevent race conditions in Purl creation by changing the conflict handling strategy to check all unique constraints and streamline batch inserts, and re-enable the parallel PURL creator test.

Bug Fixes:
- Broaden ON CONFLICT clause to cover all unique constraints on purl tables to prevent duplicate key violations

Enhancements:
- Switch batch insert executions to exec_without_returning to drop redundant RETURNING clause
- Re-enable the parallel purl_creator test by removing its ignore annotation