### PR TITLE
chore: removes redundant clones

### DIFF
--- a/modules/analysis/src/service/load.rs
+++ b/modules/analysis/src/service/load.rs
@@ -109,7 +109,7 @@ impl Node {
                 base,
                 purl: to_purls(self.purls).into(),
                 cpe: to_cpes(self.cpes).into(),
-                version: self.package_version.clone().unwrap_or_default(),
+                version: self.package_version.unwrap_or_default(),
             }),
             (_, Some(_)) => graph::Node::External(graph::ExternalNode {
                 base,

--- a/modules/fundamental/src/endpoints.rs
+++ b/modules/fundamental/src/endpoints.rs
@@ -29,7 +29,7 @@ pub fn configure(
     crate::product::endpoints::configure(svc, db.clone());
     crate::sbom::endpoints::configure(svc, db.clone(), config.sbom_upload_limit);
     crate::vulnerability::endpoints::configure(svc, db.clone());
-    crate::weakness::endpoints::configure(svc, db.clone());
+    crate::weakness::endpoints::configure(svc, db);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default, ToSchema, serde::Deserialize, IntoParams)]

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -138,7 +138,7 @@ pub async fn get_license_export(
                 "Content-Disposition",
                 format!(
                     "attachment; filename=\"{}_licenses.tar.gz\"",
-                    get_sanitize_filename(name_group_version.sbom_name.clone())
+                    get_sanitize_filename(name_group_version.sbom_name)
                 ),
             ))
             .body(zip))

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -63,9 +63,7 @@ impl SbomHead {
             published: sbom.published,
             authors: sbom.authors.clone(),
             suppliers: sbom.suppliers.clone(),
-            name: sbom_node
-                .map(|node| node.name.clone())
-                .unwrap_or("".to_string()),
+            name: sbom_node.map(|node| node.name).unwrap_or("".to_string()),
             data_licenses: sbom.data_licenses.clone(),
             number_of_packages,
         })

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -811,7 +811,7 @@ fn package_from_row(row: PackageCatcher, licensing_infos: BTreeMap<String, Strin
         .purls
         .into_iter()
         .flat_map(|purl| {
-            serde_json::from_value::<CanonicalPurl>(purl.clone())
+            serde_json::from_value::<CanonicalPurl>(purl)
                 .inspect_err(|err| {
                     log::warn!("Failed to deserialize PURL: {err}");
                 })
@@ -849,9 +849,7 @@ fn package_from_row(row: PackageCatcher, licensing_infos: BTreeMap<String, Strin
         .into_iter()
         .map(|license| {
             // if the license contains a LicenseRef, its mapping must be added to the licenses_ref_mapping
-            if let Ok(parsed) =
-                spdx_expression::SpdxExpression::parse(&license.license_name.clone())
-            {
+            if let Ok(parsed) = spdx_expression::SpdxExpression::parse(&license.license_name) {
                 parsed
                     .licenses()
                     .into_iter()

--- a/modules/graphql/src/endpoints.rs
+++ b/modules/graphql/src/endpoints.rs
@@ -15,7 +15,7 @@ async fn index_graphiql() -> Result<HttpResponse> {
 pub fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfig, db: Database) {
     let schema = Schema::build(RootQuery::default(), EmptyMutation, EmptySubscription)
         .data::<Arc<Graph>>(Arc::new(Graph::new(db.clone())))
-        .data::<Arc<Database>>(Arc::new(db.clone()))
+        .data::<Arc<Database>>(Arc::new(db))
         .finish();
 
     svc.route(

--- a/modules/ingestor/src/graph/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/graph/sbom/cyclonedx.rs
@@ -185,7 +185,7 @@ impl SbomContext {
                 .ingest_product(
                     component.name.clone(),
                     ProductInformation {
-                        vendor: component.publisher.clone().map(|p| p.to_string()),
+                        vendor: component.publisher.clone(),
                         cpe: product_cpe,
                     },
                     connection,

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -342,7 +342,7 @@ impl<'g> CveLoader<'g> {
             assigned,
             affected,
             information: VulnerabilityInformation {
-                title: title.clone(),
+                title,
                 reserved,
                 published,
                 modified,

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -115,7 +115,7 @@ fn extract_labels(components: Option<&Vec<Component>>, labels_in: Labels) -> Lab
     }
 
     if !labels_in.is_empty() {
-        return labels.extend(labels_in.0.clone());
+        return labels.extend(labels_in.0);
     }
 
     labels

--- a/server/src/profile/mod.rs
+++ b/server/src/profile/mod.rs
@@ -8,7 +8,6 @@ pub mod importer;
 /// A common database check
 pub fn spawn_db_check(db: Database) -> anyhow::Result<impl Check> {
     Local::spawn_periodic("no database connection", Duration::from_secs(1), {
-        let db = db.clone();
         move || {
             let db = db.clone();
             async move {


### PR DESCRIPTION
## Summary by Sourcery

Remove redundant cloning of values across SBOM, analysis, endpoint, GraphQL, ingestor, and server modules to simplify data handling and reduce unnecessary allocations.

Enhancements:
- Avoid cloning temporary values when deserializing PURLs and parsing license expressions in SBOM services.
- Reuse existing owned values instead of cloning when constructing SBOM model heads and analysis graph nodes.
- Streamline endpoint and GraphQL configuration by passing database handles without superfluous clones.
- Simplify CycloneDX ingestor logic by eliminating unnecessary cloning of publisher, title, and label data.
- Clean up server profile database check by removing an unused pre-clone of the database handle.