### PR TITLE
feat: include all scores in PurlStatus and deprecate average_severity/average_score

### DIFF
--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -6,8 +6,8 @@ use crate::{
     endpoints::Deprecation,
     vulnerability::{
         model::{
-            AnalysisRequest, AnalysisResponse, VulnerabilityDetails, VulnerabilitySummary,
-            v2::AnalysisResponseV2,
+            AnalysisRequest, AnalysisResponseV3, VulnerabilityDetails, VulnerabilitySummary,
+            v2::AnalysisResponse,
         },
         service::VulnerabilityService,
     },
@@ -111,7 +111,7 @@ pub async fn get(
   tag = "vulnerability",
   request_body = AnalysisRequest,
   responses(
-      (status = 200, description = "Analyze the provided purls to search for known vulnerabilities", body = AnalysisResponseV2),
+      (status = 200, description = "Analyze the provided purls to search for known vulnerabilities", body = AnalysisResponse),
   ),
 )]
 #[post("/v2/vulnerability/analyze")]
@@ -133,7 +133,7 @@ pub async fn analyze(
     tag = "vulnerability",
     request_body = AnalysisRequest,
     responses(
-        (status = 200, description = "Analyze the provided purls to search for known vulnerabilities", body = AnalysisResponse),
+        (status = 200, description = "Analyze the provided purls to search for known vulnerabilities", body = AnalysisResponseV3),
     ),
 )]
 #[post("/v3/vulnerability/analyze")]
@@ -144,7 +144,7 @@ pub async fn analyze_v3(
     _: Require<ReadAdvisory>,
 ) -> actix_web::Result<impl Responder> {
     let tx = db.begin_read().await?;
-    let details = service.analyze_purls(purls, &tx).await?;
+    let details = service.analyze_purls_v3(purls, &tx).await?;
 
     Ok(HttpResponse::Ok().json(details))
 }

--- a/modules/fundamental/src/vulnerability/model/analyze.rs
+++ b/modules/fundamental/src/vulnerability/model/analyze.rs
@@ -1,4 +1,4 @@
-use crate::{purl::model::details::purl::PurlStatus, vulnerability::model::VulnerabilityHead};
+use crate::purl::model::details::purl::PurlStatus;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, ops::Deref};
 use utoipa::ToSchema;
