### PR TITLE
Backport #2165 to release/0.4.x

### DIFF
--- a/etc/test-data/cyclonedx/loop.json
+++ b/etc/test-data/cyclonedx/loop.json
@@ -11,18 +11,21 @@
   },
   "components": [
     {
+      "bom-ref": "A",
       "name": "A",
       "version": "1",
       "purl": "pkg:rpm/redhat/A@0.0.0?arch=src",
       "type": "library"
     },
     {
+      "bom-ref": "B",
       "name": "B",
       "version": "1",
       "purl": "pkg:rpm/redhat/B@0.0.0?arch=src",
       "type": "library"
     },
     {
+      "bom-ref": "C",
       "name": "C",
       "version": "1",
       "purl": "pkg:rpm/redhat/C@0.0.0?arch=src",

--- a/modules/analysis/src/model.rs
+++ b/modules/analysis/src/model.rs
@@ -107,6 +107,26 @@ pub struct Node {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(no_recursion)]
     pub descendants: Option<Vec<Node>>,
+
+    /// Warnings when processing this node.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+impl Node {
+    /// Create a node only with warnings.
+    pub fn warning(
+        base: impl Into<BaseSummary>,
+        warnings: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        Self {
+            base: base.into(),
+            ancestors: None,
+            descendants: None,
+            relationship: None,
+            warnings: warnings.into_iter().map(|warning| warning.into()).collect(),
+        }
+    }
 }
 
 impl Deref for Node {

--- a/modules/analysis/src/model/roots.rs
+++ b/modules/analysis/src/model/roots.rs
@@ -121,6 +121,7 @@ mod test {
             relationship: None,
             ancestors: None,
             descendants: None,
+            warnings: vec![],
         }
     }
 
@@ -135,6 +136,7 @@ mod test {
                 ..node("A")
             }]),
             descendants: None,
+            warnings: vec![],
         }]
         .roots();
 
@@ -145,6 +147,7 @@ mod test {
                 relationship: Some(Relationship::Dependency),
                 ancestors: Some(vec![]),
                 descendants: None,
+                warnings: vec![],
             }]
         );
     }
@@ -161,6 +164,7 @@ mod test {
                     ..node("A")
                 }]),
                 descendants: None,
+                warnings: vec![],
             }]),
             ..node("AAA")
         }]
@@ -173,6 +177,7 @@ mod test {
                 relationship: Some(Relationship::Dependency),
                 ancestors: Some(vec![]),
                 descendants: None,
+                warnings: vec![],
             }]
         );
     }
@@ -189,6 +194,7 @@ mod test {
                     ..node("A")
                 }]),
                 descendants: None,
+                warnings: vec![],
             }]),
             ..node("AAA")
         }];

