### PR TITLE
chore: refactor sort_by_id into sort_by_key

### DIFF
--- a/modules/ingestor/src/service/advisory/csaf/creator.rs
+++ b/modules/ingestor/src/service/advisory/csaf/creator.rs
@@ -150,6 +150,7 @@ impl<'a> StatusCreator<'a> {
 
             let product_id = ProductInformation::create_uuid(org_id, product.product.clone());
 
+            // Warn: id must be Set(), required for sorting
             let product_entity = product::ActiveModel {
                 id: Set(product_id),
                 name: Set(product.product.clone()),
@@ -165,6 +166,7 @@ impl<'a> StatusCreator<'a> {
                     cpe: product.cpe.clone(),
                 };
 
+                // Warn: into_active_model() sets id with Set(), required for sorting
                 let (version_range_entity, product_version_range_entity) =
                     range.clone().into_active_model();
                 version_ranges.push(version_range_entity);
@@ -189,6 +191,7 @@ impl<'a> StatusCreator<'a> {
                         product_version_range_id: range.uuid(),
                     };
 
+                    // Warn: into_active_model() sets id with Set(), required for sorting
                     let base_product = product_status
                         .into_active_model(self.advisory_id, self.vulnerability_id.clone());
 
@@ -253,6 +256,7 @@ impl<'a> StatusCreator<'a> {
         cpes.create(connection).await?;
 
         for ps in &self.entries {
+            // Warn: into_active_model() sets id with Set(), required for sorting
             let (version_range, purl_status) = ps
                 .clone()
                 .into_active_model(self.advisory_id, self.vulnerability_id.clone());
@@ -263,6 +267,7 @@ impl<'a> StatusCreator<'a> {
         // Sort all collections by ID before batch inserting to ensure consistent lock acquisition
         // order across transactions. This prevents deadlocks from index page lock contention
         // when multiple concurrent transactions insert overlapping data.
+        // Warn: as_ref() requires id fields to be Set() (never NotSet), guaranteed by constructors above.
         product_models.sort_by_key(|model| *model.id.as_ref());
         version_ranges.sort_by_key(|model| *model.id.as_ref());
         package_statuses.sort_by_key(|model| *model.id.as_ref());


### PR DESCRIPTION
Addressing comment https://github.com/guacsec/trustify/pull/2138#pullrequestreview-3510103919

## Summary by Sourcery

Enhancements:
- Remove the generic sort_by_id macro and inline explicit ID-based sort_by_key calls for all relevant model collections prior to batch inserts.