### PR TITLE
docs: document "sample data" switch and function

### DIFF
--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -42,6 +42,7 @@ pub struct Run {
     #[arg(long, env)]
     pub devmode: bool,
 
+    /// Inject example importer configurations during startup
     #[arg(long, env)]
     pub sample_data: bool,
 

--- a/server/src/sample_data.rs
+++ b/server/src/sample_data.rs
@@ -170,6 +170,7 @@ async fn add_quay(
     .await
 }
 
+/// Insert example importers, ignoring existing ones
 pub async fn sample_data(db: trustify_common::db::Database) -> anyhow::Result<()> {
     let importer = ImporterService::new(db);
 


### PR DESCRIPTION
## Summary by Sourcery

Add and document a new `sample_data` flag in the profile API to enable injection of example importer configurations during startup

New Features:
- Add a `sample_data` CLI flag to inject example importer configurations at startup

Documentation:
- Document the `sample_data` flag in the Run struct
- Add doc comment for the `sample_data` function explaining its behavior