### PR TITLE
chore: update OTEL collector to 0.140.0

### DIFF
--- a/etc/deploy/compose/compose-otel.yaml
+++ b/etc/deploy/compose/compose-otel.yaml
@@ -43,7 +43,7 @@ services:
     restart: unless-stopped
 
   collector:
-    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.135.0
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.140.0
     command: ["--config=/otel-collector-config.yaml"]
     volumes:
       - './config-collector.yaml:/otel-collector-config.yaml:z'


### PR DESCRIPTION

<img width="1222" height="206" alt="2025-12-05_06-26" src="https://github.com/user-attachments/assets/903b5cf9-ddc6-413a-b1f9-9b2e4608c244" />

## Summary by Sourcery

Build:
- Update the OpenTelemetry Collector image tag in the Docker Compose OTEL configuration from 0.135.0 to 0.140.0.