### PR TITLE
fix: reinstate original /v2/vulnerability/analyze and introduce /v3/vulnerability/analyze

### DIFF
--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -5,7 +5,10 @@ use crate::{
     db::DatabaseExt,
     endpoints::Deprecation,
     vulnerability::{
-        model::{AnalysisRequest, AnalysisResponse, VulnerabilityDetails, VulnerabilitySummary},
+        model::{
+            AnalysisRequest, AnalysisResponse, VulnerabilityDetails, VulnerabilitySummary,
+            v2::AnalysisResponseV2,
+        },
         service::VulnerabilityService,
     },
 };
@@ -27,7 +30,8 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         .app_data(web::Data::new(db))
         .service(all)
         .service(get)
-        .service(analyze);
+        .service(analyze)
+        .service(analyze_v3);
 }
 
 #[allow(dead_code)]
@@ -107,12 +111,33 @@ pub async fn get(
   tag = "vulnerability",
   request_body = AnalysisRequest,
   responses(
-      (status = 200, description = "Analyze the provided purls to search for known vulnerabilities", body = AnalysisResponse),
+      (status = 200, description = "Analyze the provided purls to search for known vulnerabilities", body = AnalysisResponseV2),
   ),
 )]
 #[post("/v2/vulnerability/analyze")]
 /// Analyze the provided purls for the known vulnerabilities
 pub async fn analyze(
+    service: web::Data<VulnerabilityService>,
+    db: web::Data<Database>,
+    web::Json(AnalysisRequest { purls }): web::Json<AnalysisRequest>,
+    _: Require<ReadAdvisory>,
+) -> actix_web::Result<impl Responder> {
+    let tx = db.begin_read().await?;
+    let details = service.analyze_purls_v2(purls, &tx).await?;
+
+    Ok(HttpResponse::Ok().json(details))
+}
+
+#[utoipa::path(
+    operation_id = "analyze_v3",
+    tag = "vulnerability",
+    request_body = AnalysisRequest,
+    responses(
+        (status = 200, description = "Analyze the provided purls to search for known vulnerabilities", body = AnalysisResponse),
+    ),
+)]
+#[post("/v3/vulnerability/analyze")]
+pub async fn analyze_v3(
     service: web::Data<VulnerabilityService>,
     db: web::Data<Database>,
     web::Json(AnalysisRequest { purls }): web::Json<AnalysisRequest>,

--- a/modules/fundamental/src/vulnerability/model/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/mod.rs
@@ -1,6 +1,7 @@
 mod analyze;
 mod details;
 mod summary;
+pub mod v2;
 
 pub use analyze::*;
 pub use details::*;

--- a/modules/fundamental/src/vulnerability/model/v2.rs
+++ b/modules/fundamental/src/vulnerability/model/v2.rs
@@ -1,0 +1,41 @@
+use crate::{
+    advisory::model::AdvisoryHead, common::model::Score, vulnerability::model::VulnerabilityHead,
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, ops::Deref};
+use utoipa::ToSchema;
+
+#[derive(Serialize, Deserialize, Debug, ToSchema, Default)]
+pub struct AnalysisResultV2 {
+    pub details: Vec<AnalysisDetailsV2>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct AnalysisDetailsV2 {
+    #[serde(flatten)]
+    pub head: VulnerabilityHead,
+
+    /// List of purl statuses
+    pub status: BTreeMap<String, Vec<AnalysisAdvisory>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct AnalysisAdvisory {
+    #[serde(flatten)]
+    pub advisory: AdvisoryHead,
+
+    /// CVSS scores
+    pub scores: Vec<Score>,
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct AnalysisResponseV2(pub BTreeMap<String, AnalysisResultV2>);
+
+impl Deref for AnalysisResponseV2 {
+    type Target = BTreeMap<String, AnalysisResultV2>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -3,10 +3,13 @@ mod test;
 
 use crate::{
     Error,
+    advisory::model::AdvisoryHead,
+    common::model::Score,
     purl::model::details::{purl::PurlStatus, version_range::VersionRange},
     vulnerability::model::{
         AnalysisDetails, AnalysisResponse, AnalysisResult, VulnerabilityDetails, VulnerabilityHead,
         VulnerabilitySummary,
+        v2::{AnalysisAdvisory, AnalysisDetailsV2, AnalysisResponseV2, AnalysisResultV2},
     },
 };
 use sea_orm::{EntityTrait, FromQueryResult, Statement, prelude::*};
@@ -25,9 +28,17 @@ use trustify_common::{
     model::{Paginated, PaginatedResults},
     purl::Purl,
 };
-use trustify_cvss::cvss3::{Cvss3Base, score::Score};
-use trustify_entity::{cvss3, vulnerability, vulnerability_description};
+use trustify_cvss::cvss3::{Cvss3Base, score::Score as CvssScore};
+use trustify_entity::{advisory, cvss3, vulnerability, vulnerability_description};
 use trustify_module_ingestor::common::Deprecation;
+
+struct AnalysisData {
+    purls_with_vulnerabilities: Vec<QueryResult>,
+    warnings: HashMap<String, Vec<String>>,
+    descriptions_map: HashMap<String, vulnerability_description::Model>,
+    cvss3_scores: Vec<cvss3::Model>,
+    advisories_map: HashMap<Uuid, advisory::Model>,
+}
 
 #[derive(Default)]
 pub struct VulnerabilityService {}
@@ -101,6 +112,38 @@ impl VulnerabilityService {
         purls: impl IntoIterator<Item = impl AsRef<str>>,
         connection: &C,
     ) -> Result<AnalysisResponse, Error>
+    where
+        C: ConnectionTrait,
+    {
+        let data = self
+            .fetch_vulnerability_analysis_data(purls, connection)
+            .await?;
+        self.format_response(data, connection).await
+    }
+
+    #[instrument(
+        skip_all,
+        err(level=tracing::Level::INFO),
+    )]
+    pub async fn analyze_purls_v2<C>(
+        &self,
+        purls: impl IntoIterator<Item = impl AsRef<str>>,
+        connection: &C,
+    ) -> Result<AnalysisResponseV2, Error>
+    where
+        C: ConnectionTrait,
+    {
+        let data = self
+            .fetch_vulnerability_analysis_data(purls, connection)
+            .await?;
+        self.format_response_v2(data, connection).await
+    }
+
+    async fn fetch_vulnerability_analysis_data<C>(
+        &self,
+        purls: impl IntoIterator<Item = impl AsRef<str>>,
+        connection: &C,
+    ) -> Result<AnalysisData, Error>
     where
         C: ConnectionTrait,
     {
@@ -180,6 +223,45 @@ impl VulnerabilityService {
         };
         log::debug!("Pre-fetched {} cvss3 scores", cvss3_scores.len());
 
+        // Pre-fetch advisories
+        let advisories = if !advisory_ids.is_empty() {
+            advisory::Entity::find()
+                .filter(Expr::col(advisory::Column::Id).eq(PgFunc::any(advisory_ids)))
+                .all(connection)
+                .await?
+        } else {
+            vec![]
+        };
+        log::debug!("Pre-fetched {} advisories", advisories.len());
+
+        let advisories: HashMap<Uuid, advisory::Model> =
+            advisories.into_iter().map(|adv| (adv.id, adv)).collect();
+
+        Ok(AnalysisData {
+            purls_with_vulnerabilities,
+            warnings,
+            descriptions_map,
+            cvss3_scores,
+            advisories_map: advisories,
+        })
+    }
+
+    async fn format_response<C>(
+        &self,
+        data: AnalysisData,
+        connection: &C,
+    ) -> Result<AnalysisResponse, Error>
+    where
+        C: ConnectionTrait,
+    {
+        let AnalysisData {
+            purls_with_vulnerabilities,
+            mut warnings,
+            descriptions_map,
+            cvss3_scores,
+            ..
+        } = data;
+
         let mut cvss3_map: HashMap<(Uuid, String), Vec<Cvss3Base>> = HashMap::new();
         for score in cvss3_scores {
             let converted_score = Cvss3Base::from(score.clone());
@@ -189,7 +271,6 @@ impl VulnerabilityService {
                 .push(converted_score);
         }
 
-        // Process all rows
         let mut result = BTreeMap::new();
 
         for row in purls_with_vulnerabilities {
@@ -215,6 +296,65 @@ impl VulnerabilityService {
         }
 
         Ok(AnalysisResponse(result))
+    }
+
+    async fn format_response_v2<C>(
+        &self,
+        data: AnalysisData,
+        connection: &C,
+    ) -> Result<AnalysisResponseV2, Error>
+    where
+        C: ConnectionTrait,
+    {
+        let AnalysisData {
+            purls_with_vulnerabilities,
+            mut warnings,
+            descriptions_map,
+            cvss3_scores,
+            advisories_map,
+        } = data;
+
+        let mut cvss3_map: HashMap<(Uuid, String), Vec<Score>> = HashMap::new();
+        for score in cvss3_scores {
+            if let Ok(converted_score) = Score::try_from(score.clone()) {
+                cvss3_map
+                    .entry((score.advisory_id, score.vulnerability_id))
+                    .or_default()
+                    .push(converted_score);
+            }
+        }
+
+        let mut result = BTreeMap::new();
+
+        for row in purls_with_vulnerabilities {
+            let (requested_purl, head) = Self::row_to_vuln_v2(
+                row,
+                connection,
+                &descriptions_map,
+                &cvss3_map,
+                &advisories_map,
+            )
+            .await?;
+
+            match result.entry(requested_purl.clone()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(AnalysisResultV2 {
+                        details: vec![head],
+                        warnings: warnings.remove(&requested_purl).unwrap_or_default(),
+                    });
+                }
+                Entry::Occupied(mut entry) => {
+                    entry.get_mut().details.push(head);
+                }
+            }
+        }
+
+        // add the remaining warnings
+        for (purl, warnings) in warnings {
+            result.entry(purl).or_default().warnings.extend(warnings);
+        }
+
+        Ok(AnalysisResponseV2(result))
     }
 
     /// Build the query for finding matching vulnerabilities
@@ -384,7 +524,7 @@ GROUP BY
         let mut purl_statuses = Vec::new();
 
         for (advisory_id, entries) in &statuses {
-            let score = Score::from_iter(
+            let score = CvssScore::from_iter(
                 cvss3_map
                     .get(&(*advisory_id, vulnerability.id.clone()))
                     .cloned()
@@ -407,6 +547,100 @@ GROUP BY
             AnalysisDetails {
                 head,
                 purl_statuses,
+            },
+        ))
+    }
+
+    /// Take a row from [`Self::build_query`] and turn it into a result entry
+    ///
+    /// This will return a tuple of the original PURL and then the result
+    #[instrument(
+        skip_all,
+        fields(purl, id),
+        err(level=tracing::Level::INFO),
+    )]
+    async fn row_to_vuln_v2<C>(
+        row: QueryResult,
+        connection: &C,
+        descriptions_map: &HashMap<String, vulnerability_description::Model>,
+        cvss3_map: &HashMap<(Uuid, String), Vec<Score>>,
+        advisories_map: &HashMap<Uuid, advisory::Model>,
+    ) -> Result<(String, AnalysisDetailsV2), Error>
+    where
+        C: ConnectionTrait,
+    {
+        let requested_purl: String = row.try_get_by("requested_purl")?;
+
+        let vulnerability = vulnerability::Model::from_query_result(&row, "")?;
+
+        let span = tracing::Span::current();
+        span.record("purl", &requested_purl);
+        span.record("id", &vulnerability.id);
+
+        // Look up description from pre-fetched map
+        let description_memo = descriptions_map
+            .get(&vulnerability.id)
+            .map(|desc| Memo::Provided(Some(desc.clone())))
+            .unwrap_or(Memo::Provided(None));
+
+        let head = VulnerabilityHead::from_vulnerability_entity(
+            &vulnerability,
+            description_memo,
+            connection,
+        )
+        .await?;
+
+        /// result struct for getting the array of status/advisory entries
+        #[derive(serde::Deserialize)]
+        struct Entry {
+            status: String,
+            advisory_id: Uuid,
+        }
+        impl sea_orm::TryGetableFromJson for Entry {}
+
+        // deserialize from JSONB
+
+        let advisories: Option<Vec<Entry>> = row.try_get_by("advisories")?;
+
+        // create a map for looking up the status once we resolved the ID to a struct
+        // This also de-duplicates advisory IDs
+        let statuses = advisories
+            .into_iter()
+            .flatten()
+            .map(|e| (e.advisory_id, e.status))
+            .collect::<HashMap<_, _>>();
+
+        // Process advisories using pre-fetched data
+        let mut status_map = BTreeMap::<String, Vec<AnalysisAdvisory>>::new();
+
+        for (advisory_id, status) in &statuses {
+            let Some(advisory) = advisories_map.get(advisory_id) else {
+                continue;
+            };
+
+            // Look up scores from pre-fetched cvss3_map
+            let scores: Vec<Score> = cvss3_map
+                .get(&(*advisory_id, vulnerability.id.clone()))
+                .cloned()
+                .unwrap_or_default();
+
+            let analysis_advisory = AnalysisAdvisory {
+                advisory: AdvisoryHead::from_advisory(advisory, Memo::NotProvided, connection)
+                    .await?,
+                scores,
+            };
+
+            status_map
+                .entry(status.clone())
+                .or_default()
+                .push(analysis_advisory);
+        }
+
+        Ok((
+            requested_purl,
+            AnalysisDetailsV2 {
+                head,
+                status: status_map,
             },
         ))
     }

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -657,3 +657,78 @@ async fn analyze_purls_no_score(ctx: &TrustifyContext) -> Result<(), anyhow::Err
 
     Ok(())
 }
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn analyze_purls_v2(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let service = VulnerabilityService::new();
+
+    ctx.ingest_documents([
+        "osv/RUSTSEC-2021-0079.json",
+        "osv/GHSA-2ccf-ffrj-m4qw.json",
+        "osv/GHSA-69ch-w2m2-3vjp.json",
+        "osv/GHSA-ppp9-7jff-5vj2.json",
+    ])
+    .await?;
+
+    // test empty request
+
+    let result = service
+        .analyze_purls_v2(Vec::<&str>::new(), &ctx.db)
+        .await?;
+    assert!(result.is_empty());
+
+    // test some invalid PURLs
+
+    for purl in ["this is not valid"].iter() {
+        let result = service.analyze_purls_v2(vec![purl], &ctx.db).await;
+        assert!(result.is_err());
+    }
+
+    // test some unsuitable PURLs
+
+    for purl in ["pkg:npm/missing.version"].iter() {
+        let result = service.analyze_purls_v2(vec![purl], &ctx.db).await;
+        // must still be ok
+        assert!(result.is_ok(), "{purl} should not fail the request");
+        let result = result.unwrap();
+        // has exactly one entry
+        assert_eq!(result.len(), 1);
+        // which is the purl
+        let result = &result[*purl];
+        // and has one warning, but no details
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.details.is_empty());
+    }
+
+    let expected = [
+        "pkg:npm/%40fastify/passport@1.0.0",   // ECOSYSTEM:affected
+        "pkg:cargo/hyper@0.14.9",              // SEMVER:affected - no namespace
+        "pkg:golang/golang.org/x/text@v0.3.6", // GOLANG:affected
+        "pkg:golang/golang.org/x/text@0.3.6",  // SEMVER:affected
+    ];
+
+    let not_found = [
+        "pkg:npm/%40fastify/passport@2.3.0", // ECOSYSTEM:fixed
+        "pkg:golang/github.com/metal3-io/baremetal-operator/apis@0.8.0", // Missing
+        "pkg:cargo/hyper@0.14.11",           // SEMVER:fixed - no namespace
+    ];
+
+    let items: Vec<&str> = expected.iter().chain(&not_found).copied().collect();
+
+    let result = service.analyze_purls_v2(items, &ctx.db).await?;
+
+    expected.iter().for_each(|&item| {
+        assert!(
+            result.contains_key(item),
+            "Expected key '{item}' not found in result"
+        )
+    });
+    not_found.iter().for_each(|&item| {
+        assert!(
+            !result.contains_key(item),
+            "Unexpected key '{item}' found in result"
+        )
+    });
+    Ok(())
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2992,7 +2992,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AnalysisResponse'
+                $ref: '#/components/schemas/AnalysisResponseV2'
   /api/v2/vulnerability/{id}:
     get:
       tags:
@@ -3146,6 +3146,24 @@ paths:
                 $ref: '#/components/schemas/LicenseSummary'
         '404':
           description: The weakness could not be found
+  /api/v3/vulnerability/analyze:
+    post:
+      tags:
+      - vulnerability
+      operationId: analyze_v3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnalysisRequest'
+        required: true
+      responses:
+        '200':
+          description: Analyze the provided purls to search for known vulnerabilities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnalysisResponse'
 components:
   schemas:
     AdvisoryDetails:
@@ -3300,6 +3318,18 @@ components:
               All CVSS3 scores from the advisory for the given vulnerability.
               May include several, varying by minor version of the CVSS3 vector.
       description: Summary of information from this advisory regarding a single specific vulnerability.
+    AnalysisAdvisory:
+      allOf:
+      - $ref: '#/components/schemas/AdvisoryHead'
+      - type: object
+        required:
+        - scores
+        properties:
+          scores:
+            type: array
+            items:
+              $ref: '#/components/schemas/Score'
+            description: CVSS scores
     AnalysisDetails:
       allOf:
       - $ref: '#/components/schemas/VulnerabilityHead'
@@ -3312,6 +3342,22 @@ components:
             items:
               $ref: '#/components/schemas/PurlStatus'
             description: List of purl statuses
+    AnalysisDetailsV2:
+      allOf:
+      - $ref: '#/components/schemas/VulnerabilityHead'
+      - type: object
+        required:
+        - status
+        properties:
+          status:
+            type: object
+            description: List of purl statuses
+            additionalProperties:
+              type: array
+              items:
+                $ref: '#/components/schemas/AnalysisAdvisory'
+            propertyNames:
+              type: string
     AnalysisRequest:
       type: object
       required:
@@ -3327,6 +3373,12 @@ components:
         $ref: '#/components/schemas/AnalysisResult'
       propertyNames:
         type: string
+    AnalysisResponseV2:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/AnalysisResultV2'
+      propertyNames:
+        type: string
     AnalysisResult:
       type: object
       required:
@@ -3337,6 +3389,20 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AnalysisDetails'
+        warnings:
+          type: array
+          items:
+            type: string
+    AnalysisResultV2:
+      type: object
+      required:
+      - details
+      - warnings
+      properties:
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/AnalysisDetailsV2'
         warnings:
           type: array
           items:


### PR DESCRIPTION
Closes https://github.com/guacsec/trustify/issues/2142 by introducing `/v3/vulnerability/analyze` with the new behaviour and reverting /v2/ to its original behaviour

## Summary by Sourcery

Reinstate the original v2 vulnerability analysis API behavior and introduce a new v3 endpoint with the updated analysis response format.

New Features:
- Add a versioned v3 /vulnerability/analyze API endpoint that exposes the new AnalysisResponse schema while keeping v2 stable.

Bug Fixes:
- Restore the original /v2/vulnerability/analyze behavior and response structure via a dedicated analyze_purls_v2 service path.

Enhancements:
- Refactor vulnerability analysis to prefetch descriptions, advisories, and CVSS scores for v2 responses to reduce per-row database lookups.
- Introduce v2-specific analysis models and OpenAPI schemas to clearly separate legacy and new response formats.

Tests:
- Add integration tests covering the reinstated v2 analysis behavior, including empty, invalid, unsuitable, and mixed PURL inputs.