### PR TITLE
chore: refactor sort_by_id

### DIFF
--- a/modules/ingestor/src/service/advisory/csaf/creator.rs
+++ b/modules/ingestor/src/service/advisory/csaf/creator.rs
@@ -28,6 +28,13 @@ use trustify_entity::{
 };
 use uuid::Uuid;
 
+/// Helper macro to sort ActiveModel vectors by their id field
+macro_rules! sort_by_id {
+    ($vec:expr) => {
+        $vec.sort_by(|a, b| a.id.as_ref().cmp(b.id.as_ref()))
+    };
+}
+
 #[derive(Debug)]
 pub struct StatusCreator<'a> {
     cache: ResolveProductIdCache<'a>,
@@ -263,11 +270,11 @@ impl<'a> StatusCreator<'a> {
         // Sort all collections by ID before batch inserting to ensure consistent lock acquisition
         // order across transactions. This prevents deadlocks from index page lock contention
         // when multiple concurrent transactions insert overlapping data.
-        product_models.sort_by(|a, b| a.id.as_ref().cmp(b.id.as_ref()));
-        version_ranges.sort_by(|a, b| a.id.as_ref().cmp(b.id.as_ref()));
-        package_statuses.sort_by(|a, b| a.id.as_ref().cmp(b.id.as_ref()));
-        product_version_ranges.sort_by(|a, b| a.id.as_ref().cmp(b.id.as_ref()));
-        product_status_models.sort_by(|a, b| a.id.as_ref().cmp(b.id.as_ref()));
+        sort_by_id!(product_models);
+        sort_by_id!(version_ranges);
+        sort_by_id!(package_statuses);
+        sort_by_id!(product_version_ranges);
+        sort_by_id!(product_status_models);
 
         for batch in &product_models.chunked() {
             product::Entity::insert_many(batch)


### PR DESCRIPTION
Follow-up on comment https://github.com/guacsec/trustify/pull/2102/files#r2534028104

## Summary by Sourcery

Extract repetitive sorting logic into a helper macro and apply it to streamline sorting of ActiveModel vectors in StatusCreator

Enhancements:
- Introduce a new sort_by_id! macro to sort ActiveModel vectors by their id field
- Replace five inline sort_by closures in StatusCreator with the sort_by_id! macro