### PR TITLE
chore: further batch to insert vulnerabilities

### DIFF
--- a/modules/ingestor/src/graph/vulnerability/creator.rs
+++ b/modules/ingestor/src/graph/vulnerability/creator.rs
@@ -1,5 +1,5 @@
 use crate::graph::{error::Error, vulnerability::VulnerabilityInformation};
-use sea_orm::{ActiveValue::Set, ConnectionTrait, DatabaseBackend, EntityTrait, Statement};
+use sea_orm::{ActiveValue::Set, ConnectionTrait, EntityTrait};
 use sea_query::OnConflict;
 use std::collections::BTreeMap;
 use tracing::instrument;
@@ -40,6 +40,23 @@ impl VulnerabilityCreator {
             .or_insert(information);
     }
 
+    /// Convert a (identifier, information) tuple to an ActiveModel
+    fn entry_to_model(
+        (identifier, info): (String, VulnerabilityInformation),
+    ) -> vulnerability::ActiveModel {
+        vulnerability::ActiveModel {
+            id: Set(identifier),
+            title: Set(info.title),
+            reserved: Set(info.reserved),
+            published: Set(info.published),
+            modified: Set(info.modified),
+            withdrawn: Set(info.withdrawn),
+            cwes: Set(info.cwes),
+            base_score: Set(info.base_score),
+            base_severity: Set(info.base_severity),
+        }
+    }
+
     /// Create all collected vulnerabilities in batches
     #[instrument(skip_all, fields(num = self.entries.len()), err(level=tracing::Level::INFO))]
     pub async fn create<C>(self, connection: &C) -> Result<(), Error>
@@ -68,20 +85,7 @@ impl VulnerabilityCreator {
 
         // Batch insert vulnerabilities with data (DO UPDATE)
         if !with_data.is_empty() {
-            let models: Vec<_> = with_data
-                .into_iter()
-                .map(|(identifier, info)| vulnerability::ActiveModel {
-                    id: Set(identifier),
-                    title: Set(info.title),
-                    reserved: Set(info.reserved),
-                    published: Set(info.published),
-                    modified: Set(info.modified),
-                    withdrawn: Set(info.withdrawn),
-                    cwes: Set(info.cwes),
-                    base_score: Set(info.base_score),
-                    base_severity: Set(info.base_severity),
-                })
-                .collect();
+            let models: Vec<_> = with_data.into_iter().map(Self::entry_to_model).collect();
 
             for batch in &models.chunked() {
                 vulnerability::Entity::insert_many(batch)
@@ -105,34 +109,15 @@ impl VulnerabilityCreator {
         }
 
         // Batch insert vulnerabilities without data (DO NOTHING)
-        // Use raw SQL to avoid exclusive locks
         if !without_data.is_empty() {
-            for chunk in without_data.chunks(((u16::MAX - 128) as usize / 9).max(1)) {
-                let sql_insert = r#"
-                    INSERT INTO vulnerability (id, title, reserved, published, modified, withdrawn, cwes, base_score, base_severity)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7::text[], $8, $9::cvss3_severity)
-                    ON CONFLICT (id) DO NOTHING
-                "#;
+            let models: Vec<_> = without_data.into_iter().map(Self::entry_to_model).collect();
 
-                for (identifier, info) in chunk {
-                    connection
-                        .execute(Statement::from_sql_and_values(
-                            DatabaseBackend::Postgres,
-                            sql_insert,
-                            vec![
-                                identifier.clone().into(),
-                                info.title.clone().into(),
-                                info.reserved.into(),
-                                info.published.into(),
-                                info.modified.into(),
-                                info.withdrawn.into(),
-                                info.cwes.clone().into(),
-                                info.base_score.into(),
-                                info.base_severity.into(),
-                            ],
-                        ))
-                        .await?;
-                }
+            for batch in &models.chunked() {
+                vulnerability::Entity::insert_many(batch)
+                    .on_conflict(OnConflict::new().do_nothing().to_owned())
+                    .do_nothing()
+                    .exec_without_returning(connection)
+                    .await?;
             }
         }
 


### PR DESCRIPTION
Follow-up change for https://github.com/guacsec/trustify/pull/2102/files#r2534004812

## Summary by Sourcery

Extract tuple-to-ActiveModel conversion into a helper and unify batch insertion logic for vulnerabilities, replacing custom SQL with SeaORM insert_many calls.

Enhancements:
- Add entry_to_model helper to convert vulnerability entries into ActiveModels
- Refactor batch insert for vulnerabilities with data to use entry_to_model
- Replace raw SQL insert for vulnerabilities without data with SeaORM insert_many on_conflict do_nothing