--- a/modules/analysis/src/service/test/recursive.rs
+++ b/modules/analysis/src/service/test/recursive.rs
@@ -1,0 +1,147 @@
+use crate::{
+    config::AnalysisConfig,
+    service::{
+        AnalysisService, ComponentReference, QueryOptions,
+        test::warnings::{ChainKeys, Direction, Key, collect_warnings},
+    },
+};
+use rstest::rstest;
+use test_context::test_context;
+use trustify_common::model::Paginated;
+use trustify_test_context::{IngestionResult, TrustifyContext};
+
+#[test_context(TrustifyContext)]
+#[rstest]
+#[case(QueryOptions{ descendants: u64::MAX, ..Default::default() }, 22)]
+#[case(QueryOptions{ ancestors: u64::MAX, ..Default::default() }, 40)]
+#[test_log::test(tokio::test)]
+async fn test_circular_deps_cyclonedx_service_count(
+    ctx: &TrustifyContext,
+    #[case] query: QueryOptions,
+    #[case] len: usize,
+) -> Result<(), anyhow::Error> {
+    ctx.ingest_documents(["cyclonedx/cyclonedx-circular.json"])
+        .await?;
+
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
+
+    let analysis_graph = service
+        .retrieve(
+            ComponentReference::Name("junit-bom"),
+            query,
+            Paginated::default(),
+            &ctx.db,
+        )
+        .await?;
+
+    log::info!("response: {analysis_graph:#?}");
+
+    // assert warnings
+
+    let warnings = collect_warnings(&analysis_graph.items);
+    assert_eq!(warnings.len(), len);
+
+    // assert result count
+
+    assert_eq!(analysis_graph.total, 1);
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[rstest]
+#[case(QueryOptions{ descendants: u64::MAX, ..Default::default() }, Direction::Descendant, ["B", "C", "A"])]
+#[case(QueryOptions{ ancestors: u64::MAX, ..Default::default() }, Direction::Ancestor, ["C", "B", "A"])]
+#[test_log::test(tokio::test)]
+async fn test_circular_deps_cyclonedx_service<const N: usize>(
+    ctx: &TrustifyContext,
+    #[case] query: QueryOptions,
+    #[case] direction: Direction,
+    #[case] chain: [&str; N],
+) -> Result<(), anyhow::Error> {
+    let [sbom] = ctx
+        .ingest_documents(["cyclonedx/loop.json"])
+        .await?
+        .into_uuid_str();
+
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
+
+    let analysis_graph = service
+        .retrieve(
+            ComponentReference::Name("A"),
+            query,
+            Paginated::default(),
+            &ctx.db,
+        )
+        .await?;
+
+    log::info!("response: {analysis_graph:#?}");
+
+    // assert warnings
+
+    let warnings = collect_warnings(&analysis_graph.items);
+
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+        Vec::from_iter(warnings),
+        [(
+            Key::top(&sbom, "A")
+                .chain(direction, &sbom, chain),
+            &["This node was already visited. Possible relationship loop. Skipping further processing.".to_string()][..]
+        )
+        ]
+    );
+
+    assert_eq!(analysis_graph.total, 1);
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[rstest]
+#[case(QueryOptions{ descendants: u64::MAX, ..Default::default() }, Direction::Descendant, ["SPDXRef-B", "SPDXRef-C", "SPDXRef-A"])]
+#[case(QueryOptions{ ancestors: u64::MAX, ..Default::default() }, Direction::Ancestor, ["SPDXRef-C", "SPDXRef-B", "SPDXRef-A"])]
+#[test_log::test(tokio::test)]
+async fn test_circular_deps_spdx_service<const N: usize>(
+    ctx: &TrustifyContext,
+    #[case] query: QueryOptions,
+    #[case] direction: Direction,
+    #[case] chain: [&str; N],
+) -> Result<(), anyhow::Error> {
+    let [sbom] = ctx
+        .ingest_documents(["spdx/loop.json"])
+        .await?
+        .into_uuid_str();
+
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
+
+    let analysis_graph = service
+        .retrieve(
+            ComponentReference::Name("A"),
+            query,
+            Paginated::default(),
+            &ctx.db,
+        )
+        .await?;
+
+    log::info!("response: {analysis_graph:#?}");
+
+    // assert warnings
+
+    let warnings = collect_warnings(&analysis_graph.items);
+
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+        Vec::from_iter(warnings),
+        [(
+            Key::top(&sbom, "SPDXRef-A")
+                .chain(direction, &sbom, chain),
+                &["This node was already visited. Possible relationship loop. Skipping further processing.".to_string()][..]
+        )
+        ]
+    );
+
+    assert_eq!(analysis_graph.total, 1);
+
+    Ok(())
+}

