### PR TITLE
latest endpoints: investigations.

### DIFF
--- a/entity/src/sbom_package.rs
+++ b/entity/src/sbom_package.rs
@@ -35,6 +35,13 @@ pub enum Relation {
     Cpe,
 
     #[sea_orm(
+        belongs_to = "super::sbom_package_cpe_ref::Entity",
+        from = "(Column::SbomId)",
+        to = "(super::sbom_package_cpe_ref::Column::SbomId)"
+    )]
+    CpeSbomId,
+
+    #[sea_orm(
         belongs_to = "super::sbom_package_license::Entity",
         from = "(Column::SbomId, Column::NodeId)",
         to = "(super::sbom_package_license::Column::SbomId, super::sbom_package_license::Column::NodeId)"

--- a/modules/analysis/src/service/load.rs
+++ b/modules/analysis/src/service/load.rs
@@ -409,7 +409,7 @@ impl InnerService {
                 .column(cpe::Column::Id)
                 .column_as(Expr::cust(rank_sql), "rank") // Use the selected SQL string
                 .join(JoinType::LeftJoin, sbom_package_relation.def())
-                .join(JoinType::LeftJoin, sbom_package::Relation::Cpe.def())
+                .join(JoinType::LeftJoin, sbom_package::Relation::CpeSbomId.def())
                 .join(
                     JoinType::LeftJoin,
                     sbom_package_cpe_ref::Relation::Cpe.def(),


### PR DESCRIPTION
expirement

## Summary by Sourcery

Adjust SBOM package–CPE joins to use a dedicated relation keyed by SBOM ID.

Bug Fixes:
- Correct the SBOM package analysis query to join CPE references via SBOM ID instead of the previous CPE relation.

Enhancements:
- Introduce a dedicated SeaORM relation from SBOM packages to CPE references keyed on SBOM ID for clearer modeling.