### PR TITLE
feat: include AdvisoryHead in PurlStatus

### DIFF
--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -29,15 +29,20 @@ use trustify_common::{
     purl::Purl,
 };
 use trustify_cvss::cvss3::{Cvss3Base, score::Score as CvssScore};
-use trustify_entity::{advisory, cvss3, vulnerability, vulnerability_description};
+use trustify_entity::{advisory, cvss3, organization, vulnerability, vulnerability_description};
 use trustify_module_ingestor::common::Deprecation;
+
+struct AdvisoryData {
+    advisory: advisory::Model,
+    issuer: Memo<organization::Model>,
+}
 
 struct AnalysisData {
     purls_with_vulnerabilities: Vec<QueryResult>,
     warnings: HashMap<String, Vec<String>>,
     descriptions_map: HashMap<String, vulnerability_description::Model>,
     cvss3_scores: Vec<cvss3::Model>,
-    advisories_map: HashMap<Uuid, advisory::Model>,
+    advisories_map: HashMap<Uuid, AdvisoryData>,
 }
 
 #[derive(Default)]
@@ -234,8 +239,23 @@ impl VulnerabilityService {
         };
         log::debug!("Pre-fetched {} advisories", advisories.len());
 
-        let advisories: HashMap<Uuid, advisory::Model> =
-            advisories.into_iter().map(|adv| (adv.id, adv)).collect();
+        let organizations = advisories
+            .load_one(organization::Entity, connection)
+            .await?;
+
+        let advisories = advisories
+            .iter()
+            .zip(organizations)
+            .map(|(advisory, org)| {
+                (
+                    advisory.id,
+                    AdvisoryData {
+                        advisory: advisory.clone(),
+                        issuer: Memo::Provided(org),
+                    },
+                )
+            })
+            .collect();
 
         Ok(AnalysisData {
             purls_with_vulnerabilities,
@@ -259,7 +279,7 @@ impl VulnerabilityService {
             mut warnings,
             descriptions_map,
             cvss3_scores,
-            ..
+            advisories_map,
         } = data;
 
         let mut cvss3_map: HashMap<(Uuid, String), Vec<Cvss3Base>> = HashMap::new();
@@ -274,8 +294,14 @@ impl VulnerabilityService {
         let mut result = BTreeMap::new();
 
         for row in purls_with_vulnerabilities {
-            let (requested_purl, head) =
-                Self::row_to_vuln(row, connection, &descriptions_map, &cvss3_map).await?;
+            let (requested_purl, head) = Self::row_to_vuln(
+                row,
+                connection,
+                &descriptions_map,
+                &cvss3_map,
+                &advisories_map,
+            )
+            .await?;
 
             match result.entry(requested_purl.clone()) {
                 Entry::Vacant(entry) => {
@@ -467,6 +493,7 @@ GROUP BY
         connection: &C,
         descriptions_map: &HashMap<String, vulnerability_description::Model>,
         cvss3_map: &HashMap<(Uuid, String), Vec<Cvss3Base>>,
+        advisories_map: &HashMap<Uuid, AdvisoryData>,
     ) -> Result<(String, AnalysisDetails), Error>
     where
         C: ConnectionTrait,
@@ -503,10 +530,10 @@ GROUP BY
 
         // deserialize from JSONB
 
-        let advisories: Option<Vec<RowEntry>> = row.try_get_by("advisories")?;
+        let advisory_entries: Option<Vec<RowEntry>> = row.try_get_by("advisories")?;
 
         // create a map for looking up the status once we resolved the ID to a struct
-        let statuses = advisories.into_iter().flatten().fold(
+        let statuses = advisory_entries.into_iter().flatten().fold(
             BTreeMap::new(),
             |mut acc: BTreeMap<Uuid, Vec<RowEntry>>, entry| {
                 match acc.entry(entry.advisory_id) {
@@ -524,6 +551,10 @@ GROUP BY
         let mut purl_statuses = Vec::new();
 
         for (advisory_id, entries) in &statuses {
+            let Some(advisory) = advisories_map.get(advisory_id) else {
+                continue;
+            };
+
             let score = CvssScore::from_iter(
                 cvss3_map
                     .get(&(*advisory_id, vulnerability.id.clone()))
@@ -533,6 +564,12 @@ GROUP BY
             for entry in entries {
                 let purl_status = PurlStatus::from_head(
                     head.clone(),
+                    AdvisoryHead::from_advisory(
+                        &advisory.advisory,
+                        advisory.issuer.clone(),
+                        connection,
+                    )
+                    .await?,
                     entry.status.clone(),
                     Some(entry.version_range.clone()),
                     None,
@@ -564,7 +601,7 @@ GROUP BY
         connection: &C,
         descriptions_map: &HashMap<String, vulnerability_description::Model>,
         cvss3_map: &HashMap<(Uuid, String), Vec<Score>>,
-        advisories_map: &HashMap<Uuid, advisory::Model>,
+        advisories_map: &HashMap<Uuid, AdvisoryData>,
     ) -> Result<(String, AnalysisDetailsV2), Error>
     where
         C: ConnectionTrait,
@@ -625,8 +662,12 @@ GROUP BY
                 .unwrap_or_default();
 
             let analysis_advisory = AnalysisAdvisory {
-                advisory: AdvisoryHead::from_advisory(advisory, Memo::NotProvided, connection)
-                    .await?,
+                advisory: AdvisoryHead::from_advisory(
+                    &advisory.advisory,
+                    advisory.issuer.clone(),
+                    connection,
+                )
+                .await?,
                 scores,
             };
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4693,11 +4693,14 @@ components:
       type: object
       required:
       - vulnerability
+      - advisory
       - average_severity
       - average_score
       - status
       - context
       properties:
+        advisory:
+          $ref: '#/components/schemas/AdvisoryHead'
         average_score:
           type: number
           format: double


### PR DESCRIPTION
## Summary by Sourcery

Include advisory metadata alongside vulnerabilities in purl status responses and wire this through the service layer and API schema.

New Features:
- Expose AdvisoryHead information on each PurlStatus returned by vulnerability and purl advisory APIs.

Enhancements:
- Populate PurlStatus.advisory using pre-fetched advisory entities and their issuers in vulnerability analysis and purl details flows.
- Adjust advisory reingestion and deletion tests (CSAF/OSV) to validate the new advisory payload within PurlStatus entries.

Documentation:
- Extend the OpenAPI schema for PurlStatus to document the new advisory field as required.