### PR TITLE
ci: switch to macos-15

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -58,10 +58,10 @@ jobs:
               sudo apt install -y libssl-dev
 
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
             args: --features vendored
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-15
             args: --features vendored
 
           - target: x86_64-pc-windows-msvc


### PR DESCRIPTION
See: https://github.com/actions/runner-images/issues/13046

## Summary by Sourcery

Update build-binary GitHub Actions workflow to use macos-15 runner images for Apple targets

CI:
- Bump x86_64-apple-darwin runner image from macos-13 to macos-15-intel
- Bump aarch64-apple-darwin runner image from macos-14 to macos-15