### PR TITLE
chore: add source_document.id indexes to FKs (TC-3214)

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -31,6 +31,7 @@ mod m0001160_improve_expand_spdx_licenses_function;
 mod m0001170_non_null_source_document_id;
 mod m0001180_expand_spdx_licenses_with_mappings_function;
 mod m0001190_optimize_product_advisory_query;
+mod m0001200_source_document_fk_indexes;
 
 pub struct Migrator;
 
@@ -69,6 +70,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001170_non_null_source_document_id::Migration),
             Box::new(m0001180_expand_spdx_licenses_with_mappings_function::Migration),
             Box::new(m0001190_optimize_product_advisory_query::Migration),
+            Box::new(m0001200_source_document_fk_indexes::Migration),
         ]
     }
 }

--- a/migration/src/m0001200_source_document_fk_indexes.rs
+++ b/migration/src/m0001200_source_document_fk_indexes.rs
@@ -1,0 +1,85 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Create index on advisory.source_document_id
+        // This FK was missing an index, causing severe performance issues
+        // when deleting source_documents (must scan 596K+ advisory rows)
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(Advisory::Table)
+                    .name(Indexes::AdvisorySourceDocumentIdIdx.to_string())
+                    .col(Advisory::SourceDocumentId)
+                    .to_owned(),
+            )
+            .await?;
+
+        // Create index on sbom.source_document_id
+        // This FK was also missing an index, causing performance issues
+        // during source_document deletion and SBOM lookups
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(Sbom::Table)
+                    .name(Indexes::SbomSourceDocumentIdIdx.to_string())
+                    .col(Sbom::SourceDocumentId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Drop index on sbom.source_document_id
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(Sbom::Table)
+                    .name(Indexes::SbomSourceDocumentIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        // Drop index on advisory.source_document_id
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(Advisory::Table)
+                    .name(Indexes::AdvisorySourceDocumentIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+pub enum Indexes {
+    AdvisorySourceDocumentIdIdx,
+    SbomSourceDocumentIdIdx,
+}
+
+#[derive(DeriveIden)]
+pub enum Advisory {
+    Table,
+    SourceDocumentId,
+}
+
+#[derive(DeriveIden)]
+pub enum Sbom {
+    Table,
+    SourceDocumentId,
+}


### PR DESCRIPTION
During some performance investigations, it turned out that during the SBOM delete execution, there's a delete from the `source_document` table in

https://github.com/guacsec/trustify/blob/e149e96dc198b53c10c6bde8c96b078084112b9e/modules/fundamental/src/sbom/service/sbom.rs#L144

The `source_document.id` value is a FK in two tables, i.e. `advisory` and `sbom`.

Postgresql documentation regarding FK states:
`Since a DELETE of a row from the referenced table or an UPDATE of a referenced column will require a scan of the referencing table for rows matching the old value, it is often a good idea to index the referencing columns too.` in [1] hence the creation of the indexes in this PR.

Relates to https://issues.redhat.com/browse/TC-3214

[1] https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK

## Summary by Sourcery

Enhancements:
- Introduce a new migration that creates indexes on advisory.source_document_id and sbom.source_document_id foreign key columns to optimize source document deletions and related queries.