### PR TITLE
fix: avoid formatting errors with query markdown docs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -33,8 +33,9 @@ paths:
       parameters:
       - name: q
         in: query
-        description: |-
+        description: |
           Query for advisories defined using the following EBNF grammar (ISO/IEC 14977):
+          ```text
           (* Query Grammar - EBNF Compliant *)
           query = ( values | filter ) , { "&" , query } ;
           values = value , { "|" , value } ;
@@ -46,13 +47,13 @@ paths:
           escaped_char = "\" , special_char ;
           normal_char = ? any character except '&', '|', '=', '!', '~', '>', '<', '\' ? ;
           special_char = "&" | "|" | "=" | "!" | "~" | ">" | "<" | "\" ;
-          (* Examples:
-              - Simple filter: title=example
-              - Multiple values filter: title=foo|bar|baz
-              - Complex filter: modified>2024-01-01
-              - Combined query: title=foo&average_severity=high
-              - Escaped characters: title=foo\&bar
-          *)
+          ```
+          Examples:
+          - Simple filter: title=example
+          - Multiple values filter: title=foo|bar|baz
+          - Complex filter: modified>2024-01-01
+          - Combined query: title=foo&average_severity=high
+          - Escaped characters: title=foo\\&bar
         required: false
         schema:
           type: string
@@ -1183,8 +1184,9 @@ paths:
       parameters:
       - name: q
         in: query
-        description: |-
+        description: |
           Query for advisories defined using the following EBNF grammar (ISO/IEC 14977):
+          ```text
           (* Query Grammar - EBNF Compliant *)
           query = ( values | filter ) , { "&" , query } ;
           values = value , { "|" , value } ;
@@ -1196,13 +1198,13 @@ paths:
           escaped_char = "\" , special_char ;
           normal_char = ? any character except '&', '|', '=', '!', '~', '>', '<', '\' ? ;
           special_char = "&" | "|" | "=" | "!" | "~" | ">" | "<" | "\" ;
-          (* Examples:
-              - Simple filter: title=example
-              - Multiple values filter: title=foo|bar|baz
-              - Complex filter: modified>2024-01-01
-              - Combined query: title=foo&average_severity=high
-              - Escaped characters: title=foo\&bar
-          *)
+          ```
+          Examples:
+          - Simple filter: title=example
+          - Multiple values filter: title=foo|bar|baz
+          - Complex filter: modified>2024-01-01
+          - Combined query: title=foo&average_severity=high
+          - Escaped characters: title=foo\\&bar
         required: false
         schema:
           type: string
@@ -2899,8 +2901,9 @@ paths:
       parameters:
       - name: q
         in: query
-        description: |-
+        description: |
           Query for advisories defined using the following EBNF grammar (ISO/IEC 14977):
+          ```text
           (* Query Grammar - EBNF Compliant *)
           query = ( values | filter ) , { "&" , query } ;
           values = value , { "|" , value } ;
@@ -2912,13 +2915,13 @@ paths:
           escaped_char = "\" , special_char ;
           normal_char = ? any character except '&', '|', '=', '!', '~', '>', '<', '\' ? ;
           special_char = "&" | "|" | "=" | "!" | "~" | ">" | "<" | "\" ;
-          (* Examples:
-              - Simple filter: title=example
-              - Multiple values filter: title=foo|bar|baz
-              - Complex filter: modified>2024-01-01
-              - Combined query: title=foo&average_severity=high
-              - Escaped characters: title=foo\&bar
-          *)
+          ```
+          Examples:
+          - Simple filter: title=example
+          - Multiple values filter: title=foo|bar|baz
+          - Complex filter: modified>2024-01-01
+          - Combined query: title=foo&average_severity=high
+          - Escaped characters: title=foo\\&bar
         required: false
         schema:
           type: string

--- a/query/query-derive/src/lib.rs
+++ b/query/query-derive/src/lib.rs
@@ -28,25 +28,27 @@ fn impl_query(ast: &syn::DeriveInput) -> TokenStream {
     };
     let field_names = format!("\"{}\"", fields.join("\" | \""));
     let query_description = format!(
-        "Query for advisories defined using the following EBNF grammar (ISO/IEC 14977):
+        r#"Query for advisories defined using the following EBNF grammar (ISO/IEC 14977):
+```text
 (* Query Grammar - EBNF Compliant *)
-query = ( values | filter ) , {{ \"&\" , query }} ;
-values = value , {{ \"|\" , value }} ;
+query = ( values | filter ) , {{ "&" , query }} ;
+values = value , {{ "|" , value }} ;
 filter = field , operator , values ;
-operator = \"=\" | \"!=\" | \"~\" | \"!~\" | \">=\" | \">\" | \"<=\" | \"<\" ;
+operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<" ;
 field = ({field_names})
 value = {{ value_char }} ;
 value_char = escaped_char | normal_char ;
-escaped_char = \"\\\" , special_char ;
-normal_char = ? any character except '&', '|', '=', '!', '~', '>', '<', '\\' ? ;
-special_char = \"&\" | \"|\" | \"=\" | \"!\" | \"~\" | \">\" | \"<\" | \"\\\" ;
-(* Examples:
-    - Simple filter: title=example
-    - Multiple values filter: title=foo|bar|baz
-    - Complex filter: modified>2024-01-01
-    - Combined query: title=foo&average_severity=high
-    - Escaped characters: title=foo\\&bar
-*)"
+escaped_char = "\" , special_char ;
+normal_char = ? any character except '&', '|', '=', '!', '~', '>', '<', '\' ? ;
+special_char = "&" | "|" | "=" | "!" | "~" | ">" | "<" | "\" ;
+```
+Examples:
+- Simple filter: title=example
+- Multiple values filter: title=foo|bar|baz
+- Complex filter: modified>2024-01-01
+- Combined query: title=foo&average_severity=high
+- Escaped characters: title=foo\\&bar
+"#
     );
     let sort_description = format!(
         "EBNF grammar for the _sort_ parameter:


### PR DESCRIPTION
fixes: #2081

## Summary by Sourcery

Fix formatting errors in query parameter markdown documentation by using fenced code blocks and correctly escaping characters

Bug Fixes:
- Correct query parameter descriptions in OpenAPI spec to avoid missing code fences and escape issues

Enhancements:
- Update Rust query derive macro to generate properly formatted markdown with fenced code blocks and examples