### PR TITLE
latest-endpoint: fix missing hash checksum in resolve_rh_variant_latest_filter_container_cdx test data 

### DIFF
--- a/etc/test-data/cyclonedx/rh/latest_filters/container/quay_builder_qemu_rhcos_rhel8_2025-04-02/quay-builder-qemu-rhcos-rhel8-v3.14.0-4-index.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/container/quay_builder_qemu_rhcos_rhel8_2025-04-02/quay-builder-qemu-rhcos-rhel8-v3.14.0-4-index.json
@@ -69,7 +69,13 @@
               ],
               "name": "Red Hat"
             },
-            "publisher": "Red Hat"
+            "publisher": "Red Hat",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "62547876e96ec9e555f7fde9f8cf034b0a87b0b12f9706893fa57a8f972706b8"
+              }
+            ]
           },
           {
             "name": "quay/quay-builder-qemu-rhcos-rhel8",

--- a/modules/analysis/src/endpoints/tests/latest_filters.rs
+++ b/modules/analysis/src/endpoints/tests/latest_filters.rs
@@ -28,6 +28,10 @@ use trustify_test_context::{TrustifyContext, subset::ContainsSubset};
     Req { what: What::Q("purl:name~quay-builder-qemu-rhcos-rhel8&purl:ty=oci"), ancestors: Some(10), latest: true, ..Req::default() },
     7
 )]
+#[case( // purl partial search latest
+    Req { what: What::Q("pkg:rpm/redhat/harfbuzz"), ancestors: Some(10), latest: true, ..Req::default() },
+    1
+)]
 #[test_log::test(actix_web::test)]
 async fn resolve_rh_variant_latest_filter_container_cdx(
     ctx: &TrustifyContext,


### PR DESCRIPTION
Fix omission in test data, confirm by adding explicit test.

## Summary by Sourcery

Correct latest endpoint behavior for RH container variant resolution by fixing missing checksum data in test fixtures and validating it with an additional latest-filter test case.

Bug Fixes:
- Restore missing hash checksum information in RH container CycloneDX test data used by latest-filter resolution tests.

Tests:
- Add a latest-filter test case for partial purl search of an RPM package to confirm correct behavior with updated test data.