--- a/modules/analysis/src/service/test/warnings.rs
+++ b/modules/analysis/src/service/test/warnings.rs
@@ -1,0 +1,115 @@
+use crate::model;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Copy, Hash, PartialOrd, PartialEq, Ord, Eq)]
+pub struct Key<'a> {
+    direction: Direction,
+    sbom: &'a str,
+    node: &'a str,
+}
+
+impl<'a> Key<'a> {
+    pub fn top(sbom: &'a str, node: &'a str) -> Vec<Key<'a>> {
+        vec![Self {
+            direction: Direction::Top,
+            sbom,
+            node,
+        }]
+    }
+}
+
+pub trait ChainKeys<'a>: Sized {
+    /// Add a key to the chain
+    fn add(self, direction: Direction, sbom: &'a str, node: &'a str) -> Self;
+
+    /// Add keys for the same SBOM to the chain
+    fn chain(
+        self,
+        direction: Direction,
+        sbom: &'a str,
+        nodes: impl IntoIterator<Item = &'a str>,
+    ) -> Self {
+        let mut current = self;
+
+        for node in nodes {
+            current = current.add(direction, sbom, node);
+        }
+
+        current
+    }
+
+    /// add a single ancestor node to the chain
+    #[allow(unused)]
+    fn ancestor(self, sbom: &'a str, node: &'a str) -> Self {
+        self.add(Direction::Ancestor, sbom, node)
+    }
+
+    /// add a single descendant node to the chain
+    #[allow(unused)]
+    fn descendant(self, sbom: &'a str, node: &'a str) -> Self {
+        self.add(Direction::Descendant, sbom, node)
+    }
+}
+
+impl<'a> ChainKeys<'a> for Vec<Key<'a>> {
+    fn add(mut self, direction: Direction, sbom: &'a str, node: &'a str) -> Self {
+        self.push(Key {
+            direction,
+            sbom,
+            node,
+        });
+
+        self
+    }
+}
+
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq, Ord, Eq)]
+pub enum Direction {
+    Top,
+    Ancestor,
+    Descendant,
+}
+
+impl<'a> From<(Direction, &'a model::Node)> for Key<'a> {
+    fn from((direction, node): (Direction, &'a model::Node)) -> Self {
+        Self {
+            direction,
+            sbom: &node.sbom_id,
+            node: &node.node_id,
+        }
+    }
+}
+
+/// Collect all warnings
+pub fn collect_warnings(nodes: &'_ [model::Node]) -> BTreeMap<Vec<Key<'_>>, &'_ [String]> {
+    fn collect<'a: 'b, 'b>(
+        direction: Direction,
+        nodes: &'a [model::Node],
+        key: &'b mut Vec<Key<'a>>,
+        result: &'b mut BTreeMap<Vec<Key<'a>>, &'a [String]>,
+    ) {
+        for node in nodes {
+            key.push((direction, node).into());
+            if !node.warnings.is_empty() {
+                result.insert(key.clone(), &*node.warnings);
+            }
+
+            if let Some(ancestors) = &node.ancestors {
+                collect(Direction::Ancestor, ancestors, key, result);
+            }
+
+            if let Some(descendants) = &node.descendants {
+                collect(Direction::Descendant, descendants, key, result);
+            }
+
+            key.pop();
+        }
+    }
+
+    let mut result = BTreeMap::new();
+    let mut key = Vec::new();
+
+    collect(Direction::Top, nodes, &mut key, &mut result);
+
+    result
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3972,6 +3972,11 @@ components:
             - type: 'null'
             - $ref: '#/components/schemas/Relationship'
               description: The relationship the node has to it's containing node, if any.
+          warnings:
+            type: array
+            items:
+              type: string
+            description: Warnings when processing this node.
     OrganizationDetails:
       allOf:
       - $ref: '#/components/schemas/OrganizationHead'
@@ -4231,6 +4236,11 @@ components:
                   - type: 'null'
                   - $ref: '#/components/schemas/Relationship'
                     description: The relationship the node has to it's containing node, if any.
+                warnings:
+                  type: array
+                  items:
+                    type: string
+                  description: Warnings when processing this node.
         total:
           type: integer
           format: int64


### PR DESCRIPTION
## Summary by Sourcery

Propagate collection warnings through analysis results instead of dropping cyclic graphs, and surface them on nodes in the API model.

New Features:
- Expose per-node processing warnings in the analysis Node model and OpenAPI schema.
- Provide helper utilities to extract IDs and UUIDs from ingestion results for tests.

Bug Fixes:
- Handle circular dependency graphs by recording visit-loop warnings instead of excluding cyclic SBOM graphs from analysis.
- Return detailed warnings when external SBOMs, graphs, or nodes cannot be resolved during collection.

Enhancements:
- Refine collector APIs to return both collected nodes and accumulated warning messages, and propagate these warnings through ancestor/descendant traversal.
- Simplify analysis retrieval to process all graphs without pre-filtering for acyclicity.
- Add utilities to traverse analysis trees and collect warnings for verification in tests.

Tests:
- Replace previous circular-dependency tests with new cases that assert warning generation and graph contents for CycloneDX and SPDX loops, including end-to-end retrieval and warning-chain validation.
- Add test helpers for building warning key chains and collecting warnings from nested nodes.