### PR TITLE
chore: refactor vulnerability DB read

### DIFF
--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -131,6 +131,53 @@ impl Graph {
             .map(|vulnerability| VulnerabilityContext::new(self, vulnerability))
             .collect())
     }
+
+    /// Add descriptions for a vulnerability
+    ///
+    /// This is a standalone method that doesn't require a VulnerabilityContext,
+    /// allowing callers to add descriptions without querying the vulnerability first.
+    #[instrument(skip(connection, descriptions), err(level=tracing::Level::INFO))]
+    pub async fn add_vulnerability_descriptions<C: ConnectionTrait>(
+        vulnerability_id: impl Into<String> + Debug,
+        advisory_id: Uuid,
+        descriptions: impl IntoIterator<Item = (&str, &str)>,
+        connection: &C,
+    ) -> Result<(), Error> {
+        let vulnerability_id = vulnerability_id.into();
+        let entries = descriptions.into_iter().map(|(lang, description)| {
+            vulnerability_description::ActiveModel {
+                id: Default::default(),
+                advisory_id: Set(advisory_id),
+                vulnerability_id: Set(vulnerability_id.clone()),
+                lang: Set(lang.to_string()),
+                description: Set(description.to_string()),
+            }
+        });
+
+        for batch in &entries.chunked() {
+            vulnerability_description::Entity::insert_many(batch)
+                .exec(connection)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Drop all descriptions for a vulnerability associated with a specific advisory
+    ///
+    /// This is a standalone method that doesn't require a VulnerabilityContext.
+    #[instrument(skip(connection), err(level=tracing::Level::INFO))]
+    pub async fn drop_vulnerability_descriptions_for_advisory<C: ConnectionTrait>(
+        advisory_id: Uuid,
+        connection: &C,
+    ) -> Result<(), Error> {
+        vulnerability_description::Entity::delete_many()
+            .filter(vulnerability_description::Column::AdvisoryId.eq(advisory_id))
+            .exec(connection)
+            .await?;
+
+        Ok(())
+    }
 }
 
 #[derive(Clone)]
@@ -191,23 +238,13 @@ impl VulnerabilityContext {
         descriptions: impl IntoIterator<Item = (&str, &str)>,
         connection: &C,
     ) -> Result<(), Error> {
-        let entries = descriptions.into_iter().map(|(lang, description)| {
-            vulnerability_description::ActiveModel {
-                id: Default::default(),
-                advisory_id: Set(advisory),
-                vulnerability_id: Set(self.vulnerability.id.clone()),
-                lang: Set(lang.to_string()),
-                description: Set(description.to_string()),
-            }
-        });
-
-        for batch in &entries.chunked() {
-            vulnerability_description::Entity::insert_many(batch)
-                .exec(connection)
-                .await?;
-        }
-
-        Ok(())
+        Graph::add_vulnerability_descriptions(
+            &self.vulnerability.id,
+            advisory,
+            descriptions,
+            connection,
+        )
+        .await
     }
 
     pub async fn drop_descriptions_for_advisory<C: ConnectionTrait>(
@@ -215,12 +252,7 @@ impl VulnerabilityContext {
         advisory: Uuid,
         connection: &C,
     ) -> Result<(), Error> {
-        vulnerability_description::Entity::delete_many()
-            .filter(vulnerability_description::Column::AdvisoryId.eq(advisory))
-            .exec(connection)
-            .await?;
-
-        Ok(())
+        Graph::drop_vulnerability_descriptions_for_advisory(advisory, connection).await
     }
 
     // Get all descriptions for a vulnerability


### PR DESCRIPTION
Follow-up comment https://github.com/guacsec/trustify/pull/2102/files#r2534020590

## Summary by Sourcery

Extract vulnerability description handling into Graph methods and update VulnerabilityContext and CveLoader to use them

Enhancements:
- Introduce standalone Graph methods add_vulnerability_descriptions and drop_vulnerability_descriptions_for_advisory to manage vulnerability descriptions without requiring a VulnerabilityContext
- Refactor VulnerabilityContext and CveLoader to delegate description insertion and deletion to the new Graph methods, removing redundant queries