### PR TITLE
fix: remove check for previously ingested SBOM from gensbom script

### DIFF
--- a/etc/gensbom/gensbom.sh
+++ b/etc/gensbom/gensbom.sh
@@ -170,20 +170,6 @@ while IFS="" read -r _IMAGE || [[ -n "${_IMAGE}" ]]; do
         continue
     fi
 
-    _SHA512="sha512:$(sha512sum "${_SBOM}" | awk '{print $1}')"
-    inform "File ${_Q1}${_SBOM}${_Q0} with ${_Q1}${_SHA512}${_Q0} has been created"
-
-    if curl ${_CURL_FLAGS} \
-        ${_CA_OPTS[@]} \
-        ${_AUTH_HEADER:+-H "${_AUTH_HEADER}"} \
-        "${TPA_SERVICE_URL}/api/v2/sbom/${_SHA512}/download" \
-        >/dev/null 2>&1; \
-    then
-        # Do not ingest already ingested SBOM
-        inform "File ${_Q1}${_SBOM}${_Q0} is already ingested"
-        continue
-    fi
-
     if ! curl ${_CURL_FLAGS} \
         -X POST \
         ${_CA_OPTS[@]} \


### PR DESCRIPTION
downstream issue: https://issues.redhat.com/browse/TC-3160

There's no reason to do this. SBOM ingestion is designed to be idempotent.

## Summary by Sourcery

Remove the redundant SBOM existence check in the gensbom script to rely on the idempotent ingestion process

Enhancements:
- Remove SHA512-based GET request and related logging in gensbom.sh
- Eliminate skip logic for already ingested SBOM files