### PR TITLE
chore: add sbom_node - node_id index

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -32,6 +32,7 @@ mod m0001170_non_null_source_document_id;
 mod m0001180_expand_spdx_licenses_with_mappings_function;
 mod m0001190_optimize_product_advisory_query;
 mod m0001200_source_document_fk_indexes;
+mod m0001210_sbom_node_node_id_index;
 
 pub struct Migrator;
 
@@ -71,6 +72,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001180_expand_spdx_licenses_with_mappings_function::Migration),
             Box::new(m0001190_optimize_product_advisory_query::Migration),
             Box::new(m0001200_source_document_fk_indexes::Migration),
+            Box::new(m0001210_sbom_node_node_id_index::Migration),
         ]
     }
 }

--- a/migration/src/m0001210_sbom_node_node_id_index.rs
+++ b/migration/src/m0001210_sbom_node_node_id_index.rs
@@ -1,0 +1,48 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .table(SbomNode::Table)
+                    .name(Indexes::SbomNodeNodeIdIdx.to_string())
+                    .col(SbomNode::NodeId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(SbomNode::Table)
+                    .name(Indexes::SbomNodeNodeIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+pub enum Indexes {
+    SbomNodeNodeIdIdx,
+}
+
+#[derive(DeriveIden)]
+pub enum SbomNode {
+    Table,
+    NodeId,
+}


### PR DESCRIPTION
Dahsboard is calling some endpoints and one of them is using a big rust function that contains the following `select`:

```sql
SELECT "sbom_node"."sbom_id", "sbom_node"."node_id",
"sbom_node"."name" FROM "sbom_node" WHERE "node_id" = ANY($1)
```

This is the worse query that is making dashboard page slow because the table is big and the index is not getting a hit because `node_id` is part of a composite index (with position 2) and consequently not using cache.

## Summary by Sourcery

Add a database migration to improve lookup performance on sbom_node by indexing node_id.

Enhancements:
- Introduce a new migration that creates a dedicated index on sbom_node.node_id to speed up queries filtering by node_id.
- Ensure the new sbom_node.node_id index can be safely rolled back by dropping it in the down migration.



EDIT:

https://gist.github.com/helio-frota/f821493c83a2c62c248f321d5e2c738b