@@ -9,25 +9,22 @@ pub struct AnalysisRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema, Default)]
-pub struct AnalysisResult {
-    pub details: Vec<AnalysisDetails>,
+pub struct AnalysisResultV3 {
+    pub details: Vec<AnalysisDetailsV3>,
     pub warnings: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
-pub struct AnalysisDetails {
-    #[serde(flatten)]
-    pub head: VulnerabilityHead,
-
+pub struct AnalysisDetailsV3 {
     /// List of purl statuses
     pub purl_statuses: Vec<PurlStatus>,
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
-pub struct AnalysisResponse(pub BTreeMap<String, AnalysisResult>);
+pub struct AnalysisResponseV3(pub BTreeMap<String, AnalysisResultV3>);
 
-impl Deref for AnalysisResponse {
-    type Target = BTreeMap<String, AnalysisResult>;
+impl Deref for AnalysisResponseV3 {
+    type Target = BTreeMap<String, AnalysisResultV3>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/modules/fundamental/src/vulnerability/model/v2.rs
+++ b/modules/fundamental/src/vulnerability/model/v2.rs
@@ -6,13 +6,13 @@ use std::{collections::BTreeMap, ops::Deref};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, ToSchema, Default)]
-pub struct AnalysisResultV2 {
-    pub details: Vec<AnalysisDetailsV2>,
+pub struct AnalysisResult {
+    pub details: Vec<AnalysisDetails>,
     pub warnings: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
-pub struct AnalysisDetailsV2 {
+pub struct AnalysisDetails {
     #[serde(flatten)]
     pub head: VulnerabilityHead,
 
@@ -30,10 +30,10 @@ pub struct AnalysisAdvisory {
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
-pub struct AnalysisResponseV2(pub BTreeMap<String, AnalysisResultV2>);
+pub struct AnalysisResponse(pub BTreeMap<String, AnalysisResult>);
 
-impl Deref for AnalysisResponseV2 {
-    type Target = BTreeMap<String, AnalysisResultV2>;
+impl Deref for AnalysisResponse {
+    type Target = BTreeMap<String, AnalysisResult>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -7,9 +7,9 @@ use crate::{
     common::model::Score,
     purl::model::details::{purl::PurlStatus, version_range::VersionRange},
     vulnerability::model::{
-        AnalysisDetails, AnalysisResponse, AnalysisResult, VulnerabilityDetails, VulnerabilityHead,
-        VulnerabilitySummary,
-        v2::{AnalysisAdvisory, AnalysisDetailsV2, AnalysisResponseV2, AnalysisResultV2},
+        AnalysisDetailsV3, AnalysisResponseV3, AnalysisResultV3, VulnerabilityDetails,
+        VulnerabilityHead, VulnerabilitySummary,
+        v2::{AnalysisAdvisory, AnalysisDetails, AnalysisResponse, AnalysisResult},
     },
 };
 use sea_orm::{EntityTrait, FromQueryResult, Statement, prelude::*};
@@ -28,7 +28,6 @@ use trustify_common::{
     model::{Paginated, PaginatedResults},
     purl::Purl,
 };
-use trustify_cvss::cvss3::{Cvss3Base, score::Score as CvssScore};
 use trustify_entity::{advisory, cvss3, organization, vulnerability, vulnerability_description};
 use trustify_module_ingestor::common::Deprecation;
 
@@ -108,15 +107,18 @@ impl VulnerabilityService {
         Ok(result.rows_affected)
     }
 
+    /// Analyze PURLs and return vulnerability data in the v3 response format.
+    ///
+    /// V3 response uses `AnalysisResponseV3` / `AnalysisResultV3` / `AnalysisDetailsV3`.
     #[instrument(
         skip_all,
         err(level=tracing::Level::INFO),
     )]
-    pub async fn analyze_purls<C>(
+    pub async fn analyze_purls_v3<C>(
         &self,
         purls: impl IntoIterator<Item = impl AsRef<str>>,
         connection: &C,
-    ) -> Result<AnalysisResponse, Error>
+    ) -> Result<AnalysisResponseV3, Error>
     where
         C: ConnectionTrait,
     {
@@ -126,6 +128,9 @@ impl VulnerabilityService {
         self.format_response(data, connection).await
     }
 
+    /// Analyze PURLs and return vulnerability data in the legacy v2 response format.
+    ///
+    /// V2 response uses `AnalysisResponse` / `AnalysisResult` / `AnalysisDetails` / `AnalysisAdvisory`.
     #[instrument(
         skip_all,
         err(level=tracing::Level::INFO),
@@ -134,7 +139,7 @@ impl VulnerabilityService {
         &self,
         purls: impl IntoIterator<Item = impl AsRef<str>>,
         connection: &C,
-    ) -> Result<AnalysisResponseV2, Error>
+    ) -> Result<AnalysisResponse, Error>
     where
         C: ConnectionTrait,
     {
@@ -266,11 +271,12 @@ impl VulnerabilityService {
         })
     }
 
+    /// Format vulnerability analysis data into the v3 response structure.
     async fn format_response<C>(
         &self,
         data: AnalysisData,
         connection: &C,
-    ) -> Result<AnalysisResponse, Error>
+    ) -> Result<AnalysisResponseV3, Error>
     where
         C: ConnectionTrait,
     {
@@ -282,19 +288,18 @@ impl VulnerabilityService {
             advisories_map,
         } = data;
 
-        let mut cvss3_map: HashMap<(Uuid, String), Vec<Cvss3Base>> = HashMap::new();
+        let mut cvss3_map: HashMap<(Uuid, String), Vec<cvss3::Model>> = HashMap::new();
         for score in cvss3_scores {
-            let converted_score = Cvss3Base::from(score.clone());
             cvss3_map
-                .entry((score.advisory_id, score.vulnerability_id))
+                .entry((score.advisory_id, score.vulnerability_id.clone()))
                 .or_default()
-                .push(converted_score);
+                .push(score);
         }
 
         let mut result = BTreeMap::new();
 
         for row in purls_with_vulnerabilities {
-            let (requested_purl, head) = Self::row_to_vuln(
+            let (requested_purl, head) = Self::row_to_vuln_v3(
                 row,
                 connection,
                 &descriptions_map,
@@ -305,7 +310,7 @@ impl VulnerabilityService {
 
             match result.entry(requested_purl.clone()) {
                 Entry::Vacant(entry) => {
-                    entry.insert(AnalysisResult {
+                    entry.insert(AnalysisResultV3 {
                         details: vec![head],
                         warnings: warnings.remove(&requested_purl).unwrap_or_default(),
                     });
@@ -321,14 +326,15 @@ impl VulnerabilityService {
             result.entry(purl).or_default().warnings.extend(warnings);
         }
 
-        Ok(AnalysisResponse(result))
+        Ok(AnalysisResponseV3(result))
     }
 
+    /// Format vulnerability analysis data into the v2 response structure.
     async fn format_response_v2<C>(
         &self,
         data: AnalysisData,
         connection: &C,
-    ) -> Result<AnalysisResponseV2, Error>
+    ) -> Result<AnalysisResponse, Error>
     where
         C: ConnectionTrait,
     {
@@ -364,7 +370,7 @@ impl VulnerabilityService {
 
             match result.entry(requested_purl.clone()) {
                 Entry::Vacant(entry) => {
-                    entry.insert(AnalysisResultV2 {
+                    entry.insert(AnalysisResult {
                         details: vec![head],
                         warnings: warnings.remove(&requested_purl).unwrap_or_default(),
                     });
@@ -380,7 +386,7 @@ impl VulnerabilityService {
             result.entry(purl).or_default().warnings.extend(warnings);
         }
 
-        Ok(AnalysisResponseV2(result))
+        Ok(AnalysisResponse(result))
     }
 
     /// Build the query for finding matching vulnerabilities
@@ -488,13 +494,13 @@ GROUP BY
         fields(purl, id),
         err(level=tracing::Level::INFO),
     )]
-    async fn row_to_vuln<C>(
+    async fn row_to_vuln_v3<C>(
         row: QueryResult,
         connection: &C,
         descriptions_map: &HashMap<String, vulnerability_description::Model>,
-        cvss3_map: &HashMap<(Uuid, String), Vec<Cvss3Base>>,
+        cvss3_map: &HashMap<(Uuid, String), Vec<cvss3::Model>>,
         advisories_map: &HashMap<Uuid, AdvisoryData>,
-    ) -> Result<(String, AnalysisDetails), Error>
+    ) -> Result<(String, AnalysisDetailsV3), Error>
     where
         C: ConnectionTrait,
     {
@@ -555,12 +561,10 @@ GROUP BY
                 continue;
             };
 
-            let score = CvssScore::from_iter(
-                cvss3_map
-                    .get(&(*advisory_id, vulnerability.id.clone()))
-                    .cloned()
-                    .unwrap_or_default(),
-            );
+            let scores = cvss3_map
+                .get(&(*advisory_id, vulnerability.id.clone()))
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
             for entry in entries {
                 let purl_status = PurlStatus::from_head(
                     head.clone(),
@@ -573,19 +577,13 @@ GROUP BY
                     entry.status.clone(),
                     Some(entry.version_range.clone()),
                     None,
-                    score,
+                    scores,
                 )?;
                 purl_statuses.push(purl_status);
             }
         }
 
-        Ok((
-            requested_purl,
-            AnalysisDetails {
-                head,
-                purl_statuses,
-            },
-        ))
+        Ok((requested_purl, AnalysisDetailsV3 { purl_statuses }))
     }
 
     /// Take a row from [`Self::build_query`] and turn it into a result entry
@@ -602,7 +600,7 @@ GROUP BY
         descriptions_map: &HashMap<String, vulnerability_description::Model>,
         cvss3_map: &HashMap<(Uuid, String), Vec<Score>>,
         advisories_map: &HashMap<Uuid, AdvisoryData>,
-    ) -> Result<(String, AnalysisDetailsV2), Error>
+    ) -> Result<(String, AnalysisDetails), Error>
     where
         C: ConnectionTrait,
     {
@@ -679,7 +677,7 @@ GROUP BY
 
         Ok((
             requested_purl,
-            AnalysisDetailsV2 {
+            AnalysisDetails {
                 head,
                 status: status_map,
             },

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -568,20 +568,22 @@ async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // test empty request
 
-    let result = service.analyze_purls(Vec::<&str>::new(), &ctx.db).await?;
+    let result = service
+        .analyze_purls_v3(Vec::<&str>::new(), &ctx.db)
+        .await?;
     assert!(result.is_empty());
 
     // test some invalid PURLs
 
     for purl in ["this is not valid"].iter() {
-        let result = service.analyze_purls(vec![purl], &ctx.db).await;
+        let result = service.analyze_purls_v3(vec![purl], &ctx.db).await;
         assert!(result.is_err());
     }
 
     // test some unsuitable PURLs
 
     for purl in ["pkg:npm/missing.version"].iter() {
-        let result = service.analyze_purls(vec![purl], &ctx.db).await;
+        let result = service.analyze_purls_v3(vec![purl], &ctx.db).await;
         // must still be ok
         assert!(result.is_ok(), "{purl} should not fail the request");
         let result = result.unwrap();
@@ -609,7 +611,7 @@ async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let items: Vec<&str> = expected.iter().chain(&not_found).copied().collect();
 
-    let result = service.analyze_purls(items, &ctx.db).await?;
+    let result = service.analyze_purls_v3(items, &ctx.db).await?;
 
     expected.iter().for_each(|&item| {
         assert!(
@@ -636,7 +638,7 @@ async fn analyze_purls_no_score(ctx: &TrustifyContext) -> Result<(), anyhow::Err
 
     ctx.ingest_documents(["osv/RUSTSEC-2022-0022.json"]).await?;
 
-    let result = service.analyze_purls([PURL], &ctx.db).await?;
+    let result = service.analyze_purls_v3([PURL], &ctx.db).await?;
 
     // ensure there is no warning
     assert!(result[PURL].warnings.is_empty());

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -8,6 +8,7 @@ use trustify_common::purl::Purl;
 use trustify_cvss::cvss3::severity::Severity;
 use trustify_entity::labels::Labels;
 use trustify_module_fundamental::advisory::model::AdvisoryHead;
+use trustify_module_fundamental::common::model::{Score, ScoreType};
 use trustify_module_fundamental::organization::model::{OrganizationHead, OrganizationSummary};
 use trustify_module_fundamental::purl::model::details::version_range::VersionRange;
 use trustify_module_fundamental::{
@@ -151,8 +152,15 @@ async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
                 identifier: "CVE-2023-33201".to_string(),
                 ..Default::default()
             },
+            #[allow(deprecated)]
             average_severity: Severity::Medium,
+            #[allow(deprecated)]
             average_score: 5.3f64,
+            scores: vec![Score {
+                severity: Severity::Medium,
+                value: 5.3,
+                r#type: ScoreType::V3_1,
+            }],
             status: "affected".to_string(),
             context: Some(StatusContext::Cpe(
                 "cpe:/a:redhat:jboss_enterprise_application_platform:7.4:*:el9:*".to_string()

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -8,6 +8,8 @@ use trustify_common::purl::Purl;
 use trustify_cvss::cvss3::severity::Severity;
 use trustify_entity::labels::Labels;
 use trustify_module_fundamental::advisory::model::AdvisoryHead;
+use trustify_module_fundamental::common::model::Score;
+use trustify_module_fundamental::common::model::ScoreType;
 use trustify_module_fundamental::purl::model::details::version_range::VersionRange;
 use trustify_module_fundamental::{
     purl::{
@@ -83,7 +85,6 @@ async fn change_ps_num_advisories(ctx: &TrustifyContext) -> anyhow::Result<()> {
 /// Ingest the same document twice. First having an affected, then fixed state.
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
-
 async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let (r1, r2) = prepare_ps_state_change(ctx).await?;
 
@@ -168,8 +169,22 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
                 identifier: "CVE-2023-33201".to_string(),
                 ..Default::default()
             },
+            #[allow(deprecated)]
             average_severity: Severity::Medium,
+            #[allow(deprecated)]
             average_score: 5.3f64,
+            scores: vec![
+                Score {
+                    severity: Severity::Medium,
+                    value: 5.3,
+                    r#type: ScoreType::V3_1,
+                },
+                Score {
+                    severity: Severity::Medium,
+                    value: 5.3,
+                    r#type: ScoreType::V3_1,
+                }
+            ],
             status: "fixed".to_string(),
             context: Some(StatusContext::Cpe(
                 "cpe:/a:redhat:jboss_enterprise_application_platform:7.4:*:el9:*".to_string()
@@ -308,8 +323,22 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
                 identifier: "CVE-2023-33201".to_string(),
                 ..Default::default()
             },
+            #[allow(deprecated)]
             average_severity: Severity::Medium,
+            #[allow(deprecated)]
             average_score: 5.3f64,
+            scores: vec![
+                Score {
+                    severity: Severity::Medium,
+                    value: 5.3,
+                    r#type: ScoreType::V3_1,
+                },
+                Score {
+                    severity: Severity::Medium,
+                    value: 5.3,
+                    r#type: ScoreType::V3_1,
+                }
+            ],
             status: "affected".to_string(),
             context: Some(StatusContext::Cpe(
                 "cpe:/a:redhat:jboss_enterprise_application_platform:7.4:*:el9:*".to_string()
@@ -359,8 +388,22 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
                 identifier: "CVE-2023-33201".to_string(),
                 ..Default::default()
             },
+            #[allow(deprecated)]
             average_severity: Severity::Medium,
+            #[allow(deprecated)]
             average_score: 5.3f64,
+            scores: vec![
+                Score {
+                    severity: Severity::Medium,
+                    value: 5.3,
+                    r#type: ScoreType::V3_1
+                },
+                Score {
+                    severity: Severity::Medium,
+                    value: 5.3,
+                    r#type: ScoreType::V3_1
+                }
+            ],
             status: "fixed".to_string(),
             context: Some(StatusContext::Cpe(
                 "cpe:/a:redhat:jboss_enterprise_application_platform:7.4:*:el9:*".to_string()

--- a/modules/fundamental/tests/advisory/osv/reingest.rs
+++ b/modules/fundamental/tests/advisory/osv/reingest.rs
@@ -142,8 +142,11 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
                 identifier: "CVE-2020-5238".to_string(),
                 ..Default::default()
             },
+            #[allow(deprecated)]
             average_severity: Severity::None,
+            #[allow(deprecated)]
             average_score: 0f64,
+            scores: vec![],
             status: "affected".to_string(),
             context: None,
             version_range: Some(VersionRange::Full {
@@ -183,8 +186,11 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
                 identifier: "CVE-2020-5238".to_string(),
                 ..Default::default()
             },
+            #[allow(deprecated)]
             average_severity: Severity::None,
+            #[allow(deprecated)]
             average_score: 0f64,
+            scores: vec![],
             status: "affected".to_string(),
             context: None,
             version_range: Some(VersionRange::Full {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2992,7 +2992,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AnalysisResponseV2'
+                $ref: '#/components/schemas/AnalysisResponse'
   /api/v2/vulnerability/{id}:
     get:
       tags:
@@ -3163,7 +3163,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AnalysisResponse'
+                $ref: '#/components/schemas/AnalysisResponseV3'
 components:
   schemas:
     AdvisoryDetails:
@@ -3335,18 +3335,6 @@ components:
       - $ref: '#/components/schemas/VulnerabilityHead'
       - type: object
         required:
-        - purl_statuses
-        properties:
-          purl_statuses:
-            type: array
-            items:
-              $ref: '#/components/schemas/PurlStatus'
-            description: List of purl statuses
-    AnalysisDetailsV2:
-      allOf:
-      - $ref: '#/components/schemas/VulnerabilityHead'
-      - type: object
-        required:
         - status
         properties:
           status:
@@ -3358,6 +3346,16 @@ components:
                 $ref: '#/components/schemas/AnalysisAdvisory'
             propertyNames:
               type: string
+    AnalysisDetailsV3:
+      type: object
+      required:
+      - purl_statuses
+      properties:
+        purl_statuses:
+          type: array
+          items:
+            $ref: '#/components/schemas/PurlStatus'
+          description: List of purl statuses
     AnalysisRequest:
       type: object
       required:
@@ -3373,10 +3371,10 @@ components:
         $ref: '#/components/schemas/AnalysisResult'
       propertyNames:
         type: string
-    AnalysisResponseV2:
+    AnalysisResponseV3:
       type: object
       additionalProperties:
-        $ref: '#/components/schemas/AnalysisResultV2'
+        $ref: '#/components/schemas/AnalysisResultV3'
       propertyNames:
         type: string
     AnalysisResult:
@@ -3393,7 +3391,7 @@ components:
           type: array
           items:
             type: string
-    AnalysisResultV2:
+    AnalysisResultV3:
       type: object
       required:
       - details
@@ -3402,7 +3400,7 @@ components:
         details:
           type: array
           items:
-            $ref: '#/components/schemas/AnalysisDetailsV2'
+            $ref: '#/components/schemas/AnalysisDetailsV3'
         warnings:
           type: array
           items:
@@ -4694,6 +4692,7 @@ components:
       required:
       - vulnerability
       - advisory
+      - scores
       - average_severity
       - average_score
       - status
@@ -4704,12 +4703,18 @@ components:
         average_score:
           type: number
           format: double
+          deprecated: true
         average_severity:
           $ref: '#/components/schemas/Severity'
         context:
           oneOf:
           - type: 'null'
           - $ref: '#/components/schemas/StatusContext'
+        scores:
+          type: array
+          items:
+            $ref: '#/components/schemas/Score'
+          description: All CVSS scores associated with the vulnerability
         status:
           type: string
         version_range:


### PR DESCRIPTION
UI needs the full list of scores to adopt /api/v3/vulnerability/analyze endpoint, which was included in the v2 version in the AnalysisAdvisory struct

## Summary by Sourcery

Expose full CVSS score lists per vulnerability in PurlStatus and update v2/v3 analysis response models accordingly.

New Features:
- Add a scores list to PurlStatus and propagate it through the v3 /vulnerability/analyze API so callers receive all CVSS scores.
- Introduce dedicated v3 analysis response types that return purl-centric status details without flattening vulnerability heads.

Enhancements:
- Swap v2 and v3 analysis response model wiring so v2 retains the original head-based structure while v3 uses the new PurlStatus-only details.
- Adjust vulnerability service helpers and endpoints to use the new v3 analysis types and scoring aggregation logic.

Tests:
- Extend advisory and vulnerability tests to cover the new scores field on PurlStatus and the updated v3 analysis response shape.