### PR TITLE
chore: Add `gensbom` also to the latest-release

### DIFF
--- a/.github/workflows/latest-release.yaml
+++ b/.github/workflows/latest-release.yaml
@@ -113,6 +113,16 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Push to ghcr.io (gensbom)
+        id: push-gensbom
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: gensbom
+          tags: ${{ needs.init.outputs.version }}
+          registry: ghcr.io/${{ github.repository_owner }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
   deploy:
     if: ${{ (github.repository == 'guacsec/trustify') && (needs.init.outputs.version == 'main') }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Add `gensbom` also to the `latest-release` GitHub workflow.

## Summary by Sourcery

Build:
- Extend the latest-release GitHub Actions workflow to push the gensbom image to ghcr.io using the existing registry credentials.