### PR TITLE
fix: upgrade cve library to support 5.2 scheme version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "cve"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba109f3a468c9e2cd871c259040cf11ca95caaaed10427c6c8879515ae87896"
+checksum = "3077b0b3df7108da3ff51db5c258785866d0c2392b7dd63c554b085d3bc075cc"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ criterion = "0.7.0"
 csaf = { version = "0.5.0", default-features = false }
 csaf-walker = { version = "0.14.1", default-features = false }
 csv = "1.3.0"
-cve = "0.4.0"
+cve = "0.5.0"
 deepsize = "0.2.0"
 fixedbitset = "0.5.7"
 flate2 = "1.0.35"

--- a/etc/test-data/cve/CVE-2025-1000.json
+++ b/etc/test-data/cve/CVE-2025-1000.json
@@ -1,0 +1,191 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.2",
+    "cveMetadata": {
+        "cveId": "CVE-2025-1000",
+        "assignerOrgId": "9a959283-ebb5-44b6-b705-dcc2bbced522",
+        "state": "PUBLISHED",
+        "assignerShortName": "ibm",
+        "dateReserved": "2025-02-03T18:09:41.315Z",
+        "datePublished": "2025-05-05T20:55:46.335Z",
+        "dateUpdated": "2025-11-03T19:35:12.546Z"
+    },
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "cpes": [
+                        "cpe:2.3:a:ibm:db2:11.5.0:*:*:*:*:linux:*:*",
+                        "cpe:2.3:a:ibm:db2:11.5.0:*:*:*:*:unix:*:*",
+                        "cpe:2.3:a:ibm:db2:11.5.0:*:*:*:*:aix:*:*",
+                        "cpe:2.3:a:ibm:db2:11.5.0:*:*:*:*:windows:*:*",
+                        "cpe:2.3:a:ibm:db2:11.5.0:*:*:*:*:zos:*:*",
+                        "cpe:2.3:a:ibm:db2:11.5.9:*:*:*:*:linux:*:*",
+                        "cpe:2.3:a:ibm:db2:11.5.9:*:*:*:*:unix:*:*",
+                        "cpe:2.3:a:ibm:db2:11.5.9:*:*:*:*:aix:*:*",
+                        "cpe:2.3:a:ibm:db2:11.5.9:*:*:*:*:windows:*:*",
+                        "cpe:2.3:a:ibm:db2:11.5.9:*:*:*:*:zos:*:*",
+                        "cpe:2.3:a:ibm:db2:12.1.0:*:*:*:*:linux:*:*",
+                        "cpe:2.3:a:ibm:db2:12.1.0:*:*:*:*:unix:*:*",
+                        "cpe:2.3:a:ibm:db2:12.1.0:*:*:*:*:aix:*:*",
+                        "cpe:2.3:a:ibm:db2:12.1.0:*:*:*:*:windows:*:*",
+                        "cpe:2.3:a:ibm:db2:12.1.0:*:*:*:*:zos:*:*",
+                        "cpe:2.3:a:ibm:db2:12.1.1:*:*:*:*:linux:*:*",
+                        "cpe:2.3:a:ibm:db2:12.1.1:*:*:*:*:unix:*:*",
+                        "cpe:2.3:a:ibm:db2:12.1.1:*:*:*:*:aix:*:*",
+                        "cpe:2.3:a:ibm:db2:12.1.1:*:*:*:*:windows:*:*",
+                        "cpe:2.3:a:ibm:db2:12.1.1:*:*:*:*:zos:*:*"
+                    ],
+                    "defaultStatus": "unaffected",
+                    "product": "Db2 for Linux, UNIX and Windows",
+                    "vendor": "IBM",
+                    "versions": [
+                        {
+                            "lessThanOrEqual": "11.5.9",
+                            "status": "affected",
+                            "version": "11.5.0",
+                            "versionType": "semver"
+                        },
+                        {
+                            "lessThanOrEqual": "12.1.1",
+                            "status": "affected",
+                            "version": "12.1.0",
+                            "versionType": "semver"
+                        }
+                    ]
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "supportingMedia": [
+                        {
+                            "base64": false,
+                            "type": "text/html",
+                            "value": "IBM Db2 for Linux, UNIX and Windows (includes DB2 Connect Server) 11.5.0 through 11.5.9 and 12.1.0 through 12.1.1 \n\n<span style=\"background-color: rgb(255, 255, 255);\">could allow an authenticated user to cause a denial of service when connecting to a z/OS database due to improper handling of automatic client rerouting.</span>"
+                        }
+                    ],
+                    "value": "IBM Db2 for Linux, UNIX and Windows (includes DB2 Connect Server) 11.5.0 through 11.5.9 and 12.1.0 through 12.1.1 \n\ncould allow an authenticated user to cause a denial of service when connecting to a z/OS database due to improper handling of automatic client rerouting."
+                }
+            ],
+            "metrics": [
+                {
+                    "cvssV3_1": {
+                        "attackComplexity": "HIGH",
+                        "attackVector": "NETWORK",
+                        "availabilityImpact": "HIGH",
+                        "baseScore": 5.3,
+                        "baseSeverity": "MEDIUM",
+                        "confidentialityImpact": "NONE",
+                        "integrityImpact": "NONE",
+                        "privilegesRequired": "LOW",
+                        "scope": "UNCHANGED",
+                        "userInteraction": "NONE",
+                        "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
+                        "version": "3.1"
+                    },
+                    "format": "CVSS",
+                    "scenarios": [
+                        {
+                            "lang": "en",
+                            "value": "GENERAL"
+                        }
+                    ]
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "cweId": "CWE-770",
+                            "description": "CWE-770 Allocation of Resources Without Limits or Throttling",
+                            "lang": "en",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "9a959283-ebb5-44b6-b705-dcc2bbced522",
+                "shortName": "ibm",
+                "dateUpdated": "2025-08-28T14:27:44.782Z"
+            },
+            "references": [
+                {
+                    "tags": [
+                        "vendor-advisory",
+                        "patch"
+                    ],
+                    "url": "https://www.ibm.com/support/pages/node/7232528"
+                }
+            ],
+            "solutions": [
+                {
+                    "lang": "en",
+                    "supportingMedia": [
+                        {
+                            "base64": false,
+                            "type": "text/html",
+                            "value": "Customers running any vulnerable affected level of an affected Program, V11.5 and V12.1 can download the special build containing the interim fix for this issue from Fix Central. These special builds are available based on the most recent affected level for each impacted release: V11.5.9 and V12.1.1. They can be applied to any affected level of the appropriate release to remediate this vulnerability."
+                        }
+                    ],
+                    "value": "Customers running any vulnerable affected level of an affected Program, V11.5 and V12.1 can download the special build containing the interim fix for this issue from Fix Central. These special builds are available based on the most recent affected level for each impacted release: V11.5.9 and V12.1.1. They can be applied to any affected level of the appropriate release to remediate this vulnerability."
+                }
+            ],
+            "source": {
+                "discovery": "UNKNOWN"
+            },
+            "title": "IBM Db2 denial of service",
+            "x_generator": {
+                "engine": "Vulnogram 0.2.0"
+            }
+        },
+        "adp": [
+            {
+                "metrics": [
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "timestamp": "2025-05-06T02:54:14.923211Z",
+                                "id": "CVE-2025-1000",
+                                "options": [
+                                    {
+                                        "Exploitation": "none"
+                                    },
+                                    {
+                                        "Automatable": "no"
+                                    },
+                                    {
+                                        "Technical Impact": "partial"
+                                    }
+                                ],
+                                "role": "CISA Coordinator",
+                                "version": "2.0.3"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2025-05-06T02:54:27.634Z"
+                }
+            },
+            {
+                "title": "CVE Program Container",
+                "references": [
+                    {
+                        "url": "https://security.netapp.com/advisory/ntap-20250516-0002/"
+                    }
+                ],
+                "providerMetadata": {
+                    "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+                    "shortName": "CVE",
+                    "dateUpdated": "2025-11-03T19:35:12.546Z"
+                }
+            }
+        ]
+    }
+}

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -436,13 +436,14 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
         "cve/CVE-2023-44487.json",
         "cve/CVE-2024-7826.json",
         "cve/CVE-2017-20197.json",
