### PR TITLE
ci: switch to macos-15

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -58,10 +58,10 @@ jobs:
               sudo apt install -y libssl-dev
 
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
             args: --features vendored
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-15
             args: --features vendored
 
           - target: x86_64-pc-windows-msvc


### PR DESCRIPTION
See: https://github.com/actions/runner-images/issues/13046

backport from main

## Summary by Sourcery

Update GitHub Actions macOS runner versions in the build-binary workflow to macos-15 for both Intel and ARM targets.

CI:
- Use macos-15-intel for x86_64-apple-darwin builds
- Use macos-15 for aarch64-apple-darwin builds