### PR TITLE
Ensure rejected CVE's are ingested (and queryable) properly

### DIFF
--- a/etc/test-data/cve/CVE-2024-25704.json
+++ b/etc/test-data/cve/CVE-2024-25704.json
@@ -1,0 +1,39 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0",
+    "cveMetadata": {
+        "cveId": "CVE-2024-25704",
+        "assignerOrgId": "cedc17bb-4939-4f40-a1f4-30ae8af1094e",
+        "state": "REJECTED",
+        "assignerShortName": "Esri",
+        "dateReserved": "2024-02-09T19:08:35.888Z",
+        "datePublished": "2024-04-04T17:56:09.842Z",
+        "dateUpdated": "2024-04-25T18:21:10.150Z",
+        "dateRejected": "2024-04-25T18:21:10.150Z"
+    },
+    "containers": {
+        "cna": {
+            "providerMetadata": {
+                "orgId": "cedc17bb-4939-4f40-a1f4-30ae8af1094e",
+                "shortName": "Esri",
+                "dateUpdated": "2024-04-25T18:21:10.150Z"
+            },
+            "rejectedReasons": [
+                {
+                    "lang": "en",
+                    "supportingMedia": [
+                        {
+                            "base64": false,
+                            "type": "text/html",
+                            "value": "\n\nThis CVE ID has been rejected or withdrawn by its CVE Numbering Authority because this item is scheduled to be patched at a future time.\n\n"
+                        }
+                    ],
+                    "value": "\nThis CVE ID has been rejected or withdrawn by its CVE Numbering Authority because this item is scheduled to be patched at a future time.\n\n"
+                }
+            ],
+            "x_generator": {
+                "engine": "Vulnogram 0.1.0-dev"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Relates to downstream issue: https://issues.redhat.com/browse/TC-3167

## Summary by Sourcery

Add integration test to ensure that rejected CVEs are ingested and searchable by withdrawn status and date filters, and include a corresponding test fixture

Tests:
- Add 'rejected_cve' test to verify rejected (withdrawn) CVEs are ingested and queryable by various withdrawn field filters

Chores:
- Add test data fixture for CVE-2024-25704 JSON