### PR TITLE
Allow publishing a `gensbom` container

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -44,6 +44,20 @@ runs:
         containerfiles: |
           .github/scripts/Containerfile.xtask
 
+    - name: Build Image (gensbom)
+      id: build-image-gensbom
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: gensbom
+        tags: ${{ inputs.image_tag }}
+        envs: |
+          TAG=${{ inputs.image_tag }}
+        build-args: |
+          tag=${{ inputs.image_tag }}
+        platforms: linux/amd64, linux/arm64
+        containerfiles: |
+          etc/gensbom/Containerfile
+
     - name: Check images created
       shell: bash
       run: buildah images
@@ -54,6 +68,7 @@ runs:
       run: |
         podman save --multi-image-archive trustd:${{ inputs.image_tag }} > trustd.tar
         podman save --multi-image-archive xtask:${{ inputs.image_tag }} > xtask.tar
+        podman save --multi-image-archive gensbom:${{ inputs.image_tag }} > gensbom.tar
 
     - uses: actions/upload-artifact@v4
       with:
@@ -65,4 +80,10 @@ runs:
       with:
         name: container-xtask
         path: xtask.tar
+        if-no-files-found: error
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: container-gensbom
+        path: gensbom.tar
         if-no-files-found: error

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,6 +157,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Push to ghcr.io (gensbom)
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: gensbom
+          tags: ${{ needs.init.outputs.version }}
+          registry: ghcr.io/${{ github.repository_owner }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Final step, create the GitHub release, attaching the files
 
       - name: Create Release


### PR DESCRIPTION
Publish `gensbom` container together with `trustd` and `xtask` containers so users do not need build it locally.

## Summary by Sourcery

Add gensbom container image to the existing container build and release workflows.

Build:
- Extend the shared build-container GitHub Action to build and save a gensbom image artifact alongside trustd and xtask.

CI:
- Update the release workflow to push the gensbom container image to ghcr.io as part of the release process.