### PR TITLE
fix: Add missing build context

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -57,6 +57,7 @@ runs:
         platforms: linux/amd64, linux/arm64
         containerfiles: |
           etc/gensbom/Containerfile
+        context: ./etc/gensbom
 
     - name: Check images created
       shell: bash


### PR DESCRIPTION
Add missing build context to `buildah` action to fix failing pipeline (fixes PR #2136).

## Summary by Sourcery

Build:
- Add an explicit build context (./etc/gensbom) to the build-container GitHub Action configuration for the gensbom image.