### PR TITLE
ci: switch to macos-15

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -58,10 +58,10 @@ jobs:
               sudo apt install -y libssl-dev
 
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
             args: --features vendored
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-15
             args: --features vendored
 
           - target: x86_64-pc-windows-msvc


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions build matrix to use macOS-15 runners for both Intel and ARM targets

CI:
- Switch x86_64-apple-darwin runner from macos-13 to macos-15-intel
- Switch aarch64-apple-darwin runner from macos-14 to macos-15