### PR TITLE
chore: fix up OpenAPI spec

### DIFF
--- a/modules/analysis/src/endpoints/mod.rs
+++ b/modules/analysis/src/endpoints/mod.rs
@@ -71,7 +71,6 @@ pub async fn analysis_status(
     operation_id = "getComponent",
     params(
         ("key" = String, Path, description = "provide component name, URL-encoded pURL, or CPE itself"),
-        Query,
         Paginated,
         QueryOptions,
     ),
@@ -201,7 +200,6 @@ pub async fn search_latest_component(
     operation_id = "getLatestComponent",
     params(
         ("key" = String, Path, description = "provide component name, URL-encoded pURL, or CPE itself"),
-        Query,
         Paginated,
         QueryOptions,
     ),
@@ -211,7 +209,7 @@ pub async fn search_latest_component(
     ),
 )]
 #[get("/v2/analysis/latest/component/{key}")]
-/// Retrieve SBOM components (packages) by name, Package URL, or CPE.
+/// Retrieve latest SBOM components (packages) by name, Package URL, or CPE.
 pub async fn get_latest_component(
     service: web::Data<AnalysisService>,
     db: web::Data<Database>,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -462,80 +462,6 @@ paths:
         required: true
         schema:
           type: string
-      - name: q
-        in: path
-        description: |
-          EBNF grammar for the _q_ parameter:
-          ```text
-              q = ( values | filter ) { '&' q }
-              values = value { '|', values }
-              filter = field, operator, values
-              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
-              value = (* any text but escape special characters with '\' *)
-              field = (* must match an entity attribute name *)
-          ```
-          Any values in a _q_ will result in a case-insensitive "full
-          text search", effectively producing an OR clause of LIKE
-          clauses for every string-ish field in the resource being
-          queried.
-
-          Examples:
-          - `foo` - any field containing 'foo'
-          - `foo|bar` - any field containing either 'foo' OR 'bar'
-          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
-
-          A _filter_ may also be used to constrain the results. The
-          filter's field name must correspond to one of the resource's
-          attributes. If it doesn't, an error will be returned
-          containing a list of the valid fields for that resource.
-
-          The value 'null' is treated specially for [Not]Equal filters:
-          it returns resources on which the field isn't set. Use the
-          LIKE operator, `~`, to match a literal "null" string. Omit the
-          value to match an empty string.
-
-          Examples:
-          - `name=foo` - entity's _name_ matches 'foo' exactly
-          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
-          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
-          - `name=` - entity's _name_ is the empty string, ''
-          - `name=null` - entity's _name_ isn't set
-          - `published>3 days ago` - date values can be "human time"
-
-          Multiple full text searches and/or filters should be
-          '&'-delimited -- they are logically AND'd together.
-
-          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
-
-          Fields corresponding to JSON objects in the database may use a
-          ':' to delimit the column name and the object key,
-          e.g. `purl:qualifiers:type=pom`
-
-          Any operator or special character, e.g. '|', '&', within a
-          value should be escaped by prefixing it with a backslash.
-        required: true
-        schema:
-          type: string
-      - name: sort
-        in: path
-        description: |
-          EBNF grammar for the _sort_ parameter:
-          ```text
-              sort = field [ ':', order ] { ',' sort }
-              order = ( "asc" | "desc" )
-              field = (* must match the name of entity's attributes *)
-          ```
-          The optional _order_ should be one of "asc" or "desc". If
-          omitted, the order defaults to "asc".
-
-          Each _field_ name must correspond to one of the columns of the
-          table holding the entities being queried. Those corresponding
-          to JSON objects in the database may use a ':' to delimit the
-          column name and the object key,
-          e.g. `purl:qualifiers:type:desc`
-        required: true
-        schema:
-          type: string
       - name: offset
         in: query
         description: |-
@@ -751,86 +677,12 @@ paths:
     get:
       tags:
       - analysis
-      summary: Retrieve SBOM components (packages) by name, Package URL, or CPE.
+      summary: Retrieve latest SBOM components (packages) by name, Package URL, or CPE.
       operationId: getLatestComponent
       parameters:
       - name: key
         in: path
         description: provide component name, URL-encoded pURL, or CPE itself
-        required: true
-        schema:
-          type: string
-      - name: q
-        in: path
-        description: |
-          EBNF grammar for the _q_ parameter:
-          ```text
-              q = ( values | filter ) { '&' q }
-              values = value { '|', values }
-              filter = field, operator, values
-              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
-              value = (* any text but escape special characters with '\' *)
-              field = (* must match an entity attribute name *)
-          ```
-          Any values in a _q_ will result in a case-insensitive "full
-          text search", effectively producing an OR clause of LIKE
-          clauses for every string-ish field in the resource being
-          queried.
-
-          Examples:
-          - `foo` - any field containing 'foo'
-          - `foo|bar` - any field containing either 'foo' OR 'bar'
-          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
-
-          A _filter_ may also be used to constrain the results. The
-          filter's field name must correspond to one of the resource's
-          attributes. If it doesn't, an error will be returned
-          containing a list of the valid fields for that resource.
-
-          The value 'null' is treated specially for [Not]Equal filters:
-          it returns resources on which the field isn't set. Use the
-          LIKE operator, `~`, to match a literal "null" string. Omit the
-          value to match an empty string.
-
-          Examples:
-          - `name=foo` - entity's _name_ matches 'foo' exactly
-          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
-          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
-          - `name=` - entity's _name_ is the empty string, ''
-          - `name=null` - entity's _name_ isn't set
-          - `published>3 days ago` - date values can be "human time"
-
-          Multiple full text searches and/or filters should be
-          '&'-delimited -- they are logically AND'd together.
-
-          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
-
-          Fields corresponding to JSON objects in the database may use a
-          ':' to delimit the column name and the object key,
-          e.g. `purl:qualifiers:type=pom`
-
-          Any operator or special character, e.g. '|', '&', within a
-          value should be escaped by prefixing it with a backslash.
-        required: true
-        schema:
-          type: string
-      - name: sort
-        in: path
-        description: |
-          EBNF grammar for the _sort_ parameter:
-          ```text
-              sort = field [ ':', order ] { ',' sort }
-              order = ( "asc" | "desc" )
-              field = (* must match the name of entity's attributes *)
-          ```
-          The optional _order_ should be one of "asc" or "desc". If
-          omitted, the order defaults to "asc".
-
-          Each _field_ name must correspond to one of the columns of the
-          table holding the entities being queried. Those corresponding
-          to JSON objects in the database may use a ':' to delimit the
-          column name and the object key,
-          e.g. `purl:qualifiers:type:desc`
         required: true
         schema:
           type: string


### PR DESCRIPTION
## Summary by Sourcery

Fix up OpenAPI spec by cleaning up parameter annotations and correcting endpoint documentation

Enhancements:
- Remove redundant Query parameter from analysis_status and search_latest_component OpenAPI annotations

Documentation:
- Update get_latest_component doc comment to specify 'latest' SBOM components