### PR TITLE
latest: loosen up match on CPE (exp).

### DIFF
--- a/entity/src/sbom_package.rs
+++ b/entity/src/sbom_package.rs
@@ -33,7 +33,12 @@ pub enum Relation {
         to = "(super::sbom_package_cpe_ref::Column::SbomId, super::sbom_package_cpe_ref::Column::NodeId)"
     )]
     Cpe,
-
+    #[sea_orm(
+        belongs_to = "super::sbom_package_cpe_ref::Entity",
+        from = "(Column::SbomId, Column::NodeId)",
+        to = "(super::sbom_package_cpe_ref::Column::SbomId)"
+    )]
+    CpeSbomId,
     #[sea_orm(
         belongs_to = "super::sbom_package_license::Entity",
         from = "(Column::SbomId, Column::NodeId)",

--- a/modules/analysis/src/endpoints/tests/latest_filters.rs
+++ b/modules/analysis/src/endpoints/tests/latest_filters.rs
@@ -22,11 +22,11 @@ use trustify_test_context::{TrustifyContext, subset::ContainsSubset};
 )]
 #[case( // purl partial search latest
     Req { what: What::Q("pkg:oci/quay-builder-qemu-rhcos-rhel8"), ancestors: Some(10), latest: true, ..Req::default() },
-    2
+    4
 )]
 #[case( // purl partial search latest
     Req { what: What::Q("purl:name~quay-builder-qemu-rhcos-rhel8&purl:ty=oci"), ancestors: Some(10), latest: true, ..Req::default() },
-    5
+    6
 )]
 #[case( // purl partial search latest
     Req { what: What::Q("pkg:rpm/redhat/harfbuzz"), ancestors: Some(10), latest: true, ..Req::default() },

--- a/modules/analysis/src/service/load.rs
+++ b/modules/analysis/src/service/load.rs
@@ -304,7 +304,7 @@ impl InnerService {
                 .into_query(),
             GraphQuery::Component(ComponentReference::Cpe(cpe)) => sbom_node::Entity::find()
                 .join(JoinType::Join, sbom_node::Relation::Package.def())
-                .join(JoinType::Join, sbom_package::Relation::Cpe.def())
+                .join(JoinType::Join, sbom_package::Relation::CpeSbomId.def())
                 .filter(sbom_package_cpe_ref::Column::CpeId.eq(cpe.uuid()))
                 .select_only()
                 .column(sbom_node::Column::SbomId)
@@ -313,7 +313,7 @@ impl InnerService {
             GraphQuery::Query(query) => sbom_node::Entity::find()
                 .join(JoinType::Join, sbom_node::Relation::Package.def())
                 .join(JoinType::LeftJoin, sbom_package::Relation::Purl.def())
-                .join(JoinType::LeftJoin, sbom_package::Relation::Cpe.def())
+                .join(JoinType::LeftJoin, sbom_package::Relation::CpeSbomId.def())
                 .join(
                     JoinType::LeftJoin,
                     sbom_package_cpe_ref::Relation::Cpe.def(),
@@ -416,7 +416,7 @@ impl InnerService {
             E: EntityTrait + Related<sbom::Entity>,
         {
             fn join_cpe(self) -> Self {
-                self.join(JoinType::LeftJoin, sbom_package::Relation::Cpe.def())
+                self.join(JoinType::LeftJoin, sbom_package::Relation::CpeSbomId.def())
                     .join(
                         JoinType::LeftJoin,
                         sbom_package_cpe_ref::Relation::Cpe.def(),

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -450,9 +450,7 @@ impl AnalysisService {
         let query = query.into();
 
         stream::iter(
-            graphs
-                .iter()
-                .filter(|(sbom_id, graph)| acyclic(*sbom_id, graph)),
+            graphs.iter(), // .filter(|(sbom_id, graph)| acyclic(*sbom_id, graph)),
         )
         .flat_map(|(_, graph)| {
             let create = create.clone();


### PR DESCRIPTION
mostly for @ctron to look at

## Summary by Sourcery

Adjust CPE-based package relationships and latest-query behavior to broaden match results and relax graph filtering.

Bug Fixes:
- Correct CPE joins in analysis queries to use an SbomId-based relationship, improving CPE lookup accuracy.

Enhancements:
- Introduce a separate CPE relation keyed only by SbomId on SBOM packages and adopt it across analysis queries.
- Relax latest graph processing by no longer filtering out cyclic graphs in the analysis stream.
- Update latest filter tests to reflect the expanded result set for partial PURL searches.