### PR TITLE
fix: deduplicate vulnerabilities in recommend endpoint

### DIFF
--- a/etc/test-data/osv/RUSTSEC-2021-0079-DUPLICATE.json
+++ b/etc/test-data/osv/RUSTSEC-2021-0079-DUPLICATE.json
@@ -1,0 +1,30 @@
+{
+  "id": "DUPLICATE",
+  "modified": "2021-10-19T22:14:35Z",
+  "published": "2021-07-07T12:00:00Z",
+  "aliases": [
+    "CVE-2021-32714"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "crates.io",
+        "name": "hyper",
+        "purl": "pkg:cargo/hyper"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0.0.0-0"
+            },
+            {
+              "fixed": "0.14.10"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/fundamental/src/purl/model/mod.rs
+++ b/modules/fundamental/src/purl/model/mod.rs
@@ -156,6 +156,7 @@ pub enum VexStatus {
     NotAffected,
     UnderInvestigation,
     Recommended,
+    #[serde(untagged)]
     Other(String),
 }
 

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -11,6 +11,7 @@ use crate::{
         summary::{base_purl::BasePurlSummary, purl::PurlSummary, r#type::TypeSummary},
     },
 };
+use itertools::Itertools;
 use regex::Regex;
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, FromQueryResult, QueryFilter, QueryOrder,
@@ -509,12 +510,12 @@ impl PurlService {
                     vulnerabilities: purl_details
                         .advisories
                         .iter()
-                        .flat_map(|advisory| {
-                            advisory.status.iter().map(|status| VulnerabilityStatus {
-                                id: status.vulnerability.identifier.clone(),
-                                status: Some(status.into()),
-                                justification: None,
-                            })
+                        .flat_map(|advisory| &advisory.status)
+                        .unique_by(|status| &status.vulnerability.identifier)
+                        .map(|status| VulnerabilityStatus {
+                            id: status.vulnerability.identifier.clone(),
+                            status: Some(status.into()),
+                            justification: None,
                         })
                         .collect(),
                 });


### PR DESCRIPTION
If multiple advisories referenced the same vulnerability, the /api/v2/purl/recommend endpoint would return duplicate vulnerabilities as there is no advisory ID included to differentiate them from each other.

## Summary by Sourcery

Deduplicate vulnerabilities returned by the purl recommendation endpoint when multiple advisories reference the same underlying vulnerability.

Bug Fixes:
- Ensure the /api/v2/purl/recommend endpoint returns each vulnerability only once per package even if multiple advisories reference it.

Enhancements:
- Adjust vulnerability status collection to operate on unique vulnerability identifiers across advisories.
- Update VEX status modeling to allow an untagged "Other" status variant for more flexible (de)serialization.

Tests:
- Add an integration test that verifies the recommendation endpoint returns a single vulnerability entry when duplicated advisories are ingested, along with corresponding test data.