+        "cve/CVE-2025-1000.json",
     ])
     .await?;
 
     let vulns = service
         .fetch_vulnerabilities(q(""), Paginated::default(), Default::default(), &ctx.db)
         .await?;
-    assert_eq!(7, vulns.items.len());
+    assert_eq!(8, vulns.items.len());
     let vulns = service
         .fetch_vulnerabilities(
             q("base_score>9"),
@@ -472,7 +473,7 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
         )
         .await?;
     tracing::debug!(test = "", "{vulns:#?}");
-    assert_eq!(3, vulns.items.len());
+    assert_eq!(4, vulns.items.len());
     assert_eq!(
         *vulns.items[0].average_severity.as_ref().unwrap(),
         trustify_cvss::cvss3::severity::Severity::Medium
@@ -536,6 +537,18 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     assert_eq!(vulns.items[0].advisories[0].severity, Some(Severity::High));
     assert_eq!(vulns.items[0].advisories[1].score, None);
     assert_eq!(vulns.items[0].advisories[1].severity, None);
+
+    let vulns = service
+        .fetch_vulnerabilities(
+            q("CVE-2025-1000"),
+            Paginated::default(),
+            Default::default(),
+            &ctx.db,
+        )
+        .await?;
+    assert_eq!(1, vulns.items.len());
+    assert_eq!(vulns.items[0].average_score, Some(5.3));
+    assert_eq!(vulns.items[0].average_severity, Some(Severity::Medium));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the CVE dependency and extend vulnerability handling tests for the newer CVE schema version.

Bug Fixes:
- Ensure vulnerabilities using the newer CVE schema version are correctly parsed and scored.

Enhancements:
- Add coverage for a new CVE entry, including average score and severity calculations, in the vulnerability query tests.

Build:
- Bump the cve crate dependency from 0.4.0 to 0.5.0.

Tests:
- Add a new CVE-2025-1000 test fixture and update vulnerability query expectations to account for the additional record.