### PR TITLE
fix: SBOM details filters out the deprecated advisories (TC-3191)

### DIFF
--- a/etc/test-data/cve/CVE-2024-26308-updated.json
+++ b/etc/test-data/cve/CVE-2024-26308-updated.json
@@ -1,0 +1,181 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1",
+    "cveMetadata": {
+        "cveId": "CVE-2024-26308",
+        "assignerOrgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09",
+        "state": "PUBLISHED",
+        "assignerShortName": "apache",
+        "dateReserved": "2024-02-17T22:08:44.423Z",
+        "datePublished": "2024-02-19T08:31:50.192Z",
+        "dateUpdated": "2025-03-27T19:10:43.565Z"
+    },
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "collectionURL": "https://repo.maven.apache.org/maven2/",
+                    "defaultStatus": "unaffected",
+                    "packageName": "org.apache.commons:commons-compress",
+                    "product": "Apache Commons Compress",
+                    "vendor": "Apache Software Foundation",
+                    "versions": [
+                        {
+                            "lessThan": "1.26.0",
+                            "status": "affected",
+                            "version": "1.21",
+                            "versionType": "semver"
+                        }
+                    ]
+                }
+            ],
+            "credits": [
+                {
+                    "lang": "en",
+                    "type": "reporter",
+                    "value": "Yakov Shafranovich, Amazon Web Services"
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "supportingMedia": [
+                        {
+                            "base64": false,
+                            "type": "text/html",
+                            "value": "Allocation of Resources Without Limits or Throttling vulnerability in Apache Commons Compress.<p>This issue affects Apache Commons Compress: from 1.21 before 1.26.</p><p>Users are recommended to upgrade to version 1.26, which fixes the issue.</p>"
+                        }
+                    ],
+                    "value": "Allocation of Resources Without Limits or Throttling vulnerability in Apache Commons Compress.This issue affects Apache Commons Compress: from 1.21 before 1.26.\n\nUsers are recommended to upgrade to version 1.26, which fixes the issue."
+                }
+            ],
+            "metrics": [
+                {
+                    "other": {
+                        "content": {
+                            "text": "moderate"
+                        },
+                        "type": "Textual description of severity"
+                    }
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "cweId": "CWE-770",
+                            "description": "CWE-770 Allocation of Resources Without Limits or Throttling",
+                            "lang": "en",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09",
+                "shortName": "apache",
+                "dateUpdated": "2024-03-07T17:06:31.944Z"
+            },
+            "references": [
+                {
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.apache.org/thread/ch5yo2d21p7vlqrhll9b17otbyq4npfg"
+                },
+                {
+                    "url": "http://www.openwall.com/lists/oss-security/2024/02/19/2"
+                },
+                {
+                    "url": "https://security.netapp.com/advisory/ntap-20240307-0009/"
+                }
+            ],
+            "source": {
+                "discovery": "EXTERNAL"
+            },
+            "title": "Apache Commons Compress: OutOfMemoryError unpacking broken Pack200 file",
+            "x_generator": {
+                "engine": "Vulnogram 0.1.0-dev"
+            }
+        },
+        "adp": [
+            {
+                "metrics": [
+                    {
+                        "cvssV3_1": {
+                            "scope": "UNCHANGED",
+                            "version": "3.1",
+                            "baseScore": 5.5,
+                            "attackVector": "LOCAL",
+                            "baseSeverity": "MEDIUM",
+                            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+                            "integrityImpact": "NONE",
+                            "userInteraction": "REQUIRED",
+                            "attackComplexity": "LOW",
+                            "availabilityImpact": "HIGH",
+                            "privilegesRequired": "NONE",
+                            "confidentialityImpact": "NONE"
+                        }
+                    },
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "timestamp": "2024-02-22T17:49:36.910764Z",
+                                "id": "CVE-2024-26308",
+                                "options": [
+                                    {
+                                        "Exploitation": "none"
+                                    },
+                                    {
+                                        "Automatable": "no"
+                                    },
+                                    {
+                                        "Technical Impact": "partial"
+                                    }
+                                ],
+                                "role": "CISA Coordinator",
+                                "version": "2.0.3"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2025-03-27T19:10:43.565Z"
+                }
+            },
+            {
+                "providerMetadata": {
+                    "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+                    "shortName": "CVE",
+                    "dateUpdated": "2024-08-02T00:07:19.215Z"
+                },
+                "title": "CVE Program Container",
+                "references": [
+                    {
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.apache.org/thread/ch5yo2d21p7vlqrhll9b17otbyq4npfg"
+                    },
+                    {
+                        "url": "http://www.openwall.com/lists/oss-security/2024/02/19/2",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://security.netapp.com/advisory/ntap-20240307-0009/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -154,6 +154,7 @@ impl SbomDetails {
             ))
             .join(JoinType::LeftJoin, purl_status::Relation::ContextCpe.def())
             .join(JoinType::Join, purl_status::Relation::Advisory.def())
+            .filter(Expr::col((advisory::Entity, advisory::Column::Deprecated)).eq(false))
             .join(JoinType::LeftJoin, advisory::Relation::Issuer.def())
             .join(
                 JoinType::Join,

--- a/modules/fundamental/src/sbom/model/raw_sql.rs
+++ b/modules/fundamental/src/sbom/model/raw_sql.rs
@@ -171,6 +171,7 @@ pub fn product_advisory_info_sql() -> String {
         JOIN "vulnerability" ON "advisory_vulnerability"."vulnerability_id" = "vulnerability"."id"
         LEFT JOIN "cpe" ON m.context_cpe_id = "cpe"."id"
         WHERE ($2::text[] = ARRAY[]::text[] OR "status"."slug" = ANY($2::text[]))
+          AND "advisory"."deprecated" = false
         "#
     .to_string()
 }


### PR DESCRIPTION
Starting with the investigation to define the expected numbers of vulnerabilities in https://github.com/guacsec/trustify-ui/pull/820, it turned out that there's no deprecated advisories filtering applied when retrieving the SBOM details.

A test for reproducing this has been added.

Related to https://issues.redhat.com/browse/TC-3191

## Summary by Sourcery

Filter out deprecated advisories when fetching SBOM details to prevent obsolete entries from appearing

Bug Fixes:
- Exclude deprecated advisories in SBOM details queries (ORM and raw SQL)

Tests:
- Add integration test to verify deprecated advisories are filtered out from the SBOM advisory endpoint