### PR TITLE
latest: test data for TC-3278

### DIFF
--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/README.md
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/README.md
@@ -1,0 +1,59 @@
+# Analysis of fresh_mix SBOM Structure
+
+A test package has been injected in all of these:
+  "pkg:rpm/redhat/openssl-synthetic-test@"
+
+## Requirements Check
+
+### ✅ 1. Product Types Present
+- **RPM**: `webkit2gtk3` folder
+- **Container**: `cnv-4.17` folder  
+- **Maven**: `quarkus-3.20` folder
+
+### ✅ 2. Two Releases with Same CPE
+
+#### Maven (quarkus-3.20)
+- ✅ Both files have the same CPE: `cpe:/a:redhat:quarkus:3.20::el8`
+  - `28954C62C811417.json` (advisory 155081, version 3.20.3)
+  - `EDA6638AD2F4451.json` (advisory 156615, version 3.20.4)
+
+#### Container (cnv-4.17)
+- ✅ Both product files have the same CPE: `cpe:/a:redhat:container_native_virtualization:4.17::el9`
+  - `D05BF995974542F.json` (advisory 156271, tag v4.17.35-2)
+  - `ED1F188BB5C94D8.json` (advisory 156526, tag v4.17.36-3)
+
+#### RPM (webkit2gtk3)
+- ⚠️ Both product files have the same CPEs, but they're RHEL CPEs, not RPM-specific:
+  - `A9F140D67EB2408.json` (advisory 156970)
+  - `7764C2C0C91542B.json` (advisory 154820)
+  - Both have: `cpe:/a:redhat:enterprise_linux:9.7::appstream` and `cpe:/a:redhat:enterprise_linux:9::appstream`
+  - **Note**: These are OS-level CPEs, not specific to the webkit2gtk3 RPM package
+
+### ✅ 3. Nested/Linked SBOMs
+
+#### Container (cnv-4.17)
+- ✅ **Product SBOMs**: `D05BF995974542F.json`, `ED1F188BB5C94D8.json`
+- ✅ **Image-index SBOMs**: `693F980C32C444A.json`, `CBE2989E64414F5.json`
+  - Both are for `virt-handler-rhel9` image (same image name)
+  - `693F980C32C444A.json`: tag v4.17.36-3
+  - `CBE2989E64414F5.json`: tag v4.17.35-2
+- ✅ **Binary SBOMs**: 4 files in `binary/` subdirectory
+  - All are for `virt-handler-rhel9` image (same image name)
+  - Different architectures (amd64, arm64, etc.)
+
+#### RPM (webkit2gtk3)
+- ✅ **Product SBOMs**: `A9F140D67EB2408.json`, `7764C2C0C91542B.json`
+- ✅ **Release SBOMs**: `3705CE313B0F437.json`, `CC595A02EB3545E.json`
+  - All are for `webkit2gtk3` package (same package name)
+  - Product SBOMs reference the RPM package in their components
+  - Release SBOMs contain detailed RPM package information
+
+## Summary
+1. All three product types are present (RPM, Container, Maven)
+2. Two releases with same CPE exist for Maven and Container
+3. Nested/linked SBOMs exist for both Container and RPM:
+   - Container: Product → Image-index → Binary (all for same image name: `virt-handler-rhel9`)
+   - RPM: Product → Release (all for same package name: `webkit2gtk3`)
+
+
+

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/latest/binary-2025-12-02-5C502A658F36477.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/latest/binary-2025-12-02-5C502A658F36477.json
@@ -1,0 +1,26680 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "syft",
+          "type": "application",
+          "author": "anchore",
+          "version": "1.27.1"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/virt-handler-rhel9@sha256%3A19351b7583cc2b23b6aed869a1969a23be9ecdc32d46ffc05b480750ba113118?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36-3",
+      "type": "container"
+    },
+    "timestamp": "2025-12-02T09:05:12Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156526"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/virt-handler-rhel9@sha256%3A19351b7583cc2b23b6aed869a1969a23be9ecdc32d46ffc05b480750ba113118?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36-3",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "19351b7583cc2b23b6aed869a1969a23be9ecdc32d46ffc05b480750ba113118"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-handler-rhel9@sha256%3A19351b7583cc2b23b6aed869a1969a23be9ecdc32d46ffc05b480750ba113118?arch=arm64&os=linux&tag=v4.17.36-3",
+      "version": "sha256:19351b7583cc2b23b6aed869a1969a23be9ecdc32d46ffc05b480750ba113118",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3A19351b7583cc2b23b6aed869a1969a23be9ecdc32d46ffc05b480750ba113118?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3A19351b7583cc2b23b6aed869a1969a23be9ecdc32d46ffc05b480750ba113118?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3A19351b7583cc2b23b6aed869a1969a23be9ecdc32d46ffc05b480750ba113118?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36"
+          }
+        ]
+      },
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0225273c4256b82f99e18b33e817498d1d6f4be9",
+            "url": "https://pkgs.devel.redhat.com/git/containers/virt-handler#0225273c4256b82f99e18b33e817498d1d6f4be9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:architecture",
+          "value": "aarch64"
+        },
+        {
+          "name": "sbomer:image:labels:build-date",
+          "value": "2025-11-27T15:33:59"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "virt-handler-rhel9-container"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.license_terms",
+          "value": "https://www.redhat.com/agreements"
+        },
+        {
+          "name": "sbomer:image:labels:cpe",
+          "value": "cpe:/a:redhat:rhel_eus:9.4::appstream"
+        },
+        {
+          "name": "sbomer:image:labels:description",
+          "value": "Virtualization handler for CNV"
+        },
+        {
+          "name": "sbomer:image:labels:distribution-scope",
+          "value": "public"
+        },
+        {
+          "name": "sbomer:image:labels:io.buildah.version",
+          "value": "1.33.12"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.description",
+          "value": "Virtualization handler for CNV"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.display-name",
+          "value": "virt-handler"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.tags",
+          "value": "cnv,kubevirt"
+        },
+        {
+          "name": "sbomer:image:labels:maintainer",
+          "value": "sgott@redhat.com,ibezukh@redhat.com,dhiller@redhat.com,jlejosne@redhat.com"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "container-native-virtualization/virt-handler-rhel9"
+        },
+        {
+          "name": "sbomer:image:labels:org.opencontainers.image.revision",
+          "value": "a10db0c18d62179596deb56849f57529e1cc4d73"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "3"
+        },
+        {
+          "name": "sbomer:image:labels:summary",
+          "value": "Virtualization handler"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-vcs-ref",
+          "value": "952f258d1f909636381bb2491c504618d3749a35"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-vcs-url",
+          "value": "https://github.com/kubevirt/kubevirt"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-version",
+          "value": "1.3.1-283-g952f258d1f"
+        },
+        {
+          "name": "sbomer:image:labels:url",
+          "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/container-native-virtualization/virt-handler-rhel9/images/v4.17.36-3"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-ref",
+          "value": "0225273c4256b82f99e18b33e817498d1d6f4be9"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:vendor",
+          "value": "Red Hat"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "v4.17.36"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3900484",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "https://pkgs.devel.redhat.com/git/containers/virt-handler#0225273c4256b82f99e18b33e817498d1d6f4be9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "json-glib",
+      "purl": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=aarch64",
+      "version": "1.6.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d5548792bb86a77330957962541a936d9c391896",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1707185",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "./staging/src/kubevirt.io/client-go",
+      "purl": "pkg:golang/./staging/src#kubevirt.io/client-go",
+      "type": "library",
+      "bom-ref": "pkg:golang/./staging/src#kubevirt.io/client-go",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=b6c9d8ea55ec3898",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/vsock",
+      "purl": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "time",
+      "purl": "pkg:golang/time@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/time@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "dbus-python",
+      "purl": "pkg:pypi/dbus-python@1.2.18",
+      "type": "library",
+      "bom-ref": "pkg:pypi/dbus-python@1.2.18",
+      "version": "1.2.18",
+      "licenses": [
+        {
+          "license": {
+            "name": "Expat (MIT/X11)"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/dbus_python-1.2.18-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-scheduler",
+      "purl": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/types/errors",
+      "purl": "pkg:golang/internal/types/errors@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/types/errors@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/legacy-cloud-providers",
+      "purl": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/exp/typeparams",
+      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+      "version": "v0.0.0-20230203172020-98cc5a0785f9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+      "purl": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "version": "v0.68.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "cracklib",
+      "purl": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=aarch64",
+      "version": "2.9.6-27.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+            "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689047",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgomp",
+      "purl": "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=aarch64",
+      "version": "11.4.1-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498982",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/procfs",
+      "purl": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libutempter",
+      "purl": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=aarch64",
+      "version": "1.2.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c269950567cdc8b12062724de07db72689bf55c",
+            "url": "git://pkgs.devel.redhat.com/rpms/libutempter#1c269950567cdc8b12062724de07db72689bf55c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690196",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libutempter#1c269950567cdc8b12062724de07db72689bf55c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubectl",
+      "purl": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "basesystem",
+      "purl": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "version": "11-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+            "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688850",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/godebug",
+      "purl": "pkg:golang/internal/godebug@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/godebug@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libgpg-error",
+      "purl": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=aarch64",
+      "version": "1.42-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "55660568a38dad2e4a858df692830af766ad6532",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1818836",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.1",
+      "type": "library",
+      "author": "Gustavo Niemeyer <gustavo@niemeyer.net>",
+      "bom-ref": "pkg:pypi/python-dateutil@2.8.1",
+      "version": "2.8.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Dual License"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/python_dateutil-2.8.1-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-lib",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=aarch64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libuser",
+      "purl": "pkg:rpm/redhat/libuser@0.63-13.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuser@0.63-13.el9?arch=aarch64",
+      "version": "0.63-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "13af6ac62247268424d499b1889ee11afd7e150a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libuser#13af6ac62247268424d499b1889ee11afd7e150a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2590170",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libuser#13af6ac62247268424d499b1889ee11afd7e150a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b7c26aaef6d1c9b7",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "dejavu-sans-fonts",
+      "purl": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "version": "2.37-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bitstream Vera and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1479ec5203df4c3e577d1992b22c6976c142afa9",
+            "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688969",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/client-go",
+      "purl": "pkg:golang/kubevirt.io/client-go",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/client-go",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "./staging/src/github.com/golang/glog",
+      "purl": "pkg:golang/./staging/src#github.com/golang/glog",
+      "type": "library",
+      "bom-ref": "pkg:golang/./staging/src#github.com/golang/glog",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libsepol",
+      "purl": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=aarch64",
+      "version": "3.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d568b2713a4280fad93a660b66d5047296c3853f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#d568b2713a4280fad93a660b66d5047296c3853f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820602",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#d568b2713a4280fad93a660b66d5047296c3853f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sync",
+      "purl": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/hmac",
+      "purl": "pkg:golang/crypto/hmac@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/hmac@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubernetes-csi/external-snapshotter/client/v4",
+      "purl": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "version": "v4.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "psmisc",
+      "purl": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=aarch64",
+      "version": "23.4-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4bb81408b08c44d02985b6af55bbd75260c6b3ed",
+            "url": "git://pkgs.devel.redhat.com/rpms/psmisc#4bb81408b08c44d02985b6af55bbd75260c6b3ed"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691630",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/psmisc#4bb81408b08c44d02985b6af55bbd75260c6b3ed",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/goarch",
+      "purl": "pkg:golang/internal/goarch@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goarch@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/qe-tools",
+      "purl": "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+      "version": "v0.1.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "math/rand",
+      "purl": "pkg:golang/math/rand@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math/rand@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-iniparse",
+      "purl": "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+      "version": "0.4-45.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fa613c34fcc4661d8320d1eead334cb4a43d56be",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-iniparse#fa613c34fcc4661d8320d1eead334cb4a43d56be"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-iniparse#fa613c34fcc4661d8320d1eead334cb4a43d56be",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pyinotify",
+      "purl": "pkg:pypi/pyinotify@0.9.6",
+      "type": "library",
+      "author": "Sebastien Martini <seb@dbzteam.org>",
+      "bom-ref": "pkg:pypi/pyinotify@0.9.6",
+      "version": "0.9.6",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT License"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/pyinotify-0.9.6-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "internal/saferio",
+      "purl": "pkg:golang/internal/saferio@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/saferio@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "unsafe",
+      "purl": "pkg:golang/unsafe@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unsafe@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libdb",
+      "purl": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=aarch64",
+      "version": "5.3.28-53.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and LGPLv2 and Sleepycat"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "27038c5d3e75ae33c7281b39d1b15ce166a0c420",
+            "url": "git://pkgs.devel.redhat.com/rpms/libdb#27038c5d3e75ae33c7281b39d1b15ce166a0c420"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1806145",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libdb#27038c5d3e75ae33c7281b39d1b15ce166a0c420",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nettle",
+      "purl": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=aarch64",
+      "version": "3.9.1-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7e4a847c42da5300f4bac05df9a0fb140e0a2ed2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#7e4a847c42da5300f4bac05df9a0fb140e0a2ed2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2785925",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#7e4a847c42da5300f4bac05df9a0fb140e0a2ed2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/ed25519",
+      "purl": "pkg:golang/crypto/ed25519@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/ed25519@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "net/rpc",
+      "purl": "pkg:golang/net/rpc@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/rpc@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "bufio",
+      "purl": "pkg:golang/bufio@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/bufio@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/nettrace",
+      "purl": "pkg:golang/internal/nettrace@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/nettrace@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/legacy-cloud-providers",
+      "purl": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0?package-id=6f1e377d494cf9f5",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kisielk/errcheck",
+      "purl": "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+      "version": "v1.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "mpfr",
+      "purl": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=aarch64",
+      "version": "4.1.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "207ac3816285664c0c73fa4894dbdead53d1ca40",
+            "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690656",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "redhat-release",
+      "purl": "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=aarch64",
+      "version": "9.4-0.5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94af0111c38c9daaa9b97620cd8c6237de1d1315",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#94af0111c38c9daaa9b97620cd8c6237de1d1315"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3021565",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#94af0111c38c9daaa9b97620cd8c6237de1d1315",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/nunnatsa/ginkgolinter",
+      "purl": "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gawk",
+      "purl": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=aarch64",
+      "version": "5.1.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv2+ and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3830530bfc524ab9b89fafe76d58a388675ecc11",
+            "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1891122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/spdystream",
+      "purl": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "version": "v0.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/common",
+      "purl": "pkg:golang/github.com/containers/common@v0.50.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/common@v0.50.1",
+      "version": "v0.50.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "runtime/pprof",
+      "purl": "pkg:golang/runtime/pprof@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/pprof@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libmount",
+      "purl": "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=05e9b8a9427d6786",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "p11-kit",
+      "purl": "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=aarch64",
+      "version": "0.25.3-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "af03cdd6b28123c3643c0874462f8aaa668be9e6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2792712",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vim-minimal",
+      "purl": "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=aarch64&epoch=2",
+      "version": "2:8.2.2637-20.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Vim and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0efec05571fe5baab0ca0b22db499eb5c8d42af6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/vim#0efec05571fe5baab0ca0b22db499eb5c8d42af6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3849530",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/vim#0efec05571fe5baab0ca0b22db499eb5c8d42af6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "encoding",
+      "purl": "pkg:golang/encoding@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/plugins",
+      "purl": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-rpm",
+      "purl": "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=aarch64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=f63f44519d8bc924",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/boring/bbig",
+      "purl": "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/x509/pkix",
+      "purl": "pkg:golang/crypto/x509/pkix@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/x509/pkix@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "runtime/trace",
+      "purl": "pkg:golang/runtime/trace@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/trace@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=f970a3d674d44626",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "librepo",
+      "purl": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=aarch64",
+      "version": "1.14.5-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "458f8b732e9d31cbe09323c87f796924ac30461c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797210",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/plugins",
+      "purl": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1?package-id=599ab3f3550112ac",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=9b8e9f9b128703ca",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libnftnl",
+      "purl": "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=aarch64",
+      "version": "1.2.6-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d524ea7068ac80696b2688aab672500071f38ac",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnftnl#8d524ea7068ac80696b2688aab672500071f38ac"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3052789",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnftnl#8d524ea7068ac80696b2688aab672500071f38ac",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "mvdan.cc/sh/v3",
+      "purl": "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+      "version": "v3.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/netip",
+      "purl": "pkg:golang/net/netip@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/netip@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/code-generator",
+      "purl": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/u-root/uio",
+      "purl": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "version": "v0.0.0-20230220225925-ffce2a382923",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.22.12",
+      "version": "go1.22.12",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=18734635491c2975",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cloud-provider",
+      "purl": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/goexpect",
+      "purl": "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+      "version": "v0.0.0-20190425035906-112704a48083",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.9.0",
+      "version": "v0.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sync/atomic",
+      "purl": "pkg:golang/sync/atomic@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/sync/atomic@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+      "purl": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/nistec",
+      "purl": "pkg:golang/crypto/internal/nistec@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/nistec@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libtasn1",
+      "purl": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=aarch64",
+      "version": "4.16.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "425d04e73d45b52ff50b454e85e8c512cc8fe282",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtasn1#425d04e73d45b52ff50b454e85e8c512cc8fe282"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3617876",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtasn1#425d04e73d45b52ff50b454e85e8c512cc8fe282",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "database/sql/driver",
+      "purl": "pkg:golang/database/sql/driver@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/database/sql/driver@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/machadovilaca/operator-observability",
+      "purl": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "version": "v0.0.20",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/c9s/goprocinfo",
+      "purl": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "version": "v0.0.0-20210130143923-c95fcf8c64a8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "reflect",
+      "purl": "pkg:golang/reflect@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/reflect@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libsmartcols",
+      "purl": "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-semver",
+      "purl": "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+      "version": "v0.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pmezard/go-difflib",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "version": "v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "alternatives",
+      "purl": "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=aarch64",
+      "version": "1.24-1.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2233412101349b53627f350497e1ac17dec36730",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#2233412101349b53627f350497e1ac17dec36730"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3267208",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#2233412101349b53627f350497e1ac17dec36730",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pam",
+      "purl": "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=aarch64",
+      "version": "1.5.1-24.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a62b752a294ae678f588bcb039a59078981341de",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pam#a62b752a294ae678f588bcb039a59078981341de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3807184",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pam#a62b752a294ae678f588bcb039a59078981341de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=aeac65a548510a6a#mountinfo",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/sys/cpu",
+      "purl": "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "math/bits",
+      "purl": "pkg:golang/math/bits@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math/bits@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/povsister/scp",
+      "purl": "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+      "version": "v0.0.0-20210427074412-33febfd9f13e",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/xml",
+      "purl": "pkg:golang/encoding/xml@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/xml@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic",
+      "purl": "pkg:golang/github.com/google/gnostic@v0.5.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic@v0.5.7",
+      "version": "v0.5.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/chacha8rand",
+      "purl": "pkg:golang/internal/chacha8rand@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/chacha8rand@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/insomniacslk/dhcp",
+      "purl": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "version": "v0.0.0-20230908212754-65c27093e38a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "version": "v1.1.14",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/operator-framework/operator-lifecycle-manager",
+      "purl": "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "version": "v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "pygobject",
+      "purl": "pkg:pypi/pygobject@3.40.1",
+      "type": "library",
+      "author": "James Henstridge <james@daa.com.au>",
+      "bom-ref": "pkg:pypi/pygobject@3.40.1",
+      "version": "3.40.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GNU LGPL"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/PyGObject-3.40.1.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "version": "v0.5.9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/ast",
+      "purl": "pkg:golang/go/ast@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/ast@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "version": "v1.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "ima-evm-utils",
+      "purl": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=aarch64",
+      "version": "1.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f8dae177fe0fdd6012a0f6b10dbb14b8bedd4c40",
+            "url": "git://pkgs.devel.redhat.com/rpms/ima-evm-utils#f8dae177fe0fdd6012a0f6b10dbb14b8bedd4c40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1825204",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ima-evm-utils#f8dae177fe0fdd6012a0f6b10dbb14b8bedd4c40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/common",
+      "purl": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "version": "v0.44.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/node-api",
+      "purl": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-pip-wheel",
+      "purl": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+      "version": "21.2.3-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f3400cce6a9da840f21eb4cfd81a0c2ca38eb185",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#f3400cce6a9da840f21eb4cfd81a0c2ca38eb185"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2906206",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#f3400cce6a9da840f21eb4cfd81a0c2ca38eb185",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "readline",
+      "purl": "pkg:rpm/redhat/readline@8.1-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=aarch64",
+      "version": "8.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be386f45be1322adf2bd79dd94c9904c4efa3d22",
+            "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691921",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:pypi/rpm@4.16.1.3",
+      "type": "library",
+      "author": "UNKNOWN <rpm-maint@lists.rpm.org>",
+      "bom-ref": "pkg:pypi/rpm@4.16.1.3",
+      "version": "4.16.1.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "GNU General Public License v2"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/rpm-4.16.1.3-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "syscall",
+      "purl": "pkg:golang/syscall@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/syscall@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "version": "5a6340b3-6229229e",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "version": "v1.5.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig/v3",
+      "purl": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "version": "v3.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/renameio/v2",
+      "purl": "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+      "version": "v2.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "version": "v0.3.16",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/oserror",
+      "purl": "pkg:golang/internal/oserror@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/oserror@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "bzip2-libs",
+      "purl": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=aarch64",
+      "version": "1.0.8-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00ab1bac9f740f33a2dcc6ada500c802a28bb6b2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#00ab1bac9f740f33a2dcc6ada500c802a28bb6b2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3425109",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#00ab1bac9f740f33a2dcc6ada500c802a28bb6b2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/ecdh",
+      "purl": "pkg:golang/crypto/ecdh@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/ecdh@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "compress/bzip2",
+      "purl": "pkg:golang/compress/bzip2@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/bzip2@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/socket",
+      "purl": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "version": "v0.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go.mongodb.org/mongo-driver",
+      "purl": "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+      "version": "v1.8.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gmp",
+      "purl": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=aarch64&epoch=1",
+      "version": "1:6.2.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+            "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2625518",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "net/http/internal",
+      "purl": "pkg:golang/net/http/internal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/internal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.22.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.22.0",
+      "version": "v0.22.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "compress/zlib",
+      "purl": "pkg:golang/compress/zlib@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/zlib@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/cryptobyte/asn1",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-six",
+      "purl": "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+      "version": "1.15.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7a3cef2bf49b31b0f9c2ecd4b05d34bdc214998c",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-six#7a3cef2bf49b31b0f9c2ecd4b05d34bdc214998c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1890817",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-six#7a3cef2bf49b31b0f9c2ecd4b05d34bdc214998c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libblkid",
+      "purl": "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/elliptic",
+      "purl": "pkg:golang/crypto/elliptic@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/elliptic@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cespare/xxhash/v2",
+      "purl": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "version": "v2.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/godebugs",
+      "purl": "pkg:golang/internal/godebugs@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/godebugs@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-controller-manager",
+      "purl": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/secure/bidirule",
+      "purl": "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/glog",
+      "purl": "pkg:golang/github.com/golang/glog",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/glog",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/buildcfg",
+      "purl": "pkg:golang/internal/buildcfg@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/buildcfg@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "purl": "pkg:golang/os@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager-rhsm-certificates",
+      "purl": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+      "version": "20220623-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "aa015c720c46b2548f962320f9b18de28c097691",
+            "url": "git://pkgs.devel.redhat.com/rpms/subscription-manager-rhsm-certificates#aa015c720c46b2548f962320f9b18de28c097691"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2061647",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/subscription-manager-rhsm-certificates#aa015c720c46b2548f962320f9b18de28c097691",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/http2/hpack",
+      "purl": "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/bytealg",
+      "purl": "pkg:golang/internal/bytealg@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/bytealg@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "version": "fd431d51-4ae0493b",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "net/url",
+      "purl": "pkg:golang/net/url@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/url@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "version": "v1.1.1-0.20210330154013-f5de75959ad5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/edwards25519/field",
+      "purl": "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.29.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.29.0",
+      "version": "v0.29.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/matttproud/golang_protobuf_extensions",
+      "purl": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "version": "v1.0.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.3.0",
+      "version": "v0.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/rogpeppe/go-internal",
+      "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "version": "v0.0.0-20210104183010-2eb08e3e575f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "dmidecode",
+      "purl": "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=aarch64&epoch=1",
+      "version": "1:3.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3368d91ad91bcfd15a9e66b6f1bbbf18b7491c6e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dmidecode#3368d91ad91bcfd15a9e66b6f1bbbf18b7491c6e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2841778",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dmidecode#3368d91ad91bcfd15a9e66b6f1bbbf18b7491c6e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "flag",
+      "purl": "pkg:golang/flag@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/flag@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "systemd-rpm-macros",
+      "purl": "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-aggregator",
+      "purl": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/token",
+      "purl": "pkg:golang/go/token@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/token@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "version": "v1.0.3-0.20210326190908-1c3f411f0417",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "compress/flate",
+      "purl": "pkg:golang/compress/flate@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/flate@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "go/build",
+      "purl": "pkg:golang/go/build@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/build@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/api",
+      "purl": "pkg:golang/kubevirt.io/api",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/api",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cobra",
+      "purl": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kr/logfmt",
+      "purl": "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+      "version": "v0.0.0-20210122060352-19f9bcb100e6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/platform",
+      "purl": "pkg:golang/internal/platform@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/platform@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.33.0",
+      "version": "v0.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/randutil",
+      "purl": "pkg:golang/crypto/internal/randutil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/randutil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "which",
+      "purl": "pkg:rpm/redhat/which@2.21-29.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/which@2.21-29.el9?arch=aarch64",
+      "version": "2.21-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dac12498cdc45059738012dbd5af70569b8b8100",
+            "url": "git://pkgs.devel.redhat.com/rpms/which#dac12498cdc45059738012dbd5af70569b8b8100"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2437620",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/which#dac12498cdc45059738012dbd5af70569b8b8100",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=aec23c0e1d75ee8a",
+      "version": "v1.0.3-0.20210326190908-1c3f411f0417",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "libmodulemd",
+      "purl": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=aarch64",
+      "version": "2.13.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d48969327abbcbfad2ab893639cfb7d22362223d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1695462",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnetfilter_conntrack",
+      "purl": "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=aarch64",
+      "version": "1.0.9-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a8c7bd7fc24180e59c191a4d5a05a475afdcf17",
+            "url": "git://pkgs.devel.redhat.com/rpms/libnetfilter_conntrack#2a8c7bd7fc24180e59c191a4d5a05a475afdcf17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2296866",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libnetfilter_conntrack#2a8c7bd7fc24180e59c191a4d5a05a475afdcf17",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/common",
+      "purl": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/common@v0.44.0?package-id=3a5f710d384a3dd9",
+      "version": "v0.44.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "html",
+      "purl": "pkg:golang/html@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/html@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-setuptools-wheel",
+      "purl": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+      "version": "53.0.0-12.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and (BSD or ASL 2.0)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e118582dafc46c5b61049eb79598ec15e88c3b7d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3754759",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=64880854c531d875",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=b024122f6e41d561",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "p11-kit-trust",
+      "purl": "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=aarch64",
+      "version": "0.25.3-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "af03cdd6b28123c3643c0874462f8aaa668be9e6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2792712",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "systemd-pam",
+      "purl": "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=aarch64",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/goos",
+      "purl": "pkg:golang/internal/goos@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goos@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-colorable",
+      "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "version": "v0.1.13",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/gob",
+      "purl": "pkg:golang/encoding/gob@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/gob@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_golang",
+      "purl": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "version": "v1.16.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "lz4-libs",
+      "purl": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=aarch64",
+      "version": "1.9.3-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690509",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=3f115ef0cb31e7b8",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/fmtsort",
+      "purl": "pkg:golang/internal/fmtsort@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/fmtsort@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pierrec/lz4/v4",
+      "purl": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "version": "v4.1.15",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/krolaw/dhcp4",
+      "purl": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "version": "v0.0.0-20180925202202-7cead472c414",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "slices",
+      "purl": "pkg:golang/slices@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/slices@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=8c45f6a8d1cca06d",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/mapstructure",
+      "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/aes",
+      "purl": "pkg:golang/crypto/aes@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/aes@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "rpm-libs",
+      "purl": "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=aarch64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-common",
+      "purl": "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcomps",
+      "purl": "pkg:pypi/libcomps@0.1.18",
+      "type": "library",
+      "author": "RPM Software Management <rpm-ecosystem@lists.rpm.org>",
+      "bom-ref": "pkg:pypi/libcomps@0.1.18",
+      "version": "0.1.18",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/libcomps-0.1.18-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "libfdisk",
+      "purl": "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "strconv",
+      "purl": "pkg:golang/strconv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/strconv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "bytes",
+      "purl": "pkg:golang/bytes@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/bytes@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/sha256",
+      "purl": "pkg:golang/crypto/sha256@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/sha256@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=ff4b8706a44511d7",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=45b68313e6b7649d",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "io",
+      "purl": "pkg:golang/io@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/io@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=2ccbb81b4bfbf67e",
+      "version": "v1.1.14",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/vsock",
+      "purl": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=97ce01b8d036cd18",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "langpacks-en",
+      "purl": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v0.2.1",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "iniparse",
+      "purl": "pkg:pypi/iniparse@0.4",
+      "type": "library",
+      "author": "Paramjit Oberoi <param@cs.wisc.edu>",
+      "bom-ref": "pkg:pypi/iniparse@0.4",
+      "version": "0.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/iniparse-0.4-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cheggaaa/pb/v3",
+      "purl": "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+      "version": "v3.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sqlite-libs",
+      "purl": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=aarch64",
+      "version": "3.34.1-7.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b1dd0e13763f804a7e224ec726c7037b9fda6a0c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#b1dd0e13763f804a7e224ec726c7037b9fda6a0c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3767409",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#b1dd0e13763f804a7e224ec726c7037b9fda6a0c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig/v3",
+      "purl": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0?package-id=c5265481edb963f4#v3",
+      "version": "v3.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libxml2",
+      "purl": "pkg:rpm/redhat/libxml2@2.9.13-13.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxml2@2.9.13-13.el9_4?arch=aarch64",
+      "version": "2.9.13-13.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cf7eb9f10d160efd999180567c5a603209ce5828",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#cf7eb9f10d160efd999180567c5a603209ce5828"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3893010",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#cf7eb9f10d160efd999180567c5a603209ce5828",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsemanage",
+      "purl": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=aarch64",
+      "version": "3.6-2.1.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "96eef030fb0a0f4d27e17961dd585c8730df12e4",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#96eef030fb0a0f4d27e17961dd585c8730df12e4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3418014",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#96eef030fb0a0f4d27e17961dd585c8730df12e4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnl3",
+      "purl": "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=aarch64",
+      "version": "3.9.0-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "23021690a101b6f1b14fd6b0d4fe318934dbb9c3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnl3#23021690a101b6f1b14fd6b0d4fe318934dbb9c3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2805134",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnl3#23021690a101b6f1b14fd6b0d4fe318934dbb9c3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/cipher",
+      "purl": "pkg:golang/crypto/cipher@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/cipher@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "debug/elf",
+      "purl": "pkg:golang/debug/elf@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/debug/elf@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/rsa",
+      "purl": "pkg:golang/crypto/rsa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/rsa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/diff",
+      "purl": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "version": "v0.0.0-20210226163009-20ebb0f2a09e",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/metrics",
+      "purl": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+      "version": "v0.0.0-20210105115604-44119421ec6b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "container/heap",
+      "purl": "pkg:golang/container/heap@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/container/heap@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "mime/multipart",
+      "purl": "pkg:golang/mime/multipart@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/mime/multipart@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "mime/quotedprintable",
+      "purl": "pkg:golang/mime/quotedprintable@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/mime/quotedprintable@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/alias",
+      "purl": "pkg:golang/crypto/internal/alias@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/alias@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "encoding/hex",
+      "purl": "pkg:golang/encoding/hex@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/hex@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies",
+      "purl": "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+      "version": "20240202-1.git283706d.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a950d9ca3218bf47d75befa4639b7990b00c99eb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2889114",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/appengine",
+      "purl": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "version": "v1.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/abi",
+      "purl": "pkg:golang/internal/abi@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/abi@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.29.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.29.0?package-id=6367701eacddef15",
+      "version": "v0.29.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libbpf",
+      "purl": "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=aarch64&epoch=2",
+      "version": "2:1.3.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 or BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "39db39a8f05a831c2cff398273dbc03597e85c8a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libbpf#39db39a8f05a831c2cff398273dbc03597e85c8a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2924610",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libbpf#39db39a8f05a831c2cff398273dbc03597e85c8a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/tomb.v1",
+      "purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "version": "v1.0.0-20141024135613-dd632973f1e7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "ncurses-base",
+      "purl": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+      "version": "6.2-10.20210508.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "539ab619cec841979d6b46943d3f82c15b7a8467",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3759616",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=7f71bb3211c40e1e",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/parser",
+      "purl": "pkg:golang/go/parser@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/parser@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+      "version": "v0.0.0-20230503133300-8bbcb7ca7183",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-gobject-base",
+      "purl": "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=aarch64",
+      "version": "3.40.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79ff68bd91179f855796360827ad65f2a83577dc",
+            "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2049891",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e5133fb001ac7926",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-hawkey",
+      "purl": "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=aarch64",
+      "version": "0.69.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e5984c195dca639c24fa8a25263d2faf9419e97d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134146",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "image/color",
+      "purl": "pkg:golang/image/color@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/color@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "glib2",
+      "purl": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=aarch64",
+      "version": "2.68.4-14.el9_4.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "14a7b9b0aeb14a071ad69f0c1c3779c0c31c03e3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#14a7b9b0aeb14a071ad69f0c1c3779c0c31c03e3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3857383",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#14a7b9b0aeb14a071ad69f0c1c3779c0c31c03e3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/chacha20",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "dbus",
+      "purl": "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=aarch64&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/pprof",
+      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "version": "v0.0.0-20240424215950-a892ee059fd6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "context",
+      "purl": "pkg:golang/context@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/context@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=06ba511a601e36d7",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/http/internal/ascii",
+      "purl": "pkg:golang/net/http/internal/ascii@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/internal/ascii@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "librhsm",
+      "purl": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=aarch64",
+      "version": "0.0.3-7.el9_3.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25c62475abb565eb8ebef5f1df66a6c5eff74ccd",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#25c62475abb565eb8ebef5f1df66a6c5eff74ccd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2845494",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#25c62475abb565eb8ebef5f1df66a6c5eff74ccd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=874d616b5ffd59b7",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/nxadm/tail",
+      "purl": "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+      "version": "v0.0.0-20211216163028-4472660a31a6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.22.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.22.0?package-id=b0628cbb477d7801",
+      "version": "v0.22.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "chardet",
+      "purl": "pkg:pypi/chardet@4.0.0",
+      "type": "library",
+      "author": "Mark Pilgrim <mark@diveintomark.org>",
+      "bom-ref": "pkg:pypi/chardet@4.0.0",
+      "version": "4.0.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPL"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/chardet-4.0.0.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d6c72ae7c47adf6d",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "cmp",
+      "purl": "pkg:golang/cmp@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/cmp@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libcurl-minimal",
+      "purl": "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+      "version": "7.76.1-29.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80195397e7d61d156d731499be9884797b75dbb1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471237",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/syscall/unix",
+      "purl": "pkg:golang/internal/syscall/unix@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/syscall/unix@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "bash",
+      "purl": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=aarch64",
+      "version": "5.1.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80326284a249f523c3e2d14e0eed2dbaece63c4e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2910143",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-isatty",
+      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "version": "v0.0.17",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.24.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.24.0",
+      "version": "v0.24.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/unsafeheader",
+      "purl": "pkg:golang/internal/unsafeheader@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/unsafeheader@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "path",
+      "purl": "pkg:golang/path@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/path@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.33.0?package-id=cb71f9386c7676b0",
+      "version": "v0.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "iptables-libs",
+      "purl": "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=aarch64",
+      "version": "1.8.10-5.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and Artistic 2.0 and ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6eebdb82213f2bb74f3104414ce85d304151f2c7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/iptables#6eebdb82213f2bb74f3104414ce85d304151f2c7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3227256",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/iptables#6eebdb82213f2bb74f3104414ce85d304151f2c7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "math",
+      "purl": "pkg:golang/math@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "coreutils-single",
+      "purl": "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=aarch64",
+      "version": "8.32-35.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a5b35b64130afa26d91d771af474f947cc02a099",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#a5b35b64130afa26d91d771af474f947cc02a099"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2875684",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#a5b35b64130afa26d91d771af474f947cc02a099",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/cpu",
+      "purl": "pkg:golang/internal/cpu@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/cpu@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "fmt",
+      "purl": "pkg:golang/fmt@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/fmt@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "xz-libs",
+      "purl": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=aarch64",
+      "version": "5.2.5-8.el9_0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+            "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2032531",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog",
+      "purl": "pkg:golang/k8s.io/klog@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog@v0.4.0",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/cheggaaa/pb.v1",
+      "purl": "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+      "version": "v1.0.28",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=723cf855d020f756",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "krb5-libs",
+      "purl": "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=aarch64",
+      "version": "1.21.1-2.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fb34142b8ed95c27cf052bbe556c0df07e04db51",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#fb34142b8ed95c27cf052bbe556c0df07e04db51"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3731292",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#fb34142b8ed95c27cf052bbe556c0df07e04db51",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "go/doc",
+      "purl": "pkg:golang/go/doc@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/doc@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "dbus-broker",
+      "purl": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=aarch64",
+      "version": "28-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "df7a36f938130717b6c201d8bf2ca8edf68719f6",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus-broker#df7a36f938130717b6c201d8bf2ca8edf68719f6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2130514",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus-broker#df7a36f938130717b6c201d8bf2ca8edf68719f6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "embed",
+      "purl": "pkg:golang/embed@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/embed@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/lazyregexp",
+      "purl": "pkg:golang/internal/lazyregexp@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/lazyregexp@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=3d1a8018c3d8d52a",
+      "version": "v1.1.1-0.20210330154013-f5de75959ad5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "openssl-fips-provider",
+      "purl": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=aarch64",
+      "version": "3.0.7-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "74dea6ff6f98ab99d3a2b6aba58cd38346734b79",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#74dea6ff6f98ab99d3a2b6aba58cd38346734b79"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2922752",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#74dea6ff6f98ab99d3a2b6aba58cd38346734b79",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/library-go",
+      "purl": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "version": "v0.0.0-20211220195323-eca2c467c492",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "path/filepath",
+      "purl": "pkg:golang/path/filepath@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/path/filepath@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cobra",
+      "purl": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.7.0?package-id=ddac4fa55f03e408",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/singleflight",
+      "purl": "pkg:golang/internal/singleflight@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/singleflight@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=7209f81d42d9fb42",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=c63cc068a81d5b95",
+      "version": "v0.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "log/slog",
+      "purl": "pkg:golang/log/slog@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/slog@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "debug/dwarf",
+      "purl": "pkg:golang/debug/dwarf@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/debug/dwarf@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/api",
+      "purl": "pkg:golang/kubevirt.io/api",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/api?package-id=8271ccebef8c7fbf",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libcom_err",
+      "purl": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=aarch64",
+      "version": "1.46.5-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "55211469981d94577ec3da753afcdf2cc4d651ab",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#55211469981d94577ec3da753afcdf2cc4d651ab"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820207",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#55211469981d94577ec3da753afcdf2cc4d651ab",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/component-base",
+      "purl": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "purl": "pkg:golang/image@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "hash/crc32",
+      "purl": "pkg:golang/hash/crc32@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash/crc32@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libmnl",
+      "purl": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=aarch64",
+      "version": "1.0.4-16.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e4e253af7af3650798d04664f7b96965ed5365ad",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libmnl#e4e253af7af3650798d04664f7b96965ed5365ad"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3049134",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libmnl#e4e253af7af3650798d04664f7b96965ed5365ad",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "decorator",
+      "purl": "pkg:pypi/decorator@4.4.2",
+      "type": "library",
+      "author": "Michele Simionato <michele.simionato@gmail.com>",
+      "bom-ref": "pkg:pypi/decorator@4.4.2",
+      "version": "4.4.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "new BSD License"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/decorator-4.4.2-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "libxcrypt",
+      "purl": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=aarch64",
+      "version": "4.4.18-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and BSD and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5ae2c88752320b1d81d70ae38259ce56b1c692de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690260",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "os/exec",
+      "purl": "pkg:golang/os/exec@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os/exec@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/glog",
+      "purl": "pkg:golang/github.com/golang/glog@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/glog@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=44dea5fe0373ffc7",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libcap",
+      "purl": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=aarch64",
+      "version": "2.48-9.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "579dc340bc85f77708d4c04f72f9cc7c2ad16e27",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap#579dc340bc85f77708d4c04f72f9cc7c2ad16e27"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2590508",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap#579dc340bc85f77708d4c04f72f9cc7c2ad16e27",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcc",
+      "purl": "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=aarch64",
+      "version": "11.4.1-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498982",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/grpc",
+      "purl": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "version": "v1.58.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cli-runtime",
+      "purl": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiserver",
+      "purl": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/grafana/regexp",
+      "purl": "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "version": "v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/sha512",
+      "purl": "pkg:golang/crypto/sha512@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/sha512@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/node-api",
+      "purl": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/node-api@v0.30.0?package-id=69b6b0afb2bc8383",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libassuan",
+      "purl": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=aarch64",
+      "version": "2.5.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5b185f851a42718727fee9efcf42ba525a59a8bb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689887",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/blang/semver",
+      "purl": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+      "version": "v3.5.1+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "hash/fnv",
+      "purl": "pkg:golang/hash/fnv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash/fnv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "go/scanner",
+      "purl": "pkg:golang/go/scanner@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/scanner@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "file-libs",
+      "purl": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=aarch64",
+      "version": "5.39-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2800051",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=5af92f389a804379",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/testlog",
+      "purl": "pkg:golang/internal/testlog@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/testlog@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubelet",
+      "purl": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "text/template",
+      "purl": "pkg:golang/text/template@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/text/template@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "compress/gzip",
+      "purl": "pkg:golang/compress/gzip@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/gzip@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=64a952cc8f95048c",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "purl": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=aarch64",
+      "version": "2.34-100.el9_4.12",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676435",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog",
+      "purl": "pkg:golang/k8s.io/klog@v0.3.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog@v0.3.3",
+      "version": "v0.3.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libseccomp",
+      "purl": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=aarch64",
+      "version": "2.5.2-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "81d3550e24896c1929fda36335626a6807df3922",
+            "url": "git://pkgs.devel.redhat.com/rpms/libseccomp#81d3550e24896c1929fda36335626a6807df3922"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1788033",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libseccomp#81d3550e24896c1929fda36335626a6807df3922",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=211a5c0c1a7524b9",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=42ecb449d13ca189",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libacl",
+      "purl": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=aarch64",
+      "version": "2.3.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2709815",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/library-go",
+      "purl": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492?package-id=fb57a5f09377d6b1",
+      "version": "v0.0.0-20211220195323-eca2c467c492",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libunistring",
+      "purl": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=aarch64",
+      "version": "0.9.10-15.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690195",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua-libs",
+      "purl": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=aarch64",
+      "version": "5.4.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d795270f6d1372b9636433ed1fb08b2439eed16",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467503",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnfnetlink",
+      "purl": "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=aarch64",
+      "version": "1.0.1-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9ba3ebe2fec01b51fb3dbee7005578f6c9257add",
+            "url": "git://pkgs.devel.redhat.com/rpms/libnfnetlink#9ba3ebe2fec01b51fb3dbee7005578f6c9257add"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690058",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libnfnetlink#9ba3ebe2fec01b51fb3dbee7005578f6c9257add",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tpm2-tss",
+      "purl": "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=aarch64",
+      "version": "3.2.2-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fda97b14b55a52fff507835adba9e6a9bf396f65",
+            "url": "git://pkgs.devel.redhat.com/rpms/tpm2-tss#fda97b14b55a52fff507835adba9e6a9bf396f65"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2577728",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/tpm2-tss#fda97b14b55a52fff507835adba9e6a9bf396f65",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=c251c2070b6d837f",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mxk/go-flowrate",
+      "purl": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "version": "v0.0.0-20140419014527-cca7078d478f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "dnf",
+      "purl": "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=a3f45ccc2eaef8aa",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libffi",
+      "purl": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=aarch64",
+      "version": "3.4.2-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6f484e5230669fffb71870ce41c386e01ab4e47d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467679",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-controller",
+      "purl": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/binary",
+      "purl": "pkg:golang/encoding/binary@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/binary@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/ecdsa",
+      "purl": "pkg:golang/crypto/ecdsa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/ecdsa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubectl",
+      "purl": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=75bca8ba1ca22c9b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubernetes-csi/external-snapshotter/client/v4",
+      "purl": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=45a8c7aac0e298e2#client/v4",
+      "version": "v4.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/poll",
+      "purl": "pkg:golang/internal/poll@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/poll@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.15",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.15",
+      "version": "v0.3.15",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=b5d6576591ff84ae",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=1a97d0dde17253ca",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e519b37240b7b6af",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glibc",
+      "purl": "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=aarch64",
+      "version": "2.34-100.el9_4.12",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676435",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "io/fs",
+      "purl": "pkg:golang/io/fs@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/io/fs@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.23.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.23.0",
+      "version": "v0.23.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=0c548e794e085974",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-urllib3",
+      "purl": "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+      "version": "1.26.5-5.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b5a869c4fb0e5683a40c5007515de8ed8e9a182f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-urllib3#b5a869c4fb0e5683a40c5007515de8ed8e9a182f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3236012",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-urllib3#b5a869c4fb0e5683a40c5007515de8ed8e9a182f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/log",
+      "purl": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "filesystem",
+      "purl": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=aarch64",
+      "version": "3.16-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c7ae0c7b52a9e8a78431e06733a8f808418df283",
+            "url": "git://pkgs.devel.redhat.com/rpms/filesystem#c7ae0c7b52a9e8a78431e06733a8f808418df283"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689243",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/filesystem#c7ae0c7b52a9e8a78431e06733a8f808418df283",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/kubevirt",
+      "purl": "pkg:golang/kubevirt.io/kubevirt",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/kubevirt",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog",
+      "purl": "pkg:golang/k8s.io/klog@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog@v0.4.0?package-id=a6cf3f8305ce0756",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=f72df465d2f4ba73",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/client-go",
+      "purl": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "version": "v0.0.0-20210112165513-ebc401615f47",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=92cbc10610ba936e",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=4f70a6c87f97190b",
+      "version": "v1.0.3-0.20210326190908-1c3f411f0417",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libpwquality",
+      "purl": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=aarch64",
+      "version": "1.4.4-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d78e5ea6e840372c17fabdd2cc371c7105a69b4e",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpwquality#d78e5ea6e840372c17fabdd2cc371c7105a69b4e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690098",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpwquality#d78e5ea6e840372c17fabdd2cc371c7105a69b4e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=aarch64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre2-syntax",
+      "purl": "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+      "version": "10.40-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "29947c528818ead0dfcd77753bd76a46d617d18a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2914968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/safefilepath",
+      "purl": "pkg:golang/internal/safefilepath@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/safefilepath@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=dc0ee049f53c27e7",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/md5",
+      "purl": "pkg:golang/crypto/md5@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/md5@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libelf",
+      "purl": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=aarch64",
+      "version": "0.190-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03f1598bbe94308cc7655234a5dcf75092cd1968",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2817160",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "procps-ng",
+      "purl": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=aarch64",
+      "version": "3.3.17-14.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "277f9aaff8edd7603ea88dfe5e42cbb2d229a76f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/procps-ng#277f9aaff8edd7603ea88dfe5e42cbb2d229a76f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2865070",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/procps-ng#277f9aaff8edd7603ea88dfe5e42cbb2d229a76f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log/slog/internal/buffer",
+      "purl": "pkg:golang/log/slog/internal/buffer@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/slog/internal/buffer@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "version": "v5.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-pysocks",
+      "purl": "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+      "version": "1.7.1-12.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc8ec2cb464cfd2ed3729ebd577824893559ecbd",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-pysocks#dc8ec2cb464cfd2ed3729ebd577824893559ecbd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1891067",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-pysocks#dc8ec2cb464cfd2ed3729ebd577824893559ecbd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/wadey/gocovmerge",
+      "purl": "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+      "version": "v0.0.0-20160331181800-b5bfa59ec0ad",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=6bfd33acc02b178b",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/go-vnc",
+      "purl": "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+      "version": "v0.0.0-20150629162542-723ed9867aed",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libzstd",
+      "purl": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=aarch64",
+      "version": "1.5.1-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dcda9fe564e51b7222a5efca3b14840bcc341b44",
+            "url": "git://pkgs.devel.redhat.com/rpms/zstd#dcda9fe564e51b7222a5efca3b14840bcc341b44"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1879398",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zstd#dcda9fe564e51b7222a5efca3b14840bcc341b44",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-cli-plugin",
+      "purl": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libsigsegv",
+      "purl": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=aarch64",
+      "version": "2.13-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b3dee05a0458f11a68b0f9a878aa676670814326",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690130",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sync",
+      "purl": "pkg:golang/sync@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/sync@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "zlib",
+      "purl": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=aarch64",
+      "version": "1.2.11-40.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Boost"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+            "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2495976",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-librepo",
+      "purl": "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=aarch64",
+      "version": "1.14.5-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "458f8b732e9d31cbe09323c87f796924ac30461c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797210",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=c91ff645d6ce8388",
+      "version": "v0.0.0-20210104183010-2eb08e3e575f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "libuuid",
+      "purl": "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tar",
+      "purl": "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=aarch64&epoch=2",
+      "version": "2:1.34-6.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a171e3d125646d2a953c247715ef2788c1829c1c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tar#a171e3d125646d2a953c247715ef2788c1829c1c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3229110",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tar#a171e3d125646d2a953c247715ef2788c1829c1c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libarchive",
+      "purl": "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=aarch64",
+      "version": "3.5.3-4.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "64e0b899f452b7e78dde9b8df8e5ecd358f1c837",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#64e0b899f452b7e78dde9b8df8e5ecd358f1c837"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3807112",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#64e0b899f452b7e78dde9b8df8e5ecd358f1c837",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/beorn7/perks",
+      "purl": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "version": "v1.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=7b9209a64c9c952b",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=2e766a71ac55c8c1",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/hkdf",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "net/http/httputil",
+      "purl": "pkg:golang/net/http/httputil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/httputil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=264ee8e18d5b5c8a",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+      "version": "v0.0.0-20230501164219-8b0f38b5fd1f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/googleapis/gnostic",
+      "purl": "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+      "version": "v0.2.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-stack/stack",
+      "purl": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "version": "v1.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "ncurses-libs",
+      "purl": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=aarch64",
+      "version": "6.2-10.20210508.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "539ab619cec841979d6b46943d3f82c15b7a8467",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3759616",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "curl-minimal",
+      "purl": "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+      "version": "7.76.1-29.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80195397e7d61d156d731499be9884797b75dbb1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471237",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/goexperiment",
+      "purl": "pkg:golang/internal/goexperiment@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goexperiment@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=647cefa32ef8dbed",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/sysinfo",
+      "purl": "pkg:golang/internal/sysinfo@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/sysinfo@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/cryptobyte",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.1.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.5",
+      "version": "v1.1.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libstdc++",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=aarch64",
+      "version": "11.4.1-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498982",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dnf",
+      "purl": "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-cloud-what",
+      "purl": "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=aarch64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cli-runtime",
+      "purl": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0?package-id=372a4fd9b7953904",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=bcb125b3ee0ac2bf",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "popt",
+      "purl": "pkg:rpm/redhat/popt@1.18-8.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=aarch64",
+      "version": "1.18-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+            "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691597",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3",
+      "purl": "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=aarch64",
+      "version": "3.9.18-3.el9_4.9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2e1b452fcf120e44a7613701e28dd40a7931fc59",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3828922",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "yajl",
+      "purl": "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=aarch64",
+      "version": "2.1.0-22.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3b4891fe107c68e6e41550e4be2a5c9ad4f870a6",
+            "url": "git://pkgs.devel.redhat.com/rpms/yajl#3b4891fe107c68e6e41550e4be2a5c9ad4f870a6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2592251",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/yajl#3b4891fe107c68e6e41550e4be2a5c9ad4f870a6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-gssapi",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=aarch64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libvirt.org/go/libvirtxml",
+      "purl": "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+      "version": "v1.10000.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/procfs",
+      "purl": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0?package-id=53509fccb635cdaf",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libverto",
+      "purl": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=aarch64",
+      "version": "0.3.2-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690209",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "text/template/parse",
+      "purl": "pkg:golang/text/template/parse@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/text/template/parse@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/crypto",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+      "version": "v0.0.0-20220321153916-2c7772ba3064",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.14.0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cloud-provider",
+      "purl": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0?package-id=213905a8e9bf9bca",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/version",
+      "purl": "pkg:golang/go/version@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/version@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=fd55bfb7c4801b59",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/boring/sig",
+      "purl": "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-runewidth",
+      "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+      "version": "v0.0.13",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sync",
+      "purl": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.11.0?package-id=d30348b75bd8dbbe",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubelet",
+      "purl": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubelet@v0.30.0?package-id=0d174a34ad4bac4b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+      "purl": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=b4f2daad5b1d001e#pkg/apis/monitoring",
+      "version": "v0.68.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/types",
+      "purl": "pkg:golang/go/types@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/types@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "audit-libs",
+      "purl": "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=aarch64",
+      "version": "3.1.2-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3d2d297e67e32b5ce4c2914cc64169fd0be4ace0",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#3d2d297e67e32b5ce4c2914cc64169fd0be4ace0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2769499",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#3d2d297e67e32b5ce4c2914cc64169fd0be4ace0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/goterm",
+      "purl": "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+      "version": "v0.0.0-20190311235235-ce302be1d114",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "hash/adler32",
+      "purl": "pkg:golang/hash/adler32@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash/adler32@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=777844465b60ad81",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_model",
+      "purl": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/cni",
+      "purl": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "rpm-build-libs",
+      "purl": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=aarch64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/syscall",
+      "purl": "pkg:golang/runtime/internal/syscall@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/syscall@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gregjones/httpcache",
+      "purl": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+      "version": "v0.0.0-20190611155906-901d90724c79",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/log",
+      "purl": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=7349fb61f86b922a",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=4b04ea23556ed395",
+      "version": "v0.3.16",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_model",
+      "purl": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0?package-id=ecb7f6c81f243c3b",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "regexp",
+      "purl": "pkg:golang/regexp@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/regexp@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "maps",
+      "purl": "pkg:golang/maps@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/maps@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "net",
+      "purl": "pkg:golang/net@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=e0646f8826c197e7",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "encoding/csv",
+      "purl": "pkg:golang/encoding/csv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/csv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=9cb7e0ef1a4f0772",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "gnupg2",
+      "purl": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=aarch64",
+      "version": "2.3.3-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2481337",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libdnf",
+      "purl": "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+      "version": "0.69.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e5984c195dca639c24fa8a25263d2faf9419e97d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134146",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "os/signal",
+      "purl": "pkg:golang/os/signal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os/signal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "net/mail",
+      "purl": "pkg:golang/net/mail@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/mail@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/goroot",
+      "purl": "pkg:golang/internal/goroot@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goroot@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/analysis",
+      "purl": "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/transform",
+      "purl": "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/internal/alias",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=e0fc581ee7f4ac53",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/inconshreveable/mousetrap",
+      "purl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "strings",
+      "purl": "pkg:golang/strings@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/strings@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "go/build/constraint",
+      "purl": "pkg:golang/go/build/constraint@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/build/constraint@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-libs",
+      "purl": "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=aarch64",
+      "version": "3.9.18-3.el9_4.9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2e1b452fcf120e44a7613701e28dd40a7931fc59",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3828922",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "os/user",
+      "purl": "pkg:golang/os/user@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os/user@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/golang-crypto",
+      "purl": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "version": "v0.33.1-0.20250310193910-9003f682e581",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/dsa",
+      "purl": "pkg:golang/crypto/dsa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/dsa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-subscription-manager-rhsm",
+      "purl": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=aarch64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=b1e90c3e1ac1f792",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/http/httptrace",
+      "purl": "pkg:golang/net/http/httptrace@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/httptrace@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/client-go",
+      "purl": "pkg:golang/kubevirt.io/client-go@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/client-go@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=d49025084db5e534",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "log/slog/internal",
+      "purl": "pkg:golang/log/slog/internal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/slog/internal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/spec",
+      "purl": "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+      "version": "v0.20.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=30a0f7618c550bd4",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/http/httpproxy",
+      "purl": "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/insomniacslk/dhcp",
+      "purl": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a?package-id=f5ed66e6e2ff252b",
+      "version": "v0.0.0-20230908212754-65c27093e38a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "version": "v0.0.0-20191219222812-2987a591a72c",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "pysocks",
+      "purl": "pkg:pypi/pysocks@1.7.1",
+      "type": "library",
+      "author": "Anorov <anorov.vorona@gmail.com>",
+      "bom-ref": "pkg:pypi/pysocks@1.7.1",
+      "version": "1.7.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/PySocks-1.7.1-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "rootfiles",
+      "purl": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "version": "8.1-31.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30d4e6354acbcb23c1f2485151e08cc352871e75",
+            "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#30d4e6354acbcb23c1f2485151e08cc352871e75"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691770",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#30d4e6354acbcb23c1f2485151e08cc352871e75",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/x509",
+      "purl": "pkg:golang/crypto/x509@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/x509@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/matttproud/golang_protobuf_extensions",
+      "purl": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4?package-id=3ef7d310780b1738",
+      "version": "v1.0.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "go/printer",
+      "purl": "pkg:golang/go/printer@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/printer@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=d8c2f26e9986efc0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=875c60b36880d488",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/constant",
+      "purl": "pkg:golang/go/constant@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/constant@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=56fa540c52a6e225",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-apiserver",
+      "purl": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/beorn7/perks",
+      "purl": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/beorn7/perks@v1.0.1?package-id=d6fd5b144cc18be1",
+      "version": "v1.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+      "version": "v0.0.0-20190221213512-86fb29eff628",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "systemd-libs",
+      "purl": "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=aarch64",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/boring",
+      "purl": "pkg:golang/crypto/internal/boring@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/boring@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "./staging/src/kubevirt.io/api",
+      "purl": "pkg:golang/./staging/src#kubevirt.io/api",
+      "type": "library",
+      "bom-ref": "pkg:golang/./staging/src#kubevirt.io/api",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c?package-id=6c31ceb0e3238027",
+      "version": "v0.0.0-20191219222812-2987a591a72c",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=c27f4e3f0f288cba",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@1.26.5",
+      "type": "library",
+      "author": "Andrey Petrov <andrey.petrov@shazow.net>",
+      "bom-ref": "pkg:pypi/urllib3@1.26.5",
+      "version": "1.26.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/urllib3-1.26.5-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "tzdata",
+      "purl": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "version": "2025b-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff671e79a03e80cf1c432e92fa02aff95d597a97",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3572007",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/itoa",
+      "purl": "pkg:golang/internal/itoa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/itoa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libtirpc",
+      "purl": "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=aarch64",
+      "version": "1.3.3-8.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "SISSL and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bef7b741bc0541226473d5dae03ff0ab1df11b88",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#bef7b741bc0541226473d5dae03ff0ab1df11b88"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2966395",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#bef7b741bc0541226473d5dae03ff0ab1df11b88",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/zstd",
+      "purl": "pkg:golang/internal/zstd@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/zstd@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "net/http/httptest",
+      "purl": "pkg:golang/net/http/httptest@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/httptest@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-requests",
+      "purl": "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+      "version": "2.25.1-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a4dc4a098af1480c6eded62b59f1e385c7b01058",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-requests#a4dc4a098af1480c6eded62b59f1e385c7b01058"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870541",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-requests#a4dc4a098af1480c6eded62b59f1e385c7b01058",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-idna",
+      "purl": "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+      "version": "2.10-7.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and Python and Unicode"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "112df0c7ea79f88a152381810b589b5bfa07e68b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-idna#112df0c7ea79f88a152381810b589b5bfa07e68b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3024021",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-idna#112df0c7ea79f88a152381810b589b5bfa07e68b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-toolsmith/astcopy",
+      "purl": "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "systemd",
+      "purl": "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=aarch64",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=426c1ef83fb90a34",
+      "version": "v1.1.1-0.20210330154013-f5de75959ad5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto",
+      "purl": "pkg:golang/crypto@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/evanphx/json-patch",
+      "purl": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "version": "v5.6.0+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/groupcache",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "encoding/base64",
+      "purl": "pkg:golang/encoding/base64@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/base64@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/csi-translation-lib",
+      "purl": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=4947e27687df8894",
+      "version": "v1.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/go-ps",
+      "purl": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "version": "v0.0.0-20190716172923-621e5597135b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=b5787214009aa9c8",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/des",
+      "purl": "pkg:golang/crypto/des@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/des@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=cdc588c277efc41e",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=ea627eb359d3ebbf",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+      "purl": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+      "version": "v0.0.0-20191119172530-79f836b90111",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=61ff33db308e1c87",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-querystring",
+      "purl": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "version": "v22.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=6b3967bbe5e4f770#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "iproute",
+      "purl": "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=aarch64",
+      "version": "6.2.0-6.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-or-later AND NIST-PD"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "50f71af59d28c401b90bb35a222dc94b3eb7cfae",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/iproute#50f71af59d28c401b90bb35a222dc94b3eb7cfae"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2950524",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/iproute#50f71af59d28c401b90bb35a222dc94b3eb7cfae",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/http/httpguts",
+      "purl": "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/krolaw/dhcp4",
+      "purl": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414?package-id=1f03719fd30cb426",
+      "version": "v0.0.0-20180925202202-7cead472c414",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-setuptools",
+      "purl": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+      "version": "53.0.0-12.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and (BSD or ASL 2.0)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e118582dafc46c5b61049eb79598ec15e88c3b7d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3754759",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm-sign-libs",
+      "purl": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=aarch64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libvirt.org/go/libvirt",
+      "purl": "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+      "version": "v1.10000.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+      "purl": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0?package-id=85656f3ce4c495dd",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=392c78985b3ee866",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "requests",
+      "purl": "pkg:pypi/requests@2.25.1",
+      "type": "library",
+      "author": "Kenneth Reitz <me@kennethreitz.org>",
+      "bom-ref": "pkg:pypi/requests@2.25.1",
+      "version": "2.25.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache 2.0"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/requests-2.25.1.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.14.0?package-id=a47e6c64839baca0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glibc-common",
+      "purl": "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=aarch64",
+      "version": "2.34-100.el9_4.12",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676435",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "yum",
+      "purl": "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=de8b89d7a225278d",
+      "version": "v0.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager",
+      "purl": "pkg:pypi/subscription-manager@1.29.40.1",
+      "type": "library",
+      "author": "Adrian Likins <alikins@redhat.com>",
+      "bom-ref": "pkg:pypi/subscription-manager@1.29.40.1",
+      "version": "1.29.40.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/subscription_manager-1.29.40.1-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-scheduler",
+      "purl": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0?package-id=c6f4b38d0e64a871",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libcomps",
+      "purl": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=aarch64",
+      "version": "0.1.18-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1771556",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-libs",
+      "purl": "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+      "version": "1:3.0.7-29.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3880294",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=617dda993ef91b06",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/sha1",
+      "purl": "pkg:golang/crypto/sha1@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/sha1@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/tls",
+      "purl": "pkg:golang/crypto/tls@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/tls@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-apiserver",
+      "purl": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0?package-id=a7d282fdf5bcfc3a",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "mime",
+      "purl": "pkg:golang/mime@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/mime@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-font-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "net/http",
+      "purl": "pkg:golang/net/http@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/c9s/goprocinfo",
+      "purl": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8?package-id=5324f65a18aa4075",
+      "version": "v0.0.0-20210130143923-c95fcf8c64a8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=7fd9e721114377fd",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=e91ba32bfe0dcfe9",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/client-go",
+      "purl": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=82dbb4bd95c1a6af",
+      "version": "v0.0.0-20210112165513-ebc401615f47",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "log",
+      "purl": "pkg:golang/log@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "util-linux-core",
+      "purl": "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dnf-plugins-core",
+      "purl": "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+      "version": "4.3.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4f5d16cec79f81e1d37edd64ee4cdc2e8289d48b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf-plugins-core#4f5d16cec79f81e1d37edd64ee4cdc2e8289d48b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2850557",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf-plugins-core#4f5d16cec79f81e1d37edd64ee4cdc2e8289d48b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fonts-filesystem",
+      "purl": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "version": "1:2.0.5-7.el9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ac288ee82aa9655c3784dd2f59cedb3562638129",
+            "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1732053",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/unicode/norm",
+      "purl": "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libreport-filesystem",
+      "purl": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "version": "2.15.2-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4690267165817ccc06cb342d8ef955ae10b54c75",
+            "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1852394",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/metrics",
+      "purl": "pkg:golang/runtime/metrics@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/metrics@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/chacha20poly1305",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=bd15d762c1c6c3a1",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=5b48db5542316992",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gdbm-libs",
+      "purl": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=aarch64&epoch=1",
+      "version": "1:1.19-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6bade26c052b6560b132f163484ee009c04e3cce",
+            "url": "git://pkgs.devel.redhat.com/rpms/gdbm#6bade26c052b6560b132f163484ee009c04e3cce"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689293",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gdbm#6bade26c052b6560b132f163484ee009c04e3cce",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-inotify",
+      "purl": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+      "version": "0.9.6-25.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bf5a869472d075a22ea709682b68d1343609c9af",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-inotify#bf5a869472d075a22ea709682b68d1343609c9af"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691386",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-inotify#bf5a869472d075a22ea709682b68d1343609c9af",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.22.12?package-id=0263aa6b4909132a",
+      "version": "go1.22.12",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "unicode/utf16",
+      "purl": "pkg:golang/unicode/utf16@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unicode/utf16@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=e5f84b4525280ceb",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=a40b75a240613ee9#v5",
+      "version": "v5.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "version": "v0.0.0-20240430033511-f0e62f92d13f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=ef4b943e758b9b6b",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cluster-bootstrap",
+      "purl": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "dnf-data",
+      "purl": "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=1651c6ba29f925e5",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=3cfe059b9c8f0896",
+      "version": "v0.3.16",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "setup",
+      "purl": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "version": "2.13.7-10.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2892761",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubevirt/monitoring/pkg/metrics/parser",
+      "purl": "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+      "version": "v0.0.0-20230627123556-81a891d4462a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "nftables",
+      "purl": "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=aarch64&epoch=1",
+      "version": "1:1.0.9-1.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6bd061508fbd17f371f610037fe4b4b89d8cd95e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nftables#6bd061508fbd17f371f610037fe4b4b89d8cd95e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3693063",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nftables#6bd061508fbd17f371f610037fe4b4b89d8cd95e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdb-gdbserver",
+      "purl": "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=aarch64",
+      "version": "10.2-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ and GPLv2+ with exceptions and GPL+ and LGPLv2+ and LGPLv3+ and BSD and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0cda5771bf25da9b298b20bf195cfb9b05928603",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdb#0cda5771bf25da9b298b20bf195cfb9b05928603"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2822968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdb#0cda5771bf25da9b298b20bf195cfb9b05928603",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/nistec/fiat",
+      "purl": "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "shadow-utils",
+      "purl": "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=aarch64&epoch=2",
+      "version": "2:4.9-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "183ec47a68eb739420b44e0d9db15ffb5c4e5753",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#183ec47a68eb739420b44e0d9db15ffb5c4e5753"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3303839",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#183ec47a68eb739420b44e0d9db15ffb5c4e5753",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=3a7a3480e12ba94a",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gzip",
+      "purl": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=aarch64",
+      "version": "1.12-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "11df222a2dc5ce7dc943b1bce364d46ea97a535b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gzip#11df222a2dc5ce7dc943b1bce364d46ea97a535b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1982016",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gzip#11df222a2dc5ce7dc943b1bce364d46ea97a535b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cluster-bootstrap",
+      "purl": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0?package-id=7c0f2e47ca097803",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/intern",
+      "purl": "pkg:golang/internal/intern@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/intern@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "errors",
+      "purl": "pkg:golang/errors@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/errors@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-aggregator",
+      "purl": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4ca57bd69d22480b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=79287922c4530134",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=6d74791bcbcea4ec",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "pcre2",
+      "purl": "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=aarch64",
+      "version": "10.40-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "29947c528818ead0dfcd77753bd76a46d617d18a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2914968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-gobject-base-noarch",
+      "purl": "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+      "version": "3.40.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79ff68bd91179f855796360827ad65f2a83577dc",
+            "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2049891",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hash",
+      "purl": "pkg:golang/hash@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/socket",
+      "purl": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=a8fb70acf7ce028c",
+      "version": "v0.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=58fd55d3a3e68d9a",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=812518b1d5de5b6b",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/fatih/color",
+      "purl": "pkg:golang/github.com/fatih/color@v1.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fatih/color@v1.13.0",
+      "version": "v1.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=44034bb305ad6df8#v5",
+      "version": "v5.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/csi-translation-lib",
+      "purl": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0?package-id=e493ecdd6cef073d",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "idna",
+      "purl": "pkg:pypi/idna@2.10",
+      "type": "library",
+      "author": "Kim Davies <kim@cynosure.com.au>",
+      "bom-ref": "pkg:pypi/idna@2.10",
+      "version": "2.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-like"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/idna-2.10-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "image/internal/imageutil",
+      "purl": "pkg:golang/image/internal/imageutil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/internal/imageutil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-cli-plugin",
+      "purl": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0?package-id=b57f2d304a79c9d2",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gordonklaus/ineffassign",
+      "purl": "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+      "version": "v0.0.0-20210209182638-d0e41b2fc8ed",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/strfmt",
+      "purl": "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=0cf48c7c4e0c2225",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=5f3161d14fb9986b",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/rivo/uniseg",
+      "purl": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+      "version": "v0.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=9cd65210b34ae131",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "container/list",
+      "purl": "pkg:golang/container/list@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/container/list@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "version": "v1.33.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "container/ring",
+      "purl": "pkg:golang/container/ring@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/container/ring@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "unicode",
+      "purl": "pkg:golang/unicode@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unicode@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "runtime",
+      "purl": "pkg:golang/runtime@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-gpg",
+      "purl": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=aarch64",
+      "version": "1.15.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+            "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892040",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "systemd-python",
+      "purl": "pkg:pypi/systemd-python@234",
+      "type": "library",
+      "author": "systemd developers <systemd-devel@lists.freedesktop.org>",
+      "bom-ref": "pkg:pypi/systemd-python@234",
+      "version": "234",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/systemd_python-234-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "image/png",
+      "purl": "pkg:golang/image/png@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/png@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/btree",
+      "purl": "pkg:golang/github.com/google/btree@v1.1.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/btree@v1.1.3",
+      "version": "v1.1.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/unicode/bidi",
+      "purl": "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "virt-what",
+      "purl": "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=aarch64",
+      "version": "1.25-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc9eaee5d4f089206bd81208cc7e4448bdae8233",
+            "url": "git://pkgs.devel.redhat.com/rpms/virt-what#fc9eaee5d4f089206bd81208cc7e4448bdae8233"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2574109",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/virt-what#fc9eaee5d4f089206bd81208cc7e4448bdae8233",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/code-generator",
+      "purl": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/code-generator@v0.30.0?package-id=c9d95bf42170291b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=fa2fc500853b500e",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libsolv",
+      "purl": "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=aarch64",
+      "version": "0.7.24-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9ab325a2961e60cb85d36bcd381102753a990bff",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsolv#9ab325a2961e60cb85d36bcd381102753a990bff"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2563465",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsolv#9ab325a2961e60cb85d36bcd381102753a990bff",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cracklib-dicts",
+      "purl": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=aarch64",
+      "version": "2.9.6-27.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+            "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689047",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "elfutils-default-yama-scope",
+      "purl": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+      "version": "0.190-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03f1598bbe94308cc7655234a5dcf75092cd1968",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2817160",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "go/doc/comment",
+      "purl": "pkg:golang/go/doc/comment@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/doc/comment@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libdnf",
+      "purl": "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+      "version": "0.69.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e5984c195dca639c24fa8a25263d2faf9419e97d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134146",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/math",
+      "purl": "pkg:golang/runtime/internal/math@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/math@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo/v2",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "version": "v2.17.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=38f081dbc5ce4d6a",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/go-ps",
+      "purl": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b?package-id=1264b58e962ebcac",
+      "version": "v0.0.0-20190716172923-621e5597135b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=317d26dbf41e923a",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=20f072e6e3225e24",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=b026cc4209959195",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libcap-ng",
+      "purl": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=aarch64",
+      "version": "0.8.2-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1888632",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=58a2f3ed700462d3",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "regexp/syntax",
+      "purl": "pkg:golang/regexp/syntax@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/regexp/syntax@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=a0115c013e649a4c",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/evanphx/json-patch",
+      "purl": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible?package-id=15ebdd24a0c721e7",
+      "version": "v5.6.0+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "passwd",
+      "purl": "pkg:rpm/redhat/passwd@0.80-12.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/passwd@0.80-12.el9?arch=aarch64",
+      "version": "0.80-12.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPL+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc8f2d3ecfe371757ee51d81b0b9e4b7e3a8cdc5",
+            "url": "git://pkgs.devel.redhat.com/rpms/passwd#dc8f2d3ecfe371757ee51d81b0b9e4b7e3a8cdc5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691236",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/passwd#dc8f2d3ecfe371757ee51d81b0b9e4b7e3a8cdc5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-decorator",
+      "purl": "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+      "version": "4.4.2-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc2368c1fe0e7914e6027cc70f05d59862dbf2ec",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-decorator#fc2368c1fe0e7914e6027cc70f05d59862dbf2ec"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691358",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-decorator#fc2368c1fe0e7914e6027cc70f05d59862dbf2ec",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sed",
+      "purl": "pkg:rpm/redhat/sed@4.8-9.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=aarch64",
+      "version": "4.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dad14ff8a62e967c0afb23d1d237a927d847e86e",
+            "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1692031",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl",
+      "purl": "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+      "version": "1:3.0.7-29.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3880294",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/race",
+      "purl": "pkg:golang/internal/race@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/race@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_golang",
+      "purl": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0?package-id=802b60ddf07e5522",
+      "version": "v1.16.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "internal/goversion",
+      "purl": "pkg:golang/internal/goversion@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goversion@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/idna",
+      "purl": "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/appengine",
+      "purl": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=d183acc87e1fa62e",
+      "version": "v1.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/btree",
+      "purl": "pkg:golang/github.com/google/btree@v1.1.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/btree@v1.1.3?package-id=2655799dd02f4564",
+      "version": "v1.1.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-dbus",
+      "purl": "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=aarch64",
+      "version": "1.2.18-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f3a764ea144cc2b6b80a1ebd2925c96b2d81653b",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus-python#f3a764ea144cc2b6b80a1ebd2925c96b2d81653b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus-python#f3a764ea144cc2b6b80a1ebd2925c96b2d81653b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=87c0cbf8954e0580",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/rc4",
+      "purl": "pkg:golang/crypto/rc4@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/rc4@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cri-api",
+      "purl": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=aabc29983e2a9841",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-controller-manager",
+      "purl": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0?package-id=0814f25a8e4531ce",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-aggregator",
+      "purl": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4bf18231eac48ba4",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/base32",
+      "purl": "pkg:golang/encoding/base32@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/base32@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "text/tabwriter",
+      "purl": "pkg:golang/text/tabwriter@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/text/tabwriter@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cri-api",
+      "purl": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cri-api@v0.30.0?package-id=4de173f6a5765211",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/component-base",
+      "purl": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/component-base@v0.30.0?package-id=94800364440cc1a6",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "image/jpeg",
+      "purl": "pkg:golang/image/jpeg@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/jpeg@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libeconf",
+      "purl": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=aarch64",
+      "version": "0.4.1-3.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "aeb088c5c9095f978d2e8b5a06f3079b3b15c9a9",
+            "url": "git://pkgs.devel.redhat.com/rpms/libeconf#aeb088c5c9095f978d2e8b5a06f3079b3b15c9a9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2539463",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libeconf#aeb088c5c9095f978d2e8b5a06f3079b3b15c9a9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=a1ff2ebea07a529d",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/native",
+      "purl": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "internal/coverage/rtcov",
+      "purl": "pkg:golang/internal/coverage/rtcov@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/coverage/rtcov@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "usermode",
+      "purl": "pkg:rpm/redhat/usermode@1.114-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/usermode@1.114-4.el9?arch=aarch64",
+      "version": "1.114-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6fcf2ff19afca6b8a061136d7df6189faec5f15c",
+            "url": "git://pkgs.devel.redhat.com/rpms/usermode#6fcf2ff19afca6b8a061136d7df6189faec5f15c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1821463",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/usermode#6fcf2ff19afca6b8a061136d7df6189faec5f15c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gpg",
+      "purl": "pkg:pypi/gpg@1.15.1",
+      "type": "library",
+      "author": "The GnuPG hackers <gnupg-devel@gnupg.org>",
+      "bom-ref": "pkg:pypi/gpg@1.15.1",
+      "version": "1.15.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPL2.1+ (the library), GPL2+ (tests and examples)"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/gpg-1.15.1-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/groupcache",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=406cd2654be0fcc8",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "acl",
+      "purl": "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=aarch64",
+      "version": "2.3.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2709815",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=8899651b157fa55b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies-scripts",
+      "purl": "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+      "version": "20240202-1.git283706d.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a950d9ca3218bf47d75befa4639b7990b00c99eb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2889114",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=34e50fc47ddb109c",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/dns/dnsmessage",
+      "purl": "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/metrics",
+      "purl": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/metrics@v0.30.0?package-id=e5a9c757e0ba76d0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=bd9cfde5eb7d49da",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/Masterminds/semver",
+      "purl": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=a6a4677db3654d87",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+      "purl": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=41c9ffe89c4328dd#pkg/apis/monitoring",
+      "version": "v0.68.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e87736d4223a3553",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/gover",
+      "purl": "pkg:golang/internal/gover@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/gover@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=077b67d110fda982",
+      "version": "v0.0.0-20240430033511-f0e62f92d13f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "mvdan.cc/editorconfig",
+      "purl": "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+      "type": "library",
+      "bom-ref": "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+      "version": "v0.2.1-0.20231228180347-1925077f8eb2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/client-go",
+      "purl": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=332ab3a9d173ca98",
+      "version": "v0.0.0-20210112165513-ebc401615f47",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libnghttp2",
+      "purl": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=aarch64",
+      "version": "1.43.0-5.el9_4.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3c2e4449d7e195f89fc8f2d9c566b05a2e315dae",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#3c2e4449d7e195f89fc8f2d9c566b05a2e315dae"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2996729",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#3c2e4449d7e195f89fc8f2d9c566b05a2e315dae",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=d3adc2bc60fefccb",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "ca-certificates",
+      "purl": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "version": "2025.2.80_v9.0.305-91.el9",
+      "licenses": [
+        {
+          "expression": "MIT AND GPL-2.0-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80abd67ad7d828eba9c44be633f42b67f21751b1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#80abd67ad7d828eba9c44be633f42b67f21751b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3864618",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#80abd67ad7d828eba9c44be633f42b67f21751b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=2f055f6cdf8e3fb1",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "npth",
+      "purl": "pkg:rpm/redhat/npth@1.6-8.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=aarch64",
+      "version": "1.6-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+            "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690792",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubectl",
+      "purl": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=747804ed972e87a1",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/pprof",
+      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6?package-id=0bc6f5896c6cb1a9",
+      "version": "v0.0.0-20240424215950-a892ee059fd6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=9de2c8dc0803d74e",
+      "version": "v0.0.0-20210104183010-2eb08e3e575f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=2e7c033a75be1ef6",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=8256c45ca06407ab",
+      "version": "v1.33.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/controller-runtime",
+      "purl": "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "jansson",
+      "purl": "pkg:rpm/redhat/jansson@2.14-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/jansson@2.14-1.el9?arch=aarch64",
+      "version": "2.14-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4580a680e5f19adde10c25adad0a31f1d3dc1078",
+            "url": "git://pkgs.devel.redhat.com/rpms/jansson#4580a680e5f19adde10c25adad0a31f1d3dc1078"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1798464",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/jansson#4580a680e5f19adde10c25adad0a31f1d3dc1078",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b135113b0301cc3e",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "math/big",
+      "purl": "pkg:golang/math/big@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math/big@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=5df1a932dc364fae",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/seccomp/libseccomp-golang",
+      "purl": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "version": "v0.10.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-proxy",
+      "purl": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=49b478fdfd04f997",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "expat",
+      "purl": "pkg:rpm/redhat/expat@2.5.0-2.el9_4.3?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/expat@2.5.0-2.el9_4.3?arch=aarch64",
+      "version": "2.5.0-2.el9_4.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f2ce204d810179faaa965fdb380b9aaba6cea668",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#f2ce204d810179faaa965fdb380b9aaba6cea668"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3894491",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#f2ce204d810179faaa965fdb380b9aaba6cea668",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "findutils",
+      "purl": "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=aarch64&epoch=1",
+      "version": "1:4.8.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "52a86f6303fb86be2412eeeb8df53ec3ee4c4b60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#52a86f6303fb86be2412eeeb8df53ec3ee4c4b60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2641338",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#52a86f6303fb86be2412eeeb8df53ec3ee4c4b60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=2f1b091e7ebc59e5#mountinfo",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libgcrypt",
+      "purl": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=aarch64",
+      "version": "1.10.0-10.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "06551d4cc2458fcbe36fe78ec1a5cdbc5dbbf914",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#06551d4cc2458fcbe36fe78ec1a5cdbc5dbbf914"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3567943",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#06551d4cc2458fcbe36fe78ec1a5cdbc5dbbf914",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/syscall/execenv",
+      "purl": "pkg:golang/internal/syscall/execenv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/syscall/execenv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cespare/xxhash/v2",
+      "purl": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0?package-id=ff6ddf5ac62bb415#v2",
+      "version": "v2.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "purl": "pkg:golang/golang.org/x/tools@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-proxy",
+      "purl": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0?package-id=da08354393870645",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/atomic",
+      "purl": "pkg:golang/runtime/internal/atomic@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/atomic@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=14c598a63cb5e9db",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libyaml",
+      "purl": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=aarch64",
+      "version": "0.2.5-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70e1549fe5e56c95f1e23967e02c657d7af570ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690356",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=0f468cc3892f0124",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "json-c",
+      "purl": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=aarch64",
+      "version": "0.14-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "391500fb2a46f72180ba1353136c1b3327d71c55",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1728857",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/subtle",
+      "purl": "pkg:golang/crypto/subtle@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/subtle@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-libcomps",
+      "purl": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=aarch64",
+      "version": "0.1.18-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1771556",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/native",
+      "purl": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/native@v1.1.0?package-id=6604c5cd4c4748cf",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=14c57ecad0b43747",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=db67540c07b5beb9",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+      "version": "v2.6.1+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=db815b5d0b61f513",
+      "version": "v1.1.14",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-stack/stack",
+      "purl": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-stack/stack@v1.8.0?package-id=48631dee752774c6",
+      "version": "v1.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/bisect",
+      "purl": "pkg:golang/internal/bisect@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/bisect@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/edwards25519",
+      "purl": "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=71cd8ab004151c77",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/internal/typeparams",
+      "purl": "pkg:golang/go/internal/typeparams@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/internal/typeparams@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "testing",
+      "purl": "pkg:golang/testing@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/testing@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-github/v32",
+      "purl": "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+      "version": "v32.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libattr",
+      "purl": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=aarch64",
+      "version": "2.5.1-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+            "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688838",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/validate",
+      "purl": "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "numactl-libs",
+      "purl": "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=aarch64",
+      "version": "2.0.16-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4ace9e459353675439dae46e01102853d6c8f37d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/numactl#4ace9e459353675439dae46e01102853d6c8f37d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2692430",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/numactl#4ace9e459353675439dae46e01102853d6c8f37d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "io/ioutil",
+      "purl": "pkg:golang/io/ioutil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/io/ioutil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/VividCortex/ewma",
+      "purl": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=077a5e8ca27fa924",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-systemd",
+      "purl": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=aarch64",
+      "version": "234-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bdb294f1932ff4b5a881daeea1375f1b93b7cf5b",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-systemd#bdb294f1932ff4b5a881daeea1375f1b93b7cf5b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691650",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-systemd#bdb294f1932ff4b5a881daeea1375f1b93b7cf5b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "html/template",
+      "purl": "pkg:golang/html/template@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/html/template@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/u-root/uio",
+      "purl": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923?package-id=a98cba5ae186c4f5",
+      "version": "v0.0.0-20230220225925-ffce2a382923",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=c774b777664a4bb0",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/common",
+      "purl": "pkg:golang/github.com/containers/common@v0.50.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/common@v0.50.1?package-id=e36d1d0f2ba91772",
+      "version": "v0.50.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libvirt-libs",
+      "purl": "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=aarch64",
+      "version": "10.0.0-6.19.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND OFL-1.1"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b48e93554655d865ca027aaceb12b91dc5dc6a5c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libvirt#b48e93554655d865ca027aaceb12b91dc5dc6a5c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3782117",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libvirt#b48e93554655d865ca027aaceb12b91dc5dc6a5c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dateutil",
+      "purl": "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+      "version": "1:2.8.1-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8f4fa349cd64e4143fc3b417b01a2ab1f433b40d",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-dateutil#8f4fa349cd64e4143fc3b417b01a2ab1f433b40d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2628796",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-dateutil#8f4fa349cd64e4143fc3b417b01a2ab1f433b40d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/debug",
+      "purl": "pkg:golang/runtime/debug@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/debug@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=c3d9773d12fa39a7",
+      "version": "v1.33.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/internal/poly1305",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/log",
+      "purl": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=429112dfb9428aeb",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pierrec/lz4/v4",
+      "purl": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15?package-id=8f6dd5f7ba6a62ec#v4",
+      "version": "v4.1.15",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=6619c43cfd07c933",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libssh-config",
+      "purl": "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+      "version": "0.10.4-13.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35756743d06f7dc2fde2d65495ae0d4866011d1b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3866387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/http/internal/testcert",
+      "purl": "pkg:golang/net/http/internal/testcert@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/internal/testcert@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pborman/uuid",
+      "purl": "pkg:golang/github.com/pborman/uuid@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pborman/uuid@v1.2.1",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-chardet",
+      "purl": "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+      "version": "4.0.0-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f8acd16e754d66fa555ae3facafdae9e6befdbb3",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-chardet#f8acd16e754d66fa555ae3facafdae9e6befdbb3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1894647",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-chardet#f8acd16e754d66fa555ae3facafdae9e6befdbb3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=5ce12f7eaebfe865",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=2510cbce9c179e69",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "purl": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "version": "v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "grep",
+      "purl": "pkg:rpm/redhat/grep@3.6-5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=aarch64",
+      "version": "3.6-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7779e81140d7afaf33d2a97f4afdd682457f9697",
+            "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689607",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "encoding/json",
+      "purl": "pkg:golang/encoding/json@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/json@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libselinux",
+      "purl": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=aarch64",
+      "version": "3.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b604bc7c7288a43b90e0f88226ddff652b945e40",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#b604bc7c7288a43b90e0f88226ddff652b945e40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2821561",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#b604bc7c7288a43b90e0f88226ddff652b945e40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/errors",
+      "purl": "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+      "version": "v0.19.9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/reflectlite",
+      "purl": "pkg:golang/internal/reflectlite@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/reflectlite@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/bigmod",
+      "purl": "pkg:golang/crypto/internal/bigmod@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/bigmod@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/genproto/googleapis/rpc",
+      "purl": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "version": "v0.0.0-20230822172742-b8732ec3820d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-controller",
+      "purl": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-controller@v0.30.0?package-id=95847fe4258b57c0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/rand",
+      "purl": "pkg:golang/crypto/rand@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/rand@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libevent",
+      "purl": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=aarch64",
+      "version": "2.1.12-8.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3235991",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/genproto/googleapis/rpc",
+      "purl": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d?package-id=454c35570125ce2f#rpc",
+      "version": "v0.0.0-20230822172742-b8732ec3820d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=f4fcb5b06080adbf",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo/v2",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2?package-id=709ca981edc6d5d6#v2",
+      "version": "v2.17.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/mod",
+      "purl": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "version": "v0.17.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl",
+      "purl": "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=aarch64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=fd7558abcd37e57d",
+      "version": "v0.0.0-20240430033511-f0e62f92d13f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=dd84eb4f391fe51e",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "unicode/utf8",
+      "purl": "pkg:golang/unicode/utf8@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unicode/utf8@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "pcre",
+      "purl": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=aarch64",
+      "version": "8.44-3.el9.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1007ce35c0150110a7bcd4c1741380a726434e46",
+            "url": "git://pkgs.devel.redhat.com/rpms/pcre#1007ce35c0150110a7bcd4c1741380a726434e46"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691250",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pcre#1007ce35c0150110a7bcd4c1741380a726434e46",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/grpc",
+      "purl": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=1663864887e439eb",
+      "version": "v1.58.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=f1bc226b87c469d8",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/asn1",
+      "purl": "pkg:golang/encoding/asn1@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/asn1@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=5eee73adffd25455",
+      "version": "v1.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "gnutls",
+      "purl": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=aarch64",
+      "version": "3.8.3-4.el9_4.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b773160a90460399f962c17953398ff7f781803b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#b773160a90460399f962c17953398ff7f781803b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3821445",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#b773160a90460399f962c17953398ff7f781803b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sort",
+      "purl": "pkg:golang/sort@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/sort@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "keyutils-libs",
+      "purl": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=aarch64",
+      "version": "1.6.3-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+            "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2212253",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=f951095dca4572e3",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "archive/tar",
+      "purl": "pkg:golang/archive/tar@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/archive/tar@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=3bccae874729638f",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=892f25b58ba2cadb",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gobject-introspection",
+      "purl": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=aarch64",
+      "version": "1.68.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5fa3808a6c90b0da8da9a85fad983244c13640ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2248264",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=3cee09b2c9d8346a",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libksba",
+      "purl": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=aarch64",
+      "version": "1.5.1-6.el9_1",
+      "licenses": [
+        {
+          "license": {
+            "name": "(LGPLv3+ or GPLv2+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7112a8f2afeccb3acd42cba9a99b4c2c8fe70306",
+            "url": "git://pkgs.devel.redhat.com/rpms/libksba#7112a8f2afeccb3acd42cba9a99b4c2c8fe70306"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2345715",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libksba#7112a8f2afeccb3acd42cba9a99b4c2c8fe70306",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=a8276711fb26ec2c#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libs",
+      "purl": "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=aarch64",
+      "version": "0.190-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03f1598bbe94308cc7655234a5dcf75092cd1968",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2817160",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/machadovilaca/operator-observability",
+      "purl": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20?package-id=ce832bdd3e643f49",
+      "version": "v0.0.20",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "six",
+      "purl": "pkg:pypi/six@1.15.0",
+      "type": "library",
+      "author": "Benjamin Peterson <benjamin@python.org>",
+      "bom-ref": "pkg:pypi/six@1.15.0",
+      "version": "1.15.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/six-1.15.0.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/runtime",
+      "purl": "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+      "version": "v0.19.24",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "log/internal",
+      "purl": "pkg:golang/log/internal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/internal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/asaskevich/govalidator",
+      "purl": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+      "version": "v0.0.0-20200907205600-7a23bdc65eef",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gpgme",
+      "purl": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=aarch64",
+      "version": "1.15.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+            "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892040",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openldap",
+      "purl": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=aarch64",
+      "version": "2.6.6-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "OLDAP-2.8"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "409b72030310df96b296a5dd8cf80f0a211cc038",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#409b72030310df96b296a5dd8cf80f0a211cc038"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2899087",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#409b72030310df96b296a5dd8cf80f0a211cc038",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager",
+      "purl": "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "expvar",
+      "purl": "pkg:golang/expvar@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/expvar@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libidn2",
+      "purl": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=aarch64",
+      "version": "2.3.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or LGPLv3+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c781354177446e1bb6a5b48d2113feaed50cc860",
+            "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=67a13c4d057a96fd#v22",
+      "version": "v22.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/loads",
+      "purl": "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libdnf-plugin-subscription-manager",
+      "purl": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kmod-libs",
+      "purl": "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=aarch64",
+      "version": "28-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "36aca425e7d25f5daca7109dc963da87294cd1b5",
+            "url": "git://pkgs.devel.redhat.com/rpms/kmod#36aca425e7d25f5daca7109dc963da87294cd1b5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2512428",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/kmod#36aca425e7d25f5daca7109dc963da87294cd1b5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libssh",
+      "purl": "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=aarch64",
+      "version": "0.10.4-13.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35756743d06f7dc2fde2d65495ae0d4866011d1b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3866387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "net/textproto",
+      "purl": "pkg:golang/net/textproto@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/textproto@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=5804e51cbc6df18a",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "util-linux",
+      "purl": "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/kubevirt",
+      "purl": "pkg:golang/kubevirt.io/kubevirt",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/kubevirt?package-id=62dfaac137453ac8",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=c9e73a9ce3fca441",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=ebbb976b0b9a6691",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=ed2a22c702bae008",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=3f70c1e082cb9132",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/sys",
+      "purl": "pkg:golang/runtime/internal/sys@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/sys@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "setuptools",
+      "purl": "pkg:pypi/setuptools@53.0.0",
+      "type": "library",
+      "author": "Python Packaging Authority <distutils-sig@python.org>",
+      "bom-ref": "pkg:pypi/setuptools@53.0.0",
+      "version": "53.0.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "UNKNOWN"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/setuptools-53.0.0.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "dbus-libs",
+      "purl": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=aarch64&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiserver",
+      "purl": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiserver@v0.30.0?package-id=46f0784d88e673c3",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubernetes-csi/external-snapshotter/client/v4",
+      "purl": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=c379c7237a34dcc0#client/v4",
+      "version": "v4.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=7338c535d9c880a0#v22",
+      "version": "v22.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "encoding/pem",
+      "purl": "pkg:golang/encoding/pem@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/pem@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:oci/virt-handler-rhel9@sha256%3A19351b7583cc2b23b6aed869a1969a23be9ecdc32d46ffc05b480750ba113118?arch=arm64&os=linux&tag=v4.17.36-3",
+      "dependsOn": [
+        "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=aarch64",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+        "pkg:golang/./staging/src#kubevirt.io/client-go",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=b6c9d8ea55ec3898",
+        "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+        "pkg:golang/time@go1.22.12",
+        "pkg:pypi/dbus-python@1.2.18",
+        "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+        "pkg:golang/internal/types/errors@go1.22.12",
+        "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+        "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+        "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=aarch64",
+        "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=aarch64",
+        "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+        "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=aarch64",
+        "pkg:golang/k8s.io/kubectl@v0.30.0",
+        "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+        "pkg:golang/internal/godebug@go1.22.12",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=aarch64",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+        "pkg:pypi/python-dateutil@2.8.1",
+        "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=aarch64",
+        "pkg:rpm/redhat/libuser@0.63-13.el9?arch=aarch64",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b7c26aaef6d1c9b7",
+        "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+        "pkg:golang/kubevirt.io/client-go",
+        "pkg:golang/./staging/src#github.com/golang/glog",
+        "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=aarch64",
+        "pkg:golang/golang.org/x/sync@v0.11.0",
+        "pkg:golang/crypto/hmac@go1.22.12",
+        "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+        "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=aarch64",
+        "pkg:golang/internal/goarch@go1.22.12",
+        "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+        "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+        "pkg:golang/math/rand@go1.22.12",
+        "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+        "pkg:pypi/pyinotify@0.9.6",
+        "pkg:golang/internal/saferio@go1.22.12",
+        "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0",
+        "pkg:golang/unsafe@go1.22.12",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+        "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=aarch64",
+        "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=aarch64",
+        "pkg:golang/crypto/ed25519@go1.22.12",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/net/rpc@go1.22.12",
+        "pkg:golang/bufio@go1.22.12",
+        "pkg:golang/internal/nettrace@go1.22.12",
+        "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0?package-id=6f1e377d494cf9f5",
+        "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+        "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=aarch64",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+        "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=aarch64",
+        "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+        "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=aarch64",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1",
+        "pkg:golang/github.com/moby/spdystream@v0.2.0",
+        "pkg:golang/github.com/containers/common@v0.50.1",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+        "pkg:golang/runtime/pprof@go1.22.12",
+        "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=aarch64",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=05e9b8a9427d6786",
+        "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=aarch64",
+        "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=aarch64&epoch=2",
+        "pkg:golang/encoding@go1.22.12",
+        "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+        "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=aarch64",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=f63f44519d8bc924",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+        "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+        "pkg:golang/crypto/x509/pkix@go1.22.12",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+        "pkg:golang/runtime/trace@go1.22.12",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=f970a3d674d44626",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+        "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=aarch64",
+        "pkg:golang/github.com/containernetworking/plugins@v1.1.1?package-id=599ab3f3550112ac",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=9b8e9f9b128703ca",
+        "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=aarch64",
+        "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+        "pkg:golang/net/netip@go1.22.12",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0",
+        "pkg:golang/k8s.io/code-generator@v0.30.0",
+        "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/stdlib@1.22.12",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+        "pkg:golang/github.com/go-kit/kit@v0.13.0",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=18734635491c2975",
+        "pkg:golang/k8s.io/client-go@v0.30.0",
+        "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+        "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+        "pkg:golang/github.com/go-kit/kit@v0.9.0",
+        "pkg:golang/sync/atomic@go1.22.12",
+        "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+        "pkg:golang/crypto/internal/nistec@go1.22.12",
+        "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=aarch64",
+        "pkg:golang/database/sql/driver@go1.22.12",
+        "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+        "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+        "pkg:golang/reflect@go1.22.12",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=aarch64",
+        "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+        "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=aarch64",
+        "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=aarch64",
+        "pkg:golang/github.com/moby/sys@v0.6.2?package-id=aeac65a548510a6a#mountinfo",
+        "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+        "pkg:golang/math/bits@go1.22.12",
+        "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+        "pkg:golang/encoding/xml@go1.22.12",
+        "pkg:golang/github.com/google/gnostic@v0.5.7",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/internal/chacha8rand@go1.22.12",
+        "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+        "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:pypi/pygobject@3.40.1",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/go/ast@go1.22.12",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+        "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=aarch64",
+        "pkg:golang/github.com/prometheus/common@v0.44.0",
+        "pkg:golang/k8s.io/node-api@v0.30.0",
+        "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=aarch64",
+        "pkg:pypi/rpm@4.16.1.3",
+        "pkg:golang/syscall@go1.22.12",
+        "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+        "pkg:golang/github.com/golang/protobuf@v1.5.3",
+        "pkg:golang/github.com/google/uuid@v1.3.1",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+        "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+        "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+        "pkg:golang/github.com/imdario/mergo@v0.3.16",
+        "pkg:golang/internal/oserror@go1.22.12",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=aarch64",
+        "pkg:golang/crypto/ecdh@go1.22.12",
+        "pkg:golang/compress/bzip2@go1.22.12",
+        "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+        "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+        "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=aarch64&epoch=1",
+        "pkg:golang/net/http/internal@go1.22.12",
+        "pkg:golang/golang.org/x/text@v0.22.0",
+        "pkg:golang/compress/zlib@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+        "pkg:golang/github.com/google/uuid@v1.3.0",
+        "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+        "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=aarch64",
+        "pkg:golang/crypto/elliptic@go1.22.12",
+        "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/internal/godebugs@go1.22.12",
+        "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+        "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+        "pkg:golang/github.com/golang/glog",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0",
+        "pkg:golang/internal/buildcfg@go1.22.12",
+        "pkg:golang/os@go1.22.12",
+        "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+        "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+        "pkg:golang/internal/bytealg@go1.22.12",
+        "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+        "pkg:golang/net/url@go1.22.12",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+        "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+        "pkg:golang/golang.org/x/term@v0.29.0",
+        "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+        "pkg:golang/golang.org/x/time@v0.3.0",
+        "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+        "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=aarch64&epoch=1",
+        "pkg:golang/flag@go1.22.12",
+        "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+        "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+        "pkg:golang/go/token@go1.22.12",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+        "pkg:golang/compress/flate@go1.22.12",
+        "pkg:golang/go/build@go1.22.12",
+        "pkg:golang/kubevirt.io/api",
+        "pkg:golang/github.com/spf13/cobra@v1.7.0",
+        "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+        "pkg:golang/internal/platform@go1.22.12",
+        "pkg:golang/golang.org/x/net@v0.33.0",
+        "pkg:golang/crypto/internal/randutil@go1.22.12",
+        "pkg:rpm/redhat/which@2.21-29.el9?arch=aarch64",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=aec23c0e1d75ee8a",
+        "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=aarch64",
+        "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=aarch64",
+        "pkg:golang/github.com/prometheus/common@v0.44.0?package-id=3a5f710d384a3dd9",
+        "pkg:golang/html@go1.22.12",
+        "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=64880854c531d875",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=b024122f6e41d561",
+        "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=aarch64",
+        "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=aarch64",
+        "pkg:golang/internal/goos@go1.22.12",
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+        "pkg:golang/encoding/gob@go1.22.12",
+        "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+        "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=aarch64",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=3f115ef0cb31e7b8",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+        "pkg:golang/internal/fmtsort@go1.22.12",
+        "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+        "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+        "pkg:golang/slices@go1.22.12",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=8c45f6a8d1cca06d",
+        "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+        "pkg:golang/crypto/aes@go1.22.12",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+        "pkg:golang/golang.org/x/sys@v0.30.0",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=aarch64",
+        "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+        "pkg:pypi/libcomps@0.1.18",
+        "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=aarch64",
+        "pkg:golang/strconv@go1.22.12",
+        "pkg:golang/bytes@go1.22.12",
+        "pkg:golang/crypto/sha256@go1.22.12",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=ff4b8706a44511d7",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=45b68313e6b7649d",
+        "pkg:golang/io@go1.22.12",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=2ccbb81b4bfbf67e",
+        "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=97ce01b8d036cd18",
+        "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+        "pkg:golang/github.com/go-logr/logr@v0.2.1",
+        "pkg:pypi/iniparse@0.4",
+        "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=aarch64",
+        "pkg:golang/github.com/go-task/slim-sprig@v3.0.0?package-id=c5265481edb963f4#v3",
+        "pkg:rpm/redhat/libxml2@2.9.13-13.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=aarch64",
+        "pkg:golang/crypto/cipher@go1.22.12",
+        "pkg:golang/debug/elf@go1.22.12",
+        "pkg:golang/crypto/rsa@go1.22.12",
+        "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+        "pkg:golang/k8s.io/metrics@v0.30.0",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+        "pkg:golang/container/heap@go1.22.12",
+        "pkg:golang/mime/multipart@go1.22.12",
+        "pkg:golang/mime/quotedprintable@go1.22.12",
+        "pkg:golang/crypto/internal/alias@go1.22.12",
+        "pkg:golang/encoding/hex@go1.22.12",
+        "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4",
+        "pkg:golang/google.golang.org/appengine@v1.6.8",
+        "pkg:golang/internal/abi@go1.22.12",
+        "pkg:golang/golang.org/x/term@v0.29.0?package-id=6367701eacddef15",
+        "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=aarch64&epoch=2",
+        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1",
+        "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=7f71bb3211c40e1e",
+        "pkg:golang/go/parser@go1.22.12",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+        "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=aarch64",
+        "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e5133fb001ac7926",
+        "pkg:golang/github.com/pkg/errors@v0.9.1",
+        "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=aarch64",
+        "pkg:golang/image/color@go1.22.12",
+        "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=aarch64",
+        "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+        "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=aarch64&epoch=1",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+        "pkg:golang/context@go1.22.12",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=06ba511a601e36d7",
+        "pkg:golang/net/http/internal/ascii@go1.22.12",
+        "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=aarch64",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=874d616b5ffd59b7",
+        "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+        "pkg:golang/golang.org/x/text@v0.22.0?package-id=b0628cbb477d7801",
+        "pkg:pypi/chardet@4.0.0",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d6c72ae7c47adf6d",
+        "pkg:golang/cmp@go1.22.12",
+        "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+        "pkg:golang/internal/syscall/unix@go1.22.12",
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=aarch64",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+        "pkg:golang/golang.org/x/net@v0.24.0",
+        "pkg:golang/internal/unsafeheader@go1.22.12",
+        "pkg:golang/path@go1.22.12",
+        "pkg:golang/golang.org/x/net@v0.33.0?package-id=cb71f9386c7676b0",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+        "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=aarch64",
+        "pkg:golang/math@go1.22.12",
+        "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=aarch64",
+        "pkg:golang/internal/cpu@go1.22.12",
+        "pkg:golang/fmt@go1.22.12",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=aarch64",
+        "pkg:golang/k8s.io/klog@v0.4.0",
+        "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=723cf855d020f756",
+        "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=aarch64",
+        "pkg:golang/go/doc@go1.22.12",
+        "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=aarch64",
+        "pkg:golang/embed@go1.22.12",
+        "pkg:golang/internal/lazyregexp@go1.22.12",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=3d1a8018c3d8d52a",
+        "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=aarch64",
+        "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+        "pkg:golang/path/filepath@go1.22.12",
+        "pkg:golang/github.com/spf13/cobra@v1.7.0?package-id=ddac4fa55f03e408",
+        "pkg:golang/internal/singleflight@go1.22.12",
+        "pkg:golang/k8s.io/client-go@v0.30.0?package-id=7209f81d42d9fb42",
+        "pkg:golang/golang.org/x/time@v0.3.0?package-id=c63cc068a81d5b95",
+        "pkg:golang/log/slog@go1.22.12",
+        "pkg:golang/debug/dwarf@go1.22.12",
+        "pkg:golang/kubevirt.io/api?package-id=8271ccebef8c7fbf",
+        "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=aarch64",
+        "pkg:golang/k8s.io/component-base@v0.30.0",
+        "pkg:golang/golang.org/x/term@v0.19.0",
+        "pkg:golang/image@go1.22.12",
+        "pkg:golang/hash/crc32@go1.22.12",
+        "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=aarch64",
+        "pkg:pypi/decorator@4.4.2",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=aarch64",
+        "pkg:golang/os/exec@go1.22.12",
+        "pkg:golang/github.com/golang/glog@v1.1.0",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=44dea5fe0373ffc7",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=aarch64",
+        "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=aarch64",
+        "pkg:golang/google.golang.org/grpc@v1.58.3",
+        "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+        "pkg:golang/k8s.io/apiserver@v0.30.0",
+        "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+        "pkg:golang/crypto/sha512@go1.22.12",
+        "pkg:golang/k8s.io/node-api@v0.30.0?package-id=69b6b0afb2bc8383",
+        "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=aarch64",
+        "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+        "pkg:golang/hash/fnv@go1.22.12",
+        "pkg:golang/go/scanner@go1.22.12",
+        "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=aarch64",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=5af92f389a804379",
+        "pkg:golang/internal/testlog@go1.22.12",
+        "pkg:golang/k8s.io/kubelet@v0.30.0",
+        "pkg:golang/text/template@go1.22.12",
+        "pkg:golang/compress/gzip@go1.22.12",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=64a952cc8f95048c",
+        "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=aarch64",
+        "pkg:golang/k8s.io/klog@v0.3.3",
+        "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=aarch64",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=211a5c0c1a7524b9",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=42ecb449d13ca189",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=aarch64",
+        "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492?package-id=fb57a5f09377d6b1",
+        "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=aarch64",
+        "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=aarch64",
+        "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=aarch64",
+        "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=aarch64",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=c251c2070b6d837f",
+        "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+        "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=a3f45ccc2eaef8aa",
+        "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=aarch64",
+        "pkg:golang/k8s.io/sample-controller@v0.30.0",
+        "pkg:golang/encoding/binary@go1.22.12",
+        "pkg:golang/crypto/ecdsa@go1.22.12",
+        "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=75bca8ba1ca22c9b",
+        "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=45a8c7aac0e298e2#client/v4",
+        "pkg:golang/internal/poll@go1.22.12",
+        "pkg:golang/github.com/imdario/mergo@v0.3.15",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=b5d6576591ff84ae",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=1a97d0dde17253ca",
+        "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e519b37240b7b6af",
+        "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=aarch64",
+        "pkg:golang/io/fs@go1.22.12",
+        "pkg:golang/golang.org/x/net@v0.23.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=0c548e794e085974",
+        "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+        "pkg:golang/github.com/go-kit/log@v0.2.1",
+        "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=aarch64",
+        "pkg:golang/kubevirt.io/kubevirt",
+        "pkg:golang/k8s.io/klog@v0.4.0?package-id=a6cf3f8305ce0756",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=f72df465d2f4ba73",
+        "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=92cbc10610ba936e",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=4f70a6c87f97190b",
+        "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=aarch64",
+        "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=aarch64",
+        "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+        "pkg:golang/internal/safefilepath@go1.22.12",
+        "pkg:golang/k8s.io/api@v0.30.0",
+        "pkg:golang/k8s.io/client-go@v0.30.0?package-id=dc0ee049f53c27e7",
+        "pkg:golang/crypto/md5@go1.22.12",
+        "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=aarch64",
+        "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=aarch64",
+        "pkg:golang/log/slog/internal/buffer@go1.22.12",
+        "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+        "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+        "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=6bfd33acc02b178b",
+        "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=aarch64",
+        "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+        "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=aarch64",
+        "pkg:golang/sync@go1.22.12",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=aarch64",
+        "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=aarch64",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=c91ff645d6ce8388",
+        "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=aarch64",
+        "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=aarch64&epoch=2",
+        "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=aarch64",
+        "pkg:golang/github.com/beorn7/perks@v1.0.1",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=7b9209a64c9c952b",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=2e766a71ac55c8c1",
+        "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+        "pkg:golang/net/http/httputil@go1.22.12",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=264ee8e18d5b5c8a",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+        "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+        "pkg:golang/github.com/go-stack/stack@v1.8.0",
+        "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=aarch64",
+        "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+        "pkg:golang/internal/goexperiment@go1.22.12",
+        "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=647cefa32ef8dbed",
+        "pkg:golang/internal/sysinfo@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+        "pkg:golang/github.com/google/uuid@v1.1.5",
+        "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+        "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=aarch64",
+        "pkg:golang/k8s.io/cli-runtime@v0.30.0?package-id=372a4fd9b7953904",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=bcb125b3ee0ac2bf",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=aarch64",
+        "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=aarch64",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=aarch64",
+        "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=aarch64",
+        "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+        "pkg:golang/github.com/prometheus/procfs@v0.11.0?package-id=53509fccb635cdaf",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+        "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=aarch64",
+        "pkg:golang/text/template/parse@go1.22.12",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+        "pkg:golang/golang.org/x/text@v0.14.0",
+        "pkg:golang/k8s.io/cloud-provider@v0.30.0?package-id=213905a8e9bf9bca",
+        "pkg:golang/go/version@go1.22.12",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=fd55bfb7c4801b59",
+        "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+        "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+        "pkg:golang/golang.org/x/sync@v0.11.0?package-id=d30348b75bd8dbbe",
+        "pkg:golang/github.com/josharian/intern@v1.0.0",
+        "pkg:golang/k8s.io/kubelet@v0.30.0?package-id=0d174a34ad4bac4b",
+        "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=b4f2daad5b1d001e#pkg/apis/monitoring",
+        "pkg:golang/go/types@go1.22.12",
+        "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=aarch64",
+        "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+        "pkg:golang/hash/adler32@go1.22.12",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=777844465b60ad81",
+        "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+        "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+        "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=aarch64",
+        "pkg:golang/runtime/internal/syscall@go1.22.12",
+        "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+        "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=7349fb61f86b922a",
+        "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=4b04ea23556ed395",
+        "pkg:golang/github.com/prometheus/client_model@v0.4.0?package-id=ecb7f6c81f243c3b",
+        "pkg:golang/regexp@go1.22.12",
+        "pkg:golang/maps@go1.22.12",
+        "pkg:golang/net@go1.22.12",
+        "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=e0646f8826c197e7",
+        "pkg:golang/encoding/csv@go1.22.12",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=9cb7e0ef1a4f0772",
+        "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=aarch64",
+        "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+        "pkg:golang/os/signal@go1.22.12",
+        "pkg:golang/net/mail@go1.22.12",
+        "pkg:golang/internal/goroot@go1.22.12",
+        "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+        "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=e0fc581ee7f4ac53",
+        "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+        "pkg:golang/strings@go1.22.12",
+        "pkg:golang/go/build/constraint@go1.22.12",
+        "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=aarch64",
+        "pkg:golang/os/user@go1.22.12",
+        "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+        "pkg:golang/crypto/dsa@go1.22.12",
+        "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=aarch64",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=b1e90c3e1ac1f792",
+        "pkg:golang/net/http/httptrace@go1.22.12",
+        "pkg:golang/kubevirt.io/client-go@v0.19.0",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=d49025084db5e534",
+        "pkg:golang/log/slog/internal@go1.22.12",
+        "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+        "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=30a0f7618c550bd4",
+        "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+        "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a?package-id=f5ed66e6e2ff252b",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+        "pkg:pypi/pysocks@1.7.1",
+        "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+        "pkg:golang/crypto/x509@go1.22.12",
+        "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4?package-id=3ef7d310780b1738",
+        "pkg:golang/go/printer@go1.22.12",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=d8c2f26e9986efc0",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=875c60b36880d488",
+        "pkg:golang/golang.org/x/sys@v0.19.0",
+        "pkg:golang/go/constant@go1.22.12",
+        "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=56fa540c52a6e225",
+        "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+        "pkg:golang/github.com/beorn7/perks@v1.0.1?package-id=d6fd5b144cc18be1",
+        "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+        "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=aarch64",
+        "pkg:golang/crypto/internal/boring@go1.22.12",
+        "pkg:golang/./staging/src#kubevirt.io/api",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c?package-id=6c31ceb0e3238027",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=c27f4e3f0f288cba",
+        "pkg:pypi/urllib3@1.26.5",
+        "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+        "pkg:golang/internal/itoa@go1.22.12",
+        "pkg:golang/golang.org/x/oauth2@v0.12.0",
+        "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=aarch64",
+        "pkg:golang/internal/zstd@go1.22.12",
+        "pkg:golang/net/http/httptest@go1.22.12",
+        "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+        "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+        "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+        "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=aarch64",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=426c1ef83fb90a34",
+        "pkg:golang/crypto@go1.22.12",
+        "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/encoding/base64@go1.22.12",
+        "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=4947e27687df8894",
+        "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=b5787214009aa9c8",
+        "pkg:golang/crypto/des@go1.22.12",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=cdc588c277efc41e",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=ea627eb359d3ebbf",
+        "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=61ff33db308e1c87",
+        "pkg:golang/github.com/google/go-querystring@v1.0.0",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=6b3967bbe5e4f770#v3",
+        "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=aarch64",
+        "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+        "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414?package-id=1f03719fd30cb426",
+        "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+        "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=aarch64",
+        "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+        "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0?package-id=85656f3ce4c495dd",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=392c78985b3ee866",
+        "pkg:pypi/requests@2.25.1",
+        "pkg:golang/golang.org/x/text@v0.14.0?package-id=a47e6c64839baca0",
+        "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=aarch64",
+        "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+        "pkg:golang/golang.org/x/time@v0.3.0?package-id=de8b89d7a225278d",
+        "pkg:pypi/subscription-manager@1.29.40.1",
+        "pkg:golang/k8s.io/kube-scheduler@v0.30.0?package-id=c6f4b38d0e64a871",
+        "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=aarch64",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=617dda993ef91b06",
+        "pkg:golang/crypto/sha1@go1.22.12",
+        "pkg:golang/crypto/tls@go1.22.12",
+        "pkg:golang/k8s.io/sample-apiserver@v0.30.0?package-id=a7d282fdf5bcfc3a",
+        "pkg:golang/mime@go1.22.12",
+        "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+        "pkg:golang/net/http@go1.22.12",
+        "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8?package-id=5324f65a18aa4075",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=7fd9e721114377fd",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=e91ba32bfe0dcfe9",
+        "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=82dbb4bd95c1a6af",
+        "pkg:golang/log@go1.22.12",
+        "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=aarch64",
+        "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+        "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+        "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+        "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+        "pkg:golang/runtime/metrics@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=bd15d762c1c6c3a1",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=5b48db5542316992",
+        "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=aarch64&epoch=1",
+        "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+        "pkg:golang/stdlib@1.22.12?package-id=0263aa6b4909132a",
+        "pkg:golang/unicode/utf16@go1.22.12",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=e5f84b4525280ceb",
+        "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=a40b75a240613ee9#v5",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=ef4b943e758b9b6b",
+        "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+        "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+        "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=1651c6ba29f925e5",
+        "pkg:golang/github.com/golang/mock@v1.6.0",
+        "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=3cfe059b9c8f0896",
+        "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+        "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+        "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=aarch64&epoch=1",
+        "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=aarch64",
+        "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+        "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=aarch64&epoch=2",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=3a7a3480e12ba94a",
+        "pkg:rpm/redhat/gzip@1.12-1.el9?arch=aarch64",
+        "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0?package-id=7c0f2e47ca097803",
+        "pkg:golang/internal/intern@go1.22.12",
+        "pkg:golang/errors@go1.22.12",
+        "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4ca57bd69d22480b",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=79287922c4530134",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=6d74791bcbcea4ec",
+        "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=aarch64",
+        "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+        "pkg:golang/hash@go1.22.12",
+        "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=a8fb70acf7ce028c",
+        "pkg:golang/github.com/golang/mock@v1.6.0?package-id=58fd55d3a3e68d9a",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=812518b1d5de5b6b",
+        "pkg:golang/github.com/fatih/color@v1.13.0",
+        "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=44034bb305ad6df8#v5",
+        "pkg:golang/k8s.io/csi-translation-lib@v0.30.0?package-id=e493ecdd6cef073d",
+        "pkg:pypi/idna@2.10",
+        "pkg:golang/image/internal/imageutil@go1.22.12",
+        "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0?package-id=b57f2d304a79c9d2",
+        "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+        "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=0cf48c7c4e0c2225",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=5f3161d14fb9986b",
+        "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+        "pkg:golang/k8s.io/api@v0.30.0?package-id=9cd65210b34ae131",
+        "pkg:golang/container/list@go1.22.12",
+        "pkg:golang/github.com/onsi/gomega@v1.33.1",
+        "pkg:golang/container/ring@go1.22.12",
+        "pkg:golang/unicode@go1.22.12",
+        "pkg:golang/runtime@go1.22.12",
+        "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=aarch64",
+        "pkg:pypi/systemd-python@234",
+        "pkg:golang/image/png@go1.22.12",
+        "pkg:golang/github.com/google/btree@v1.1.3",
+        "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+        "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=aarch64",
+        "pkg:golang/k8s.io/code-generator@v0.30.0?package-id=c9d95bf42170291b",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=fa2fc500853b500e",
+        "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=aarch64",
+        "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=aarch64",
+        "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+        "pkg:golang/go/doc/comment@go1.22.12",
+        "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+        "pkg:golang/runtime/internal/math@go1.22.12",
+        "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=38f081dbc5ce4d6a",
+        "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b?package-id=1264b58e962ebcac",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=317d26dbf41e923a",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=20f072e6e3225e24",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=b026cc4209959195",
+        "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=aarch64",
+        "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=58a2f3ed700462d3",
+        "pkg:golang/regexp/syntax@go1.22.12",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=a0115c013e649a4c",
+        "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible?package-id=15ebdd24a0c721e7",
+        "pkg:rpm/redhat/passwd@0.80-12.el9?arch=aarch64",
+        "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=aarch64",
+        "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+        "pkg:golang/internal/race@go1.22.12",
+        "pkg:golang/github.com/prometheus/client_golang@v1.16.0?package-id=802b60ddf07e5522",
+        "pkg:golang/internal/goversion@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+        "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=d183acc87e1fa62e",
+        "pkg:golang/github.com/google/btree@v1.1.3?package-id=2655799dd02f4564",
+        "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=aarch64",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=87c0cbf8954e0580",
+        "pkg:golang/crypto/rc4@go1.22.12",
+        "pkg:golang/k8s.io/cri-api@v0.30.0",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=aabc29983e2a9841",
+        "pkg:golang/k8s.io/kube-controller-manager@v0.30.0?package-id=0814f25a8e4531ce",
+        "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4bf18231eac48ba4",
+        "pkg:golang/encoding/base32@go1.22.12",
+        "pkg:golang/text/tabwriter@go1.22.12",
+        "pkg:golang/k8s.io/cri-api@v0.30.0?package-id=4de173f6a5765211",
+        "pkg:golang/k8s.io/component-base@v0.30.0?package-id=94800364440cc1a6",
+        "pkg:golang/image/jpeg@go1.22.12",
+        "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=aarch64",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=a1ff2ebea07a529d",
+        "pkg:golang/github.com/josharian/native@v1.1.0",
+        "pkg:golang/internal/coverage/rtcov@go1.22.12",
+        "pkg:rpm/redhat/usermode@1.114-4.el9?arch=aarch64",
+        "pkg:pypi/gpg@1.15.1",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=406cd2654be0fcc8",
+        "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=aarch64",
+        "pkg:golang/golang.org/x/sys@v0.30.0?package-id=8899651b157fa55b",
+        "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=34e50fc47ddb109c",
+        "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+        "pkg:golang/k8s.io/metrics@v0.30.0?package-id=e5a9c757e0ba76d0",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=bd9cfde5eb7d49da",
+        "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+        "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=a6a4677db3654d87",
+        "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=41c9ffe89c4328dd#pkg/apis/monitoring",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e87736d4223a3553",
+        "pkg:golang/internal/gover@go1.22.12",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=077b67d110fda982",
+        "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+        "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=332ab3a9d173ca98",
+        "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=aarch64",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=d3adc2bc60fefccb",
+        "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=2f055f6cdf8e3fb1",
+        "pkg:rpm/redhat/npth@1.6-8.el9?arch=aarch64",
+        "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=747804ed972e87a1",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6?package-id=0bc6f5896c6cb1a9",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=9de2c8dc0803d74e",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=2e7c033a75be1ef6",
+        "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=8256c45ca06407ab",
+        "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+        "pkg:rpm/redhat/jansson@2.14-1.el9?arch=aarch64",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b135113b0301cc3e",
+        "pkg:golang/math/big@go1.22.12",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=5df1a932dc364fae",
+        "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+        "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+        "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=49b478fdfd04f997",
+        "pkg:rpm/redhat/expat@2.5.0-2.el9_4.3?arch=aarch64",
+        "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=aarch64&epoch=1",
+        "pkg:golang/github.com/moby/sys@v0.6.2?package-id=2f1b091e7ebc59e5#mountinfo",
+        "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=aarch64",
+        "pkg:golang/internal/syscall/execenv@go1.22.12",
+        "pkg:golang/github.com/cespare/xxhash@v2.2.0?package-id=ff6ddf5ac62bb415#v2",
+        "pkg:golang/golang.org/x/tools@v0.20.0",
+        "pkg:golang/k8s.io/kube-proxy@v0.30.0?package-id=da08354393870645",
+        "pkg:golang/runtime/internal/atomic@go1.22.12",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=14c598a63cb5e9db",
+        "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=aarch64",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=0f468cc3892f0124",
+        "pkg:rpm/redhat/json-c@0.14-11.el9?arch=aarch64",
+        "pkg:golang/crypto/subtle@go1.22.12",
+        "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=aarch64",
+        "pkg:golang/github.com/josharian/native@v1.1.0?package-id=6604c5cd4c4748cf",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=14c57ecad0b43747",
+        "pkg:golang/golang.org/x/sys@v0.30.0?package-id=db67540c07b5beb9",
+        "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=db815b5d0b61f513",
+        "pkg:golang/github.com/go-stack/stack@v1.8.0?package-id=48631dee752774c6",
+        "pkg:golang/internal/bisect@go1.22.12",
+        "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=71cd8ab004151c77",
+        "pkg:golang/go/internal/typeparams@go1.22.12",
+        "pkg:golang/testing@go1.22.12",
+        "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+        "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=aarch64",
+        "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+        "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=aarch64",
+        "pkg:golang/io/ioutil@go1.22.12",
+        "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+        "pkg:golang/k8s.io/api@v0.30.0?package-id=077a5e8ca27fa924",
+        "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=aarch64",
+        "pkg:golang/html/template@go1.22.12",
+        "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923?package-id=a98cba5ae186c4f5",
+        "pkg:golang/github.com/golang/mock@v1.6.0?package-id=c774b777664a4bb0",
+        "pkg:golang/github.com/containers/common@v0.50.1?package-id=e36d1d0f2ba91772",
+        "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+        "pkg:golang/runtime/debug@go1.22.12",
+        "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=c3d9773d12fa39a7",
+        "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+        "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=429112dfb9428aeb",
+        "pkg:golang/github.com/pierrec/lz4@v4.1.15?package-id=8f6dd5f7ba6a62ec#v4",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=6619c43cfd07c933",
+        "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+        "pkg:golang/net/http/internal/testcert@go1.22.12",
+        "pkg:golang/github.com/pborman/uuid@v1.2.1",
+        "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=5ce12f7eaebfe865",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=2510cbce9c179e69",
+        "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=aarch64",
+        "pkg:golang/encoding/json@go1.22.12",
+        "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=aarch64",
+        "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+        "pkg:golang/internal/reflectlite@go1.22.12",
+        "pkg:golang/crypto/internal/bigmod@go1.22.12",
+        "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+        "pkg:golang/k8s.io/sample-controller@v0.30.0?package-id=95847fe4258b57c0",
+        "pkg:golang/crypto/rand@go1.22.12",
+        "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=aarch64",
+        "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d?package-id=454c35570125ce2f#rpc",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=f4fcb5b06080adbf",
+        "pkg:golang/github.com/onsi/ginkgo@v2.17.2?package-id=709ca981edc6d5d6#v2",
+        "pkg:golang/golang.org/x/mod@v0.17.0",
+        "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=aarch64",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=fd7558abcd37e57d",
+        "pkg:golang/k8s.io/api@v0.30.0?package-id=dd84eb4f391fe51e",
+        "pkg:golang/unicode/utf8@go1.22.12",
+        "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=aarch64",
+        "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=1663864887e439eb",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=f1bc226b87c469d8",
+        "pkg:golang/encoding/asn1@go1.22.12",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=5eee73adffd25455",
+        "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=aarch64",
+        "pkg:golang/sort@go1.22.12",
+        "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=aarch64",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=f951095dca4572e3",
+        "pkg:golang/archive/tar@go1.22.12",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=3bccae874729638f",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=892f25b58ba2cadb",
+        "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=aarch64",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=3cee09b2c9d8346a",
+        "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=aarch64",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=a8276711fb26ec2c#v3",
+        "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=aarch64",
+        "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20?package-id=ce832bdd3e643f49",
+        "pkg:pypi/six@1.15.0",
+        "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+        "pkg:golang/log/internal@go1.22.12",
+        "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+        "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=aarch64",
+        "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=aarch64",
+        "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+        "pkg:golang/expvar@go1.22.12",
+        "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=aarch64",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=67a13c4d057a96fd#v22",
+        "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+        "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=aarch64",
+        "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=aarch64",
+        "pkg:golang/net/textproto@go1.22.12",
+        "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=5804e51cbc6df18a",
+        "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=aarch64",
+        "pkg:golang/kubevirt.io/kubevirt?package-id=62dfaac137453ac8",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=c9e73a9ce3fca441",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=ebbb976b0b9a6691",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=ed2a22c702bae008",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=3f70c1e082cb9132",
+        "pkg:golang/runtime/internal/sys@go1.22.12",
+        "pkg:pypi/setuptools@53.0.0",
+        "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=aarch64&epoch=1",
+        "pkg:golang/k8s.io/apiserver@v0.30.0?package-id=46f0784d88e673c3",
+        "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=c379c7237a34dcc0#client/v4",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=7338c535d9c880a0#v22",
+        "pkg:golang/encoding/pem@go1.22.12"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/./staging/src#kubevirt.io/client-go",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=b6c9d8ea55ec3898",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/time@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/dbus-python@1.2.18",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/types/errors@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/godebug@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/python-dateutil@2.8.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuser@0.63-13.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b7c26aaef6d1c9b7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/client-go",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/./staging/src#github.com/golang/glog",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/hmac@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goarch@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math/rand@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/pyinotify@0.9.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/saferio@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unsafe@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/ed25519@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/rpc@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/bufio@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/nettrace@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0?package-id=6f1e377d494cf9f5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/common@v0.50.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/pprof@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=05e9b8a9427d6786",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=aarch64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=f63f44519d8bc924",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/x509/pkix@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/trace@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=f970a3d674d44626",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1?package-id=599ab3f3550112ac",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=9b8e9f9b128703ca",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/netip@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/stdlib@1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=18734635491c2975",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.9.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sync/atomic@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/nistec@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/database/sql/driver@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/reflect@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=aeac65a548510a6a#mountinfo",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math/bits@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/xml@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic@v0.5.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/chacha8rand@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/pygobject@3.40.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/ast@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/rpm@4.16.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/syscall@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/oserror@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/ecdh@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/bzip2@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/internal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.22.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/zlib@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/elliptic@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/godebugs@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/glog",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/buildcfg@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/bytealg@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/url@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.29.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/flag@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/token@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/flate@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/build@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/api",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/platform@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.33.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/randutil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/which@2.21-29.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=aec23c0e1d75ee8a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/common@v0.44.0?package-id=3a5f710d384a3dd9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/html@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=64880854c531d875",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=b024122f6e41d561",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goos@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/gob@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=3f115ef0cb31e7b8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/fmtsort@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/slices@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=8c45f6a8d1cca06d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/aes@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/libcomps@0.1.18",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/strconv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/bytes@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/sha256@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=ff4b8706a44511d7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=45b68313e6b7649d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/io@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=2ccbb81b4bfbf67e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=97ce01b8d036cd18",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v0.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/iniparse@0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0?package-id=c5265481edb963f4#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxml2@2.9.13-13.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/cipher@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/debug/elf@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/rsa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/container/heap@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mime/multipart@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mime/quotedprintable@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/alias@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/hex@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/abi@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.29.0?package-id=6367701eacddef15",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=aarch64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=7f71bb3211c40e1e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/parser@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e5133fb001ac7926",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/color@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/context@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=06ba511a601e36d7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/internal/ascii@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=874d616b5ffd59b7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.22.0?package-id=b0628cbb477d7801",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/chardet@4.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d6c72ae7c47adf6d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/cmp@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/syscall/unix@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.24.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/unsafeheader@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/path@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.33.0?package-id=cb71f9386c7676b0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/cpu@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/fmt@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog@v0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=723cf855d020f756",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/doc@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/embed@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/lazyregexp@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=3d1a8018c3d8d52a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/path/filepath@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cobra@v1.7.0?package-id=ddac4fa55f03e408",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/singleflight@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=7209f81d42d9fb42",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=c63cc068a81d5b95",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/slog@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/debug/dwarf@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/api?package-id=8271ccebef8c7fbf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash/crc32@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/decorator@4.4.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os/exec@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/glog@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=44dea5fe0373ffc7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/sha512@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/node-api@v0.30.0?package-id=69b6b0afb2bc8383",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash/fnv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/scanner@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=5af92f389a804379",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/testlog@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/text/template@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/gzip@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=64a952cc8f95048c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog@v0.3.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=211a5c0c1a7524b9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=42ecb449d13ca189",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492?package-id=fb57a5f09377d6b1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=c251c2070b6d837f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=a3f45ccc2eaef8aa",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/binary@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/ecdsa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=75bca8ba1ca22c9b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=45a8c7aac0e298e2#client/v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/poll@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.15",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=b5d6576591ff84ae",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=1a97d0dde17253ca",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e519b37240b7b6af",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/io/fs@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.23.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=0c548e794e085974",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/kubevirt",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog@v0.4.0?package-id=a6cf3f8305ce0756",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=f72df465d2f4ba73",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=92cbc10610ba936e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=4f70a6c87f97190b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/safefilepath@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=dc0ee049f53c27e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/md5@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/slog/internal/buffer@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=6bfd33acc02b178b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sync@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=c91ff645d6ce8388",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=aarch64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=7b9209a64c9c952b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=2e766a71ac55c8c1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/httputil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=264ee8e18d5b5c8a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goexperiment@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=647cefa32ef8dbed",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/sysinfo@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.1.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0?package-id=372a4fd9b7953904",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=bcb125b3ee0ac2bf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0?package-id=53509fccb635cdaf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/text/template/parse@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0?package-id=213905a8e9bf9bca",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/version@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=fd55bfb7c4801b59",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.11.0?package-id=d30348b75bd8dbbe",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubelet@v0.30.0?package-id=0d174a34ad4bac4b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=b4f2daad5b1d001e#pkg/apis/monitoring",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/types@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash/adler32@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=777844465b60ad81",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/syscall@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=7349fb61f86b922a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=4b04ea23556ed395",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0?package-id=ecb7f6c81f243c3b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/regexp@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/maps@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=e0646f8826c197e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/csv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=9cb7e0ef1a4f0772",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os/signal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/mail@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goroot@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=e0fc581ee7f4ac53",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/strings@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/build/constraint@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os/user@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/dsa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=b1e90c3e1ac1f792",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/httptrace@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/client-go@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=d49025084db5e534",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/slog/internal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=30a0f7618c550bd4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a?package-id=f5ed66e6e2ff252b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/pysocks@1.7.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/x509@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4?package-id=3ef7d310780b1738",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/printer@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=d8c2f26e9986efc0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=875c60b36880d488",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/constant@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=56fa540c52a6e225",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/beorn7/perks@v1.0.1?package-id=d6fd5b144cc18be1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/boring@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/./staging/src#kubevirt.io/api",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c?package-id=6c31ceb0e3238027",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=c27f4e3f0f288cba",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/urllib3@1.26.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/itoa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/zstd@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/httptest@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=426c1ef83fb90a34",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/base64@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=4947e27687df8894",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=b5787214009aa9c8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/des@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=cdc588c277efc41e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=ea627eb359d3ebbf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=61ff33db308e1c87",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=6b3967bbe5e4f770#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414?package-id=1f03719fd30cb426",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0?package-id=85656f3ce4c495dd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=392c78985b3ee866",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/requests@2.25.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.14.0?package-id=a47e6c64839baca0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=de8b89d7a225278d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/subscription-manager@1.29.40.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0?package-id=c6f4b38d0e64a871",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=617dda993ef91b06",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/sha1@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/tls@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0?package-id=a7d282fdf5bcfc3a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mime@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8?package-id=5324f65a18aa4075",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=7fd9e721114377fd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=e91ba32bfe0dcfe9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=82dbb4bd95c1a6af",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/metrics@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=bd15d762c1c6c3a1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=5b48db5542316992",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/stdlib@1.22.12?package-id=0263aa6b4909132a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unicode/utf16@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=e5f84b4525280ceb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=a40b75a240613ee9#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=ef4b943e758b9b6b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=1651c6ba29f925e5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=3cfe059b9c8f0896",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=aarch64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=3a7a3480e12ba94a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0?package-id=7c0f2e47ca097803",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/intern@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/errors@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4ca57bd69d22480b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=79287922c4530134",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=6d74791bcbcea4ec",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=a8fb70acf7ce028c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=58fd55d3a3e68d9a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=812518b1d5de5b6b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fatih/color@v1.13.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=44034bb305ad6df8#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0?package-id=e493ecdd6cef073d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/idna@2.10",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/internal/imageutil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0?package-id=b57f2d304a79c9d2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=0cf48c7c4e0c2225",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=5f3161d14fb9986b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=9cd65210b34ae131",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/container/list@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/container/ring@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unicode@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/systemd-python@234",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/png@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/btree@v1.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/code-generator@v0.30.0?package-id=c9d95bf42170291b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=fa2fc500853b500e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/doc/comment@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/math@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=38f081dbc5ce4d6a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b?package-id=1264b58e962ebcac",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=317d26dbf41e923a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=20f072e6e3225e24",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=b026cc4209959195",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=58a2f3ed700462d3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/regexp/syntax@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=a0115c013e649a4c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible?package-id=15ebdd24a0c721e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/passwd@0.80-12.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/race@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0?package-id=802b60ddf07e5522",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goversion@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=d183acc87e1fa62e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/btree@v1.1.3?package-id=2655799dd02f4564",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=87c0cbf8954e0580",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/rc4@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=aabc29983e2a9841",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0?package-id=0814f25a8e4531ce",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4bf18231eac48ba4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/base32@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/text/tabwriter@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cri-api@v0.30.0?package-id=4de173f6a5765211",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/component-base@v0.30.0?package-id=94800364440cc1a6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/jpeg@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=a1ff2ebea07a529d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/coverage/rtcov@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/usermode@1.114-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/gpg@1.15.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=406cd2654be0fcc8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=8899651b157fa55b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=34e50fc47ddb109c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/metrics@v0.30.0?package-id=e5a9c757e0ba76d0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=bd9cfde5eb7d49da",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=a6a4677db3654d87",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=41c9ffe89c4328dd#pkg/apis/monitoring",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e87736d4223a3553",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/gover@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=077b67d110fda982",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=332ab3a9d173ca98",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=d3adc2bc60fefccb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=2f055f6cdf8e3fb1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=747804ed972e87a1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6?package-id=0bc6f5896c6cb1a9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=9de2c8dc0803d74e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=2e7c033a75be1ef6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=8256c45ca06407ab",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/jansson@2.14-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b135113b0301cc3e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math/big@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=5df1a932dc364fae",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=49b478fdfd04f997",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/expat@2.5.0-2.el9_4.3?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=2f1b091e7ebc59e5#mountinfo",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/syscall/execenv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0?package-id=ff6ddf5ac62bb415#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0?package-id=da08354393870645",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/atomic@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=14c598a63cb5e9db",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=0f468cc3892f0124",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/subtle@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/native@v1.1.0?package-id=6604c5cd4c4748cf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=14c57ecad0b43747",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=db67540c07b5beb9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=db815b5d0b61f513",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-stack/stack@v1.8.0?package-id=48631dee752774c6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/bisect@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=71cd8ab004151c77",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/internal/typeparams@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/testing@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/io/ioutil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=077a5e8ca27fa924",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/html/template@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923?package-id=a98cba5ae186c4f5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=c774b777664a4bb0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/common@v0.50.1?package-id=e36d1d0f2ba91772",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/debug@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=c3d9773d12fa39a7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=429112dfb9428aeb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15?package-id=8f6dd5f7ba6a62ec#v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=6619c43cfd07c933",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/internal/testcert@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pborman/uuid@v1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=5ce12f7eaebfe865",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=2510cbce9c179e69",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/json@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/reflectlite@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/bigmod@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-controller@v0.30.0?package-id=95847fe4258b57c0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/rand@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d?package-id=454c35570125ce2f#rpc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=f4fcb5b06080adbf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2?package-id=709ca981edc6d5d6#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=fd7558abcd37e57d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=dd84eb4f391fe51e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unicode/utf8@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=1663864887e439eb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=f1bc226b87c469d8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/asn1@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=5eee73adffd25455",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sort@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=f951095dca4572e3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/archive/tar@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=3bccae874729638f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=892f25b58ba2cadb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=3cee09b2c9d8346a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=a8276711fb26ec2c#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20?package-id=ce832bdd3e643f49",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/six@1.15.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/internal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/expvar@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=67a13c4d057a96fd#v22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/textproto@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=5804e51cbc6df18a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/kubevirt?package-id=62dfaac137453ac8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=c9e73a9ce3fca441",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=ebbb976b0b9a6691",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=ed2a22c702bae008",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=3f70c1e082cb9132",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/sys@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/setuptools@53.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiserver@v0.30.0?package-id=46f0784d88e673c3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=c379c7237a34dcc0#client/v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=7338c535d9c880a0#v22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/pem@go1.22.12",
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:79453efa-c924-4c99-aa3a-f88b05b29313"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/latest/binary-2025-12-02-C0CF40B259B1491.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/latest/binary-2025-12-02-C0CF40B259B1491.json
@@ -1,0 +1,26701 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "syft",
+          "type": "application",
+          "author": "anchore",
+          "version": "1.27.1"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/virt-handler-rhel9@sha256%3A507d126fa23811854bb17531194f9e832167022a1a30542561aadfd668bf1542?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36-3",
+      "type": "container"
+    },
+    "timestamp": "2025-12-02T09:04:54Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156526"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/virt-handler-rhel9@sha256%3A507d126fa23811854bb17531194f9e832167022a1a30542561aadfd668bf1542?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36-3",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "507d126fa23811854bb17531194f9e832167022a1a30542561aadfd668bf1542"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-handler-rhel9@sha256%3A507d126fa23811854bb17531194f9e832167022a1a30542561aadfd668bf1542?arch=amd64&os=linux&tag=v4.17.36-3",
+      "version": "sha256:507d126fa23811854bb17531194f9e832167022a1a30542561aadfd668bf1542",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3A507d126fa23811854bb17531194f9e832167022a1a30542561aadfd668bf1542?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3A507d126fa23811854bb17531194f9e832167022a1a30542561aadfd668bf1542?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3A507d126fa23811854bb17531194f9e832167022a1a30542561aadfd668bf1542?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0225273c4256b82f99e18b33e817498d1d6f4be9",
+            "url": "https://pkgs.devel.redhat.com/git/containers/virt-handler#0225273c4256b82f99e18b33e817498d1d6f4be9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:architecture",
+          "value": "x86_64"
+        },
+        {
+          "name": "sbomer:image:labels:build-date",
+          "value": "2025-11-27T15:33:59"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "virt-handler-rhel9-container"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.license_terms",
+          "value": "https://www.redhat.com/agreements"
+        },
+        {
+          "name": "sbomer:image:labels:cpe",
+          "value": "cpe:/a:redhat:rhel_eus:9.4::appstream"
+        },
+        {
+          "name": "sbomer:image:labels:description",
+          "value": "Virtualization handler for CNV"
+        },
+        {
+          "name": "sbomer:image:labels:distribution-scope",
+          "value": "public"
+        },
+        {
+          "name": "sbomer:image:labels:io.buildah.version",
+          "value": "1.33.12"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.description",
+          "value": "Virtualization handler for CNV"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.display-name",
+          "value": "virt-handler"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.tags",
+          "value": "cnv,kubevirt"
+        },
+        {
+          "name": "sbomer:image:labels:maintainer",
+          "value": "sgott@redhat.com,ibezukh@redhat.com,dhiller@redhat.com,jlejosne@redhat.com"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "container-native-virtualization/virt-handler-rhel9"
+        },
+        {
+          "name": "sbomer:image:labels:org.opencontainers.image.revision",
+          "value": "a10db0c18d62179596deb56849f57529e1cc4d73"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "3"
+        },
+        {
+          "name": "sbomer:image:labels:summary",
+          "value": "Virtualization handler"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-vcs-ref",
+          "value": "952f258d1f909636381bb2491c504618d3749a35"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-vcs-url",
+          "value": "https://github.com/kubevirt/kubevirt"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-version",
+          "value": "1.3.1-283-g952f258d1f"
+        },
+        {
+          "name": "sbomer:image:labels:url",
+          "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/container-native-virtualization/virt-handler-rhel9/images/v4.17.36-3"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-ref",
+          "value": "0225273c4256b82f99e18b33e817498d1d6f4be9"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:vendor",
+          "value": "Red Hat"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "v4.17.36"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3900484",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "https://pkgs.devel.redhat.com/git/containers/virt-handler#0225273c4256b82f99e18b33e817498d1d6f4be9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/machadovilaca/operator-observability",
+      "purl": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "version": "v0.0.20",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=b6c9d8ea55ec3898",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "version": "v1.0.3-0.20210326190908-1c3f411f0417",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/vsock",
+      "purl": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "time",
+      "purl": "pkg:golang/time@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/time@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "dbus-python",
+      "purl": "pkg:pypi/dbus-python@1.2.18",
+      "type": "library",
+      "bom-ref": "pkg:pypi/dbus-python@1.2.18",
+      "version": "1.2.18",
+      "licenses": [
+        {
+          "license": {
+            "name": "Expat (MIT/X11)"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/dbus_python-1.2.18-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-scheduler",
+      "purl": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/types/errors",
+      "purl": "pkg:golang/internal/types/errors@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/types/errors@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libgpg-error",
+      "purl": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "version": "1.42-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "55660568a38dad2e4a858df692830af766ad6532",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1818836",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/legacy-cloud-providers",
+      "purl": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/exp/typeparams",
+      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+      "version": "v0.0.0-20230203172020-98cc5a0785f9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libnftnl",
+      "purl": "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=x86_64",
+      "version": "1.2.6-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d524ea7068ac80696b2688aab672500071f38ac",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnftnl#8d524ea7068ac80696b2688aab672500071f38ac"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3052789",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnftnl#8d524ea7068ac80696b2688aab672500071f38ac",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/common",
+      "purl": "pkg:golang/github.com/containers/common@v0.50.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/common@v0.50.1",
+      "version": "v0.50.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/procfs",
+      "purl": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubectl",
+      "purl": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "basesystem",
+      "purl": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "version": "11-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+            "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688850",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/godebug",
+      "purl": "pkg:golang/internal/godebug@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/godebug@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-gssapi",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=x86_64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.1",
+      "type": "library",
+      "author": "Gustavo Niemeyer <gustavo@niemeyer.net>",
+      "bom-ref": "pkg:pypi/python-dateutil@2.8.1",
+      "version": "2.8.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Dual License"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/python_dateutil-2.8.1-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "dejavu-sans-fonts",
+      "purl": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "version": "2.37-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bitstream Vera and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1479ec5203df4c3e577d1992b22c6976c142afa9",
+            "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688969",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/client-go",
+      "purl": "pkg:golang/kubevirt.io/client-go",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/client-go",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libelf",
+      "purl": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=x86_64",
+      "version": "0.190-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03f1598bbe94308cc7655234a5dcf75092cd1968",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2817160",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/hmac",
+      "purl": "pkg:golang/crypto/hmac@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/hmac@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "libcap",
+      "purl": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+      "version": "2.48-9.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "579dc340bc85f77708d4c04f72f9cc7c2ad16e27",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap#579dc340bc85f77708d4c04f72f9cc7c2ad16e27"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2590508",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap#579dc340bc85f77708d4c04f72f9cc7c2ad16e27",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "virt-what",
+      "purl": "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=x86_64",
+      "version": "1.25-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc9eaee5d4f089206bd81208cc7e4448bdae8233",
+            "url": "git://pkgs.devel.redhat.com/rpms/virt-what#fc9eaee5d4f089206bd81208cc7e4448bdae8233"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2574109",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/virt-what#fc9eaee5d4f089206bd81208cc7e4448bdae8233",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/goarch",
+      "purl": "pkg:golang/internal/goarch@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goarch@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "version": "v1.1.1-0.20210330154013-f5de75959ad5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/qe-tools",
+      "purl": "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+      "version": "v0.1.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "math/rand",
+      "purl": "pkg:golang/math/rand@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math/rand@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-iniparse",
+      "purl": "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+      "version": "0.4-45.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fa613c34fcc4661d8320d1eead334cb4a43d56be",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-iniparse#fa613c34fcc4661d8320d1eead334cb4a43d56be"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-iniparse#fa613c34fcc4661d8320d1eead334cb4a43d56be",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pyinotify",
+      "purl": "pkg:pypi/pyinotify@0.9.6",
+      "type": "library",
+      "author": "Sebastien Martini <seb@dbzteam.org>",
+      "bom-ref": "pkg:pypi/pyinotify@0.9.6",
+      "version": "0.9.6",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT License"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/pyinotify-0.9.6-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "internal/saferio",
+      "purl": "pkg:golang/internal/saferio@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/saferio@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "unsafe",
+      "purl": "pkg:golang/unsafe@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unsafe@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/ed25519",
+      "purl": "pkg:golang/crypto/ed25519@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/ed25519@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "net/rpc",
+      "purl": "pkg:golang/net/rpc@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/rpc@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/kubevirt",
+      "purl": "pkg:golang/kubevirt.io/kubevirt",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/kubevirt",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "bufio",
+      "purl": "pkg:golang/bufio@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/bufio@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "internal/nettrace",
+      "purl": "pkg:golang/internal/nettrace@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/nettrace@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/legacy-cloud-providers",
+      "purl": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0?package-id=6f1e377d494cf9f5",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kisielk/errcheck",
+      "purl": "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+      "version": "v1.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libcap-ng",
+      "purl": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "version": "0.8.2-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1888632",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/nunnatsa/ginkgolinter",
+      "purl": "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/spdystream",
+      "purl": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "version": "v0.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libzstd",
+      "purl": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64",
+      "version": "1.5.1-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dcda9fe564e51b7222a5efca3b14840bcc341b44",
+            "url": "git://pkgs.devel.redhat.com/rpms/zstd#dcda9fe564e51b7222a5efca3b14840bcc341b44"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1879398",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zstd#dcda9fe564e51b7222a5efca3b14840bcc341b44",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/pprof",
+      "purl": "pkg:golang/runtime/pprof@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/pprof@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libeconf",
+      "purl": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=x86_64",
+      "version": "0.4.1-3.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "aeb088c5c9095f978d2e8b5a06f3079b3b15c9a9",
+            "url": "git://pkgs.devel.redhat.com/rpms/libeconf#aeb088c5c9095f978d2e8b5a06f3079b3b15c9a9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2539463",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libeconf#aeb088c5c9095f978d2e8b5a06f3079b3b15c9a9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding",
+      "purl": "pkg:golang/encoding@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "librepo",
+      "purl": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+      "version": "1.14.5-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "458f8b732e9d31cbe09323c87f796924ac30461c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797210",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=2fae184f36a99a47",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libacl",
+      "purl": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "version": "2.3.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2709815",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "shadow-utils",
+      "purl": "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=x86_64&epoch=2",
+      "version": "2:4.9-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "183ec47a68eb739420b44e0d9db15ffb5c4e5753",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#183ec47a68eb739420b44e0d9db15ffb5c4e5753"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3303839",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#183ec47a68eb739420b44e0d9db15ffb5c4e5753",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/boring/bbig",
+      "purl": "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libsmartcols",
+      "purl": "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/x509/pkix",
+      "purl": "pkg:golang/crypto/x509/pkix@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/x509/pkix@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "runtime/trace",
+      "purl": "pkg:golang/runtime/trace@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/trace@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=f970a3d674d44626",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/btree",
+      "purl": "pkg:golang/github.com/google/btree@v1.1.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/btree@v1.1.3",
+      "version": "v1.1.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/plugins",
+      "purl": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "mvdan.cc/sh/v3",
+      "purl": "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+      "version": "v3.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/netip",
+      "purl": "pkg:golang/net/netip@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/netip@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=48602be9269bc897",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/code-generator",
+      "purl": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/u-root/uio",
+      "purl": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "version": "v0.0.0-20230220225925-ffce2a382923",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/groupcache",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.22.12",
+      "version": "go1.22.12",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=18734635491c2975",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libssh",
+      "purl": "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=x86_64",
+      "version": "0.10.4-13.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35756743d06f7dc2fde2d65495ae0d4866011d1b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3866387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=1b0cc1bbf3f8ed78",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cloud-provider",
+      "purl": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/goexpect",
+      "purl": "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+      "version": "v0.0.0-20190425035906-112704a48083",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.9.0",
+      "version": "v0.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/client-go",
+      "purl": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "version": "v0.0.0-20210112165513-ebc401615f47",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libdnf",
+      "purl": "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+      "version": "0.69.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e5984c195dca639c24fa8a25263d2faf9419e97d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134146",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "which",
+      "purl": "pkg:rpm/redhat/which@2.21-29.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/which@2.21-29.el9?arch=x86_64",
+      "version": "2.21-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dac12498cdc45059738012dbd5af70569b8b8100",
+            "url": "git://pkgs.devel.redhat.com/rpms/which#dac12498cdc45059738012dbd5af70569b8b8100"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2437620",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/which#dac12498cdc45059738012dbd5af70569b8b8100",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sync/atomic",
+      "purl": "pkg:golang/sync/atomic@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/sync/atomic@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+      "purl": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/nistec",
+      "purl": "pkg:golang/crypto/internal/nistec@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/nistec@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "database/sql/driver",
+      "purl": "pkg:golang/database/sql/driver@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/database/sql/driver@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "expat",
+      "purl": "pkg:rpm/redhat/expat@2.5.0-2.el9_4.3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/expat@2.5.0-2.el9_4.3?arch=x86_64",
+      "version": "2.5.0-2.el9_4.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f2ce204d810179faaa965fdb380b9aaba6cea668",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#f2ce204d810179faaa965fdb380b9aaba6cea668"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3894491",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#f2ce204d810179faaa965fdb380b9aaba6cea668",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "reflect",
+      "purl": "pkg:golang/reflect@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/reflect@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-semver",
+      "purl": "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+      "version": "v0.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "version": "v0.0.0-20210104183010-2eb08e3e575f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubectl",
+      "purl": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=b4c3f12b0f973ad1",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pmezard/go-difflib",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "version": "v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/sys/cpu",
+      "purl": "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "usermode",
+      "purl": "pkg:rpm/redhat/usermode@1.114-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/usermode@1.114-4.el9?arch=x86_64",
+      "version": "1.114-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6fcf2ff19afca6b8a061136d7df6189faec5f15c",
+            "url": "git://pkgs.devel.redhat.com/rpms/usermode#6fcf2ff19afca6b8a061136d7df6189faec5f15c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1821463",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/usermode#6fcf2ff19afca6b8a061136d7df6189faec5f15c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "math/bits",
+      "purl": "pkg:golang/math/bits@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math/bits@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/povsister/scp",
+      "purl": "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+      "version": "v0.0.0-20210427074412-33febfd9f13e",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/xml",
+      "purl": "pkg:golang/encoding/xml@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/xml@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic",
+      "purl": "pkg:golang/github.com/google/gnostic@v0.5.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic@v0.5.7",
+      "version": "v0.5.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/chacha8rand",
+      "purl": "pkg:golang/internal/chacha8rand@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/chacha8rand@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libnghttp2",
+      "purl": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=x86_64",
+      "version": "1.43.0-5.el9_4.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3c2e4449d7e195f89fc8f2d9c566b05a2e315dae",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#3c2e4449d7e195f89fc8f2d9c566b05a2e315dae"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2996729",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#3c2e4449d7e195f89fc8f2d9c566b05a2e315dae",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "version": "v1.1.14",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/operator-framework/operator-lifecycle-manager",
+      "purl": "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "version": "v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libdnf-plugin-subscription-manager",
+      "purl": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "pygobject",
+      "purl": "pkg:pypi/pygobject@3.40.1",
+      "type": "library",
+      "author": "James Henstridge <james@daa.com.au>",
+      "bom-ref": "pkg:pypi/pygobject@3.40.1",
+      "version": "3.40.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GNU LGPL"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/PyGObject-3.40.1.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "version": "v0.5.9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=1f351b9d12dd5e8b",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=807835609b958430",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "go/ast",
+      "purl": "pkg:golang/go/ast@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/ast@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libassuan",
+      "purl": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "version": "2.5.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5b185f851a42718727fee9efcf42ba525a59a8bb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689887",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "version": "v1.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/node-api",
+      "purl": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-libdnf",
+      "purl": "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+      "version": "0.69.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e5984c195dca639c24fa8a25263d2faf9419e97d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134146",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-pip-wheel",
+      "purl": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+      "version": "21.2.3-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f3400cce6a9da840f21eb4cfd81a0c2ca38eb185",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#f3400cce6a9da840f21eb4cfd81a0c2ca38eb185"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2906206",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#f3400cce6a9da840f21eb4cfd81a0c2ca38eb185",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:pypi/rpm@4.16.1.3",
+      "type": "library",
+      "author": "UNKNOWN <rpm-maint@lists.rpm.org>",
+      "bom-ref": "pkg:pypi/rpm@4.16.1.3",
+      "version": "4.16.1.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "GNU General Public License v2"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/rpm-4.16.1.3-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "systemd-libs",
+      "purl": "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=x86_64",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "syscall",
+      "purl": "pkg:golang/syscall@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/syscall@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "version": "5a6340b3-6229229e",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "version": "v1.5.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig/v3",
+      "purl": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "version": "v3.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/renameio/v2",
+      "purl": "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+      "version": "v2.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "version": "v0.3.16",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "yajl",
+      "purl": "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=x86_64",
+      "version": "2.1.0-22.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3b4891fe107c68e6e41550e4be2a5c9ad4f870a6",
+            "url": "git://pkgs.devel.redhat.com/rpms/yajl#3b4891fe107c68e6e41550e4be2a5c9ad4f870a6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2592251",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/yajl#3b4891fe107c68e6e41550e4be2a5c9ad4f870a6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsepol",
+      "purl": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=x86_64",
+      "version": "3.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d568b2713a4280fad93a660b66d5047296c3853f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#d568b2713a4280fad93a660b66d5047296c3853f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820602",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#d568b2713a4280fad93a660b66d5047296c3853f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/oserror",
+      "purl": "pkg:golang/internal/oserror@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/oserror@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/ecdh",
+      "purl": "pkg:golang/crypto/ecdh@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/ecdh@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "compress/bzip2",
+      "purl": "pkg:golang/compress/bzip2@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/bzip2@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/socket",
+      "purl": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "version": "v0.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go.mongodb.org/mongo-driver",
+      "purl": "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+      "version": "v1.8.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/insomniacslk/dhcp",
+      "purl": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "version": "v0.0.0-20230908212754-65c27093e38a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "net/http/internal",
+      "purl": "pkg:golang/net/http/internal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/internal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.22.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.22.0",
+      "version": "v0.22.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=848770ad63e2adc0",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/common",
+      "purl": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "version": "v0.44.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "compress/zlib",
+      "purl": "pkg:golang/compress/zlib@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/zlib@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libbpf",
+      "purl": "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=x86_64&epoch=2",
+      "version": "2:1.3.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 or BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "39db39a8f05a831c2cff398273dbc03597e85c8a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libbpf#39db39a8f05a831c2cff398273dbc03597e85c8a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2924610",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libbpf#39db39a8f05a831c2cff398273dbc03597e85c8a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/cryptobyte/asn1",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libsemanage",
+      "purl": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=x86_64",
+      "version": "3.6-2.1.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "96eef030fb0a0f4d27e17961dd585c8730df12e4",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#96eef030fb0a0f4d27e17961dd585c8730df12e4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3418014",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#96eef030fb0a0f4d27e17961dd585c8730df12e4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-six",
+      "purl": "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+      "version": "1.15.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7a3cef2bf49b31b0f9c2ecd4b05d34bdc214998c",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-six#7a3cef2bf49b31b0f9c2ecd4b05d34bdc214998c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1890817",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-six#7a3cef2bf49b31b0f9c2ecd4b05d34bdc214998c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/elliptic",
+      "purl": "pkg:golang/crypto/elliptic@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/elliptic@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libksba",
+      "purl": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=x86_64",
+      "version": "1.5.1-6.el9_1",
+      "licenses": [
+        {
+          "license": {
+            "name": "(LGPLv3+ or GPLv2+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7112a8f2afeccb3acd42cba9a99b4c2c8fe70306",
+            "url": "git://pkgs.devel.redhat.com/rpms/libksba#7112a8f2afeccb3acd42cba9a99b4c2c8fe70306"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2345715",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libksba#7112a8f2afeccb3acd42cba9a99b4c2c8fe70306",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/cespare/xxhash/v2",
+      "purl": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "version": "v2.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=b15f37518ae084d6",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/godebugs",
+      "purl": "pkg:golang/internal/godebugs@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/godebugs@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-controller-manager",
+      "purl": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/secure/bidirule",
+      "purl": "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/glog",
+      "purl": "pkg:golang/github.com/golang/glog",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/glog",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-cloud-what",
+      "purl": "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=x86_64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmnl",
+      "purl": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+      "version": "1.0.4-16.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e4e253af7af3650798d04664f7b96965ed5365ad",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libmnl#e4e253af7af3650798d04664f7b96965ed5365ad"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3049134",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libmnl#e4e253af7af3650798d04664f7b96965ed5365ad",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/buildcfg",
+      "purl": "pkg:golang/internal/buildcfg@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/buildcfg@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "purl": "pkg:golang/os@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager-rhsm-certificates",
+      "purl": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+      "version": "20220623-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "aa015c720c46b2548f962320f9b18de28c097691",
+            "url": "git://pkgs.devel.redhat.com/rpms/subscription-manager-rhsm-certificates#aa015c720c46b2548f962320f9b18de28c097691"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2061647",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/subscription-manager-rhsm-certificates#aa015c720c46b2548f962320f9b18de28c097691",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libattr",
+      "purl": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "version": "2.5.1-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+            "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688838",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/http2/hpack",
+      "purl": "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/bytealg",
+      "purl": "pkg:golang/internal/bytealg@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/bytealg@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "version": "fd431d51-4ae0493b",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "net/url",
+      "purl": "pkg:golang/net/url@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/url@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/edwards25519/field",
+      "purl": "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.29.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.29.0",
+      "version": "v0.29.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/matttproud/golang_protobuf_extensions",
+      "purl": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "version": "v1.0.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/rogpeppe/go-internal",
+      "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "flag",
+      "purl": "pkg:golang/flag@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/flag@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "systemd-rpm-macros",
+      "purl": "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnfnetlink",
+      "purl": "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=x86_64",
+      "version": "1.0.1-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9ba3ebe2fec01b51fb3dbee7005578f6c9257add",
+            "url": "git://pkgs.devel.redhat.com/rpms/libnfnetlink#9ba3ebe2fec01b51fb3dbee7005578f6c9257add"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690058",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libnfnetlink#9ba3ebe2fec01b51fb3dbee7005578f6c9257add",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/matttproud/golang_protobuf_extensions",
+      "purl": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4?package-id=e4e1dce43844ff08",
+      "version": "v1.0.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-aggregator",
+      "purl": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+      "purl": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0?package-id=3f73b8c486d0a009",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.22.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.22.0?package-id=341ee6986e5d85c1",
+      "version": "v0.22.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.33.0",
+      "version": "v0.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubernetes-csi/external-snapshotter/client/v4",
+      "purl": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "version": "v4.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "go/token",
+      "purl": "pkg:golang/go/token@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/token@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libgcrypt",
+      "purl": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=x86_64",
+      "version": "1.10.0-10.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "06551d4cc2458fcbe36fe78ec1a5cdbc5dbbf914",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#06551d4cc2458fcbe36fe78ec1a5cdbc5dbbf914"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3567943",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#06551d4cc2458fcbe36fe78ec1a5cdbc5dbbf914",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "compress/flate",
+      "purl": "pkg:golang/compress/flate@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/flate@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "go/build",
+      "purl": "pkg:golang/go/build@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/build@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/api",
+      "purl": "pkg:golang/kubevirt.io/api",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/api",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kr/logfmt",
+      "purl": "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+      "version": "v0.0.0-20210122060352-19f9bcb100e6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "acl",
+      "purl": "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64",
+      "version": "2.3.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2709815",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/platform",
+      "purl": "pkg:golang/internal/platform@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/platform@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/randutil",
+      "purl": "pkg:golang/crypto/internal/randutil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/randutil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/log",
+      "purl": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/common",
+      "purl": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/common@v0.44.0?package-id=3a5f710d384a3dd9",
+      "version": "v0.44.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "html",
+      "purl": "pkg:golang/html@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/html@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-setuptools-wheel",
+      "purl": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+      "version": "53.0.0-12.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and (BSD or ASL 2.0)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e118582dafc46c5b61049eb79598ec15e88c3b7d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3754759",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=64880854c531d875",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/goos",
+      "purl": "pkg:golang/internal/goos@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goos@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=fa36e4581bae4e38",
+      "version": "v1.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-colorable",
+      "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "version": "v0.1.13",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/gob",
+      "purl": "pkg:golang/encoding/gob@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/gob@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_golang",
+      "purl": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "version": "v1.16.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=3f115ef0cb31e7b8",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/fmtsort",
+      "purl": "pkg:golang/internal/fmtsort@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/fmtsort@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "slices",
+      "purl": "pkg:golang/slices@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/slices@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=bbfbb1eba9b1b80e",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/mapstructure",
+      "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libcurl-minimal",
+      "purl": "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+      "version": "7.76.1-29.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80195397e7d61d156d731499be9884797b75dbb1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471237",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=9312f2882f8a9a02",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "crypto/aes",
+      "purl": "pkg:golang/crypto/aes@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/aes@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "pcre2",
+      "purl": "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=x86_64",
+      "version": "10.40-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "29947c528818ead0dfcd77753bd76a46d617d18a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2914968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libselinux",
+      "purl": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=x86_64",
+      "version": "3.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b604bc7c7288a43b90e0f88226ddff652b945e40",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#b604bc7c7288a43b90e0f88226ddff652b945e40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2821561",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#b604bc7c7288a43b90e0f88226ddff652b945e40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=66f62c4a3380d295",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "dbus-common",
+      "purl": "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcomps",
+      "purl": "pkg:pypi/libcomps@0.1.18",
+      "type": "library",
+      "author": "RPM Software Management <rpm-ecosystem@lists.rpm.org>",
+      "bom-ref": "pkg:pypi/libcomps@0.1.18",
+      "version": "0.1.18",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/libcomps-0.1.18-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "strconv",
+      "purl": "pkg:golang/strconv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/strconv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "bytes",
+      "purl": "pkg:golang/bytes@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/bytes@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/sha256",
+      "purl": "pkg:golang/crypto/sha256@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/sha256@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libnl3",
+      "purl": "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=x86_64",
+      "version": "3.9.0-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "23021690a101b6f1b14fd6b0d4fe318934dbb9c3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnl3#23021690a101b6f1b14fd6b0d4fe318934dbb9c3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2805134",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnl3#23021690a101b6f1b14fd6b0d4fe318934dbb9c3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=8fbdfdc32aa3f0c7",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-lib",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=45b68313e6b7649d",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "io",
+      "purl": "pkg:golang/io@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/io@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "langpacks-en",
+      "purl": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl",
+      "purl": "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+      "version": "1:3.0.7-29.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3880294",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v0.2.1",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "iniparse",
+      "purl": "pkg:pypi/iniparse@0.4",
+      "type": "library",
+      "author": "Paramjit Oberoi <param@cs.wisc.edu>",
+      "bom-ref": "pkg:pypi/iniparse@0.4",
+      "version": "0.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/iniparse-0.4-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "kmod-libs",
+      "purl": "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=x86_64",
+      "version": "28-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "36aca425e7d25f5daca7109dc963da87294cd1b5",
+            "url": "git://pkgs.devel.redhat.com/rpms/kmod#36aca425e7d25f5daca7109dc963da87294cd1b5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2512428",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/kmod#36aca425e7d25f5daca7109dc963da87294cd1b5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/cheggaaa/pb/v3",
+      "purl": "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+      "version": "v3.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig/v3",
+      "purl": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0?package-id=c5265481edb963f4#v3",
+      "version": "v3.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=6025e076d202b258",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gnutls",
+      "purl": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=x86_64",
+      "version": "3.8.3-4.el9_4.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b773160a90460399f962c17953398ff7f781803b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#b773160a90460399f962c17953398ff7f781803b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3821445",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#b773160a90460399f962c17953398ff7f781803b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/cipher",
+      "purl": "pkg:golang/crypto/cipher@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/cipher@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "debug/elf",
+      "purl": "pkg:golang/debug/elf@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/debug/elf@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/rsa",
+      "purl": "pkg:golang/crypto/rsa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/rsa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/diff",
+      "purl": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "version": "v0.0.0-20210226163009-20ebb0f2a09e",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/metrics",
+      "purl": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libffi",
+      "purl": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "version": "3.4.2-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6f484e5230669fffb71870ce41c386e01ab4e47d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467679",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nftables",
+      "purl": "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=x86_64&epoch=1",
+      "version": "1:1.0.9-1.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6bd061508fbd17f371f610037fe4b4b89d8cd95e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nftables#6bd061508fbd17f371f610037fe4b4b89d8cd95e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3693063",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nftables#6bd061508fbd17f371f610037fe4b4b89d8cd95e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=68f83d538edd1c62",
+      "version": "v1.1.1-0.20210330154013-f5de75959ad5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "iproute",
+      "purl": "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=x86_64",
+      "version": "6.2.0-6.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-or-later AND NIST-PD"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "50f71af59d28c401b90bb35a222dc94b3eb7cfae",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/iproute#50f71af59d28c401b90bb35a222dc94b3eb7cfae"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2950524",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/iproute#50f71af59d28c401b90bb35a222dc94b3eb7cfae",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+      "version": "v0.0.0-20210105115604-44119421ec6b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "container/heap",
+      "purl": "pkg:golang/container/heap@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/container/heap@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "mime/multipart",
+      "purl": "pkg:golang/mime/multipart@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/mime/multipart@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "mime/quotedprintable",
+      "purl": "pkg:golang/mime/quotedprintable@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/mime/quotedprintable@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/alias",
+      "purl": "pkg:golang/crypto/internal/alias@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/alias@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libdb",
+      "purl": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=x86_64",
+      "version": "5.3.28-53.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and LGPLv2 and Sleepycat"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "27038c5d3e75ae33c7281b39d1b15ce166a0c420",
+            "url": "git://pkgs.devel.redhat.com/rpms/libdb#27038c5d3e75ae33c7281b39d1b15ce166a0c420"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1806145",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libdb#27038c5d3e75ae33c7281b39d1b15ce166a0c420",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "encoding/hex",
+      "purl": "pkg:golang/encoding/hex@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/hex@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "audit-libs",
+      "purl": "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=x86_64",
+      "version": "3.1.2-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3d2d297e67e32b5ce4c2914cc64169fd0be4ace0",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#3d2d297e67e32b5ce4c2914cc64169fd0be4ace0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2769499",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#3d2d297e67e32b5ce4c2914cc64169fd0be4ace0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gobject-introspection",
+      "purl": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "version": "1.68.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5fa3808a6c90b0da8da9a85fad983244c13640ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2248264",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies",
+      "purl": "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+      "version": "20240202-1.git283706d.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a950d9ca3218bf47d75befa4639b7990b00c99eb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2889114",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/appengine",
+      "purl": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "version": "v1.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "internal/abi",
+      "purl": "pkg:golang/internal/abi@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/abi@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/tomb.v1",
+      "purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "version": "v1.0.0-20141024135613-dd632973f1e7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=38049f9b809b501e",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "ncurses-base",
+      "purl": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+      "version": "6.2-10.20210508.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "539ab619cec841979d6b46943d3f82c15b7a8467",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3759616",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=7f71bb3211c40e1e",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/parser",
+      "purl": "pkg:golang/go/parser@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/parser@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+      "version": "v0.0.0-20230503133300-8bbcb7ca7183",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "image/color",
+      "purl": "pkg:golang/image/color@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/color@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/chacha20",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/pprof",
+      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "version": "v0.0.0-20240424215950-a892ee059fd6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "context",
+      "purl": "pkg:golang/context@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/context@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=06ba511a601e36d7",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/http/internal/ascii",
+      "purl": "pkg:golang/net/http/internal/ascii@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/internal/ascii@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=874d616b5ffd59b7",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/nxadm/tail",
+      "purl": "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+      "version": "v0.0.0-20211216163028-4472660a31a6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "chardet",
+      "purl": "pkg:pypi/chardet@4.0.0",
+      "type": "library",
+      "author": "Mark Pilgrim <mark@diveintomark.org>",
+      "bom-ref": "pkg:pypi/chardet@4.0.0",
+      "version": "4.0.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPL"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/chardet-4.0.0.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d6c72ae7c47adf6d",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "cmp",
+      "purl": "pkg:golang/cmp@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/cmp@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/syscall/unix",
+      "purl": "pkg:golang/internal/syscall/unix@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/syscall/unix@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "rpm-build-libs",
+      "purl": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=x86_64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-isatty",
+      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "version": "v0.0.17",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.24.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.24.0",
+      "version": "v0.24.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/unsafeheader",
+      "purl": "pkg:golang/internal/unsafeheader@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/unsafeheader@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "path",
+      "purl": "pkg:golang/path@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/path@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.33.0?package-id=cb71f9386c7676b0",
+      "version": "v0.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "math",
+      "purl": "pkg:golang/math@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/cpu",
+      "purl": "pkg:golang/internal/cpu@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/cpu@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "fmt",
+      "purl": "pkg:golang/fmt@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/fmt@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog",
+      "purl": "pkg:golang/k8s.io/klog@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog@v0.4.0",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/cheggaaa/pb.v1",
+      "purl": "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+      "version": "v1.0.28",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/doc",
+      "purl": "pkg:golang/go/doc@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/doc@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libutempter",
+      "purl": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=x86_64",
+      "version": "1.2.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c269950567cdc8b12062724de07db72689bf55c",
+            "url": "git://pkgs.devel.redhat.com/rpms/libutempter#1c269950567cdc8b12062724de07db72689bf55c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690196",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libutempter#1c269950567cdc8b12062724de07db72689bf55c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "embed",
+      "purl": "pkg:golang/embed@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/embed@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=fd7a9516c0278d0e",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "internal/lazyregexp",
+      "purl": "pkg:golang/internal/lazyregexp@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/lazyregexp@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "librhsm",
+      "purl": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=x86_64",
+      "version": "0.0.3-7.el9_3.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25c62475abb565eb8ebef5f1df66a6c5eff74ccd",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#25c62475abb565eb8ebef5f1df66a6c5eff74ccd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2845494",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#25c62475abb565eb8ebef5f1df66a6c5eff74ccd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "grep",
+      "purl": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "version": "3.6-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7779e81140d7afaf33d2a97f4afdd682457f9697",
+            "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689607",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "path/filepath",
+      "purl": "pkg:golang/path/filepath@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/path/filepath@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cobra",
+      "purl": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/singleflight",
+      "purl": "pkg:golang/internal/singleflight@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/singleflight@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=7209f81d42d9fb42",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.3.0",
+      "version": "v0.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libmount",
+      "purl": "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log/slog",
+      "purl": "pkg:golang/log/slog@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/slog@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "debug/dwarf",
+      "purl": "pkg:golang/debug/dwarf@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/debug/dwarf@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/api",
+      "purl": "pkg:golang/kubevirt.io/api",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/api?package-id=8271ccebef8c7fbf",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/plugins",
+      "purl": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1?package-id=9ab03ca56b78d2bd",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/component-base",
+      "purl": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "purl": "pkg:golang/image@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "hash/crc32",
+      "purl": "pkg:golang/hash/crc32@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash/crc32@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "pcre",
+      "purl": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64",
+      "version": "8.44-3.el9.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1007ce35c0150110a7bcd4c1741380a726434e46",
+            "url": "git://pkgs.devel.redhat.com/rpms/pcre#1007ce35c0150110a7bcd4c1741380a726434e46"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691250",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pcre#1007ce35c0150110a7bcd4c1741380a726434e46",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "decorator",
+      "purl": "pkg:pypi/decorator@4.4.2",
+      "type": "library",
+      "author": "Michele Simionato <michele.simionato@gmail.com>",
+      "bom-ref": "pkg:pypi/decorator@4.4.2",
+      "version": "4.4.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "new BSD License"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/decorator-4.4.2-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/vsock",
+      "purl": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=cf3c5a20a21e8e64",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "os/exec",
+      "purl": "pkg:golang/os/exec@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os/exec@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/glog",
+      "purl": "pkg:golang/github.com/golang/glog@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/glog@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cli-runtime",
+      "purl": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiserver",
+      "purl": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/grafana/regexp",
+      "purl": "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "version": "v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "bzip2-libs",
+      "purl": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=x86_64",
+      "version": "1.0.8-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00ab1bac9f740f33a2dcc6ada500c802a28bb6b2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#00ab1bac9f740f33a2dcc6ada500c802a28bb6b2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3425109",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#00ab1bac9f740f33a2dcc6ada500c802a28bb6b2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/sha512",
+      "purl": "pkg:golang/crypto/sha512@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/sha512@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/node-api",
+      "purl": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/node-api@v0.30.0?package-id=69b6b0afb2bc8383",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libs",
+      "purl": "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=x86_64",
+      "version": "0.190-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03f1598bbe94308cc7655234a5dcf75092cd1968",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2817160",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/blang/semver",
+      "purl": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+      "version": "v3.5.1+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "hash/fnv",
+      "purl": "pkg:golang/hash/fnv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash/fnv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "go/scanner",
+      "purl": "pkg:golang/go/scanner@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/scanner@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=5af92f389a804379",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/testlog",
+      "purl": "pkg:golang/internal/testlog@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/testlog@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubelet",
+      "purl": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libarchive",
+      "purl": "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=x86_64",
+      "version": "3.5.3-4.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "64e0b899f452b7e78dde9b8df8e5ecd358f1c837",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#64e0b899f452b7e78dde9b8df8e5ecd358f1c837"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3807112",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#64e0b899f452b7e78dde9b8df8e5ecd358f1c837",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "text/template",
+      "purl": "pkg:golang/text/template@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/text/template@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "compress/gzip",
+      "purl": "pkg:golang/compress/gzip@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/gzip@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=64a952cc8f95048c",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog",
+      "purl": "pkg:golang/k8s.io/klog@v0.3.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog@v0.3.3",
+      "version": "v0.3.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=42ecb449d13ca189",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vim-minimal",
+      "purl": "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=x86_64&epoch=2",
+      "version": "2:8.2.2637-20.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Vim and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0efec05571fe5baab0ca0b22db499eb5c8d42af6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/vim#0efec05571fe5baab0ca0b22db499eb5c8d42af6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3849530",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/vim#0efec05571fe5baab0ca0b22db499eb5c8d42af6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtasn1",
+      "purl": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=x86_64",
+      "version": "4.16.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "425d04e73d45b52ff50b454e85e8c512cc8fe282",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtasn1#425d04e73d45b52ff50b454e85e8c512cc8fe282"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3617876",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtasn1#425d04e73d45b52ff50b454e85e8c512cc8fe282",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/library-go",
+      "purl": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "version": "v0.0.0-20211220195323-eca2c467c492",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "krb5-libs",
+      "purl": "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=x86_64",
+      "version": "1.21.1-2.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fb34142b8ed95c27cf052bbe556c0df07e04db51",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#fb34142b8ed95c27cf052bbe556c0df07e04db51"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3731292",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#fb34142b8ed95c27cf052bbe556c0df07e04db51",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-librepo",
+      "purl": "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=x86_64",
+      "version": "1.14.5-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "458f8b732e9d31cbe09323c87f796924ac30461c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797210",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cracklib-dicts",
+      "purl": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=x86_64",
+      "version": "2.9.6-27.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+            "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689047",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=c251c2070b6d837f",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mxk/go-flowrate",
+      "purl": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "version": "v0.0.0-20140419014527-cca7078d478f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "dnf",
+      "purl": "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-fips-provider",
+      "purl": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=x86_64",
+      "version": "3.0.7-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "74dea6ff6f98ab99d3a2b6aba58cd38346734b79",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#74dea6ff6f98ab99d3a2b6aba58cd38346734b79"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2922752",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#74dea6ff6f98ab99d3a2b6aba58cd38346734b79",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=a3f45ccc2eaef8aa",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-controller",
+      "purl": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-gobject-base",
+      "purl": "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=x86_64",
+      "version": "3.40.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79ff68bd91179f855796360827ad65f2a83577dc",
+            "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2049891",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcc",
+      "purl": "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=x86_64",
+      "version": "11.4.1-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498982",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "encoding/binary",
+      "purl": "pkg:golang/encoding/binary@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/binary@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/ecdsa",
+      "purl": "pkg:golang/crypto/ecdsa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/ecdsa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubectl",
+      "purl": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=75bca8ba1ca22c9b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubernetes-csi/external-snapshotter/client/v4",
+      "purl": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=45a8c7aac0e298e2#client/v4",
+      "version": "v4.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/poll",
+      "purl": "pkg:golang/internal/poll@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/poll@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.15",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.15",
+      "version": "v0.3.15",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e519b37240b7b6af",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "util-linux",
+      "purl": "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "io/fs",
+      "purl": "pkg:golang/io/fs@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/io/fs@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.23.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.23.0",
+      "version": "v0.23.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=0c548e794e085974",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-urllib3",
+      "purl": "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+      "version": "1.26.5-5.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b5a869c4fb0e5683a40c5007515de8ed8e9a182f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-urllib3#b5a869c4fb0e5683a40c5007515de8ed8e9a182f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3236012",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-urllib3#b5a869c4fb0e5683a40c5007515de8ed8e9a182f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "version": "v22.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog",
+      "purl": "pkg:golang/k8s.io/klog@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog@v0.4.0?package-id=a6cf3f8305ce0756",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/client-go",
+      "purl": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=ee6a4656125cefb2",
+      "version": "v0.0.0-20210112165513-ebc401615f47",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "./staging/src/kubevirt.io/client-go",
+      "purl": "pkg:golang/./staging/src#kubevirt.io/client-go",
+      "type": "library",
+      "bom-ref": "pkg:golang/./staging/src#kubevirt.io/client-go",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=92cbc10610ba936e",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=0610c737c3c00486",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=4f70a6c87f97190b",
+      "version": "v1.0.3-0.20210326190908-1c3f411f0417",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-dbus",
+      "purl": "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=x86_64",
+      "version": "1.2.18-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f3a764ea144cc2b6b80a1ebd2925c96b2d81653b",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus-python#f3a764ea144cc2b6b80a1ebd2925c96b2d81653b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus-python#f3a764ea144cc2b6b80a1ebd2925c96b2d81653b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/genproto/googleapis/rpc",
+      "purl": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "version": "v0.0.0-20230822172742-b8732ec3820d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "version": "v5.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "pcre2-syntax",
+      "purl": "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+      "version": "10.40-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "29947c528818ead0dfcd77753bd76a46d617d18a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2914968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/safefilepath",
+      "purl": "pkg:golang/internal/safefilepath@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/safefilepath@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=f3f74c8e52e58f96",
+      "version": "v0.3.16",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/md5",
+      "purl": "pkg:golang/crypto/md5@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/md5@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "ima-evm-utils",
+      "purl": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=x86_64",
+      "version": "1.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f8dae177fe0fdd6012a0f6b10dbb14b8bedd4c40",
+            "url": "git://pkgs.devel.redhat.com/rpms/ima-evm-utils#f8dae177fe0fdd6012a0f6b10dbb14b8bedd4c40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1825204",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ima-evm-utils#f8dae177fe0fdd6012a0f6b10dbb14b8bedd4c40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/pierrec/lz4/v4",
+      "purl": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "version": "v4.1.15",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "log/slog/internal/buffer",
+      "purl": "pkg:golang/log/slog/internal/buffer@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/slog/internal/buffer@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=4e434d83ac45a761#v5",
+      "version": "v5.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-pysocks",
+      "purl": "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+      "version": "1.7.1-12.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc8ec2cb464cfd2ed3729ebd577824893559ecbd",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-pysocks#dc8ec2cb464cfd2ed3729ebd577824893559ecbd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1891067",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-pysocks#dc8ec2cb464cfd2ed3729ebd577824893559ecbd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "popt",
+      "purl": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "version": "1.18-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+            "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691597",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "npth",
+      "purl": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "version": "1.6-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+            "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690792",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/wadey/gocovmerge",
+      "purl": "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+      "version": "v0.0.0-20160331181800-b5bfa59ec0ad",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=6bfd33acc02b178b",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/go-vnc",
+      "purl": "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+      "version": "v0.0.0-20150629162542-723ed9867aed",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "redhat-release",
+      "purl": "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=x86_64",
+      "version": "9.4-0.5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94af0111c38c9daaa9b97620cd8c6237de1d1315",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#94af0111c38c9daaa9b97620cd8c6237de1d1315"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3021565",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#94af0111c38c9daaa9b97620cd8c6237de1d1315",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-cli-plugin",
+      "purl": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sync",
+      "purl": "pkg:golang/sync@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/sync@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libuuid",
+      "purl": "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=78b5b822f572b90c",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=8c96dc44fcc58103",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-gpg",
+      "purl": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=x86_64",
+      "version": "1.15.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+            "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892040",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sync",
+      "purl": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/beorn7/perks",
+      "purl": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "version": "v1.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=7b9209a64c9c952b",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "tpm2-tss",
+      "purl": "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=x86_64",
+      "version": "3.2.2-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fda97b14b55a52fff507835adba9e6a9bf396f65",
+            "url": "git://pkgs.devel.redhat.com/rpms/tpm2-tss#fda97b14b55a52fff507835adba9e6a9bf396f65"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2577728",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/tpm2-tss#fda97b14b55a52fff507835adba9e6a9bf396f65",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3",
+      "purl": "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=x86_64",
+      "version": "3.9.18-3.el9_4.9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2e1b452fcf120e44a7613701e28dd40a7931fc59",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3828922",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=2e766a71ac55c8c1",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/hkdf",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "net/http/httputil",
+      "purl": "pkg:golang/net/http/httputil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/httputil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=264ee8e18d5b5c8a",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+      "version": "v0.0.0-20230501164219-8b0f38b5fd1f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/googleapis/gnostic",
+      "purl": "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+      "version": "v0.2.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "zlib",
+      "purl": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "version": "1.2.11-40.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Boost"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+            "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2495976",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-stack/stack",
+      "purl": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "version": "v1.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/goexperiment",
+      "purl": "pkg:golang/internal/goexperiment@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goexperiment@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glib2",
+      "purl": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=x86_64",
+      "version": "2.68.4-14.el9_4.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "14a7b9b0aeb14a071ad69f0c1c3779c0c31c03e3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#14a7b9b0aeb14a071ad69f0c1c3779c0c31c03e3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3857383",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#14a7b9b0aeb14a071ad69f0c1c3779c0c31c03e3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/sysinfo",
+      "purl": "pkg:golang/internal/sysinfo@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/sysinfo@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "mpfr",
+      "purl": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "version": "4.1.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "207ac3816285664c0c73fa4894dbdead53d1ca40",
+            "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690656",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/cryptobyte",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.1.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.5",
+      "version": "v1.1.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-dnf",
+      "purl": "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cli-runtime",
+      "purl": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0?package-id=372a4fd9b7953904",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libpwquality",
+      "purl": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=x86_64",
+      "version": "1.4.4-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d78e5ea6e840372c17fabdd2cc371c7105a69b4e",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpwquality#d78e5ea6e840372c17fabdd2cc371c7105a69b4e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690098",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpwquality#d78e5ea6e840372c17fabdd2cc371c7105a69b4e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=bcb125b3ee0ac2bf",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "p11-kit",
+      "purl": "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=x86_64",
+      "version": "0.25.3-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "af03cdd6b28123c3643c0874462f8aaa668be9e6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2792712",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ncurses-libs",
+      "purl": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=x86_64",
+      "version": "6.2-10.20210508.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "539ab619cec841979d6b46943d3f82c15b7a8467",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3759616",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=50971d92969aa29f",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "util-linux-core",
+      "purl": "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libvirt.org/go/libvirtxml",
+      "purl": "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+      "version": "v1.10000.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=deca7fef444579a8",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "text/template/parse",
+      "purl": "pkg:golang/text/template/parse@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/text/template/parse@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "psmisc",
+      "purl": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+      "version": "23.4-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4bb81408b08c44d02985b6af55bbd75260c6b3ed",
+            "url": "git://pkgs.devel.redhat.com/rpms/psmisc#4bb81408b08c44d02985b6af55bbd75260c6b3ed"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691630",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/psmisc#4bb81408b08c44d02985b6af55bbd75260c6b3ed",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/crypto",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+      "version": "v0.0.0-20220321153916-2c7772ba3064",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.14.0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=296003ccdd027f5f",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cloud-provider",
+      "purl": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0?package-id=213905a8e9bf9bca",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/version",
+      "purl": "pkg:golang/go/version@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/version@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=fd55bfb7c4801b59",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=d52596cce426463a",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/boring/sig",
+      "purl": "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-runewidth",
+      "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+      "version": "v0.0.13",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sync",
+      "purl": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.11.0?package-id=d30348b75bd8dbbe",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=x86_64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sed",
+      "purl": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "version": "4.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dad14ff8a62e967c0afb23d1d237a927d847e86e",
+            "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1692031",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/library-go",
+      "purl": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492?package-id=3ba9356bde827563",
+      "version": "v0.0.0-20211220195323-eca2c467c492",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubelet",
+      "purl": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubelet@v0.30.0?package-id=0d174a34ad4bac4b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "version": "v1.33.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+      "purl": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "version": "v0.68.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/types",
+      "purl": "pkg:golang/go/types@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/types@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/goterm",
+      "purl": "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+      "version": "v0.0.0-20190311235235-ce302be1d114",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "hash/adler32",
+      "purl": "pkg:golang/hash/adler32@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash/adler32@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=777844465b60ad81",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_model",
+      "purl": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/cni",
+      "purl": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/syscall",
+      "purl": "pkg:golang/runtime/internal/syscall@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/syscall@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gregjones/httpcache",
+      "purl": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+      "version": "v0.0.0-20190611155906-901d90724c79",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/log",
+      "purl": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=7349fb61f86b922a",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=4b04ea23556ed395",
+      "version": "v0.3.16",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glibc-common",
+      "purl": "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=x86_64",
+      "version": "2.34-100.el9_4.12",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676435",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "regexp",
+      "purl": "pkg:golang/regexp@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/regexp@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libverto",
+      "purl": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "version": "0.3.2-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690209",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "maps",
+      "purl": "pkg:golang/maps@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/maps@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/krolaw/dhcp4",
+      "purl": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "version": "v0.0.0-20180925202202-7cead472c414",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "net",
+      "purl": "pkg:golang/net@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "encoding/csv",
+      "purl": "pkg:golang/encoding/csv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/csv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=165ae9cdbab510ff",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "version": "v0.0.0-20191219222812-2987a591a72c",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "p11-kit-trust",
+      "purl": "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=x86_64",
+      "version": "0.25.3-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "af03cdd6b28123c3643c0874462f8aaa668be9e6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2792712",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "os/signal",
+      "purl": "pkg:golang/os/signal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os/signal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=37c32ab5198d2ad6",
+      "version": "v1.0.3-0.20210326190908-1c3f411f0417",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "net/mail",
+      "purl": "pkg:golang/net/mail@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/mail@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/goroot",
+      "purl": "pkg:golang/internal/goroot@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goroot@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/analysis",
+      "purl": "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/transform",
+      "purl": "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/internal/alias",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/inconshreveable/mousetrap",
+      "purl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "strings",
+      "purl": "pkg:golang/strings@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/strings@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/grpc",
+      "purl": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "version": "v1.58.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "go/build/constraint",
+      "purl": "pkg:golang/go/build/constraint@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/build/constraint@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=6676202d3cb12353",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "os/user",
+      "purl": "pkg:golang/os/user@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os/user@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/golang-crypto",
+      "purl": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "version": "v0.33.1-0.20250310193910-9003f682e581",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/dsa",
+      "purl": "pkg:golang/crypto/dsa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/dsa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=b1e90c3e1ac1f792",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/http/httptrace",
+      "purl": "pkg:golang/net/http/httptrace@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/httptrace@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "curl-minimal",
+      "purl": "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+      "version": "7.76.1-29.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80195397e7d61d156d731499be9884797b75dbb1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471237",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/procfs",
+      "purl": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0?package-id=05538c935c5bdc7f",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/client-go",
+      "purl": "pkg:golang/kubevirt.io/client-go@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/client-go@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libxml2",
+      "purl": "pkg:rpm/redhat/libxml2@2.9.13-13.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxml2@2.9.13-13.el9_4?arch=x86_64",
+      "version": "2.9.13-13.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cf7eb9f10d160efd999180567c5a603209ce5828",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#cf7eb9f10d160efd999180567c5a603209ce5828"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3893010",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#cf7eb9f10d160efd999180567c5a603209ce5828",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=d49025084db5e534",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "log/slog/internal",
+      "purl": "pkg:golang/log/slog/internal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/slog/internal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/spec",
+      "purl": "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+      "version": "v0.20.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=30a0f7618c550bd4",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/http/httpproxy",
+      "purl": "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/insomniacslk/dhcp",
+      "purl": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a?package-id=f5ed66e6e2ff252b",
+      "version": "v0.0.0-20230908212754-65c27093e38a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "purl": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=x86_64",
+      "version": "2.34-100.el9_4.12",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676435",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c?package-id=569830e89dc03f1b",
+      "version": "v0.0.0-20191219222812-2987a591a72c",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "keyutils-libs",
+      "purl": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "version": "1.6.3-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+            "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2212253",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pysocks",
+      "purl": "pkg:pypi/pysocks@1.7.1",
+      "type": "library",
+      "author": "Anorov <anorov.vorona@gmail.com>",
+      "bom-ref": "pkg:pypi/pysocks@1.7.1",
+      "version": "1.7.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/PySocks-1.7.1-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "rootfiles",
+      "purl": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "version": "8.1-31.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30d4e6354acbcb23c1f2485151e08cc352871e75",
+            "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#30d4e6354acbcb23c1f2485151e08cc352871e75"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691770",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#30d4e6354acbcb23c1f2485151e08cc352871e75",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/x509",
+      "purl": "pkg:golang/crypto/x509@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/x509@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "go/printer",
+      "purl": "pkg:golang/go/printer@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/printer@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=d8c2f26e9986efc0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=875c60b36880d488",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/constant",
+      "purl": "pkg:golang/go/constant@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/constant@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=56fa540c52a6e225",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-apiserver",
+      "purl": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libcomps",
+      "purl": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=x86_64",
+      "version": "0.1.18-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1771556",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pam",
+      "purl": "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=x86_64",
+      "version": "1.5.1-24.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a62b752a294ae678f588bcb039a59078981341de",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pam#a62b752a294ae678f588bcb039a59078981341de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3807184",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pam#a62b752a294ae678f588bcb039a59078981341de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=c76606bb87a8c509",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "file-libs",
+      "purl": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "version": "5.39-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2800051",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+      "version": "v0.0.0-20190221213512-86fb29eff628",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/boring",
+      "purl": "pkg:golang/crypto/internal/boring@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/boring@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libgomp",
+      "purl": "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=x86_64",
+      "version": "11.4.1-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498982",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=c27f4e3f0f288cba",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@1.26.5",
+      "type": "library",
+      "author": "Andrey Petrov <andrey.petrov@shazow.net>",
+      "bom-ref": "pkg:pypi/urllib3@1.26.5",
+      "version": "1.26.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/urllib3-1.26.5-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "tzdata",
+      "purl": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "version": "2025b-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff671e79a03e80cf1c432e92fa02aff95d597a97",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3572007",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/itoa",
+      "purl": "pkg:golang/internal/itoa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/itoa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=cd25ddf836753eae",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "internal/zstd",
+      "purl": "pkg:golang/internal/zstd@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/zstd@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/native",
+      "purl": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "json-c",
+      "purl": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "version": "0.14-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "391500fb2a46f72180ba1353136c1b3327d71c55",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1728857",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "net/http/httptest",
+      "purl": "pkg:golang/net/http/httptest@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/httptest@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-requests",
+      "purl": "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+      "version": "2.25.1-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a4dc4a098af1480c6eded62b59f1e385c7b01058",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-requests#a4dc4a098af1480c6eded62b59f1e385c7b01058"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870541",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-requests#a4dc4a098af1480c6eded62b59f1e385c7b01058",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-idna",
+      "purl": "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+      "version": "2.10-7.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and Python and Unicode"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "112df0c7ea79f88a152381810b589b5bfa07e68b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-idna#112df0c7ea79f88a152381810b589b5bfa07e68b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3024021",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-idna#112df0c7ea79f88a152381810b589b5bfa07e68b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-toolsmith/astcopy",
+      "purl": "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_model",
+      "purl": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0?package-id=01a656f993da3d7b",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=426c1ef83fb90a34",
+      "version": "v1.1.1-0.20210330154013-f5de75959ad5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto",
+      "purl": "pkg:golang/crypto@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=1c5457c16104bad6#mountinfo",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=8f2230e2d588c340",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/evanphx/json-patch",
+      "purl": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "version": "v5.6.0+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-rpm",
+      "purl": "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=x86_64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "findutils",
+      "purl": "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=x86_64&epoch=1",
+      "version": "1:4.8.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "52a86f6303fb86be2412eeeb8df53ec3ee4c4b60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#52a86f6303fb86be2412eeeb8df53ec3ee4c4b60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2641338",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#52a86f6303fb86be2412eeeb8df53ec3ee4c4b60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "encoding/base64",
+      "purl": "pkg:golang/encoding/base64@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/base64@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/csi-translation-lib",
+      "purl": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-systemd",
+      "purl": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=x86_64",
+      "version": "234-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bdb294f1932ff4b5a881daeea1375f1b93b7cf5b",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-systemd#bdb294f1932ff4b5a881daeea1375f1b93b7cf5b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691650",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-systemd#bdb294f1932ff4b5a881daeea1375f1b93b7cf5b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/go-ps",
+      "purl": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "version": "v0.0.0-20190716172923-621e5597135b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/des",
+      "purl": "pkg:golang/crypto/des@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/des@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=cdc588c277efc41e",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+      "purl": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+      "version": "v0.0.0-20191119172530-79f836b90111",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libfdisk",
+      "purl": "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gawk",
+      "purl": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "version": "5.1.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv2+ and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3830530bfc524ab9b89fafe76d58a388675ecc11",
+            "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1891122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=61ff33db308e1c87",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "xz-libs",
+      "purl": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "version": "5.2.5-8.el9_0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+            "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2032531",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/beorn7/perks",
+      "purl": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/beorn7/perks@v1.0.1?package-id=cf38e7467b415c45",
+      "version": "v1.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-querystring",
+      "purl": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=69c0335cd603cb43#v22",
+      "version": "v22.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=6b3967bbe5e4f770#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/http/httpguts",
+      "purl": "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/krolaw/dhcp4",
+      "purl": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414?package-id=1f03719fd30cb426",
+      "version": "v0.0.0-20180925202202-7cead472c414",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-setuptools",
+      "purl": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+      "version": "53.0.0-12.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and (BSD or ASL 2.0)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e118582dafc46c5b61049eb79598ec15e88c3b7d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3754759",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libvirt.org/go/libvirt",
+      "purl": "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+      "version": "v1.10000.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=392c78985b3ee866",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "filesystem",
+      "purl": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64",
+      "version": "3.16-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c7ae0c7b52a9e8a78431e06733a8f808418df283",
+            "url": "git://pkgs.devel.redhat.com/rpms/filesystem#c7ae0c7b52a9e8a78431e06733a8f808418df283"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689243",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/filesystem#c7ae0c7b52a9e8a78431e06733a8f808418df283",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "requests",
+      "purl": "pkg:pypi/requests@2.25.1",
+      "type": "library",
+      "author": "Kenneth Reitz <me@kennethreitz.org>",
+      "bom-ref": "pkg:pypi/requests@2.25.1",
+      "version": "2.25.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache 2.0"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/requests-2.25.1.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.14.0?package-id=a47e6c64839baca0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=507e16afff6e8cbf",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "yum",
+      "purl": "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bash",
+      "purl": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "version": "5.1.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80326284a249f523c3e2d14e0eed2dbaece63c4e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2910143",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=de8b89d7a225278d",
+      "version": "v0.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager",
+      "purl": "pkg:pypi/subscription-manager@1.29.40.1",
+      "type": "library",
+      "author": "Adrian Likins <alikins@redhat.com>",
+      "bom-ref": "pkg:pypi/subscription-manager@1.29.40.1",
+      "version": "1.29.40.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/subscription_manager-1.29.40.1-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-scheduler",
+      "purl": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0?package-id=c6f4b38d0e64a871",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=617dda993ef91b06",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/sha1",
+      "purl": "pkg:golang/crypto/sha1@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/sha1@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/tls",
+      "purl": "pkg:golang/crypto/tls@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/tls@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-apiserver",
+      "purl": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0?package-id=a7d282fdf5bcfc3a",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=28d221d2b95ef119",
+      "version": "v1.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=38a620e1191a8903",
+      "version": "v0.0.0-20210104183010-2eb08e3e575f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "mime",
+      "purl": "pkg:golang/mime@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/mime@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-font-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "readline",
+      "purl": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "version": "8.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be386f45be1322adf2bd79dd94c9904c4efa3d22",
+            "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691921",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-broker",
+      "purl": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=x86_64",
+      "version": "28-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "df7a36f938130717b6c201d8bf2ca8edf68719f6",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus-broker#df7a36f938130717b6c201d8bf2ca8edf68719f6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2130514",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus-broker#df7a36f938130717b6c201d8bf2ca8edf68719f6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "net/http",
+      "purl": "pkg:golang/net/http@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/c9s/goprocinfo",
+      "purl": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "version": "v0.0.0-20210130143923-c95fcf8c64a8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=7fd9e721114377fd",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libyaml",
+      "purl": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "version": "0.2.5-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70e1549fe5e56c95f1e23967e02c657d7af570ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690356",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sqlite-libs",
+      "purl": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=x86_64",
+      "version": "3.34.1-7.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b1dd0e13763f804a7e224ec726c7037b9fda6a0c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#b1dd0e13763f804a7e224ec726c7037b9fda6a0c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3767409",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#b1dd0e13763f804a7e224ec726c7037b9fda6a0c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log",
+      "purl": "pkg:golang/log@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=db29c54369441021",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-dnf-plugins-core",
+      "purl": "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+      "version": "4.3.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4f5d16cec79f81e1d37edd64ee4cdc2e8289d48b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf-plugins-core#4f5d16cec79f81e1d37edd64ee4cdc2e8289d48b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2850557",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf-plugins-core#4f5d16cec79f81e1d37edd64ee4cdc2e8289d48b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fonts-filesystem",
+      "purl": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "version": "1:2.0.5-7.el9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ac288ee82aa9655c3784dd2f59cedb3562638129",
+            "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1732053",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/unicode/norm",
+      "purl": "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libreport-filesystem",
+      "purl": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "version": "2.15.2-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4690267165817ccc06cb342d8ef955ae10b54c75",
+            "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1852394",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/metrics",
+      "purl": "pkg:golang/runtime/metrics@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/metrics@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/chacha20poly1305",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=bd15d762c1c6c3a1",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glibc",
+      "purl": "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=x86_64",
+      "version": "2.34-100.el9_4.12",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676435",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=abbe88d4dc25e60a",
+      "version": "v0.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-inotify",
+      "purl": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+      "version": "0.9.6-25.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bf5a869472d075a22ea709682b68d1343609c9af",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-inotify#bf5a869472d075a22ea709682b68d1343609c9af"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691386",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-inotify#bf5a869472d075a22ea709682b68d1343609c9af",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.22.12?package-id=0263aa6b4909132a",
+      "version": "go1.22.12",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "unicode/utf16",
+      "purl": "pkg:golang/unicode/utf16@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unicode/utf16@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=c8fd5af5f2696ffc",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=6871ce92eaf7233e",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=e5f84b4525280ceb",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "version": "v0.0.0-20240430033511-f0e62f92d13f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=ef4b943e758b9b6b",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cluster-bootstrap",
+      "purl": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "dnf-data",
+      "purl": "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=1651c6ba29f925e5",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "systemd",
+      "purl": "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=x86_64",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "setup",
+      "purl": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "version": "2.13.7-10.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2892761",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubevirt/monitoring/pkg/metrics/parser",
+      "purl": "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+      "version": "v0.0.0-20230627123556-81a891d4462a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "nettle",
+      "purl": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=x86_64",
+      "version": "3.9.1-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7e4a847c42da5300f4bac05df9a0fb140e0a2ed2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#7e4a847c42da5300f4bac05df9a0fb140e0a2ed2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2785925",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#7e4a847c42da5300f4bac05df9a0fb140e0a2ed2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=f3884188f09088ec#v5",
+      "version": "v5.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=9fca4ee62066efc2",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/nistec/fiat",
+      "purl": "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cluster-bootstrap",
+      "purl": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0?package-id=7c0f2e47ca097803",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/intern",
+      "purl": "pkg:golang/internal/intern@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/intern@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "errors",
+      "purl": "pkg:golang/errors@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/errors@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=79287922c4530134",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-gobject-base-noarch",
+      "purl": "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+      "version": "3.40.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79ff68bd91179f855796360827ad65f2a83577dc",
+            "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2049891",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hash",
+      "purl": "pkg:golang/hash@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=58fd55d3a3e68d9a",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=812518b1d5de5b6b",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libsigsegv",
+      "purl": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "version": "2.13-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b3dee05a0458f11a68b0f9a878aa676670814326",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690130",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/fatih/color",
+      "purl": "pkg:golang/github.com/fatih/color@v1.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fatih/color@v1.13.0",
+      "version": "v1.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/csi-translation-lib",
+      "purl": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0?package-id=e493ecdd6cef073d",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "idna",
+      "purl": "pkg:pypi/idna@2.10",
+      "type": "library",
+      "author": "Kim Davies <kim@cynosure.com.au>",
+      "bom-ref": "pkg:pypi/idna@2.10",
+      "version": "2.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-like"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/idna-2.10-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "image/internal/imageutil",
+      "purl": "pkg:golang/image/internal/imageutil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/internal/imageutil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-cli-plugin",
+      "purl": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0?package-id=b57f2d304a79c9d2",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gordonklaus/ineffassign",
+      "purl": "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+      "version": "v0.0.0-20210209182638-d0e41b2fc8ed",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/strfmt",
+      "purl": "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=0cf48c7c4e0c2225",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=5f3161d14fb9986b",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/rivo/uniseg",
+      "purl": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+      "version": "v0.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=2add8ed970e49e83",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=6ca8b50f74df1aba",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=9cd65210b34ae131",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d7e841647edf8bf8",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "container/list",
+      "purl": "pkg:golang/container/list@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/container/list@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "container/ring",
+      "purl": "pkg:golang/container/ring@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/container/ring@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "unicode",
+      "purl": "pkg:golang/unicode@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unicode@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.29.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.29.0?package-id=123dc6fd6dd76665",
+      "version": "v0.29.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "runtime",
+      "purl": "pkg:golang/runtime@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "systemd-python",
+      "purl": "pkg:pypi/systemd-python@234",
+      "type": "library",
+      "author": "systemd developers <systemd-devel@lists.freedesktop.org>",
+      "bom-ref": "pkg:pypi/systemd-python@234",
+      "version": "234",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/systemd_python-234-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "image/png",
+      "purl": "pkg:golang/image/png@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/png@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/btree",
+      "purl": "pkg:golang/github.com/google/btree@v1.1.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/btree@v1.1.3?package-id=d631efbb5e6884df",
+      "version": "v1.1.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/unicode/bidi",
+      "purl": "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "rpm-sign-libs",
+      "purl": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=x86_64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lz4-libs",
+      "purl": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "version": "1.9.3-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690509",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/code-generator",
+      "purl": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/code-generator@v0.30.0?package-id=c9d95bf42170291b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=fa2fc500853b500e",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "elfutils-default-yama-scope",
+      "purl": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+      "version": "0.190-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03f1598bbe94308cc7655234a5dcf75092cd1968",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2817160",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "go/doc/comment",
+      "purl": "pkg:golang/go/doc/comment@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/doc/comment@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/math",
+      "purl": "pkg:golang/runtime/internal/math@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/math@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo/v2",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "version": "v2.17.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=38f081dbc5ce4d6a",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=317d26dbf41e923a",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=20f072e6e3225e24",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "regexp/syntax",
+      "purl": "pkg:golang/regexp/syntax@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/regexp/syntax@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=a0115c013e649a4c",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libunistring",
+      "purl": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "version": "0.9.10-15.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690195",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/evanphx/json-patch",
+      "purl": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible?package-id=15ebdd24a0c721e7",
+      "version": "v5.6.0+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-decorator",
+      "purl": "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+      "version": "4.4.2-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc2368c1fe0e7914e6027cc70f05d59862dbf2ec",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-decorator#fc2368c1fe0e7914e6027cc70f05d59862dbf2ec"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691358",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-decorator#fc2368c1fe0e7914e6027cc70f05d59862dbf2ec",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-libs",
+      "purl": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "systemd-pam",
+      "purl": "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=x86_64",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=78d6e196699c60fb",
+      "version": "v1.1.14",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "internal/race",
+      "purl": "pkg:golang/internal/race@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/race@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/goversion",
+      "purl": "pkg:golang/internal/goversion@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goversion@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libcom_err",
+      "purl": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=x86_64",
+      "version": "1.46.5-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "55211469981d94577ec3da753afcdf2cc4d651ab",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#55211469981d94577ec3da753afcdf2cc4d651ab"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820207",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#55211469981d94577ec3da753afcdf2cc4d651ab",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/idna",
+      "purl": "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/appengine",
+      "purl": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=d183acc87e1fa62e",
+      "version": "v1.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=87c0cbf8954e0580",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/rc4",
+      "purl": "pkg:golang/crypto/rc4@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/rc4@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "cracklib",
+      "purl": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64",
+      "version": "2.9.6-27.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+            "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689047",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cri-api",
+      "purl": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=aabc29983e2a9841",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-controller-manager",
+      "purl": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0?package-id=0814f25a8e4531ce",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-aggregator",
+      "purl": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4bf18231eac48ba4",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/base32",
+      "purl": "pkg:golang/encoding/base32@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/base32@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libtirpc",
+      "purl": "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=x86_64",
+      "version": "1.3.3-8.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "SISSL and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bef7b741bc0541226473d5dae03ff0ab1df11b88",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#bef7b741bc0541226473d5dae03ff0ab1df11b88"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2966395",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#bef7b741bc0541226473d5dae03ff0ab1df11b88",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "text/tabwriter",
+      "purl": "pkg:golang/text/tabwriter@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/text/tabwriter@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cri-api",
+      "purl": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cri-api@v0.30.0?package-id=4de173f6a5765211",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/component-base",
+      "purl": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/component-base@v0.30.0?package-id=94800364440cc1a6",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "image/jpeg",
+      "purl": "pkg:golang/image/jpeg@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/jpeg@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=a1ff2ebea07a529d",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cobra",
+      "purl": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.7.0?package-id=3ba0797ce405770e",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "./staging/src/github.com/golang/glog",
+      "purl": "pkg:golang/./staging/src#github.com/golang/glog",
+      "type": "library",
+      "bom-ref": "pkg:golang/./staging/src#github.com/golang/glog",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "internal/coverage/rtcov",
+      "purl": "pkg:golang/internal/coverage/rtcov@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/coverage/rtcov@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gpg",
+      "purl": "pkg:pypi/gpg@1.15.1",
+      "type": "library",
+      "author": "The GnuPG hackers <gnupg-devel@gnupg.org>",
+      "bom-ref": "pkg:pypi/gpg@1.15.1",
+      "version": "1.15.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPL2.1+ (the library), GPL2+ (tests and examples)"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/gpg-1.15.1-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=dbb27eadf8364aee",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/groupcache",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=406cd2654be0fcc8",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=8899651b157fa55b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies-scripts",
+      "purl": "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+      "version": "20240202-1.git283706d.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a950d9ca3218bf47d75befa4639b7990b00c99eb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2889114",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/dns/dnsmessage",
+      "purl": "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=99619c8dbac171e6",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/metrics",
+      "purl": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/metrics@v0.30.0?package-id=e5a9c757e0ba76d0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/Masterminds/semver",
+      "purl": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+      "purl": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=41c9ffe89c4328dd#pkg/apis/monitoring",
+      "version": "v0.68.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e87736d4223a3553",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/gover",
+      "purl": "pkg:golang/internal/gover@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/gover@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=077b67d110fda982",
+      "version": "v0.0.0-20240430033511-f0e62f92d13f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "mvdan.cc/editorconfig",
+      "purl": "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+      "type": "library",
+      "bom-ref": "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+      "version": "v0.2.1-0.20231228180347-1925077f8eb2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/client-go",
+      "purl": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=332ab3a9d173ca98",
+      "version": "v0.0.0-20210112165513-ebc401615f47",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "openldap",
+      "purl": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=x86_64",
+      "version": "2.6.6-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "OLDAP-2.8"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "409b72030310df96b296a5dd8cf80f0a211cc038",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#409b72030310df96b296a5dd8cf80f0a211cc038"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2899087",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#409b72030310df96b296a5dd8cf80f0a211cc038",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ca-certificates",
+      "purl": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "version": "2025.2.80_v9.0.305-91.el9",
+      "licenses": [
+        {
+          "expression": "MIT AND GPL-2.0-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80abd67ad7d828eba9c44be633f42b67f21751b1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#80abd67ad7d828eba9c44be633f42b67f21751b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3864618",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#80abd67ad7d828eba9c44be633f42b67f21751b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=2f055f6cdf8e3fb1",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "json-glib",
+      "purl": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "version": "1.6.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d5548792bb86a77330957962541a936d9c391896",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1707185",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/pprof",
+      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6?package-id=0bc6f5896c6cb1a9",
+      "version": "v0.0.0-20240424215950-a892ee059fd6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=9de2c8dc0803d74e",
+      "version": "v0.0.0-20210104183010-2eb08e3e575f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=638aeba61e089e7d",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "numactl-libs",
+      "purl": "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=x86_64",
+      "version": "2.0.16-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4ace9e459353675439dae46e01102853d6c8f37d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/numactl#4ace9e459353675439dae46e01102853d6c8f37d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2692430",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/numactl#4ace9e459353675439dae46e01102853d6c8f37d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=8256c45ca06407ab",
+      "version": "v1.33.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/controller-runtime",
+      "purl": "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b135113b0301cc3e",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_golang",
+      "purl": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0?package-id=d58b9b0249e2d522",
+      "version": "v1.16.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "math/big",
+      "purl": "pkg:golang/math/big@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math/big@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=5df1a932dc364fae",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/seccomp/libseccomp-golang",
+      "purl": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "version": "v0.10.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-proxy",
+      "purl": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=49b478fdfd04f997",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=2f1b091e7ebc59e5#mountinfo",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/syscall/execenv",
+      "purl": "pkg:golang/internal/syscall/execenv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/syscall/execenv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gnupg2",
+      "purl": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "version": "2.3.3-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2481337",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager",
+      "purl": "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libseccomp",
+      "purl": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=x86_64",
+      "version": "2.5.2-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "81d3550e24896c1929fda36335626a6807df3922",
+            "url": "git://pkgs.devel.redhat.com/rpms/libseccomp#81d3550e24896c1929fda36335626a6807df3922"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1788033",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libseccomp#81d3550e24896c1929fda36335626a6807df3922",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "purl": "pkg:golang/golang.org/x/tools@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-proxy",
+      "purl": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0?package-id=da08354393870645",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/atomic",
+      "purl": "pkg:golang/runtime/internal/atomic@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/atomic@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/subtle",
+      "purl": "pkg:golang/crypto/subtle@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/subtle@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/native",
+      "purl": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/native@v1.1.0?package-id=6604c5cd4c4748cf",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "openssl-libs",
+      "purl": "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+      "version": "1:3.0.7-29.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3880294",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+      "version": "v2.6.1+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-stack/stack",
+      "purl": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-stack/stack@v1.8.0?package-id=48631dee752774c6",
+      "version": "v1.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/bisect",
+      "purl": "pkg:golang/internal/bisect@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/bisect@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libvirt-libs",
+      "purl": "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=x86_64",
+      "version": "10.0.0-6.19.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND OFL-1.1"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b48e93554655d865ca027aaceb12b91dc5dc6a5c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libvirt#b48e93554655d865ca027aaceb12b91dc5dc6a5c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3782117",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libvirt#b48e93554655d865ca027aaceb12b91dc5dc6a5c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libcomps",
+      "purl": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64",
+      "version": "0.1.18-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1771556",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/edwards25519",
+      "purl": "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=71cd8ab004151c77",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=e810f9b52b2fed54",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "dbus",
+      "purl": "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/c9s/goprocinfo",
+      "purl": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8?package-id=8753666bf11d11e8",
+      "version": "v0.0.0-20210130143923-c95fcf8c64a8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "alternatives",
+      "purl": "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=x86_64",
+      "version": "1.24-1.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2233412101349b53627f350497e1ac17dec36730",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#2233412101349b53627f350497e1ac17dec36730"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3267208",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#2233412101349b53627f350497e1ac17dec36730",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/u-root/uio",
+      "purl": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923?package-id=bf32666eb889d979",
+      "version": "v0.0.0-20230220225925-ffce2a382923",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libnetfilter_conntrack",
+      "purl": "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=x86_64",
+      "version": "1.0.9-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a8c7bd7fc24180e59c191a4d5a05a475afdcf17",
+            "url": "git://pkgs.devel.redhat.com/rpms/libnetfilter_conntrack#2a8c7bd7fc24180e59c191a4d5a05a475afdcf17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2296866",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libnetfilter_conntrack#2a8c7bd7fc24180e59c191a4d5a05a475afdcf17",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "go/internal/typeparams",
+      "purl": "pkg:golang/go/internal/typeparams@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/internal/typeparams@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "testing",
+      "purl": "pkg:golang/testing@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/testing@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl",
+      "purl": "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=x86_64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-github/v32",
+      "purl": "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+      "version": "v32.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=d06c6aae1204ae08#v22",
+      "version": "v22.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "tar",
+      "purl": "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=x86_64&epoch=2",
+      "version": "2:1.34-6.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a171e3d125646d2a953c247715ef2788c1829c1c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tar#a171e3d125646d2a953c247715ef2788c1829c1c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3229110",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tar#a171e3d125646d2a953c247715ef2788c1829c1c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/validate",
+      "purl": "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "io/ioutil",
+      "purl": "pkg:golang/io/ioutil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/io/ioutil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "procps-ng",
+      "purl": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+      "version": "3.3.17-14.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "277f9aaff8edd7603ea88dfe5e42cbb2d229a76f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/procps-ng#277f9aaff8edd7603ea88dfe5e42cbb2d229a76f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2865070",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/procps-ng#277f9aaff8edd7603ea88dfe5e42cbb2d229a76f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/VividCortex/ewma",
+      "purl": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=077a5e8ca27fa924",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "html/template",
+      "purl": "pkg:golang/html/template@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/html/template@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/common",
+      "purl": "pkg:golang/github.com/containers/common@v0.50.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/common@v0.50.1?package-id=e36d1d0f2ba91772",
+      "version": "v0.50.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libsolv",
+      "purl": "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=x86_64",
+      "version": "0.7.24-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9ab325a2961e60cb85d36bcd381102753a990bff",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsolv#9ab325a2961e60cb85d36bcd381102753a990bff"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2563465",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsolv#9ab325a2961e60cb85d36bcd381102753a990bff",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libblkid",
+      "purl": "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=ad5593f4e294dd87",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-dateutil",
+      "purl": "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+      "version": "1:2.8.1-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8f4fa349cd64e4143fc3b417b01a2ab1f433b40d",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-dateutil#8f4fa349cd64e4143fc3b417b01a2ab1f433b40d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2628796",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-dateutil#8f4fa349cd64e4143fc3b417b01a2ab1f433b40d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/debug",
+      "purl": "pkg:golang/runtime/debug@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/debug@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=c3d9773d12fa39a7",
+      "version": "v1.33.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/socket",
+      "purl": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=9e49a047878a9f7c",
+      "version": "v0.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/internal/poly1305",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cespare/xxhash/v2",
+      "purl": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0?package-id=d7fbb4f13b1bb601#v2",
+      "version": "v2.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/log",
+      "purl": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=429112dfb9428aeb",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "coreutils-single",
+      "purl": "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=x86_64",
+      "version": "8.32-35.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a5b35b64130afa26d91d771af474f947cc02a099",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#a5b35b64130afa26d91d771af474f947cc02a099"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2875684",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#a5b35b64130afa26d91d771af474f947cc02a099",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/pierrec/lz4/v4",
+      "purl": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15?package-id=8f6dd5f7ba6a62ec#v4",
+      "version": "v4.1.15",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=6619c43cfd07c933",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=59cd4b4e359e9754",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "./staging/src/kubevirt.io/api",
+      "purl": "pkg:golang/./staging/src#kubevirt.io/api",
+      "type": "library",
+      "bom-ref": "pkg:golang/./staging/src#kubevirt.io/api",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libssh-config",
+      "purl": "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+      "version": "0.10.4-13.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35756743d06f7dc2fde2d65495ae0d4866011d1b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3866387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxcrypt",
+      "purl": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "version": "4.4.18-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and BSD and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5ae2c88752320b1d81d70ae38259ce56b1c692de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690260",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gpgme",
+      "purl": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "version": "1.15.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+            "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892040",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/http/internal/testcert",
+      "purl": "pkg:golang/net/http/internal/testcert@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/internal/testcert@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pborman/uuid",
+      "purl": "pkg:golang/github.com/pborman/uuid@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pborman/uuid@v1.2.1",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-chardet",
+      "purl": "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+      "version": "4.0.0-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f8acd16e754d66fa555ae3facafdae9e6befdbb3",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-chardet#f8acd16e754d66fa555ae3facafdae9e6befdbb3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1894647",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-chardet#f8acd16e754d66fa555ae3facafdae9e6befdbb3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libs",
+      "purl": "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=x86_64",
+      "version": "3.9.18-3.el9_4.9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2e1b452fcf120e44a7613701e28dd40a7931fc59",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3828922",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=2510cbce9c179e69",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libevent",
+      "purl": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "version": "2.1.12-8.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3235991",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "purl": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "version": "v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/json",
+      "purl": "pkg:golang/encoding/json@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/json@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-aggregator",
+      "purl": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=70cc035eafb9fbd3",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=666b646207e276d6",
+      "version": "v1.1.14",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/errors",
+      "purl": "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+      "version": "v0.19.9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/reflectlite",
+      "purl": "pkg:golang/internal/reflectlite@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/reflectlite@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libstdc++",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=x86_64",
+      "version": "11.4.1-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498982",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/bigmod",
+      "purl": "pkg:golang/crypto/internal/bigmod@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/bigmod@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-hawkey",
+      "purl": "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=x86_64",
+      "version": "0.69.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e5984c195dca639c24fa8a25263d2faf9419e97d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134146",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/genproto/googleapis/rpc",
+      "purl": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d?package-id=3bb12d02cfa2e942#rpc",
+      "version": "v0.0.0-20230822172742-b8732ec3820d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-controller",
+      "purl": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-controller@v0.30.0?package-id=95847fe4258b57c0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/rand",
+      "purl": "pkg:golang/crypto/rand@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/rand@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo/v2",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2?package-id=709ca981edc6d5d6#v2",
+      "version": "v2.17.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/mod",
+      "purl": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "version": "v0.17.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=ab608fe96a3e5a01",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=13c8c846a4481335",
+      "version": "v0.0.0-20240430033511-f0e62f92d13f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "dmidecode",
+      "purl": "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=x86_64&epoch=1",
+      "version": "1:3.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3368d91ad91bcfd15a9e66b6f1bbbf18b7491c6e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dmidecode#3368d91ad91bcfd15a9e66b6f1bbbf18b7491c6e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2841778",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dmidecode#3368d91ad91bcfd15a9e66b6f1bbbf18b7491c6e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=dd84eb4f391fe51e",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "unicode/utf8",
+      "purl": "pkg:golang/unicode/utf8@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unicode/utf8@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/grpc",
+      "purl": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=1663864887e439eb",
+      "version": "v1.58.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=f1bc226b87c469d8",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/asn1",
+      "purl": "pkg:golang/encoding/asn1@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/asn1@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "sort",
+      "purl": "pkg:golang/sort@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/sort@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gzip",
+      "purl": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+      "version": "1.12-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "11df222a2dc5ce7dc943b1bce364d46ea97a535b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gzip#11df222a2dc5ce7dc943b1bce364d46ea97a535b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1982016",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gzip#11df222a2dc5ce7dc943b1bce364d46ea97a535b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=f951095dca4572e3",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "archive/tar",
+      "purl": "pkg:golang/archive/tar@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/archive/tar@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=3bccae874729638f",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=a8276711fb26ec2c#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gmp",
+      "purl": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "version": "1:6.2.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+            "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2625518",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/machadovilaca/operator-observability",
+      "purl": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20?package-id=ce832bdd3e643f49",
+      "version": "v0.0.20",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "six",
+      "purl": "pkg:pypi/six@1.15.0",
+      "type": "library",
+      "author": "Benjamin Peterson <benjamin@python.org>",
+      "bom-ref": "pkg:pypi/six@1.15.0",
+      "version": "1.15.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/six-1.15.0.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/runtime",
+      "purl": "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+      "version": "v0.19.24",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "log/internal",
+      "purl": "pkg:golang/log/internal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/internal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/asaskevich/govalidator",
+      "purl": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+      "version": "v0.0.0-20200907205600-7a23bdc65eef",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libidn2",
+      "purl": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "version": "2.3.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or LGPLv3+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c781354177446e1bb6a5b48d2113feaed50cc860",
+            "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "passwd",
+      "purl": "pkg:rpm/redhat/passwd@0.80-12.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/passwd@0.80-12.el9?arch=x86_64",
+      "version": "0.80-12.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPL+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc8f2d3ecfe371757ee51d81b0b9e4b7e3a8cdc5",
+            "url": "git://pkgs.devel.redhat.com/rpms/passwd#dc8f2d3ecfe371757ee51d81b0b9e4b7e3a8cdc5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691236",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/passwd#dc8f2d3ecfe371757ee51d81b0b9e4b7e3a8cdc5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdbm-libs",
+      "purl": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1",
+      "version": "1:1.19-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6bade26c052b6560b132f163484ee009c04e3cce",
+            "url": "git://pkgs.devel.redhat.com/rpms/gdbm#6bade26c052b6560b132f163484ee009c04e3cce"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689293",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gdbm#6bade26c052b6560b132f163484ee009c04e3cce",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=6d74c429f555275e",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libmodulemd",
+      "purl": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "version": "2.13.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d48969327abbcbfad2ab893639cfb7d22362223d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1695462",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm-libs",
+      "purl": "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=x86_64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "expvar",
+      "purl": "pkg:golang/expvar@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/expvar@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/loads",
+      "purl": "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gdb-gdbserver",
+      "purl": "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=x86_64",
+      "version": "10.2-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ and GPLv2+ with exceptions and GPL+ and LGPLv2+ and LGPLv3+ and BSD and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0cda5771bf25da9b298b20bf195cfb9b05928603",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdb#0cda5771bf25da9b298b20bf195cfb9b05928603"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2822968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdb#0cda5771bf25da9b298b20bf195cfb9b05928603",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/go-ps",
+      "purl": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b?package-id=b697414c821ee814",
+      "version": "v0.0.0-20190716172923-621e5597135b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "net/textproto",
+      "purl": "pkg:golang/net/textproto@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/textproto@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=5804e51cbc6df18a",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libuser",
+      "purl": "pkg:rpm/redhat/libuser@0.63-13.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuser@0.63-13.el9?arch=x86_64",
+      "version": "0.63-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "13af6ac62247268424d499b1889ee11afd7e150a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libuser#13af6ac62247268424d499b1889ee11afd7e150a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2590170",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libuser#13af6ac62247268424d499b1889ee11afd7e150a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+      "purl": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=62c158205e5c5cbc#pkg/apis/monitoring",
+      "version": "v0.68.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=c9e73a9ce3fca441",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "jansson",
+      "purl": "pkg:rpm/redhat/jansson@2.14-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/jansson@2.14-1.el9?arch=x86_64",
+      "version": "2.14-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4580a680e5f19adde10c25adad0a31f1d3dc1078",
+            "url": "git://pkgs.devel.redhat.com/rpms/jansson#4580a680e5f19adde10c25adad0a31f1d3dc1078"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1798464",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/jansson#4580a680e5f19adde10c25adad0a31f1d3dc1078",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua-libs",
+      "purl": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "version": "5.4.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d795270f6d1372b9636433ed1fb08b2439eed16",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467503",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/kubevirt",
+      "purl": "pkg:golang/kubevirt.io/kubevirt",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/kubevirt?package-id=12cfd8ec10f078fb",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=ed2a22c702bae008",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=3f70c1e082cb9132",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/sys",
+      "purl": "pkg:golang/runtime/internal/sys@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/sys@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "setuptools",
+      "purl": "pkg:pypi/setuptools@53.0.0",
+      "type": "library",
+      "author": "Python Packaging Authority <distutils-sig@python.org>",
+      "bom-ref": "pkg:pypi/setuptools@53.0.0",
+      "version": "53.0.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "UNKNOWN"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/setuptools-53.0.0.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiserver",
+      "purl": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiserver@v0.30.0?package-id=46f0784d88e673c3",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubernetes-csi/external-snapshotter/client/v4",
+      "purl": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=c379c7237a34dcc0#client/v4",
+      "version": "v4.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "iptables-libs",
+      "purl": "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=x86_64",
+      "version": "1.8.10-5.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and Artistic 2.0 and ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6eebdb82213f2bb74f3104414ce85d304151f2c7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/iptables#6eebdb82213f2bb74f3104414ce85d304151f2c7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3227256",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/iptables#6eebdb82213f2bb74f3104414ce85d304151f2c7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-subscription-manager-rhsm",
+      "purl": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=x86_64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "encoding/pem",
+      "purl": "pkg:golang/encoding/pem@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/pem@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "openssl-synthetic-test",
+      "purl": "pkg:rpm/redhat/openssl-synthetic-test@1.1?arch=x86_64",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bd47e171c4d5d967a828cf0464e918f47c70ab57115adb1c831d3770f2f1d034"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/openssl-synthetic-test@1.1?arch=x86_64",
+      "version": "1.1",
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "description": "This package is a TEST package for testing trustify queries."
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:oci/virt-handler-rhel9@sha256%3A507d126fa23811854bb17531194f9e832167022a1a30542561aadfd668bf1542?arch=amd64&os=linux&tag=v4.17.36-3",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0",
+        "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+        "pkg:golang/k8s.io/client-go@v0.30.0",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=b6c9d8ea55ec3898",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+        "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+        "pkg:golang/time@go1.22.12",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+        "pkg:pypi/dbus-python@1.2.18",
+        "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+        "pkg:golang/internal/types/errors@go1.22.12",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+        "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+        "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=x86_64",
+        "pkg:golang/github.com/containers/common@v0.50.1",
+        "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+        "pkg:golang/k8s.io/kubectl@v0.30.0",
+        "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+        "pkg:golang/internal/godebug@go1.22.12",
+        "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=x86_64",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+        "pkg:pypi/python-dateutil@2.8.1",
+        "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+        "pkg:golang/kubevirt.io/client-go",
+        "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=x86_64",
+        "pkg:golang/crypto/hmac@go1.22.12",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+        "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=x86_64",
+        "pkg:golang/internal/goarch@go1.22.12",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+        "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+        "pkg:golang/math/rand@go1.22.12",
+        "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+        "pkg:pypi/pyinotify@0.9.6",
+        "pkg:golang/internal/saferio@go1.22.12",
+        "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+        "pkg:golang/unsafe@go1.22.12",
+        "pkg:golang/crypto/ed25519@go1.22.12",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1",
+        "pkg:golang/net/rpc@go1.22.12",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/kubevirt.io/kubevirt",
+        "pkg:golang/bufio@go1.22.12",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+        "pkg:golang/internal/nettrace@go1.22.12",
+        "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0?package-id=6f1e377d494cf9f5",
+        "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+        "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+        "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+        "pkg:golang/github.com/moby/spdystream@v0.2.0",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64",
+        "pkg:golang/runtime/pprof@go1.22.12",
+        "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=x86_64",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0",
+        "pkg:golang/encoding@go1.22.12",
+        "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=2fae184f36a99a47",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=x86_64&epoch=2",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+        "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=x86_64",
+        "pkg:golang/crypto/x509/pkix@go1.22.12",
+        "pkg:golang/runtime/trace@go1.22.12",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=f970a3d674d44626",
+        "pkg:golang/github.com/google/btree@v1.1.3",
+        "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+        "pkg:golang/golang.org/x/sys@v0.30.0",
+        "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+        "pkg:golang/net/netip@go1.22.12",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=48602be9269bc897",
+        "pkg:golang/k8s.io/code-generator@v0.30.0",
+        "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/stdlib@1.22.12",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=18734635491c2975",
+        "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=x86_64",
+        "pkg:golang/k8s.io/client-go@v0.30.0?package-id=1b0cc1bbf3f8ed78",
+        "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+        "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+        "pkg:golang/github.com/go-kit/kit@v0.9.0",
+        "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+        "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/which@2.21-29.el9?arch=x86_64",
+        "pkg:golang/sync/atomic@go1.22.12",
+        "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+        "pkg:golang/crypto/internal/nistec@go1.22.12",
+        "pkg:golang/database/sql/driver@go1.22.12",
+        "pkg:rpm/redhat/expat@2.5.0-2.el9_4.3?arch=x86_64",
+        "pkg:golang/reflect@go1.22.12",
+        "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+        "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=b4c3f12b0f973ad1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+        "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+        "pkg:rpm/redhat/usermode@1.114-4.el9?arch=x86_64",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+        "pkg:golang/math/bits@go1.22.12",
+        "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+        "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+        "pkg:golang/encoding/xml@go1.22.12",
+        "pkg:golang/github.com/google/gnostic@v0.5.7",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/internal/chacha8rand@go1.22.12",
+        "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=x86_64",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+        "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+        "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:pypi/pygobject@3.40.1",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=1f351b9d12dd5e8b",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=807835609b958430",
+        "pkg:golang/go/ast@go1.22.12",
+        "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+        "pkg:golang/k8s.io/node-api@v0.30.0",
+        "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+        "pkg:pypi/rpm@4.16.1.3",
+        "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=x86_64",
+        "pkg:golang/syscall@go1.22.12",
+        "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+        "pkg:golang/github.com/golang/protobuf@v1.5.3",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+        "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+        "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+        "pkg:golang/github.com/imdario/mergo@v0.3.16",
+        "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=x86_64",
+        "pkg:golang/internal/oserror@go1.22.12",
+        "pkg:golang/crypto/ecdh@go1.22.12",
+        "pkg:golang/compress/bzip2@go1.22.12",
+        "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+        "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+        "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+        "pkg:golang/net/http/internal@go1.22.12",
+        "pkg:golang/golang.org/x/text@v0.22.0",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=848770ad63e2adc0",
+        "pkg:golang/github.com/prometheus/common@v0.44.0",
+        "pkg:golang/compress/zlib@go1.22.12",
+        "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=x86_64&epoch=2",
+        "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+        "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=x86_64",
+        "pkg:golang/github.com/google/uuid@v1.3.0",
+        "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+        "pkg:golang/crypto/elliptic@go1.22.12",
+        "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=x86_64",
+        "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=b15f37518ae084d6",
+        "pkg:golang/internal/godebugs@go1.22.12",
+        "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+        "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+        "pkg:golang/github.com/golang/glog",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0",
+        "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+        "pkg:golang/internal/buildcfg@go1.22.12",
+        "pkg:golang/os@go1.22.12",
+        "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+        "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+        "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+        "pkg:golang/internal/bytealg@go1.22.12",
+        "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+        "pkg:golang/net/url@go1.22.12",
+        "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+        "pkg:golang/golang.org/x/term@v0.29.0",
+        "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+        "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+        "pkg:golang/flag@go1.22.12",
+        "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+        "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=x86_64",
+        "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4?package-id=e4e1dce43844ff08",
+        "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+        "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0?package-id=3f73b8c486d0a009",
+        "pkg:golang/golang.org/x/text@v0.22.0?package-id=341ee6986e5d85c1",
+        "pkg:golang/golang.org/x/net@v0.33.0",
+        "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+        "pkg:golang/go/token@go1.22.12",
+        "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=x86_64",
+        "pkg:golang/compress/flate@go1.22.12",
+        "pkg:golang/go/build@go1.22.12",
+        "pkg:golang/kubevirt.io/api",
+        "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+        "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64",
+        "pkg:golang/internal/platform@go1.22.12",
+        "pkg:golang/crypto/internal/randutil@go1.22.12",
+        "pkg:golang/github.com/go-kit/log@v0.2.1",
+        "pkg:golang/github.com/prometheus/common@v0.44.0?package-id=3a5f710d384a3dd9",
+        "pkg:golang/html@go1.22.12",
+        "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=64880854c531d875",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+        "pkg:golang/internal/goos@go1.22.12",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=fa36e4581bae4e38",
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+        "pkg:golang/encoding/gob@go1.22.12",
+        "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=3f115ef0cb31e7b8",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+        "pkg:golang/internal/fmtsort@go1.22.12",
+        "pkg:golang/slices@go1.22.12",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=bbfbb1eba9b1b80e",
+        "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+        "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=9312f2882f8a9a02",
+        "pkg:golang/crypto/aes@go1.22.12",
+        "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=x86_64",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=66f62c4a3380d295",
+        "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+        "pkg:pypi/libcomps@0.1.18",
+        "pkg:golang/strconv@go1.22.12",
+        "pkg:golang/bytes@go1.22.12",
+        "pkg:golang/crypto/sha256@go1.22.12",
+        "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=x86_64",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=8fbdfdc32aa3f0c7",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=45b68313e6b7649d",
+        "pkg:golang/io@go1.22.12",
+        "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+        "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+        "pkg:golang/github.com/go-logr/logr@v0.2.1",
+        "pkg:pypi/iniparse@0.4",
+        "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=x86_64",
+        "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+        "pkg:golang/github.com/go-task/slim-sprig@v3.0.0?package-id=c5265481edb963f4#v3",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=6025e076d202b258",
+        "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=x86_64",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+        "pkg:golang/crypto/cipher@go1.22.12",
+        "pkg:golang/debug/elf@go1.22.12",
+        "pkg:golang/crypto/rsa@go1.22.12",
+        "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+        "pkg:golang/k8s.io/metrics@v0.30.0",
+        "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=x86_64&epoch=1",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=68f83d538edd1c62",
+        "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=x86_64",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+        "pkg:golang/container/heap@go1.22.12",
+        "pkg:golang/mime/multipart@go1.22.12",
+        "pkg:golang/mime/quotedprintable@go1.22.12",
+        "pkg:golang/crypto/internal/alias@go1.22.12",
+        "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=x86_64",
+        "pkg:golang/encoding/hex@go1.22.12",
+        "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+        "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4",
+        "pkg:golang/google.golang.org/appengine@v1.6.8",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+        "pkg:golang/internal/abi@go1.22.12",
+        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=38049f9b809b501e",
+        "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=7f71bb3211c40e1e",
+        "pkg:golang/go/parser@go1.22.12",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+        "pkg:golang/github.com/google/uuid@v1.3.1",
+        "pkg:golang/github.com/pkg/errors@v0.9.1",
+        "pkg:golang/image/color@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+        "pkg:golang/context@go1.22.12",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=06ba511a601e36d7",
+        "pkg:golang/net/http/internal/ascii@go1.22.12",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=874d616b5ffd59b7",
+        "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+        "pkg:pypi/chardet@4.0.0",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d6c72ae7c47adf6d",
+        "pkg:golang/cmp@go1.22.12",
+        "pkg:golang/internal/syscall/unix@go1.22.12",
+        "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=x86_64",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+        "pkg:golang/golang.org/x/net@v0.24.0",
+        "pkg:golang/internal/unsafeheader@go1.22.12",
+        "pkg:golang/path@go1.22.12",
+        "pkg:golang/golang.org/x/net@v0.33.0?package-id=cb71f9386c7676b0",
+        "pkg:golang/math@go1.22.12",
+        "pkg:golang/internal/cpu@go1.22.12",
+        "pkg:golang/fmt@go1.22.12",
+        "pkg:golang/k8s.io/klog@v0.4.0",
+        "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+        "pkg:golang/go/doc@go1.22.12",
+        "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=x86_64",
+        "pkg:golang/embed@go1.22.12",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=fd7a9516c0278d0e",
+        "pkg:golang/internal/lazyregexp@go1.22.12",
+        "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=x86_64",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+        "pkg:golang/path/filepath@go1.22.12",
+        "pkg:golang/github.com/spf13/cobra@v1.7.0",
+        "pkg:golang/internal/singleflight@go1.22.12",
+        "pkg:golang/k8s.io/client-go@v0.30.0?package-id=7209f81d42d9fb42",
+        "pkg:golang/golang.org/x/time@v0.3.0",
+        "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=x86_64",
+        "pkg:golang/log/slog@go1.22.12",
+        "pkg:golang/debug/dwarf@go1.22.12",
+        "pkg:golang/kubevirt.io/api?package-id=8271ccebef8c7fbf",
+        "pkg:golang/github.com/containernetworking/plugins@v1.1.1?package-id=9ab03ca56b78d2bd",
+        "pkg:golang/k8s.io/component-base@v0.30.0",
+        "pkg:golang/golang.org/x/term@v0.19.0",
+        "pkg:golang/image@go1.22.12",
+        "pkg:golang/hash/crc32@go1.22.12",
+        "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64",
+        "pkg:pypi/decorator@4.4.2",
+        "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=cf3c5a20a21e8e64",
+        "pkg:golang/os/exec@go1.22.12",
+        "pkg:golang/github.com/golang/glog@v1.1.0",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+        "pkg:golang/k8s.io/apiserver@v0.30.0",
+        "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=x86_64",
+        "pkg:golang/crypto/sha512@go1.22.12",
+        "pkg:golang/k8s.io/node-api@v0.30.0?package-id=69b6b0afb2bc8383",
+        "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=x86_64",
+        "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+        "pkg:golang/hash/fnv@go1.22.12",
+        "pkg:golang/go/scanner@go1.22.12",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=5af92f389a804379",
+        "pkg:golang/internal/testlog@go1.22.12",
+        "pkg:golang/k8s.io/kubelet@v0.30.0",
+        "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=x86_64",
+        "pkg:golang/text/template@go1.22.12",
+        "pkg:golang/compress/gzip@go1.22.12",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=64a952cc8f95048c",
+        "pkg:golang/k8s.io/klog@v0.3.3",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=42ecb449d13ca189",
+        "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=x86_64&epoch=2",
+        "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=x86_64",
+        "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+        "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=x86_64",
+        "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+        "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=x86_64",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=c251c2070b6d837f",
+        "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+        "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+        "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=x86_64",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=a3f45ccc2eaef8aa",
+        "pkg:golang/k8s.io/sample-controller@v0.30.0",
+        "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=x86_64",
+        "pkg:golang/encoding/binary@go1.22.12",
+        "pkg:golang/crypto/ecdsa@go1.22.12",
+        "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=75bca8ba1ca22c9b",
+        "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=45a8c7aac0e298e2#client/v4",
+        "pkg:golang/internal/poll@go1.22.12",
+        "pkg:golang/github.com/imdario/mergo@v0.3.15",
+        "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e519b37240b7b6af",
+        "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=x86_64",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+        "pkg:golang/io/fs@go1.22.12",
+        "pkg:golang/golang.org/x/net@v0.23.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=0c548e794e085974",
+        "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+        "pkg:golang/k8s.io/klog@v0.4.0?package-id=a6cf3f8305ce0756",
+        "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=ee6a4656125cefb2",
+        "pkg:golang/./staging/src#kubevirt.io/client-go",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=92cbc10610ba936e",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=0610c737c3c00486",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=4f70a6c87f97190b",
+        "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=x86_64",
+        "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+        "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+        "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+        "pkg:golang/internal/safefilepath@go1.22.12",
+        "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=f3f74c8e52e58f96",
+        "pkg:golang/crypto/md5@go1.22.12",
+        "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=x86_64",
+        "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+        "pkg:golang/log/slog/internal/buffer@go1.22.12",
+        "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=4e434d83ac45a761#v5",
+        "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+        "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=6bfd33acc02b178b",
+        "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+        "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=x86_64",
+        "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+        "pkg:golang/sync@go1.22.12",
+        "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=x86_64",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=78b5b822f572b90c",
+        "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=8c96dc44fcc58103",
+        "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=x86_64",
+        "pkg:golang/golang.org/x/sync@v0.11.0",
+        "pkg:golang/github.com/beorn7/perks@v1.0.1",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=7b9209a64c9c952b",
+        "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=x86_64",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=2e766a71ac55c8c1",
+        "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+        "pkg:golang/net/http/httputil@go1.22.12",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=264ee8e18d5b5c8a",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+        "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+        "pkg:golang/github.com/go-stack/stack@v1.8.0",
+        "pkg:golang/internal/goexperiment@go1.22.12",
+        "pkg:golang/github.com/go-kit/kit@v0.13.0",
+        "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=x86_64",
+        "pkg:golang/internal/sysinfo@go1.22.12",
+        "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+        "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+        "pkg:golang/github.com/google/uuid@v1.1.5",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+        "pkg:golang/k8s.io/cli-runtime@v0.30.0?package-id=372a4fd9b7953904",
+        "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=x86_64",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=bcb125b3ee0ac2bf",
+        "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=x86_64",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=50971d92969aa29f",
+        "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=x86_64",
+        "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=deca7fef444579a8",
+        "pkg:golang/text/template/parse@go1.22.12",
+        "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+        "pkg:golang/golang.org/x/text@v0.14.0",
+        "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=296003ccdd027f5f",
+        "pkg:golang/k8s.io/cloud-provider@v0.30.0?package-id=213905a8e9bf9bca",
+        "pkg:golang/go/version@go1.22.12",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=fd55bfb7c4801b59",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=d52596cce426463a",
+        "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+        "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+        "pkg:golang/golang.org/x/sync@v0.11.0?package-id=d30348b75bd8dbbe",
+        "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=x86_64",
+        "pkg:golang/github.com/josharian/intern@v1.0.0",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+        "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492?package-id=3ba9356bde827563",
+        "pkg:golang/k8s.io/kubelet@v0.30.0?package-id=0d174a34ad4bac4b",
+        "pkg:golang/github.com/onsi/gomega@v1.33.1",
+        "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+        "pkg:golang/go/types@go1.22.12",
+        "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+        "pkg:golang/hash/adler32@go1.22.12",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=777844465b60ad81",
+        "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+        "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+        "pkg:golang/runtime/internal/syscall@go1.22.12",
+        "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+        "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=7349fb61f86b922a",
+        "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=4b04ea23556ed395",
+        "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=x86_64",
+        "pkg:golang/regexp@go1.22.12",
+        "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+        "pkg:golang/maps@go1.22.12",
+        "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+        "pkg:golang/net@go1.22.12",
+        "pkg:golang/encoding/csv@go1.22.12",
+        "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=165ae9cdbab510ff",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+        "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=x86_64",
+        "pkg:golang/os/signal@go1.22.12",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=37c32ab5198d2ad6",
+        "pkg:golang/net/mail@go1.22.12",
+        "pkg:golang/internal/goroot@go1.22.12",
+        "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+        "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+        "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+        "pkg:golang/strings@go1.22.12",
+        "pkg:golang/google.golang.org/grpc@v1.58.3",
+        "pkg:golang/go/build/constraint@go1.22.12",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=6676202d3cb12353",
+        "pkg:golang/os/user@go1.22.12",
+        "pkg:golang/k8s.io/api@v0.30.0",
+        "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+        "pkg:golang/crypto/dsa@go1.22.12",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=b1e90c3e1ac1f792",
+        "pkg:golang/net/http/httptrace@go1.22.12",
+        "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+        "pkg:golang/github.com/prometheus/procfs@v0.11.0?package-id=05538c935c5bdc7f",
+        "pkg:golang/kubevirt.io/client-go@v0.19.0",
+        "pkg:rpm/redhat/libxml2@2.9.13-13.el9_4?arch=x86_64",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=d49025084db5e534",
+        "pkg:golang/log/slog/internal@go1.22.12",
+        "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+        "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=30a0f7618c550bd4",
+        "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+        "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a?package-id=f5ed66e6e2ff252b",
+        "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=x86_64",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c?package-id=569830e89dc03f1b",
+        "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+        "pkg:pypi/pysocks@1.7.1",
+        "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+        "pkg:golang/crypto/x509@go1.22.12",
+        "pkg:golang/go/printer@go1.22.12",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=d8c2f26e9986efc0",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=875c60b36880d488",
+        "pkg:golang/golang.org/x/sys@v0.19.0",
+        "pkg:golang/go/constant@go1.22.12",
+        "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=56fa540c52a6e225",
+        "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+        "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=x86_64",
+        "pkg:golang/golang.org/x/sys@v0.30.0?package-id=c76606bb87a8c509",
+        "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+        "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+        "pkg:golang/crypto/internal/boring@go1.22.12",
+        "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=x86_64",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=c27f4e3f0f288cba",
+        "pkg:pypi/urllib3@1.26.5",
+        "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+        "pkg:golang/internal/itoa@go1.22.12",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=cd25ddf836753eae",
+        "pkg:golang/internal/zstd@go1.22.12",
+        "pkg:golang/github.com/josharian/native@v1.1.0",
+        "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+        "pkg:golang/net/http/httptest@go1.22.12",
+        "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+        "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+        "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+        "pkg:golang/github.com/prometheus/client_model@v0.4.0?package-id=01a656f993da3d7b",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=426c1ef83fb90a34",
+        "pkg:golang/crypto@go1.22.12",
+        "pkg:golang/github.com/moby/sys@v0.6.2?package-id=1c5457c16104bad6#mountinfo",
+        "pkg:golang/github.com/google/uuid@v1.3.1?package-id=8f2230e2d588c340",
+        "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+        "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=x86_64",
+        "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=x86_64&epoch=1",
+        "pkg:golang/encoding/base64@go1.22.12",
+        "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+        "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=x86_64",
+        "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+        "pkg:golang/crypto/des@go1.22.12",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=cdc588c277efc41e",
+        "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+        "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=x86_64",
+        "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=61ff33db308e1c87",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+        "pkg:golang/github.com/beorn7/perks@v1.0.1?package-id=cf38e7467b415c45",
+        "pkg:golang/github.com/google/go-querystring@v1.0.0",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=69c0335cd603cb43#v22",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=6b3967bbe5e4f770#v3",
+        "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+        "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414?package-id=1f03719fd30cb426",
+        "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+        "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=392c78985b3ee866",
+        "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64",
+        "pkg:pypi/requests@2.25.1",
+        "pkg:golang/golang.org/x/text@v0.14.0?package-id=a47e6c64839baca0",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=507e16afff6e8cbf",
+        "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+        "pkg:golang/golang.org/x/time@v0.3.0?package-id=de8b89d7a225278d",
+        "pkg:pypi/subscription-manager@1.29.40.1",
+        "pkg:golang/k8s.io/kube-scheduler@v0.30.0?package-id=c6f4b38d0e64a871",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=617dda993ef91b06",
+        "pkg:golang/crypto/sha1@go1.22.12",
+        "pkg:golang/crypto/tls@go1.22.12",
+        "pkg:golang/k8s.io/sample-apiserver@v0.30.0?package-id=a7d282fdf5bcfc3a",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=28d221d2b95ef119",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=38a620e1191a8903",
+        "pkg:golang/mime@go1.22.12",
+        "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=x86_64",
+        "pkg:golang/net/http@go1.22.12",
+        "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=7fd9e721114377fd",
+        "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=x86_64",
+        "pkg:golang/log@go1.22.12",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=db29c54369441021",
+        "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+        "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+        "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+        "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+        "pkg:golang/runtime/metrics@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=bd15d762c1c6c3a1",
+        "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=x86_64",
+        "pkg:golang/golang.org/x/time@v0.3.0?package-id=abbe88d4dc25e60a",
+        "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+        "pkg:golang/stdlib@1.22.12?package-id=0263aa6b4909132a",
+        "pkg:golang/unicode/utf16@go1.22.12",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=c8fd5af5f2696ffc",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=6871ce92eaf7233e",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=e5f84b4525280ceb",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=ef4b943e758b9b6b",
+        "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+        "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+        "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=1651c6ba29f925e5",
+        "pkg:golang/github.com/golang/mock@v1.6.0",
+        "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=x86_64",
+        "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+        "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+        "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=x86_64",
+        "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=f3884188f09088ec#v5",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=9fca4ee62066efc2",
+        "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+        "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0?package-id=7c0f2e47ca097803",
+        "pkg:golang/internal/intern@go1.22.12",
+        "pkg:golang/errors@go1.22.12",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=79287922c4530134",
+        "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+        "pkg:golang/hash@go1.22.12",
+        "pkg:golang/github.com/golang/mock@v1.6.0?package-id=58fd55d3a3e68d9a",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=812518b1d5de5b6b",
+        "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+        "pkg:golang/github.com/fatih/color@v1.13.0",
+        "pkg:golang/k8s.io/csi-translation-lib@v0.30.0?package-id=e493ecdd6cef073d",
+        "pkg:pypi/idna@2.10",
+        "pkg:golang/image/internal/imageutil@go1.22.12",
+        "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0?package-id=b57f2d304a79c9d2",
+        "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+        "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=0cf48c7c4e0c2225",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=5f3161d14fb9986b",
+        "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=2add8ed970e49e83",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=6ca8b50f74df1aba",
+        "pkg:golang/k8s.io/api@v0.30.0?package-id=9cd65210b34ae131",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d7e841647edf8bf8",
+        "pkg:golang/container/list@go1.22.12",
+        "pkg:golang/container/ring@go1.22.12",
+        "pkg:golang/unicode@go1.22.12",
+        "pkg:golang/golang.org/x/term@v0.29.0?package-id=123dc6fd6dd76665",
+        "pkg:golang/runtime@go1.22.12",
+        "pkg:pypi/systemd-python@234",
+        "pkg:golang/image/png@go1.22.12",
+        "pkg:golang/github.com/google/btree@v1.1.3?package-id=d631efbb5e6884df",
+        "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+        "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=x86_64",
+        "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+        "pkg:golang/k8s.io/code-generator@v0.30.0?package-id=c9d95bf42170291b",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=fa2fc500853b500e",
+        "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+        "pkg:golang/go/doc/comment@go1.22.12",
+        "pkg:golang/runtime/internal/math@go1.22.12",
+        "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=38f081dbc5ce4d6a",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=317d26dbf41e923a",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=20f072e6e3225e24",
+        "pkg:golang/regexp/syntax@go1.22.12",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=a0115c013e649a4c",
+        "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+        "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible?package-id=15ebdd24a0c721e7",
+        "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+        "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=x86_64",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=78d6e196699c60fb",
+        "pkg:golang/internal/race@go1.22.12",
+        "pkg:golang/internal/goversion@go1.22.12",
+        "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=x86_64",
+        "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+        "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=d183acc87e1fa62e",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=87c0cbf8954e0580",
+        "pkg:golang/crypto/rc4@go1.22.12",
+        "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64",
+        "pkg:golang/k8s.io/cri-api@v0.30.0",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=aabc29983e2a9841",
+        "pkg:golang/k8s.io/kube-controller-manager@v0.30.0?package-id=0814f25a8e4531ce",
+        "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4bf18231eac48ba4",
+        "pkg:golang/encoding/base32@go1.22.12",
+        "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=x86_64",
+        "pkg:golang/text/tabwriter@go1.22.12",
+        "pkg:golang/k8s.io/cri-api@v0.30.0?package-id=4de173f6a5765211",
+        "pkg:golang/k8s.io/component-base@v0.30.0?package-id=94800364440cc1a6",
+        "pkg:golang/image/jpeg@go1.22.12",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=a1ff2ebea07a529d",
+        "pkg:golang/github.com/spf13/cobra@v1.7.0?package-id=3ba0797ce405770e",
+        "pkg:golang/./staging/src#github.com/golang/glog",
+        "pkg:golang/internal/coverage/rtcov@go1.22.12",
+        "pkg:pypi/gpg@1.15.1",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=dbb27eadf8364aee",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=406cd2654be0fcc8",
+        "pkg:golang/golang.org/x/sys@v0.30.0?package-id=8899651b157fa55b",
+        "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+        "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=99619c8dbac171e6",
+        "pkg:golang/k8s.io/metrics@v0.30.0?package-id=e5a9c757e0ba76d0",
+        "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+        "pkg:golang/golang.org/x/oauth2@v0.12.0",
+        "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=41c9ffe89c4328dd#pkg/apis/monitoring",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e87736d4223a3553",
+        "pkg:golang/internal/gover@go1.22.12",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=077b67d110fda982",
+        "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+        "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=332ab3a9d173ca98",
+        "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=2f055f6cdf8e3fb1",
+        "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6?package-id=0bc6f5896c6cb1a9",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=9de2c8dc0803d74e",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=638aeba61e089e7d",
+        "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=x86_64",
+        "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=8256c45ca06407ab",
+        "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b135113b0301cc3e",
+        "pkg:golang/github.com/prometheus/client_golang@v1.16.0?package-id=d58b9b0249e2d522",
+        "pkg:golang/math/big@go1.22.12",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=5df1a932dc364fae",
+        "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+        "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+        "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=49b478fdfd04f997",
+        "pkg:golang/github.com/moby/sys@v0.6.2?package-id=2f1b091e7ebc59e5#mountinfo",
+        "pkg:golang/internal/syscall/execenv@go1.22.12",
+        "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=x86_64",
+        "pkg:golang/golang.org/x/tools@v0.20.0",
+        "pkg:golang/k8s.io/kube-proxy@v0.30.0?package-id=da08354393870645",
+        "pkg:golang/runtime/internal/atomic@go1.22.12",
+        "pkg:golang/crypto/subtle@go1.22.12",
+        "pkg:golang/github.com/josharian/native@v1.1.0?package-id=6604c5cd4c4748cf",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+        "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+        "pkg:golang/github.com/go-stack/stack@v1.8.0?package-id=48631dee752774c6",
+        "pkg:golang/internal/bisect@go1.22.12",
+        "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64",
+        "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=71cd8ab004151c77",
+        "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=e810f9b52b2fed54",
+        "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=x86_64&epoch=1",
+        "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8?package-id=8753666bf11d11e8",
+        "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=x86_64",
+        "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923?package-id=bf32666eb889d979",
+        "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=x86_64",
+        "pkg:golang/go/internal/typeparams@go1.22.12",
+        "pkg:golang/testing@go1.22.12",
+        "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=x86_64",
+        "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=d06c6aae1204ae08#v22",
+        "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=x86_64&epoch=2",
+        "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+        "pkg:golang/io/ioutil@go1.22.12",
+        "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+        "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+        "pkg:golang/k8s.io/api@v0.30.0?package-id=077a5e8ca27fa924",
+        "pkg:golang/html/template@go1.22.12",
+        "pkg:golang/github.com/containers/common@v0.50.1?package-id=e36d1d0f2ba91772",
+        "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=x86_64",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=ad5593f4e294dd87",
+        "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+        "pkg:golang/runtime/debug@go1.22.12",
+        "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=c3d9773d12fa39a7",
+        "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=9e49a047878a9f7c",
+        "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+        "pkg:golang/github.com/cespare/xxhash@v2.2.0?package-id=d7fbb4f13b1bb601#v2",
+        "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=429112dfb9428aeb",
+        "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=x86_64",
+        "pkg:golang/github.com/pierrec/lz4@v4.1.15?package-id=8f6dd5f7ba6a62ec#v4",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=6619c43cfd07c933",
+        "pkg:golang/github.com/golang/mock@v1.6.0?package-id=59cd4b4e359e9754",
+        "pkg:golang/./staging/src#kubevirt.io/api",
+        "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+        "pkg:golang/net/http/internal/testcert@go1.22.12",
+        "pkg:golang/github.com/pborman/uuid@v1.2.1",
+        "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+        "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=x86_64",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=2510cbce9c179e69",
+        "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+        "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+        "pkg:golang/encoding/json@go1.22.12",
+        "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=70cc035eafb9fbd3",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=666b646207e276d6",
+        "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+        "pkg:golang/internal/reflectlite@go1.22.12",
+        "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=x86_64",
+        "pkg:golang/crypto/internal/bigmod@go1.22.12",
+        "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=x86_64",
+        "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d?package-id=3bb12d02cfa2e942#rpc",
+        "pkg:golang/k8s.io/sample-controller@v0.30.0?package-id=95847fe4258b57c0",
+        "pkg:golang/crypto/rand@go1.22.12",
+        "pkg:golang/github.com/onsi/ginkgo@v2.17.2?package-id=709ca981edc6d5d6#v2",
+        "pkg:golang/golang.org/x/mod@v0.17.0",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=ab608fe96a3e5a01",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=13c8c846a4481335",
+        "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=x86_64&epoch=1",
+        "pkg:golang/k8s.io/api@v0.30.0?package-id=dd84eb4f391fe51e",
+        "pkg:golang/unicode/utf8@go1.22.12",
+        "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=1663864887e439eb",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=f1bc226b87c469d8",
+        "pkg:golang/encoding/asn1@go1.22.12",
+        "pkg:golang/sort@go1.22.12",
+        "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=f951095dca4572e3",
+        "pkg:golang/archive/tar@go1.22.12",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=3bccae874729638f",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=a8276711fb26ec2c#v3",
+        "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+        "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20?package-id=ce832bdd3e643f49",
+        "pkg:pypi/six@1.15.0",
+        "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+        "pkg:golang/log/internal@go1.22.12",
+        "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+        "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/passwd@0.80-12.el9?arch=x86_64",
+        "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=6d74c429f555275e",
+        "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=x86_64",
+        "pkg:golang/expvar@go1.22.12",
+        "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+        "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=x86_64",
+        "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b?package-id=b697414c821ee814",
+        "pkg:golang/net/textproto@go1.22.12",
+        "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=5804e51cbc6df18a",
+        "pkg:rpm/redhat/libuser@0.63-13.el9?arch=x86_64",
+        "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=62c158205e5c5cbc#pkg/apis/monitoring",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=c9e73a9ce3fca441",
+        "pkg:rpm/redhat/jansson@2.14-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+        "pkg:golang/kubevirt.io/kubevirt?package-id=12cfd8ec10f078fb",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=ed2a22c702bae008",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=3f70c1e082cb9132",
+        "pkg:golang/runtime/internal/sys@go1.22.12",
+        "pkg:pypi/setuptools@53.0.0",
+        "pkg:golang/k8s.io/apiserver@v0.30.0?package-id=46f0784d88e673c3",
+        "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=c379c7237a34dcc0#client/v4",
+        "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=x86_64",
+        "pkg:golang/encoding/pem@go1.22.12",
+        "pkg:rpm/redhat/openssl-synthetic-test@1.1?arch=x86_64"
+      ]
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=b6c9d8ea55ec3898",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/time@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/dbus-python@1.2.18",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/types/errors@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/common@v0.50.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/godebug@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/python-dateutil@2.8.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/client-go",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/hmac@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goarch@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math/rand@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/pyinotify@0.9.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/saferio@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unsafe@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/ed25519@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/rpc@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/kubevirt",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/bufio@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/nettrace@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0?package-id=6f1e377d494cf9f5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/pprof@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=2fae184f36a99a47",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/x509/pkix@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/trace@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=f970a3d674d44626",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/btree@v1.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/netip@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=48602be9269bc897",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/stdlib@1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=18734635491c2975",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=1b0cc1bbf3f8ed78",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.9.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/which@2.21-29.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sync/atomic@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/nistec@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/database/sql/driver@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/expat@2.5.0-2.el9_4.3?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/reflect@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=b4c3f12b0f973ad1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/usermode@1.114-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math/bits@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/xml@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic@v0.5.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/chacha8rand@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/pygobject@3.40.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=1f351b9d12dd5e8b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=807835609b958430",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/ast@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/rpm@4.16.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/syscall@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/oserror@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/ecdh@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/bzip2@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/internal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.22.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=848770ad63e2adc0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/zlib@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/elliptic@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=b15f37518ae084d6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/godebugs@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/glog",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/buildcfg@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/bytealg@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/url@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.29.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/flag@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4?package-id=e4e1dce43844ff08",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0?package-id=3f73b8c486d0a009",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.22.0?package-id=341ee6986e5d85c1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.33.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/token@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/flate@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/build@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/api",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/platform@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/randutil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/common@v0.44.0?package-id=3a5f710d384a3dd9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/html@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=64880854c531d875",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goos@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=fa36e4581bae4e38",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/gob@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=3f115ef0cb31e7b8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/fmtsort@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/slices@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=bbfbb1eba9b1b80e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=9312f2882f8a9a02",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/aes@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=66f62c4a3380d295",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/libcomps@0.1.18",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/strconv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/bytes@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/sha256@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=8fbdfdc32aa3f0c7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=45b68313e6b7649d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/io@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v0.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/iniparse@0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0?package-id=c5265481edb963f4#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=6025e076d202b258",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/cipher@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/debug/elf@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/rsa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=68f83d538edd1c62",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/container/heap@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mime/multipart@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mime/quotedprintable@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/alias@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/hex@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/abi@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=38049f9b809b501e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=7f71bb3211c40e1e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/parser@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/color@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/context@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=06ba511a601e36d7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/internal/ascii@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=874d616b5ffd59b7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/chardet@4.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d6c72ae7c47adf6d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/cmp@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/syscall/unix@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.24.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/unsafeheader@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/path@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.33.0?package-id=cb71f9386c7676b0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/cpu@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/fmt@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog@v0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/doc@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/embed@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=fd7a9516c0278d0e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/lazyregexp@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/path/filepath@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/singleflight@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=7209f81d42d9fb42",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/slog@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/debug/dwarf@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/api?package-id=8271ccebef8c7fbf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1?package-id=9ab03ca56b78d2bd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash/crc32@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/decorator@4.4.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=cf3c5a20a21e8e64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os/exec@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/glog@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/sha512@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/node-api@v0.30.0?package-id=69b6b0afb2bc8383",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash/fnv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/scanner@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=5af92f389a804379",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/testlog@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/text/template@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/gzip@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=64a952cc8f95048c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog@v0.3.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=42ecb449d13ca189",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=c251c2070b6d837f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=a3f45ccc2eaef8aa",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/binary@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/ecdsa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=75bca8ba1ca22c9b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=45a8c7aac0e298e2#client/v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/poll@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.15",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e519b37240b7b6af",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/io/fs@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.23.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=0c548e794e085974",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog@v0.4.0?package-id=a6cf3f8305ce0756",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=ee6a4656125cefb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/./staging/src#kubevirt.io/client-go",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=92cbc10610ba936e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=0610c737c3c00486",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=4f70a6c87f97190b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/safefilepath@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=f3f74c8e52e58f96",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/md5@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/slog/internal/buffer@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=4e434d83ac45a761#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=6bfd33acc02b178b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sync@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=78b5b822f572b90c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=8c96dc44fcc58103",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=7b9209a64c9c952b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=2e766a71ac55c8c1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/httputil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=264ee8e18d5b5c8a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goexperiment@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/sysinfo@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.1.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0?package-id=372a4fd9b7953904",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=bcb125b3ee0ac2bf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=50971d92969aa29f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=deca7fef444579a8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/text/template/parse@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=296003ccdd027f5f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0?package-id=213905a8e9bf9bca",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/version@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=fd55bfb7c4801b59",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=d52596cce426463a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.11.0?package-id=d30348b75bd8dbbe",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492?package-id=3ba9356bde827563",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubelet@v0.30.0?package-id=0d174a34ad4bac4b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/types@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash/adler32@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=777844465b60ad81",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/syscall@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=7349fb61f86b922a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=4b04ea23556ed395",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/regexp@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/maps@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/csv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=165ae9cdbab510ff",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os/signal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=37c32ab5198d2ad6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/mail@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goroot@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/strings@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/build/constraint@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=6676202d3cb12353",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os/user@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/dsa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=b1e90c3e1ac1f792",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/httptrace@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0?package-id=05538c935c5bdc7f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/client-go@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxml2@2.9.13-13.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=d49025084db5e534",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/slog/internal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=30a0f7618c550bd4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a?package-id=f5ed66e6e2ff252b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c?package-id=569830e89dc03f1b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/pysocks@1.7.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/x509@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/printer@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=d8c2f26e9986efc0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=875c60b36880d488",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/constant@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=56fa540c52a6e225",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=c76606bb87a8c509",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/boring@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=c27f4e3f0f288cba",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/urllib3@1.26.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/itoa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=cd25ddf836753eae",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/zstd@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/httptest@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0?package-id=01a656f993da3d7b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=426c1ef83fb90a34",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=1c5457c16104bad6#mountinfo",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=8f2230e2d588c340",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/base64@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/des@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=cdc588c277efc41e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=61ff33db308e1c87",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/beorn7/perks@v1.0.1?package-id=cf38e7467b415c45",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=69c0335cd603cb43#v22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=6b3967bbe5e4f770#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414?package-id=1f03719fd30cb426",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=392c78985b3ee866",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/requests@2.25.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.14.0?package-id=a47e6c64839baca0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=507e16afff6e8cbf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=de8b89d7a225278d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/subscription-manager@1.29.40.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0?package-id=c6f4b38d0e64a871",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=617dda993ef91b06",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/sha1@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/tls@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0?package-id=a7d282fdf5bcfc3a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=28d221d2b95ef119",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=38a620e1191a8903",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mime@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=7fd9e721114377fd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=db29c54369441021",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/metrics@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=bd15d762c1c6c3a1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=abbe88d4dc25e60a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/stdlib@1.22.12?package-id=0263aa6b4909132a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unicode/utf16@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=c8fd5af5f2696ffc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=6871ce92eaf7233e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=e5f84b4525280ceb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=ef4b943e758b9b6b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=1651c6ba29f925e5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=f3884188f09088ec#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=9fca4ee62066efc2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0?package-id=7c0f2e47ca097803",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/intern@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/errors@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=79287922c4530134",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=58fd55d3a3e68d9a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=812518b1d5de5b6b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fatih/color@v1.13.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0?package-id=e493ecdd6cef073d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/idna@2.10",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/internal/imageutil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0?package-id=b57f2d304a79c9d2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=0cf48c7c4e0c2225",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=5f3161d14fb9986b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=2add8ed970e49e83",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=6ca8b50f74df1aba",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=9cd65210b34ae131",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d7e841647edf8bf8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/container/list@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/container/ring@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unicode@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.29.0?package-id=123dc6fd6dd76665",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/systemd-python@234",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/png@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/btree@v1.1.3?package-id=d631efbb5e6884df",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/code-generator@v0.30.0?package-id=c9d95bf42170291b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=fa2fc500853b500e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/doc/comment@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/math@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=38f081dbc5ce4d6a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=317d26dbf41e923a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=20f072e6e3225e24",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/regexp/syntax@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=a0115c013e649a4c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible?package-id=15ebdd24a0c721e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=78d6e196699c60fb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/race@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goversion@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=d183acc87e1fa62e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=87c0cbf8954e0580",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/rc4@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=aabc29983e2a9841",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0?package-id=0814f25a8e4531ce",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4bf18231eac48ba4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/base32@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/text/tabwriter@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cri-api@v0.30.0?package-id=4de173f6a5765211",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/component-base@v0.30.0?package-id=94800364440cc1a6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/jpeg@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=a1ff2ebea07a529d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cobra@v1.7.0?package-id=3ba0797ce405770e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/./staging/src#github.com/golang/glog",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/coverage/rtcov@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/gpg@1.15.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=dbb27eadf8364aee",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=406cd2654be0fcc8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=8899651b157fa55b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=99619c8dbac171e6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/metrics@v0.30.0?package-id=e5a9c757e0ba76d0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=41c9ffe89c4328dd#pkg/apis/monitoring",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e87736d4223a3553",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/gover@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=077b67d110fda982",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=332ab3a9d173ca98",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=2f055f6cdf8e3fb1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6?package-id=0bc6f5896c6cb1a9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=9de2c8dc0803d74e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=638aeba61e089e7d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=8256c45ca06407ab",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b135113b0301cc3e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0?package-id=d58b9b0249e2d522",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math/big@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=5df1a932dc364fae",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=49b478fdfd04f997",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=2f1b091e7ebc59e5#mountinfo",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/syscall/execenv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0?package-id=da08354393870645",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/atomic@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/subtle@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/native@v1.1.0?package-id=6604c5cd4c4748cf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-stack/stack@v1.8.0?package-id=48631dee752774c6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/bisect@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=71cd8ab004151c77",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=e810f9b52b2fed54",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8?package-id=8753666bf11d11e8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923?package-id=bf32666eb889d979",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/internal/typeparams@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/testing@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=d06c6aae1204ae08#v22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/io/ioutil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=077a5e8ca27fa924",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/html/template@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/common@v0.50.1?package-id=e36d1d0f2ba91772",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=ad5593f4e294dd87",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/debug@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=c3d9773d12fa39a7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=9e49a047878a9f7c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0?package-id=d7fbb4f13b1bb601#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=429112dfb9428aeb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15?package-id=8f6dd5f7ba6a62ec#v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=6619c43cfd07c933",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=59cd4b4e359e9754",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/./staging/src#kubevirt.io/api",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/internal/testcert@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pborman/uuid@v1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=2510cbce9c179e69",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/json@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=70cc035eafb9fbd3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=666b646207e276d6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/reflectlite@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/bigmod@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d?package-id=3bb12d02cfa2e942#rpc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-controller@v0.30.0?package-id=95847fe4258b57c0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/rand@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2?package-id=709ca981edc6d5d6#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=ab608fe96a3e5a01",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=13c8c846a4481335",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=dd84eb4f391fe51e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unicode/utf8@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=1663864887e439eb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=f1bc226b87c469d8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/asn1@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sort@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=f951095dca4572e3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/archive/tar@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=3bccae874729638f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=a8276711fb26ec2c#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20?package-id=ce832bdd3e643f49",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/six@1.15.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/internal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/passwd@0.80-12.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=6d74c429f555275e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/expvar@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b?package-id=b697414c821ee814",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/textproto@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=5804e51cbc6df18a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuser@0.63-13.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=62c158205e5c5cbc#pkg/apis/monitoring",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=c9e73a9ce3fca441",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/jansson@2.14-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/kubevirt?package-id=12cfd8ec10f078fb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=ed2a22c702bae008",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=3f70c1e082cb9132",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/sys@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/setuptools@53.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiserver@v0.30.0?package-id=46f0784d88e673c3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=c379c7237a34dcc0#client/v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/pem@go1.22.12",
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:23d63018-3115-4a8c-ae7b-20ed565a889d"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/latest/image-index-2025-12-02-693F980C32C444A.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/latest/image-index-2025-12-02-693F980C32C444A.json
@@ -1,0 +1,156 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [
+        {
+          "name": "SBOMer",
+          "version": "f1c3bca6",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+                "acknowledgement": "declared"
+              }
+            }
+          ],
+          "provider": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          },
+          "externalReferences": [
+            {
+              "url": "https://github.com/project-ncl/sbomer",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/container-native-virtualization-virt-handler-rhel9@sha256%3Acdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36-3",
+      "type": "container",
+      "description": "Image index manifest of pkg:oci/container-native-virtualization-virt-handler-rhel9@sha256%3Acdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa"
+    },
+    "timestamp": "2025-12-02T09:05:59Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156526"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/container-native-virtualization-virt-handler-rhel9@sha256%3Acdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36-3",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa"
+        }
+      ],
+      "bom-ref": "virt-handler-rhel9-container_image-index",
+      "version": "sha256:cdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/container-native-virtualization-virt-handler-rhel9@sha256%3Acdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/container-native-virtualization-virt-handler-rhel9@sha256%3Acdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/container-native-virtualization-virt-handler-rhel9@sha256%3Acdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36"
+          }
+        ]
+      },
+      "pedigree": {
+        "variants": [
+          {
+            "name": "container-native-virtualization/virt-handler-rhel9",
+            "purl": "pkg:oci/virt-handler-rhel9@sha256%3A507d126fa23811854bb17531194f9e832167022a1a30542561aadfd668bf1542?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36-3",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "507d126fa23811854bb17531194f9e832167022a1a30542561aadfd668bf1542"
+              }
+            ],
+            "bom-ref": "virt-handler-rhel9-container_amd64",
+            "version": "sha256:507d126fa23811854bb17531194f9e832167022a1a30542561aadfd668bf1542",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          },
+          {
+            "name": "container-native-virtualization/virt-handler-rhel9",
+            "purl": "pkg:oci/virt-handler-rhel9@sha256%3A19351b7583cc2b23b6aed869a1969a23be9ecdc32d46ffc05b480750ba113118?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36-3",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "19351b7583cc2b23b6aed869a1969a23be9ecdc32d46ffc05b480750ba113118"
+              }
+            ],
+            "bom-ref": "virt-handler-rhel9-container_arm64",
+            "version": "sha256:19351b7583cc2b23b6aed869a1969a23be9ecdc32d46ffc05b480750ba113118",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "virt-handler-rhel9-container"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "container-native-virtualization/virt-handler-rhel9"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "3"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "v4.17.36"
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:64f8a4ee-3ea5-30e5-825e-a0592909b2ef"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/latest/product-2025-12-02-ED1F188BB5C94D8.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/latest/product-2025-12-02-ED1F188BB5C94D8.json
@@ -1,0 +1,2004 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [
+        {
+          "name": "SBOMer",
+          "version": "f1c3bca6",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+                "acknowledgement": "declared"
+              }
+            }
+          ],
+          "provider": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          },
+          "externalReferences": [
+            {
+              "url": "https://github.com/project-ncl/sbomer",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "RHEL-9-CNV-4.17",
+      "type": "framework",
+      "bom-ref": "RHEL-9-CNV-4.17",
+      "version": "RHEL-9-CNV-4.17",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:container_native_virtualization:4.17::el9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-12-02T12:05:38Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156526"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "container-native-virtualization/wasp-agent-rhel9",
+      "purl": "pkg:oci/wasp-agent-rhel9@sha256%3Aa2c95d29514f3e841c83677aefbb7eb5466946178aeb2668a52b67b73d1c0e37",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a2c95d29514f3e841c83677aefbb7eb5466946178aeb2668a52b67b73d1c0e37"
+        }
+      ],
+      "bom-ref": "pkg:oci/wasp-agent-rhel9@sha256%3Aa2c95d29514f3e841c83677aefbb7eb5466946178aeb2668a52b67b73d1c0e37",
+      "version": "sha256:a2c95d29514f3e841c83677aefbb7eb5466946178aeb2668a52b67b73d1c0e37",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/wasp-agent-rhel9@sha256%3Aa2c95d29514f3e841c83677aefbb7eb5466946178aeb2668a52b67b73d1c0e37?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fwasp-agent-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/wasp-agent-rhel9@sha256%3Aa2c95d29514f3e841c83677aefbb7eb5466946178aeb2668a52b67b73d1c0e37?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fwasp-agent-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/wasp-agent-rhel9@sha256%3Aa2c95d29514f3e841c83677aefbb7eb5466946178aeb2668a52b67b73d1c0e37?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fwasp-agent-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-importer-rhel9",
+      "purl": "pkg:oci/virt-cdi-importer-rhel9@sha256%3A63e0d3bd66d81a4846772e561cd4ff4752544814c5e9ff61d4dc74d37979c1d1",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "63e0d3bd66d81a4846772e561cd4ff4752544814c5e9ff61d4dc74d37979c1d1"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-importer-rhel9@sha256%3A63e0d3bd66d81a4846772e561cd4ff4752544814c5e9ff61d4dc74d37979c1d1",
+      "version": "sha256:63e0d3bd66d81a4846772e561cd4ff4752544814c5e9ff61d4dc74d37979c1d1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-importer-rhel9@sha256%3A63e0d3bd66d81a4846772e561cd4ff4752544814c5e9ff61d4dc74d37979c1d1?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-importer-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-importer-rhel9@sha256%3A63e0d3bd66d81a4846772e561cd4ff4752544814c5e9ff61d4dc74d37979c1d1?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-importer-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-importer-rhel9@sha256%3A63e0d3bd66d81a4846772e561cd4ff4752544814c5e9ff61d4dc74d37979c1d1?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-importer-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/ovs-cni-plugin-rhel9",
+      "purl": "pkg:oci/ovs-cni-plugin-rhel9@sha256%3Abbbe09c489b4bbd8a4683f809a2988d890f85c960166d8ec55dab3f57aef3b73",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bbbe09c489b4bbd8a4683f809a2988d890f85c960166d8ec55dab3f57aef3b73"
+        }
+      ],
+      "bom-ref": "pkg:oci/ovs-cni-plugin-rhel9@sha256%3Abbbe09c489b4bbd8a4683f809a2988d890f85c960166d8ec55dab3f57aef3b73",
+      "version": "sha256:bbbe09c489b4bbd8a4683f809a2988d890f85c960166d8ec55dab3f57aef3b73",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/ovs-cni-plugin-rhel9@sha256%3Abbbe09c489b4bbd8a4683f809a2988d890f85c960166d8ec55dab3f57aef3b73?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fovs-cni-plugin-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/ovs-cni-plugin-rhel9@sha256%3Abbbe09c489b4bbd8a4683f809a2988d890f85c960166d8ec55dab3f57aef3b73?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fovs-cni-plugin-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/ovs-cni-plugin-rhel9@sha256%3Abbbe09c489b4bbd8a4683f809a2988d890f85c960166d8ec55dab3f57aef3b73?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fovs-cni-plugin-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-ssp-operator-rhel9",
+      "purl": "pkg:oci/kubevirt-ssp-operator-rhel9@sha256%3A4e2f2bea93ac4cdffead6952b2da9f5cbca960101fcec625ecfc51cb34d4e2c3",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4e2f2bea93ac4cdffead6952b2da9f5cbca960101fcec625ecfc51cb34d4e2c3"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-ssp-operator-rhel9@sha256%3A4e2f2bea93ac4cdffead6952b2da9f5cbca960101fcec625ecfc51cb34d4e2c3",
+      "version": "sha256:4e2f2bea93ac4cdffead6952b2da9f5cbca960101fcec625ecfc51cb34d4e2c3",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-ssp-operator-rhel9@sha256%3A4e2f2bea93ac4cdffead6952b2da9f5cbca960101fcec625ecfc51cb34d4e2c3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-ssp-operator-rhel9&tag=v4.17.36-4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-ssp-operator-rhel9@sha256%3A4e2f2bea93ac4cdffead6952b2da9f5cbca960101fcec625ecfc51cb34d4e2c3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-ssp-operator-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-ssp-operator-rhel9@sha256%3A4e2f2bea93ac4cdffead6952b2da9f5cbca960101fcec625ecfc51cb34d4e2c3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-ssp-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-template-validator-rhel9",
+      "purl": "pkg:oci/kubevirt-template-validator-rhel9@sha256%3A9b7411f914923d7f744ff312bc12124c0a85da98af63c615392a45d83b9e9e73",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9b7411f914923d7f744ff312bc12124c0a85da98af63c615392a45d83b9e9e73"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-template-validator-rhel9@sha256%3A9b7411f914923d7f744ff312bc12124c0a85da98af63c615392a45d83b9e9e73",
+      "version": "sha256:9b7411f914923d7f744ff312bc12124c0a85da98af63c615392a45d83b9e9e73",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-template-validator-rhel9@sha256%3A9b7411f914923d7f744ff312bc12124c0a85da98af63c615392a45d83b9e9e73?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-template-validator-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-template-validator-rhel9@sha256%3A9b7411f914923d7f744ff312bc12124c0a85da98af63c615392a45d83b9e9e73?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-template-validator-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-template-validator-rhel9@sha256%3A9b7411f914923d7f744ff312bc12124c0a85da98af63c615392a45d83b9e9e73?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-template-validator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-cloner-rhel9",
+      "purl": "pkg:oci/virt-cdi-cloner-rhel9@sha256%3A748b76396ced4519a607997debb8fedbc20976c35559cda33d318a5a7d723ad9",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "748b76396ced4519a607997debb8fedbc20976c35559cda33d318a5a7d723ad9"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-cloner-rhel9@sha256%3A748b76396ced4519a607997debb8fedbc20976c35559cda33d318a5a7d723ad9",
+      "version": "sha256:748b76396ced4519a607997debb8fedbc20976c35559cda33d318a5a7d723ad9",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-cloner-rhel9@sha256%3A748b76396ced4519a607997debb8fedbc20976c35559cda33d318a5a7d723ad9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-cloner-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-cloner-rhel9@sha256%3A748b76396ced4519a607997debb8fedbc20976c35559cda33d318a5a7d723ad9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-cloner-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-cloner-rhel9@sha256%3A748b76396ced4519a607997debb8fedbc20976c35559cda33d318a5a7d723ad9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-cloner-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-controller-rhel9",
+      "purl": "pkg:oci/virt-controller-rhel9@sha256%3A6d7d99737df7d268b018ca022d00830e57dd3451a0bbe07f606c2949c975ef76",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6d7d99737df7d268b018ca022d00830e57dd3451a0bbe07f606c2949c975ef76"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-controller-rhel9@sha256%3A6d7d99737df7d268b018ca022d00830e57dd3451a0bbe07f606c2949c975ef76",
+      "version": "sha256:6d7d99737df7d268b018ca022d00830e57dd3451a0bbe07f606c2949c975ef76",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-controller-rhel9@sha256%3A6d7d99737df7d268b018ca022d00830e57dd3451a0bbe07f606c2949c975ef76?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-controller-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-controller-rhel9@sha256%3A6d7d99737df7d268b018ca022d00830e57dd3451a0bbe07f606c2949c975ef76?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-controller-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-controller-rhel9@sha256%3A6d7d99737df7d268b018ca022d00830e57dd3451a0bbe07f606c2949c975ef76?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-controller-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/hostpath-provisioner-rhel9",
+      "purl": "pkg:oci/hostpath-provisioner-rhel9@sha256%3Aed490dfa4aea26e80fb6129a059ad762c398d5b1202a68281c228474bad25736",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ed490dfa4aea26e80fb6129a059ad762c398d5b1202a68281c228474bad25736"
+        }
+      ],
+      "bom-ref": "pkg:oci/hostpath-provisioner-rhel9@sha256%3Aed490dfa4aea26e80fb6129a059ad762c398d5b1202a68281c228474bad25736",
+      "version": "sha256:ed490dfa4aea26e80fb6129a059ad762c398d5b1202a68281c228474bad25736",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-provisioner-rhel9@sha256%3Aed490dfa4aea26e80fb6129a059ad762c398d5b1202a68281c228474bad25736?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-provisioner-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-provisioner-rhel9@sha256%3Aed490dfa4aea26e80fb6129a059ad762c398d5b1202a68281c228474bad25736?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-provisioner-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-provisioner-rhel9@sha256%3Aed490dfa4aea26e80fb6129a059ad762c398d5b1202a68281c228474bad25736?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-provisioner-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-launcher-rhel9",
+      "purl": "pkg:oci/virt-launcher-rhel9@sha256%3A7d10f7c58b2c68e0d6cdb4624b2d6970aa9741e4123cf0039673fd550c0b9604",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7d10f7c58b2c68e0d6cdb4624b2d6970aa9741e4123cf0039673fd550c0b9604"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-launcher-rhel9@sha256%3A7d10f7c58b2c68e0d6cdb4624b2d6970aa9741e4123cf0039673fd550c0b9604",
+      "version": "sha256:7d10f7c58b2c68e0d6cdb4624b2d6970aa9741e4123cf0039673fd550c0b9604",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-launcher-rhel9@sha256%3A7d10f7c58b2c68e0d6cdb4624b2d6970aa9741e4123cf0039673fd550c0b9604?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-launcher-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-launcher-rhel9@sha256%3A7d10f7c58b2c68e0d6cdb4624b2d6970aa9741e4123cf0039673fd550c0b9604?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-launcher-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-launcher-rhel9@sha256%3A7d10f7c58b2c68e0d6cdb4624b2d6970aa9741e4123cf0039673fd550c0b9604?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-launcher-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-operator-rhel9",
+      "purl": "pkg:oci/virt-cdi-operator-rhel9@sha256%3A8f551b49544e6b1fe9e12ca21887dd1501fc7a2608f00e325ef0b3374f22c5c8",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8f551b49544e6b1fe9e12ca21887dd1501fc7a2608f00e325ef0b3374f22c5c8"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-operator-rhel9@sha256%3A8f551b49544e6b1fe9e12ca21887dd1501fc7a2608f00e325ef0b3374f22c5c8",
+      "version": "sha256:8f551b49544e6b1fe9e12ca21887dd1501fc7a2608f00e325ef0b3374f22c5c8",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-operator-rhel9@sha256%3A8f551b49544e6b1fe9e12ca21887dd1501fc7a2608f00e325ef0b3374f22c5c8?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-operator-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-operator-rhel9@sha256%3A8f551b49544e6b1fe9e12ca21887dd1501fc7a2608f00e325ef0b3374f22c5c8?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-operator-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-operator-rhel9@sha256%3A8f551b49544e6b1fe9e12ca21887dd1501fc7a2608f00e325ef0b3374f22c5c8?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-operator-rhel9",
+      "purl": "pkg:oci/virt-operator-rhel9@sha256%3A1ecfdadbf0a12e7a363c814197b61f9e243c77c4265332e559a21e37b8e4a916",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1ecfdadbf0a12e7a363c814197b61f9e243c77c4265332e559a21e37b8e4a916"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-operator-rhel9@sha256%3A1ecfdadbf0a12e7a363c814197b61f9e243c77c4265332e559a21e37b8e4a916",
+      "version": "sha256:1ecfdadbf0a12e7a363c814197b61f9e243c77c4265332e559a21e37b8e4a916",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-operator-rhel9@sha256%3A1ecfdadbf0a12e7a363c814197b61f9e243c77c4265332e559a21e37b8e4a916?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-operator-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-operator-rhel9@sha256%3A1ecfdadbf0a12e7a363c814197b61f9e243c77c4265332e559a21e37b8e4a916?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-operator-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-operator-rhel9@sha256%3A1ecfdadbf0a12e7a363c814197b61f9e243c77c4265332e559a21e37b8e4a916?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/aaq-operator-rhel9",
+      "purl": "pkg:oci/aaq-operator-rhel9@sha256%3A3a0ffc27148f446956b1124834cdb5b2b62b5b2228056386f147975fafeeec31",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3a0ffc27148f446956b1124834cdb5b2b62b5b2228056386f147975fafeeec31"
+        }
+      ],
+      "bom-ref": "pkg:oci/aaq-operator-rhel9@sha256%3A3a0ffc27148f446956b1124834cdb5b2b62b5b2228056386f147975fafeeec31",
+      "version": "sha256:3a0ffc27148f446956b1124834cdb5b2b62b5b2228056386f147975fafeeec31",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-operator-rhel9@sha256%3A3a0ffc27148f446956b1124834cdb5b2b62b5b2228056386f147975fafeeec31?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-operator-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-operator-rhel9@sha256%3A3a0ffc27148f446956b1124834cdb5b2b62b5b2228056386f147975fafeeec31?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-operator-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-operator-rhel9@sha256%3A3a0ffc27148f446956b1124834cdb5b2b62b5b2228056386f147975fafeeec31?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/aaq-server-rhel9",
+      "purl": "pkg:oci/aaq-server-rhel9@sha256%3Ae45503da0c7b8b1acb7ad018b10a5cab3599ce0223627e3ab3d1ad4aef1e7bd4",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e45503da0c7b8b1acb7ad018b10a5cab3599ce0223627e3ab3d1ad4aef1e7bd4"
+        }
+      ],
+      "bom-ref": "pkg:oci/aaq-server-rhel9@sha256%3Ae45503da0c7b8b1acb7ad018b10a5cab3599ce0223627e3ab3d1ad4aef1e7bd4",
+      "version": "sha256:e45503da0c7b8b1acb7ad018b10a5cab3599ce0223627e3ab3d1ad4aef1e7bd4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-server-rhel9@sha256%3Ae45503da0c7b8b1acb7ad018b10a5cab3599ce0223627e3ab3d1ad4aef1e7bd4?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-server-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-server-rhel9@sha256%3Ae45503da0c7b8b1acb7ad018b10a5cab3599ce0223627e3ab3d1ad4aef1e7bd4?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-server-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-server-rhel9@sha256%3Ae45503da0c7b8b1acb7ad018b10a5cab3599ce0223627e3ab3d1ad4aef1e7bd4?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-server-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-uploadserver-rhel9",
+      "purl": "pkg:oci/virt-cdi-uploadserver-rhel9@sha256%3A795d9efeb758f1499f31fe23f485411659bd9ef84cc150bab0eeaba51ebabc18",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "795d9efeb758f1499f31fe23f485411659bd9ef84cc150bab0eeaba51ebabc18"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-uploadserver-rhel9@sha256%3A795d9efeb758f1499f31fe23f485411659bd9ef84cc150bab0eeaba51ebabc18",
+      "version": "sha256:795d9efeb758f1499f31fe23f485411659bd9ef84cc150bab0eeaba51ebabc18",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-uploadserver-rhel9@sha256%3A795d9efeb758f1499f31fe23f485411659bd9ef84cc150bab0eeaba51ebabc18?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-uploadserver-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-uploadserver-rhel9@sha256%3A795d9efeb758f1499f31fe23f485411659bd9ef84cc150bab0eeaba51ebabc18?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-uploadserver-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-uploadserver-rhel9@sha256%3A795d9efeb758f1499f31fe23f485411659bd9ef84cc150bab0eeaba51ebabc18?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-uploadserver-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-tekton-tasks-create-datavolume-rhel9",
+      "purl": "pkg:oci/kubevirt-tekton-tasks-create-datavolume-rhel9@sha256%3A4dd704c03cdafe5f7f811accf01bf7617568124bf0282066bfeaf263afb6e5e7",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4dd704c03cdafe5f7f811accf01bf7617568124bf0282066bfeaf263afb6e5e7"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-tekton-tasks-create-datavolume-rhel9@sha256%3A4dd704c03cdafe5f7f811accf01bf7617568124bf0282066bfeaf263afb6e5e7",
+      "version": "sha256:4dd704c03cdafe5f7f811accf01bf7617568124bf0282066bfeaf263afb6e5e7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-tekton-tasks-create-datavolume-rhel9@sha256%3A4dd704c03cdafe5f7f811accf01bf7617568124bf0282066bfeaf263afb6e5e7?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-tekton-tasks-create-datavolume-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-tekton-tasks-create-datavolume-rhel9@sha256%3A4dd704c03cdafe5f7f811accf01bf7617568124bf0282066bfeaf263afb6e5e7?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-tekton-tasks-create-datavolume-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-tekton-tasks-create-datavolume-rhel9@sha256%3A4dd704c03cdafe5f7f811accf01bf7617568124bf0282066bfeaf263afb6e5e7?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-tekton-tasks-create-datavolume-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-uploadproxy-rhel9",
+      "purl": "pkg:oci/virt-cdi-uploadproxy-rhel9@sha256%3Ab8bf22e8e0b66a1685429747719ec882b228810d4353006f97e4989243f0ce76",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b8bf22e8e0b66a1685429747719ec882b228810d4353006f97e4989243f0ce76"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-uploadproxy-rhel9@sha256%3Ab8bf22e8e0b66a1685429747719ec882b228810d4353006f97e4989243f0ce76",
+      "version": "sha256:b8bf22e8e0b66a1685429747719ec882b228810d4353006f97e4989243f0ce76",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-uploadproxy-rhel9@sha256%3Ab8bf22e8e0b66a1685429747719ec882b228810d4353006f97e4989243f0ce76?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-uploadproxy-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-uploadproxy-rhel9@sha256%3Ab8bf22e8e0b66a1685429747719ec882b228810d4353006f97e4989243f0ce76?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-uploadproxy-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-uploadproxy-rhel9@sha256%3Ab8bf22e8e0b66a1685429747719ec882b228810d4353006f97e4989243f0ce76?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-uploadproxy-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-apiserver-rhel9",
+      "purl": "pkg:oci/virt-cdi-apiserver-rhel9@sha256%3Af2083253812e68cf577f48fb081c3e41e9c7875299f3ba83b13851b9cf1f3567",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f2083253812e68cf577f48fb081c3e41e9c7875299f3ba83b13851b9cf1f3567"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-apiserver-rhel9@sha256%3Af2083253812e68cf577f48fb081c3e41e9c7875299f3ba83b13851b9cf1f3567",
+      "version": "sha256:f2083253812e68cf577f48fb081c3e41e9c7875299f3ba83b13851b9cf1f3567",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-apiserver-rhel9@sha256%3Af2083253812e68cf577f48fb081c3e41e9c7875299f3ba83b13851b9cf1f3567?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-apiserver-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-apiserver-rhel9@sha256%3Af2083253812e68cf577f48fb081c3e41e9c7875299f3ba83b13851b9cf1f3567?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-apiserver-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-apiserver-rhel9@sha256%3Af2083253812e68cf577f48fb081c3e41e9c7875299f3ba83b13851b9cf1f3567?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-apiserver-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-controller-rhel9",
+      "purl": "pkg:oci/virt-cdi-controller-rhel9@sha256%3A724a00aa0686927808d622427c008eac1d630bcb21520ba348a2c5a37316dc19",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "724a00aa0686927808d622427c008eac1d630bcb21520ba348a2c5a37316dc19"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-controller-rhel9@sha256%3A724a00aa0686927808d622427c008eac1d630bcb21520ba348a2c5a37316dc19",
+      "version": "sha256:724a00aa0686927808d622427c008eac1d630bcb21520ba348a2c5a37316dc19",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-controller-rhel9@sha256%3A724a00aa0686927808d622427c008eac1d630bcb21520ba348a2c5a37316dc19?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-controller-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-controller-rhel9@sha256%3A724a00aa0686927808d622427c008eac1d630bcb21520ba348a2c5a37316dc19?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-controller-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-controller-rhel9@sha256%3A724a00aa0686927808d622427c008eac1d630bcb21520ba348a2c5a37316dc19?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-controller-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/hostpath-csi-driver-rhel9",
+      "purl": "pkg:oci/hostpath-csi-driver-rhel9@sha256%3A45cad9b92d3cea71ce98168481fdd916528752a5df163b629cef533a1a4dce77",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "45cad9b92d3cea71ce98168481fdd916528752a5df163b629cef533a1a4dce77"
+        }
+      ],
+      "bom-ref": "pkg:oci/hostpath-csi-driver-rhel9@sha256%3A45cad9b92d3cea71ce98168481fdd916528752a5df163b629cef533a1a4dce77",
+      "version": "sha256:45cad9b92d3cea71ce98168481fdd916528752a5df163b629cef533a1a4dce77",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-csi-driver-rhel9@sha256%3A45cad9b92d3cea71ce98168481fdd916528752a5df163b629cef533a1a4dce77?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-csi-driver-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-csi-driver-rhel9@sha256%3A45cad9b92d3cea71ce98168481fdd916528752a5df163b629cef533a1a4dce77?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-csi-driver-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-csi-driver-rhel9@sha256%3A45cad9b92d3cea71ce98168481fdd916528752a5df163b629cef533a1a4dce77?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-csi-driver-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/hostpath-provisioner-operator-rhel9",
+      "purl": "pkg:oci/hostpath-provisioner-operator-rhel9@sha256%3A087a1d292d25b934bc47b47c51055b003b5092ddd1fda66cc3f89d8fbe58be17",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "087a1d292d25b934bc47b47c51055b003b5092ddd1fda66cc3f89d8fbe58be17"
+        }
+      ],
+      "bom-ref": "pkg:oci/hostpath-provisioner-operator-rhel9@sha256%3A087a1d292d25b934bc47b47c51055b003b5092ddd1fda66cc3f89d8fbe58be17",
+      "version": "sha256:087a1d292d25b934bc47b47c51055b003b5092ddd1fda66cc3f89d8fbe58be17",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-provisioner-operator-rhel9@sha256%3A087a1d292d25b934bc47b47c51055b003b5092ddd1fda66cc3f89d8fbe58be17?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-provisioner-operator-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-provisioner-operator-rhel9@sha256%3A087a1d292d25b934bc47b47c51055b003b5092ddd1fda66cc3f89d8fbe58be17?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-provisioner-operator-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-provisioner-operator-rhel9@sha256%3A087a1d292d25b934bc47b47c51055b003b5092ddd1fda66cc3f89d8fbe58be17?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-provisioner-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/cluster-network-addons-operator-rhel9",
+      "purl": "pkg:oci/cluster-network-addons-operator-rhel9@sha256%3A44eda4396eee6eeb365a1daef3cf4740298df153226c842a122f3b645b29a5c8",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "44eda4396eee6eeb365a1daef3cf4740298df153226c842a122f3b645b29a5c8"
+        }
+      ],
+      "bom-ref": "pkg:oci/cluster-network-addons-operator-rhel9@sha256%3A44eda4396eee6eeb365a1daef3cf4740298df153226c842a122f3b645b29a5c8",
+      "version": "sha256:44eda4396eee6eeb365a1daef3cf4740298df153226c842a122f3b645b29a5c8",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cluster-network-addons-operator-rhel9@sha256%3A44eda4396eee6eeb365a1daef3cf4740298df153226c842a122f3b645b29a5c8?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcluster-network-addons-operator-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cluster-network-addons-operator-rhel9@sha256%3A44eda4396eee6eeb365a1daef3cf4740298df153226c842a122f3b645b29a5c8?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcluster-network-addons-operator-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cluster-network-addons-operator-rhel9@sha256%3A44eda4396eee6eeb365a1daef3cf4740298df153226c842a122f3b645b29a5c8?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcluster-network-addons-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-common-instancetypes-rhel9",
+      "purl": "pkg:oci/kubevirt-common-instancetypes-rhel9@sha256%3A3f56642bad303fc45072b1c7809bb5e757e3243bdbc6e9e5a17725eebd76fd27",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3f56642bad303fc45072b1c7809bb5e757e3243bdbc6e9e5a17725eebd76fd27"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-common-instancetypes-rhel9@sha256%3A3f56642bad303fc45072b1c7809bb5e757e3243bdbc6e9e5a17725eebd76fd27",
+      "version": "sha256:3f56642bad303fc45072b1c7809bb5e757e3243bdbc6e9e5a17725eebd76fd27",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-common-instancetypes-rhel9@sha256%3A3f56642bad303fc45072b1c7809bb5e757e3243bdbc6e9e5a17725eebd76fd27?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-common-instancetypes-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-common-instancetypes-rhel9@sha256%3A3f56642bad303fc45072b1c7809bb5e757e3243bdbc6e9e5a17725eebd76fd27?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-common-instancetypes-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-common-instancetypes-rhel9@sha256%3A3f56642bad303fc45072b1c7809bb5e757e3243bdbc6e9e5a17725eebd76fd27?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-common-instancetypes-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/bridge-marker-rhel9",
+      "purl": "pkg:oci/bridge-marker-rhel9@sha256%3Aa8c75b8aa656f38a51b1faee7ab06cd9405cc2b82cdae754c52dbf2a3cd90554",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a8c75b8aa656f38a51b1faee7ab06cd9405cc2b82cdae754c52dbf2a3cd90554"
+        }
+      ],
+      "bom-ref": "pkg:oci/bridge-marker-rhel9@sha256%3Aa8c75b8aa656f38a51b1faee7ab06cd9405cc2b82cdae754c52dbf2a3cd90554",
+      "version": "sha256:a8c75b8aa656f38a51b1faee7ab06cd9405cc2b82cdae754c52dbf2a3cd90554",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/bridge-marker-rhel9@sha256%3Aa8c75b8aa656f38a51b1faee7ab06cd9405cc2b82cdae754c52dbf2a3cd90554?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fbridge-marker-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/bridge-marker-rhel9@sha256%3Aa8c75b8aa656f38a51b1faee7ab06cd9405cc2b82cdae754c52dbf2a3cd90554?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fbridge-marker-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/bridge-marker-rhel9@sha256%3Aa8c75b8aa656f38a51b1faee7ab06cd9405cc2b82cdae754c52dbf2a3cd90554?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fbridge-marker-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubesecondarydns-rhel9",
+      "purl": "pkg:oci/kubesecondarydns-rhel9@sha256%3Ab8834767a8715f782bc17dcaca512d246ca8b466013cddcee356fb60b890e4ec",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b8834767a8715f782bc17dcaca512d246ca8b466013cddcee356fb60b890e4ec"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubesecondarydns-rhel9@sha256%3Ab8834767a8715f782bc17dcaca512d246ca8b466013cddcee356fb60b890e4ec",
+      "version": "sha256:b8834767a8715f782bc17dcaca512d246ca8b466013cddcee356fb60b890e4ec",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubesecondarydns-rhel9@sha256%3Ab8834767a8715f782bc17dcaca512d246ca8b466013cddcee356fb60b890e4ec?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubesecondarydns-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubesecondarydns-rhel9@sha256%3Ab8834767a8715f782bc17dcaca512d246ca8b466013cddcee356fb60b890e4ec?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubesecondarydns-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubesecondarydns-rhel9@sha256%3Ab8834767a8715f782bc17dcaca512d246ca8b466013cddcee356fb60b890e4ec?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubesecondarydns-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/cnv-containernetworking-plugins-rhel9",
+      "purl": "pkg:oci/cnv-containernetworking-plugins-rhel9@sha256%3Ab4cc91b79ca2ed57b8cdee8220cfc151c15c3f07847e60bd9f13ad8c57332b00",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b4cc91b79ca2ed57b8cdee8220cfc151c15c3f07847e60bd9f13ad8c57332b00"
+        }
+      ],
+      "bom-ref": "pkg:oci/cnv-containernetworking-plugins-rhel9@sha256%3Ab4cc91b79ca2ed57b8cdee8220cfc151c15c3f07847e60bd9f13ad8c57332b00",
+      "version": "sha256:b4cc91b79ca2ed57b8cdee8220cfc151c15c3f07847e60bd9f13ad8c57332b00",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cnv-containernetworking-plugins-rhel9@sha256%3Ab4cc91b79ca2ed57b8cdee8220cfc151c15c3f07847e60bd9f13ad8c57332b00?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcnv-containernetworking-plugins-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cnv-containernetworking-plugins-rhel9@sha256%3Ab4cc91b79ca2ed57b8cdee8220cfc151c15c3f07847e60bd9f13ad8c57332b00?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcnv-containernetworking-plugins-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cnv-containernetworking-plugins-rhel9@sha256%3Ab4cc91b79ca2ed57b8cdee8220cfc151c15c3f07847e60bd9f13ad8c57332b00?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcnv-containernetworking-plugins-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubemacpool-rhel9",
+      "purl": "pkg:oci/kubemacpool-rhel9@sha256%3Afdff61819b4c031b96cefd2a4a9ca5e11136f7f0552e66796b7a6c81d8ff0c92",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fdff61819b4c031b96cefd2a4a9ca5e11136f7f0552e66796b7a6c81d8ff0c92"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubemacpool-rhel9@sha256%3Afdff61819b4c031b96cefd2a4a9ca5e11136f7f0552e66796b7a6c81d8ff0c92",
+      "version": "sha256:fdff61819b4c031b96cefd2a4a9ca5e11136f7f0552e66796b7a6c81d8ff0c92",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubemacpool-rhel9@sha256%3Afdff61819b4c031b96cefd2a4a9ca5e11136f7f0552e66796b7a6c81d8ff0c92?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubemacpool-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubemacpool-rhel9@sha256%3Afdff61819b4c031b96cefd2a4a9ca5e11136f7f0552e66796b7a6c81d8ff0c92?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubemacpool-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubemacpool-rhel9@sha256%3Afdff61819b4c031b96cefd2a4a9ca5e11136f7f0552e66796b7a6c81d8ff0c92?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubemacpool-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/multus-dynamic-networks-rhel9",
+      "purl": "pkg:oci/multus-dynamic-networks-rhel9@sha256%3A9391401b68bdb24de670af5f92fa4ff73e814cfe2adc2ead84b7023853ed19f1",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9391401b68bdb24de670af5f92fa4ff73e814cfe2adc2ead84b7023853ed19f1"
+        }
+      ],
+      "bom-ref": "pkg:oci/multus-dynamic-networks-rhel9@sha256%3A9391401b68bdb24de670af5f92fa4ff73e814cfe2adc2ead84b7023853ed19f1",
+      "version": "sha256:9391401b68bdb24de670af5f92fa4ff73e814cfe2adc2ead84b7023853ed19f1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/multus-dynamic-networks-rhel9@sha256%3A9391401b68bdb24de670af5f92fa4ff73e814cfe2adc2ead84b7023853ed19f1?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fmultus-dynamic-networks-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/multus-dynamic-networks-rhel9@sha256%3A9391401b68bdb24de670af5f92fa4ff73e814cfe2adc2ead84b7023853ed19f1?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fmultus-dynamic-networks-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/multus-dynamic-networks-rhel9@sha256%3A9391401b68bdb24de670af5f92fa4ff73e814cfe2adc2ead84b7023853ed19f1?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fmultus-dynamic-networks-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-ipam-controller-rhel9",
+      "purl": "pkg:oci/kubevirt-ipam-controller-rhel9@sha256%3A491ec75705f6fb7a2adaf22e106bedcc92061f9bcf8b41c2898727b2b624d7e9",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "491ec75705f6fb7a2adaf22e106bedcc92061f9bcf8b41c2898727b2b624d7e9"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-ipam-controller-rhel9@sha256%3A491ec75705f6fb7a2adaf22e106bedcc92061f9bcf8b41c2898727b2b624d7e9",
+      "version": "sha256:491ec75705f6fb7a2adaf22e106bedcc92061f9bcf8b41c2898727b2b624d7e9",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-ipam-controller-rhel9@sha256%3A491ec75705f6fb7a2adaf22e106bedcc92061f9bcf8b41c2898727b2b624d7e9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-ipam-controller-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-ipam-controller-rhel9@sha256%3A491ec75705f6fb7a2adaf22e106bedcc92061f9bcf8b41c2898727b2b624d7e9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-ipam-controller-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-ipam-controller-rhel9@sha256%3A491ec75705f6fb7a2adaf22e106bedcc92061f9bcf8b41c2898727b2b624d7e9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-ipam-controller-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/aaq-controller-rhel9",
+      "purl": "pkg:oci/aaq-controller-rhel9@sha256%3A479df989f7dba007cbb00ffffcf7d07aef7a93ca1628f013a7ae5c46b0f7cfb2",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "479df989f7dba007cbb00ffffcf7d07aef7a93ca1628f013a7ae5c46b0f7cfb2"
+        }
+      ],
+      "bom-ref": "pkg:oci/aaq-controller-rhel9@sha256%3A479df989f7dba007cbb00ffffcf7d07aef7a93ca1628f013a7ae5c46b0f7cfb2",
+      "version": "sha256:479df989f7dba007cbb00ffffcf7d07aef7a93ca1628f013a7ae5c46b0f7cfb2",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-controller-rhel9@sha256%3A479df989f7dba007cbb00ffffcf7d07aef7a93ca1628f013a7ae5c46b0f7cfb2?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-controller-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-controller-rhel9@sha256%3A479df989f7dba007cbb00ffffcf7d07aef7a93ca1628f013a7ae5c46b0f7cfb2?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-controller-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-controller-rhel9@sha256%3A479df989f7dba007cbb00ffffcf7d07aef7a93ca1628f013a7ae5c46b0f7cfb2?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-controller-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-api-rhel9",
+      "purl": "pkg:oci/virt-api-rhel9@sha256%3A812e18efc651fc5995cf04202f8a698f526f80ec8b4b39da4cbed499b4fac269",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "812e18efc651fc5995cf04202f8a698f526f80ec8b4b39da4cbed499b4fac269"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-api-rhel9@sha256%3A812e18efc651fc5995cf04202f8a698f526f80ec8b4b39da4cbed499b4fac269",
+      "version": "sha256:812e18efc651fc5995cf04202f8a698f526f80ec8b4b39da4cbed499b4fac269",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-api-rhel9@sha256%3A812e18efc651fc5995cf04202f8a698f526f80ec8b4b39da4cbed499b4fac269?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-api-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-api-rhel9@sha256%3A812e18efc651fc5995cf04202f8a698f526f80ec8b4b39da4cbed499b4fac269?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-api-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-api-rhel9@sha256%3A812e18efc651fc5995cf04202f8a698f526f80ec8b4b39da4cbed499b4fac269?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-api-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-artifacts-server-rhel9",
+      "purl": "pkg:oci/virt-artifacts-server-rhel9@sha256%3A2998d6f4cbfa371e2ff64cd16924ecc32a5f0cda916511c43de7ba4426651002",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2998d6f4cbfa371e2ff64cd16924ecc32a5f0cda916511c43de7ba4426651002"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-artifacts-server-rhel9@sha256%3A2998d6f4cbfa371e2ff64cd16924ecc32a5f0cda916511c43de7ba4426651002",
+      "version": "sha256:2998d6f4cbfa371e2ff64cd16924ecc32a5f0cda916511c43de7ba4426651002",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-artifacts-server-rhel9@sha256%3A2998d6f4cbfa371e2ff64cd16924ecc32a5f0cda916511c43de7ba4426651002?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-artifacts-server-rhel9&tag=v4.17.36-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-artifacts-server-rhel9@sha256%3A2998d6f4cbfa371e2ff64cd16924ecc32a5f0cda916511c43de7ba4426651002?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-artifacts-server-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-artifacts-server-rhel9@sha256%3A2998d6f4cbfa371e2ff64cd16924ecc32a5f0cda916511c43de7ba4426651002?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-artifacts-server-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/virt-handler-rhel9@sha256%3Acdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-handler-rhel9@sha256%3Acdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa",
+      "version": "sha256:cdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3Acdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3Acdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3Acdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/libguestfs-tools-rhel9",
+      "purl": "pkg:oci/libguestfs-tools-rhel9@sha256%3A2ae57817e3f34912debb993099db7cb6f305b511786ced2fc7f25d5e46817a4d",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2ae57817e3f34912debb993099db7cb6f305b511786ced2fc7f25d5e46817a4d"
+        }
+      ],
+      "bom-ref": "pkg:oci/libguestfs-tools-rhel9@sha256%3A2ae57817e3f34912debb993099db7cb6f305b511786ced2fc7f25d5e46817a4d",
+      "version": "sha256:2ae57817e3f34912debb993099db7cb6f305b511786ced2fc7f25d5e46817a4d",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/libguestfs-tools-rhel9@sha256%3A2ae57817e3f34912debb993099db7cb6f305b511786ced2fc7f25d5e46817a4d?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Flibguestfs-tools-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/libguestfs-tools-rhel9@sha256%3A2ae57817e3f34912debb993099db7cb6f305b511786ced2fc7f25d5e46817a4d?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Flibguestfs-tools-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/libguestfs-tools-rhel9@sha256%3A2ae57817e3f34912debb993099db7cb6f305b511786ced2fc7f25d5e46817a4d?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Flibguestfs-tools-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/pr-helper-rhel9",
+      "purl": "pkg:oci/pr-helper-rhel9@sha256%3Ab615704ff7c53b8a5d2622c8439a421a32064c84eaeaba7341b283a5d1a54975",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b615704ff7c53b8a5d2622c8439a421a32064c84eaeaba7341b283a5d1a54975"
+        }
+      ],
+      "bom-ref": "pkg:oci/pr-helper-rhel9@sha256%3Ab615704ff7c53b8a5d2622c8439a421a32064c84eaeaba7341b283a5d1a54975",
+      "version": "sha256:b615704ff7c53b8a5d2622c8439a421a32064c84eaeaba7341b283a5d1a54975",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/pr-helper-rhel9@sha256%3Ab615704ff7c53b8a5d2622c8439a421a32064c84eaeaba7341b283a5d1a54975?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpr-helper-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/pr-helper-rhel9@sha256%3Ab615704ff7c53b8a5d2622c8439a421a32064c84eaeaba7341b283a5d1a54975?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpr-helper-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/pr-helper-rhel9@sha256%3Ab615704ff7c53b8a5d2622c8439a421a32064c84eaeaba7341b283a5d1a54975?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpr-helper-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-exportproxy-rhel9",
+      "purl": "pkg:oci/virt-exportproxy-rhel9@sha256%3Affacb816619963aee5a7cdfc6e1396395a33b2a5ce8825ed9f40cb6d91c07aca",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ffacb816619963aee5a7cdfc6e1396395a33b2a5ce8825ed9f40cb6d91c07aca"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-exportproxy-rhel9@sha256%3Affacb816619963aee5a7cdfc6e1396395a33b2a5ce8825ed9f40cb6d91c07aca",
+      "version": "sha256:ffacb816619963aee5a7cdfc6e1396395a33b2a5ce8825ed9f40cb6d91c07aca",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-exportproxy-rhel9@sha256%3Affacb816619963aee5a7cdfc6e1396395a33b2a5ce8825ed9f40cb6d91c07aca?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-exportproxy-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-exportproxy-rhel9@sha256%3Affacb816619963aee5a7cdfc6e1396395a33b2a5ce8825ed9f40cb6d91c07aca?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-exportproxy-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-exportproxy-rhel9@sha256%3Affacb816619963aee5a7cdfc6e1396395a33b2a5ce8825ed9f40cb6d91c07aca?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-exportproxy-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-exportserver-rhel9",
+      "purl": "pkg:oci/virt-exportserver-rhel9@sha256%3A8a37fea17b83a0f01bea5c684cf349c7f46eba38ec05245f05b24dec9d0e3fa2",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8a37fea17b83a0f01bea5c684cf349c7f46eba38ec05245f05b24dec9d0e3fa2"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-exportserver-rhel9@sha256%3A8a37fea17b83a0f01bea5c684cf349c7f46eba38ec05245f05b24dec9d0e3fa2",
+      "version": "sha256:8a37fea17b83a0f01bea5c684cf349c7f46eba38ec05245f05b24dec9d0e3fa2",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-exportserver-rhel9@sha256%3A8a37fea17b83a0f01bea5c684cf349c7f46eba38ec05245f05b24dec9d0e3fa2?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-exportserver-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-exportserver-rhel9@sha256%3A8a37fea17b83a0f01bea5c684cf349c7f46eba38ec05245f05b24dec9d0e3fa2?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-exportserver-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-exportserver-rhel9@sha256%3A8a37fea17b83a0f01bea5c684cf349c7f46eba38ec05245f05b24dec9d0e3fa2?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-exportserver-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/passt-network-binding-plugin-sidecar-rhel9",
+      "purl": "pkg:oci/passt-network-binding-plugin-sidecar-rhel9@sha256%3A37ba22f3d5c3454bb8b966bb7655d914c29079db3fc1d7f1c385137feba08d8d",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "37ba22f3d5c3454bb8b966bb7655d914c29079db3fc1d7f1c385137feba08d8d"
+        }
+      ],
+      "bom-ref": "pkg:oci/passt-network-binding-plugin-sidecar-rhel9@sha256%3A37ba22f3d5c3454bb8b966bb7655d914c29079db3fc1d7f1c385137feba08d8d",
+      "version": "sha256:37ba22f3d5c3454bb8b966bb7655d914c29079db3fc1d7f1c385137feba08d8d",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/passt-network-binding-plugin-sidecar-rhel9@sha256%3A37ba22f3d5c3454bb8b966bb7655d914c29079db3fc1d7f1c385137feba08d8d?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpasst-network-binding-plugin-sidecar-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/passt-network-binding-plugin-sidecar-rhel9@sha256%3A37ba22f3d5c3454bb8b966bb7655d914c29079db3fc1d7f1c385137feba08d8d?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpasst-network-binding-plugin-sidecar-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/passt-network-binding-plugin-sidecar-rhel9@sha256%3A37ba22f3d5c3454bb8b966bb7655d914c29079db3fc1d7f1c385137feba08d8d?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpasst-network-binding-plugin-sidecar-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/passt-network-binding-plugin-cni-rhel9",
+      "purl": "pkg:oci/passt-network-binding-plugin-cni-rhel9@sha256%3A985b4e662b499377ec458370a9ab9ba8a49c9dee5718a1caebea57617a7d71ec",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "985b4e662b499377ec458370a9ab9ba8a49c9dee5718a1caebea57617a7d71ec"
+        }
+      ],
+      "bom-ref": "pkg:oci/passt-network-binding-plugin-cni-rhel9@sha256%3A985b4e662b499377ec458370a9ab9ba8a49c9dee5718a1caebea57617a7d71ec",
+      "version": "sha256:985b4e662b499377ec458370a9ab9ba8a49c9dee5718a1caebea57617a7d71ec",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/passt-network-binding-plugin-cni-rhel9@sha256%3A985b4e662b499377ec458370a9ab9ba8a49c9dee5718a1caebea57617a7d71ec?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpasst-network-binding-plugin-cni-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/passt-network-binding-plugin-cni-rhel9@sha256%3A985b4e662b499377ec458370a9ab9ba8a49c9dee5718a1caebea57617a7d71ec?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpasst-network-binding-plugin-cni-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/passt-network-binding-plugin-cni-rhel9@sha256%3A985b4e662b499377ec458370a9ab9ba8a49c9dee5718a1caebea57617a7d71ec?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpasst-network-binding-plugin-cni-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virtio-win-rhel9",
+      "purl": "pkg:oci/virtio-win-rhel9@sha256%3Ae3c8b00ce6d9d9ee45e15a5def276c66298dc8d2d61befb972b4cebd8c680f41",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e3c8b00ce6d9d9ee45e15a5def276c66298dc8d2d61befb972b4cebd8c680f41"
+        }
+      ],
+      "bom-ref": "pkg:oci/virtio-win-rhel9@sha256%3Ae3c8b00ce6d9d9ee45e15a5def276c66298dc8d2d61befb972b4cebd8c680f41",
+      "version": "sha256:e3c8b00ce6d9d9ee45e15a5def276c66298dc8d2d61befb972b4cebd8c680f41",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virtio-win-rhel9@sha256%3Ae3c8b00ce6d9d9ee45e15a5def276c66298dc8d2d61befb972b4cebd8c680f41?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirtio-win-rhel9&tag=v4.17.36-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virtio-win-rhel9@sha256%3Ae3c8b00ce6d9d9ee45e15a5def276c66298dc8d2d61befb972b4cebd8c680f41?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirtio-win-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virtio-win-rhel9@sha256%3Ae3c8b00ce6d9d9ee45e15a5def276c66298dc8d2d61befb972b4cebd8c680f41?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirtio-win-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/cnv-must-gather-rhel9",
+      "purl": "pkg:oci/cnv-must-gather-rhel9@sha256%3A8b961c4fe1eba3b3eafbda4f33ffda4fedbe8d7105ff3b4d8b38164fa6e41375",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8b961c4fe1eba3b3eafbda4f33ffda4fedbe8d7105ff3b4d8b38164fa6e41375"
+        }
+      ],
+      "bom-ref": "pkg:oci/cnv-must-gather-rhel9@sha256%3A8b961c4fe1eba3b3eafbda4f33ffda4fedbe8d7105ff3b4d8b38164fa6e41375",
+      "version": "sha256:8b961c4fe1eba3b3eafbda4f33ffda4fedbe8d7105ff3b4d8b38164fa6e41375",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cnv-must-gather-rhel9@sha256%3A8b961c4fe1eba3b3eafbda4f33ffda4fedbe8d7105ff3b4d8b38164fa6e41375?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcnv-must-gather-rhel9&tag=v4.17.36-1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cnv-must-gather-rhel9@sha256%3A8b961c4fe1eba3b3eafbda4f33ffda4fedbe8d7105ff3b4d8b38164fa6e41375?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcnv-must-gather-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cnv-must-gather-rhel9@sha256%3A8b961c4fe1eba3b3eafbda4f33ffda4fedbe8d7105ff3b4d8b38164fa6e41375?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcnv-must-gather-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-tekton-tasks-disk-virt-customize-rhel9",
+      "purl": "pkg:oci/kubevirt-tekton-tasks-disk-virt-customize-rhel9@sha256%3Acb37e2dd63ff3c1a369300f7f0aa3d7691b658dfab4140082eb881a4d4d477cd",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cb37e2dd63ff3c1a369300f7f0aa3d7691b658dfab4140082eb881a4d4d477cd"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-tekton-tasks-disk-virt-customize-rhel9@sha256%3Acb37e2dd63ff3c1a369300f7f0aa3d7691b658dfab4140082eb881a4d4d477cd",
+      "version": "sha256:cb37e2dd63ff3c1a369300f7f0aa3d7691b658dfab4140082eb881a4d4d477cd",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-tekton-tasks-disk-virt-customize-rhel9@sha256%3Acb37e2dd63ff3c1a369300f7f0aa3d7691b658dfab4140082eb881a4d4d477cd?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-tekton-tasks-disk-virt-customize-rhel9&tag=v4.17.36-4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-tekton-tasks-disk-virt-customize-rhel9@sha256%3Acb37e2dd63ff3c1a369300f7f0aa3d7691b658dfab4140082eb881a4d4d477cd?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-tekton-tasks-disk-virt-customize-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-tekton-tasks-disk-virt-customize-rhel9@sha256%3Acb37e2dd63ff3c1a369300f7f0aa3d7691b658dfab4140082eb881a4d4d477cd?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-tekton-tasks-disk-virt-customize-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/vm-network-latency-checkup-rhel9",
+      "purl": "pkg:oci/vm-network-latency-checkup-rhel9@sha256%3A6e395534736d225fb53a8e910905c48cda5deed67d60f679ee777e997d2353c7",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6e395534736d225fb53a8e910905c48cda5deed67d60f679ee777e997d2353c7"
+        }
+      ],
+      "bom-ref": "pkg:oci/vm-network-latency-checkup-rhel9@sha256%3A6e395534736d225fb53a8e910905c48cda5deed67d60f679ee777e997d2353c7",
+      "version": "sha256:6e395534736d225fb53a8e910905c48cda5deed67d60f679ee777e997d2353c7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/vm-network-latency-checkup-rhel9@sha256%3A6e395534736d225fb53a8e910905c48cda5deed67d60f679ee777e997d2353c7?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvm-network-latency-checkup-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/vm-network-latency-checkup-rhel9@sha256%3A6e395534736d225fb53a8e910905c48cda5deed67d60f679ee777e997d2353c7?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvm-network-latency-checkup-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/vm-network-latency-checkup-rhel9@sha256%3A6e395534736d225fb53a8e910905c48cda5deed67d60f679ee777e997d2353c7?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvm-network-latency-checkup-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-dpdk-checkup-rhel9",
+      "purl": "pkg:oci/kubevirt-dpdk-checkup-rhel9@sha256%3Aa1cfe75924fd98623d5bdbfd663f42e1ebcbf0891510e650bc8195ae1ad6af20",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a1cfe75924fd98623d5bdbfd663f42e1ebcbf0891510e650bc8195ae1ad6af20"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-dpdk-checkup-rhel9@sha256%3Aa1cfe75924fd98623d5bdbfd663f42e1ebcbf0891510e650bc8195ae1ad6af20",
+      "version": "sha256:a1cfe75924fd98623d5bdbfd663f42e1ebcbf0891510e650bc8195ae1ad6af20",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-dpdk-checkup-rhel9@sha256%3Aa1cfe75924fd98623d5bdbfd663f42e1ebcbf0891510e650bc8195ae1ad6af20?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-dpdk-checkup-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-dpdk-checkup-rhel9@sha256%3Aa1cfe75924fd98623d5bdbfd663f42e1ebcbf0891510e650bc8195ae1ad6af20?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-dpdk-checkup-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-dpdk-checkup-rhel9@sha256%3Aa1cfe75924fd98623d5bdbfd663f42e1ebcbf0891510e650bc8195ae1ad6af20?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-dpdk-checkup-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-realtime-checkup-rhel9",
+      "purl": "pkg:oci/kubevirt-realtime-checkup-rhel9@sha256%3A21ba2cc0f21cc319a9dccac5b27b735282801c3e378d70ab00c6cb3ec1c9d9a3",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "21ba2cc0f21cc319a9dccac5b27b735282801c3e378d70ab00c6cb3ec1c9d9a3"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-realtime-checkup-rhel9@sha256%3A21ba2cc0f21cc319a9dccac5b27b735282801c3e378d70ab00c6cb3ec1c9d9a3",
+      "version": "sha256:21ba2cc0f21cc319a9dccac5b27b735282801c3e378d70ab00c6cb3ec1c9d9a3",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-realtime-checkup-rhel9@sha256%3A21ba2cc0f21cc319a9dccac5b27b735282801c3e378d70ab00c6cb3ec1c9d9a3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-realtime-checkup-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-realtime-checkup-rhel9@sha256%3A21ba2cc0f21cc319a9dccac5b27b735282801c3e378d70ab00c6cb3ec1c9d9a3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-realtime-checkup-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-realtime-checkup-rhel9@sha256%3A21ba2cc0f21cc319a9dccac5b27b735282801c3e378d70ab00c6cb3ec1c9d9a3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-realtime-checkup-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-storage-checkup-rhel9",
+      "purl": "pkg:oci/kubevirt-storage-checkup-rhel9@sha256%3Aa387afd751151b2e68393d0afacda32bc5be87b8d60a31003f0bd386e002531a",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a387afd751151b2e68393d0afacda32bc5be87b8d60a31003f0bd386e002531a"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-storage-checkup-rhel9@sha256%3Aa387afd751151b2e68393d0afacda32bc5be87b8d60a31003f0bd386e002531a",
+      "version": "sha256:a387afd751151b2e68393d0afacda32bc5be87b8d60a31003f0bd386e002531a",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-storage-checkup-rhel9@sha256%3Aa387afd751151b2e68393d0afacda32bc5be87b8d60a31003f0bd386e002531a?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-storage-checkup-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-storage-checkup-rhel9@sha256%3Aa387afd751151b2e68393d0afacda32bc5be87b8d60a31003f0bd386e002531a?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-storage-checkup-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-storage-checkup-rhel9@sha256%3Aa387afd751151b2e68393d0afacda32bc5be87b8d60a31003f0bd386e002531a?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-storage-checkup-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-apiserver-proxy-rhel9",
+      "purl": "pkg:oci/kubevirt-apiserver-proxy-rhel9@sha256%3A2c0df8aeabb6e62f257d79e53c82f221c140557c168f4da6d1283f698fc90415",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2c0df8aeabb6e62f257d79e53c82f221c140557c168f4da6d1283f698fc90415"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-apiserver-proxy-rhel9@sha256%3A2c0df8aeabb6e62f257d79e53c82f221c140557c168f4da6d1283f698fc90415",
+      "version": "sha256:2c0df8aeabb6e62f257d79e53c82f221c140557c168f4da6d1283f698fc90415",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-apiserver-proxy-rhel9@sha256%3A2c0df8aeabb6e62f257d79e53c82f221c140557c168f4da6d1283f698fc90415?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-apiserver-proxy-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-apiserver-proxy-rhel9@sha256%3A2c0df8aeabb6e62f257d79e53c82f221c140557c168f4da6d1283f698fc90415?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-apiserver-proxy-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-apiserver-proxy-rhel9@sha256%3A2c0df8aeabb6e62f257d79e53c82f221c140557c168f4da6d1283f698fc90415?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-apiserver-proxy-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/vm-console-proxy-rhel9",
+      "purl": "pkg:oci/vm-console-proxy-rhel9@sha256%3A24317d5133999ab616432bfc89d146326765efc52d77eff21e193466835210b5",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "24317d5133999ab616432bfc89d146326765efc52d77eff21e193466835210b5"
+        }
+      ],
+      "bom-ref": "pkg:oci/vm-console-proxy-rhel9@sha256%3A24317d5133999ab616432bfc89d146326765efc52d77eff21e193466835210b5",
+      "version": "sha256:24317d5133999ab616432bfc89d146326765efc52d77eff21e193466835210b5",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/vm-console-proxy-rhel9@sha256%3A24317d5133999ab616432bfc89d146326765efc52d77eff21e193466835210b5?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvm-console-proxy-rhel9&tag=v4.17.36-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/vm-console-proxy-rhel9@sha256%3A24317d5133999ab616432bfc89d146326765efc52d77eff21e193466835210b5?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvm-console-proxy-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/vm-console-proxy-rhel9@sha256%3A24317d5133999ab616432bfc89d146326765efc52d77eff21e193466835210b5?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvm-console-proxy-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/hyperconverged-cluster-operator-rhel9",
+      "purl": "pkg:oci/hyperconverged-cluster-operator-rhel9@sha256%3Af2787270f37aabaeb19af2ee9d1b3164c5f6295642760ed71e335ecb869ba391",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f2787270f37aabaeb19af2ee9d1b3164c5f6295642760ed71e335ecb869ba391"
+        }
+      ],
+      "bom-ref": "pkg:oci/hyperconverged-cluster-operator-rhel9@sha256%3Af2787270f37aabaeb19af2ee9d1b3164c5f6295642760ed71e335ecb869ba391",
+      "version": "sha256:f2787270f37aabaeb19af2ee9d1b3164c5f6295642760ed71e335ecb869ba391",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hyperconverged-cluster-operator-rhel9@sha256%3Af2787270f37aabaeb19af2ee9d1b3164c5f6295642760ed71e335ecb869ba391?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhyperconverged-cluster-operator-rhel9&tag=v4.17.36-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hyperconverged-cluster-operator-rhel9@sha256%3Af2787270f37aabaeb19af2ee9d1b3164c5f6295642760ed71e335ecb869ba391?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhyperconverged-cluster-operator-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hyperconverged-cluster-operator-rhel9@sha256%3Af2787270f37aabaeb19af2ee9d1b3164c5f6295642760ed71e335ecb869ba391?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhyperconverged-cluster-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/hyperconverged-cluster-webhook-rhel9",
+      "purl": "pkg:oci/hyperconverged-cluster-webhook-rhel9@sha256%3A9b56a42af131b04c067ae3233b7cddf3950b95fcf2dce535572202fabd827107",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9b56a42af131b04c067ae3233b7cddf3950b95fcf2dce535572202fabd827107"
+        }
+      ],
+      "bom-ref": "pkg:oci/hyperconverged-cluster-webhook-rhel9@sha256%3A9b56a42af131b04c067ae3233b7cddf3950b95fcf2dce535572202fabd827107",
+      "version": "sha256:9b56a42af131b04c067ae3233b7cddf3950b95fcf2dce535572202fabd827107",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hyperconverged-cluster-webhook-rhel9@sha256%3A9b56a42af131b04c067ae3233b7cddf3950b95fcf2dce535572202fabd827107?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhyperconverged-cluster-webhook-rhel9&tag=v4.17.36-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hyperconverged-cluster-webhook-rhel9@sha256%3A9b56a42af131b04c067ae3233b7cddf3950b95fcf2dce535572202fabd827107?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhyperconverged-cluster-webhook-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hyperconverged-cluster-webhook-rhel9@sha256%3A9b56a42af131b04c067ae3233b7cddf3950b95fcf2dce535572202fabd827107?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhyperconverged-cluster-webhook-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/sidecar-shim-rhel9",
+      "purl": "pkg:oci/sidecar-shim-rhel9@sha256%3A91bc9eeefc2e226a6679452e244a2e2b9b5cfc8ef5fa9403c62aa12e75832586",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "91bc9eeefc2e226a6679452e244a2e2b9b5cfc8ef5fa9403c62aa12e75832586"
+        }
+      ],
+      "bom-ref": "pkg:oci/sidecar-shim-rhel9@sha256%3A91bc9eeefc2e226a6679452e244a2e2b9b5cfc8ef5fa9403c62aa12e75832586",
+      "version": "sha256:91bc9eeefc2e226a6679452e244a2e2b9b5cfc8ef5fa9403c62aa12e75832586",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/sidecar-shim-rhel9@sha256%3A91bc9eeefc2e226a6679452e244a2e2b9b5cfc8ef5fa9403c62aa12e75832586?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fsidecar-shim-rhel9&tag=v4.17.36-11"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/sidecar-shim-rhel9@sha256%3A91bc9eeefc2e226a6679452e244a2e2b9b5cfc8ef5fa9403c62aa12e75832586?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fsidecar-shim-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/sidecar-shim-rhel9@sha256%3A91bc9eeefc2e226a6679452e244a2e2b9b5cfc8ef5fa9403c62aa12e75832586?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fsidecar-shim-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-console-plugin-rhel9",
+      "purl": "pkg:oci/kubevirt-console-plugin-rhel9@sha256%3A0dc944701a52cbec15596988776c57a2744016d3b3ca5e173fff14b2c529f40d",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0dc944701a52cbec15596988776c57a2744016d3b3ca5e173fff14b2c529f40d"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-console-plugin-rhel9@sha256%3A0dc944701a52cbec15596988776c57a2744016d3b3ca5e173fff14b2c529f40d",
+      "version": "sha256:0dc944701a52cbec15596988776c57a2744016d3b3ca5e173fff14b2c529f40d",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-console-plugin-rhel9@sha256%3A0dc944701a52cbec15596988776c57a2744016d3b3ca5e173fff14b2c529f40d?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-console-plugin-rhel9&tag=v4.17.36-11"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-console-plugin-rhel9@sha256%3A0dc944701a52cbec15596988776c57a2744016d3b3ca5e173fff14b2c529f40d?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-console-plugin-rhel9&tag=v4.17.36"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-console-plugin-rhel9@sha256%3A0dc944701a52cbec15596988776c57a2744016d3b3ca5e173fff14b2c529f40d?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-console-plugin-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/hco-bundle-registry",
+      "purl": "pkg:oci/hco-bundle-registry-rhel9@sha256%3A3885ac842a87ea824642cd7708b927ee32ef94030187be89875a4f1a6fb3780f",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3885ac842a87ea824642cd7708b927ee32ef94030187be89875a4f1a6fb3780f"
+        }
+      ],
+      "bom-ref": "pkg:oci/hco-bundle-registry-rhel9@sha256%3A3885ac842a87ea824642cd7708b927ee32ef94030187be89875a4f1a6fb3780f",
+      "version": "sha256:3885ac842a87ea824642cd7708b927ee32ef94030187be89875a4f1a6fb3780f",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hco-bundle-registry-rhel9@sha256%3A3885ac842a87ea824642cd7708b927ee32ef94030187be89875a4f1a6fb3780f?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhco-bundle-registry-rhel9&tag=v4.17.36.rhel9-11"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hco-bundle-registry-rhel9@sha256%3A3885ac842a87ea824642cd7708b927ee32ef94030187be89875a4f1a6fb3780f?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhco-bundle-registry-rhel9&tag=v4.17.36.rhel9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hco-bundle-registry-rhel9@sha256%3A3885ac842a87ea824642cd7708b927ee32ef94030187be89875a4f1a6fb3780f?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhco-bundle-registry-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "RHEL-9-CNV-4.17",
+      "provides": [
+        "pkg:oci/wasp-agent-rhel9@sha256%3Aa2c95d29514f3e841c83677aefbb7eb5466946178aeb2668a52b67b73d1c0e37",
+        "pkg:oci/virt-cdi-importer-rhel9@sha256%3A63e0d3bd66d81a4846772e561cd4ff4752544814c5e9ff61d4dc74d37979c1d1",
+        "pkg:oci/ovs-cni-plugin-rhel9@sha256%3Abbbe09c489b4bbd8a4683f809a2988d890f85c960166d8ec55dab3f57aef3b73",
+        "pkg:oci/kubevirt-ssp-operator-rhel9@sha256%3A4e2f2bea93ac4cdffead6952b2da9f5cbca960101fcec625ecfc51cb34d4e2c3",
+        "pkg:oci/kubevirt-template-validator-rhel9@sha256%3A9b7411f914923d7f744ff312bc12124c0a85da98af63c615392a45d83b9e9e73",
+        "pkg:oci/virt-cdi-cloner-rhel9@sha256%3A748b76396ced4519a607997debb8fedbc20976c35559cda33d318a5a7d723ad9",
+        "pkg:oci/virt-controller-rhel9@sha256%3A6d7d99737df7d268b018ca022d00830e57dd3451a0bbe07f606c2949c975ef76",
+        "pkg:oci/hostpath-provisioner-rhel9@sha256%3Aed490dfa4aea26e80fb6129a059ad762c398d5b1202a68281c228474bad25736",
+        "pkg:oci/virt-launcher-rhel9@sha256%3A7d10f7c58b2c68e0d6cdb4624b2d6970aa9741e4123cf0039673fd550c0b9604",
+        "pkg:oci/virt-cdi-operator-rhel9@sha256%3A8f551b49544e6b1fe9e12ca21887dd1501fc7a2608f00e325ef0b3374f22c5c8",
+        "pkg:oci/virt-operator-rhel9@sha256%3A1ecfdadbf0a12e7a363c814197b61f9e243c77c4265332e559a21e37b8e4a916",
+        "pkg:oci/aaq-operator-rhel9@sha256%3A3a0ffc27148f446956b1124834cdb5b2b62b5b2228056386f147975fafeeec31",
+        "pkg:oci/aaq-server-rhel9@sha256%3Ae45503da0c7b8b1acb7ad018b10a5cab3599ce0223627e3ab3d1ad4aef1e7bd4",
+        "pkg:oci/virt-cdi-uploadserver-rhel9@sha256%3A795d9efeb758f1499f31fe23f485411659bd9ef84cc150bab0eeaba51ebabc18",
+        "pkg:oci/kubevirt-tekton-tasks-create-datavolume-rhel9@sha256%3A4dd704c03cdafe5f7f811accf01bf7617568124bf0282066bfeaf263afb6e5e7",
+        "pkg:oci/virt-cdi-uploadproxy-rhel9@sha256%3Ab8bf22e8e0b66a1685429747719ec882b228810d4353006f97e4989243f0ce76",
+        "pkg:oci/virt-cdi-apiserver-rhel9@sha256%3Af2083253812e68cf577f48fb081c3e41e9c7875299f3ba83b13851b9cf1f3567",
+        "pkg:oci/virt-cdi-controller-rhel9@sha256%3A724a00aa0686927808d622427c008eac1d630bcb21520ba348a2c5a37316dc19",
+        "pkg:oci/hostpath-csi-driver-rhel9@sha256%3A45cad9b92d3cea71ce98168481fdd916528752a5df163b629cef533a1a4dce77",
+        "pkg:oci/hostpath-provisioner-operator-rhel9@sha256%3A087a1d292d25b934bc47b47c51055b003b5092ddd1fda66cc3f89d8fbe58be17",
+        "pkg:oci/cluster-network-addons-operator-rhel9@sha256%3A44eda4396eee6eeb365a1daef3cf4740298df153226c842a122f3b645b29a5c8",
+        "pkg:oci/kubevirt-common-instancetypes-rhel9@sha256%3A3f56642bad303fc45072b1c7809bb5e757e3243bdbc6e9e5a17725eebd76fd27",
+        "pkg:oci/bridge-marker-rhel9@sha256%3Aa8c75b8aa656f38a51b1faee7ab06cd9405cc2b82cdae754c52dbf2a3cd90554",
+        "pkg:oci/kubesecondarydns-rhel9@sha256%3Ab8834767a8715f782bc17dcaca512d246ca8b466013cddcee356fb60b890e4ec",
+        "pkg:oci/cnv-containernetworking-plugins-rhel9@sha256%3Ab4cc91b79ca2ed57b8cdee8220cfc151c15c3f07847e60bd9f13ad8c57332b00",
+        "pkg:oci/kubemacpool-rhel9@sha256%3Afdff61819b4c031b96cefd2a4a9ca5e11136f7f0552e66796b7a6c81d8ff0c92",
+        "pkg:oci/multus-dynamic-networks-rhel9@sha256%3A9391401b68bdb24de670af5f92fa4ff73e814cfe2adc2ead84b7023853ed19f1",
+        "pkg:oci/kubevirt-ipam-controller-rhel9@sha256%3A491ec75705f6fb7a2adaf22e106bedcc92061f9bcf8b41c2898727b2b624d7e9",
+        "pkg:oci/aaq-controller-rhel9@sha256%3A479df989f7dba007cbb00ffffcf7d07aef7a93ca1628f013a7ae5c46b0f7cfb2",
+        "pkg:oci/virt-api-rhel9@sha256%3A812e18efc651fc5995cf04202f8a698f526f80ec8b4b39da4cbed499b4fac269",
+        "pkg:oci/virt-artifacts-server-rhel9@sha256%3A2998d6f4cbfa371e2ff64cd16924ecc32a5f0cda916511c43de7ba4426651002",
+        "pkg:oci/virt-handler-rhel9@sha256%3Acdd46acbaf731e2192c9ac9c8a2276bf8cc7aa4b598ab27131a1a096d2d879fa",
+        "pkg:oci/libguestfs-tools-rhel9@sha256%3A2ae57817e3f34912debb993099db7cb6f305b511786ced2fc7f25d5e46817a4d",
+        "pkg:oci/pr-helper-rhel9@sha256%3Ab615704ff7c53b8a5d2622c8439a421a32064c84eaeaba7341b283a5d1a54975",
+        "pkg:oci/virt-exportproxy-rhel9@sha256%3Affacb816619963aee5a7cdfc6e1396395a33b2a5ce8825ed9f40cb6d91c07aca",
+        "pkg:oci/virt-exportserver-rhel9@sha256%3A8a37fea17b83a0f01bea5c684cf349c7f46eba38ec05245f05b24dec9d0e3fa2",
+        "pkg:oci/passt-network-binding-plugin-sidecar-rhel9@sha256%3A37ba22f3d5c3454bb8b966bb7655d914c29079db3fc1d7f1c385137feba08d8d",
+        "pkg:oci/passt-network-binding-plugin-cni-rhel9@sha256%3A985b4e662b499377ec458370a9ab9ba8a49c9dee5718a1caebea57617a7d71ec",
+        "pkg:oci/virtio-win-rhel9@sha256%3Ae3c8b00ce6d9d9ee45e15a5def276c66298dc8d2d61befb972b4cebd8c680f41",
+        "pkg:oci/cnv-must-gather-rhel9@sha256%3A8b961c4fe1eba3b3eafbda4f33ffda4fedbe8d7105ff3b4d8b38164fa6e41375",
+        "pkg:oci/kubevirt-tekton-tasks-disk-virt-customize-rhel9@sha256%3Acb37e2dd63ff3c1a369300f7f0aa3d7691b658dfab4140082eb881a4d4d477cd",
+        "pkg:oci/vm-network-latency-checkup-rhel9@sha256%3A6e395534736d225fb53a8e910905c48cda5deed67d60f679ee777e997d2353c7",
+        "pkg:oci/kubevirt-dpdk-checkup-rhel9@sha256%3Aa1cfe75924fd98623d5bdbfd663f42e1ebcbf0891510e650bc8195ae1ad6af20",
+        "pkg:oci/kubevirt-realtime-checkup-rhel9@sha256%3A21ba2cc0f21cc319a9dccac5b27b735282801c3e378d70ab00c6cb3ec1c9d9a3",
+        "pkg:oci/kubevirt-storage-checkup-rhel9@sha256%3Aa387afd751151b2e68393d0afacda32bc5be87b8d60a31003f0bd386e002531a",
+        "pkg:oci/kubevirt-apiserver-proxy-rhel9@sha256%3A2c0df8aeabb6e62f257d79e53c82f221c140557c168f4da6d1283f698fc90415",
+        "pkg:oci/vm-console-proxy-rhel9@sha256%3A24317d5133999ab616432bfc89d146326765efc52d77eff21e193466835210b5",
+        "pkg:oci/hyperconverged-cluster-operator-rhel9@sha256%3Af2787270f37aabaeb19af2ee9d1b3164c5f6295642760ed71e335ecb869ba391",
+        "pkg:oci/hyperconverged-cluster-webhook-rhel9@sha256%3A9b56a42af131b04c067ae3233b7cddf3950b95fcf2dce535572202fabd827107",
+        "pkg:oci/sidecar-shim-rhel9@sha256%3A91bc9eeefc2e226a6679452e244a2e2b9b5cfc8ef5fa9403c62aa12e75832586",
+        "pkg:oci/kubevirt-console-plugin-rhel9@sha256%3A0dc944701a52cbec15596988776c57a2744016d3b3ca5e173fff14b2c529f40d",
+        "pkg:oci/hco-bundle-registry-rhel9@sha256%3A3885ac842a87ea824642cd7708b927ee32ef94030187be89875a4f1a6fb3780f"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:6fbeac32-fad4-32b5-a225-9818e0959794"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/older/binary-2025-11-25-32EBB9C7E6914AD.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/older/binary-2025-11-25-32EBB9C7E6914AD.json
@@ -1,0 +1,26701 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "syft",
+          "type": "application",
+          "author": "anchore",
+          "version": "1.27.1"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/virt-handler-rhel9@sha256%3A60bf81bdeafa73ba18d4ca19a211f9d6797fa517290a791c2fd5975ea92e73a9?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35-2",
+      "type": "container"
+    },
+    "timestamp": "2025-11-25T09:02:24Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156271"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/virt-handler-rhel9@sha256%3A60bf81bdeafa73ba18d4ca19a211f9d6797fa517290a791c2fd5975ea92e73a9?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35-2",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "60bf81bdeafa73ba18d4ca19a211f9d6797fa517290a791c2fd5975ea92e73a9"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-handler-rhel9@sha256%3A60bf81bdeafa73ba18d4ca19a211f9d6797fa517290a791c2fd5975ea92e73a9?arch=amd64&os=linux&tag=v4.17.35-2",
+      "version": "sha256:60bf81bdeafa73ba18d4ca19a211f9d6797fa517290a791c2fd5975ea92e73a9",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3A60bf81bdeafa73ba18d4ca19a211f9d6797fa517290a791c2fd5975ea92e73a9?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3A60bf81bdeafa73ba18d4ca19a211f9d6797fa517290a791c2fd5975ea92e73a9?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3A60bf81bdeafa73ba18d4ca19a211f9d6797fa517290a791c2fd5975ea92e73a9?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ca697ecfa8b17e55a6534a66691a9f7d8079e14e",
+            "url": "https://pkgs.devel.redhat.com/git/containers/virt-handler#ca697ecfa8b17e55a6534a66691a9f7d8079e14e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:architecture",
+          "value": "x86_64"
+        },
+        {
+          "name": "sbomer:image:labels:build-date",
+          "value": "2025-11-20T15:25:12"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "virt-handler-rhel9-container"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.license_terms",
+          "value": "https://www.redhat.com/agreements"
+        },
+        {
+          "name": "sbomer:image:labels:cpe",
+          "value": "cpe:/a:redhat:rhel_eus:9.4::appstream"
+        },
+        {
+          "name": "sbomer:image:labels:description",
+          "value": "Virtualization handler for CNV"
+        },
+        {
+          "name": "sbomer:image:labels:distribution-scope",
+          "value": "public"
+        },
+        {
+          "name": "sbomer:image:labels:io.buildah.version",
+          "value": "1.33.12"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.description",
+          "value": "Virtualization handler for CNV"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.display-name",
+          "value": "virt-handler"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.tags",
+          "value": "cnv,kubevirt"
+        },
+        {
+          "name": "sbomer:image:labels:maintainer",
+          "value": "sgott@redhat.com,ibezukh@redhat.com,dhiller@redhat.com,jlejosne@redhat.com"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "container-native-virtualization/virt-handler-rhel9"
+        },
+        {
+          "name": "sbomer:image:labels:org.opencontainers.image.revision",
+          "value": "2ce6c4e1853a72beb38c539476edad8d5f73a171"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "2"
+        },
+        {
+          "name": "sbomer:image:labels:summary",
+          "value": "Virtualization handler"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-vcs-ref",
+          "value": "952f258d1f909636381bb2491c504618d3749a35"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-vcs-url",
+          "value": "https://github.com/kubevirt/kubevirt"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-version",
+          "value": "1.3.1-283-g952f258d1f"
+        },
+        {
+          "name": "sbomer:image:labels:url",
+          "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/container-native-virtualization/virt-handler-rhel9/images/v4.17.35-2"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-ref",
+          "value": "ca697ecfa8b17e55a6534a66691a9f7d8079e14e"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:vendor",
+          "value": "Red Hat"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "v4.17.35"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3894652",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "https://pkgs.devel.redhat.com/git/containers/virt-handler#ca697ecfa8b17e55a6534a66691a9f7d8079e14e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/machadovilaca/operator-observability",
+      "purl": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "version": "v0.0.20",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=b6c9d8ea55ec3898",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "version": "v1.0.3-0.20210326190908-1c3f411f0417",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/vsock",
+      "purl": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "time",
+      "purl": "pkg:golang/time@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/time@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "dbus-python",
+      "purl": "pkg:pypi/dbus-python@1.2.18",
+      "type": "library",
+      "bom-ref": "pkg:pypi/dbus-python@1.2.18",
+      "version": "1.2.18",
+      "licenses": [
+        {
+          "license": {
+            "name": "Expat (MIT/X11)"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/dbus_python-1.2.18-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-scheduler",
+      "purl": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/types/errors",
+      "purl": "pkg:golang/internal/types/errors@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/types/errors@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libgpg-error",
+      "purl": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "version": "1.42-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "55660568a38dad2e4a858df692830af766ad6532",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1818836",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/legacy-cloud-providers",
+      "purl": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/exp/typeparams",
+      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+      "version": "v0.0.0-20230203172020-98cc5a0785f9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libnftnl",
+      "purl": "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=x86_64",
+      "version": "1.2.6-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d524ea7068ac80696b2688aab672500071f38ac",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnftnl#8d524ea7068ac80696b2688aab672500071f38ac"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3052789",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnftnl#8d524ea7068ac80696b2688aab672500071f38ac",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/common",
+      "purl": "pkg:golang/github.com/containers/common@v0.50.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/common@v0.50.1",
+      "version": "v0.50.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/procfs",
+      "purl": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubectl",
+      "purl": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "basesystem",
+      "purl": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "version": "11-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+            "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688850",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/godebug",
+      "purl": "pkg:golang/internal/godebug@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/godebug@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-gssapi",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=x86_64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.1",
+      "type": "library",
+      "author": "Gustavo Niemeyer <gustavo@niemeyer.net>",
+      "bom-ref": "pkg:pypi/python-dateutil@2.8.1",
+      "version": "2.8.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Dual License"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/python_dateutil-2.8.1-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "dejavu-sans-fonts",
+      "purl": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "version": "2.37-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bitstream Vera and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1479ec5203df4c3e577d1992b22c6976c142afa9",
+            "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688969",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/client-go",
+      "purl": "pkg:golang/kubevirt.io/client-go",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/client-go",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libelf",
+      "purl": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=x86_64",
+      "version": "0.190-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03f1598bbe94308cc7655234a5dcf75092cd1968",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2817160",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/hmac",
+      "purl": "pkg:golang/crypto/hmac@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/hmac@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "libcap",
+      "purl": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+      "version": "2.48-9.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "579dc340bc85f77708d4c04f72f9cc7c2ad16e27",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap#579dc340bc85f77708d4c04f72f9cc7c2ad16e27"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2590508",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap#579dc340bc85f77708d4c04f72f9cc7c2ad16e27",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "virt-what",
+      "purl": "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=x86_64",
+      "version": "1.25-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc9eaee5d4f089206bd81208cc7e4448bdae8233",
+            "url": "git://pkgs.devel.redhat.com/rpms/virt-what#fc9eaee5d4f089206bd81208cc7e4448bdae8233"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2574109",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/virt-what#fc9eaee5d4f089206bd81208cc7e4448bdae8233",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/goarch",
+      "purl": "pkg:golang/internal/goarch@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goarch@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "version": "v1.1.1-0.20210330154013-f5de75959ad5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/qe-tools",
+      "purl": "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+      "version": "v0.1.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "math/rand",
+      "purl": "pkg:golang/math/rand@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math/rand@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-iniparse",
+      "purl": "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+      "version": "0.4-45.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fa613c34fcc4661d8320d1eead334cb4a43d56be",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-iniparse#fa613c34fcc4661d8320d1eead334cb4a43d56be"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-iniparse#fa613c34fcc4661d8320d1eead334cb4a43d56be",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pyinotify",
+      "purl": "pkg:pypi/pyinotify@0.9.6",
+      "type": "library",
+      "author": "Sebastien Martini <seb@dbzteam.org>",
+      "bom-ref": "pkg:pypi/pyinotify@0.9.6",
+      "version": "0.9.6",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT License"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/pyinotify-0.9.6-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "internal/saferio",
+      "purl": "pkg:golang/internal/saferio@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/saferio@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "unsafe",
+      "purl": "pkg:golang/unsafe@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unsafe@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/ed25519",
+      "purl": "pkg:golang/crypto/ed25519@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/ed25519@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "net/rpc",
+      "purl": "pkg:golang/net/rpc@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/rpc@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "bufio",
+      "purl": "pkg:golang/bufio@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/bufio@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "internal/nettrace",
+      "purl": "pkg:golang/internal/nettrace@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/nettrace@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/legacy-cloud-providers",
+      "purl": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0?package-id=6f1e377d494cf9f5",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kisielk/errcheck",
+      "purl": "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+      "version": "v1.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libcap-ng",
+      "purl": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "version": "0.8.2-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1888632",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/nunnatsa/ginkgolinter",
+      "purl": "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/spdystream",
+      "purl": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "version": "v0.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libzstd",
+      "purl": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64",
+      "version": "1.5.1-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dcda9fe564e51b7222a5efca3b14840bcc341b44",
+            "url": "git://pkgs.devel.redhat.com/rpms/zstd#dcda9fe564e51b7222a5efca3b14840bcc341b44"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1879398",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zstd#dcda9fe564e51b7222a5efca3b14840bcc341b44",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/pprof",
+      "purl": "pkg:golang/runtime/pprof@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/pprof@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libeconf",
+      "purl": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=x86_64",
+      "version": "0.4.1-3.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "aeb088c5c9095f978d2e8b5a06f3079b3b15c9a9",
+            "url": "git://pkgs.devel.redhat.com/rpms/libeconf#aeb088c5c9095f978d2e8b5a06f3079b3b15c9a9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2539463",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libeconf#aeb088c5c9095f978d2e8b5a06f3079b3b15c9a9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding",
+      "purl": "pkg:golang/encoding@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "librepo",
+      "purl": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+      "version": "1.14.5-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "458f8b732e9d31cbe09323c87f796924ac30461c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797210",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=2fae184f36a99a47",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libacl",
+      "purl": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "version": "2.3.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2709815",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "shadow-utils",
+      "purl": "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=x86_64&epoch=2",
+      "version": "2:4.9-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "183ec47a68eb739420b44e0d9db15ffb5c4e5753",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#183ec47a68eb739420b44e0d9db15ffb5c4e5753"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3303839",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#183ec47a68eb739420b44e0d9db15ffb5c4e5753",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/boring/bbig",
+      "purl": "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libsmartcols",
+      "purl": "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/x509/pkix",
+      "purl": "pkg:golang/crypto/x509/pkix@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/x509/pkix@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "runtime/trace",
+      "purl": "pkg:golang/runtime/trace@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/trace@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=f970a3d674d44626",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/btree",
+      "purl": "pkg:golang/github.com/google/btree@v1.1.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/btree@v1.1.3",
+      "version": "v1.1.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "expat",
+      "purl": "pkg:rpm/redhat/expat@2.5.0-2.el9_4.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/expat@2.5.0-2.el9_4.2?arch=x86_64",
+      "version": "2.5.0-2.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "28121dc5b647cd04fc79c666986f5382e9f6b160",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#28121dc5b647cd04fc79c666986f5382e9f6b160"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3411400",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#28121dc5b647cd04fc79c666986f5382e9f6b160",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/plugins",
+      "purl": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "mvdan.cc/sh/v3",
+      "purl": "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+      "version": "v3.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/netip",
+      "purl": "pkg:golang/net/netip@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/netip@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=48602be9269bc897",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/code-generator",
+      "purl": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/u-root/uio",
+      "purl": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "version": "v0.0.0-20230220225925-ffce2a382923",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/groupcache",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.22.12",
+      "version": "go1.22.12",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=18734635491c2975",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libssh",
+      "purl": "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=x86_64",
+      "version": "0.10.4-13.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35756743d06f7dc2fde2d65495ae0d4866011d1b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3866387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=1b0cc1bbf3f8ed78",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cloud-provider",
+      "purl": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/goexpect",
+      "purl": "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+      "version": "v0.0.0-20190425035906-112704a48083",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.9.0",
+      "version": "v0.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/client-go",
+      "purl": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "version": "v0.0.0-20210112165513-ebc401615f47",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libdnf",
+      "purl": "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+      "version": "0.69.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e5984c195dca639c24fa8a25263d2faf9419e97d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134146",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "which",
+      "purl": "pkg:rpm/redhat/which@2.21-29.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/which@2.21-29.el9?arch=x86_64",
+      "version": "2.21-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dac12498cdc45059738012dbd5af70569b8b8100",
+            "url": "git://pkgs.devel.redhat.com/rpms/which#dac12498cdc45059738012dbd5af70569b8b8100"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2437620",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/which#dac12498cdc45059738012dbd5af70569b8b8100",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sync/atomic",
+      "purl": "pkg:golang/sync/atomic@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/sync/atomic@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+      "purl": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/nistec",
+      "purl": "pkg:golang/crypto/internal/nistec@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/nistec@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "database/sql/driver",
+      "purl": "pkg:golang/database/sql/driver@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/database/sql/driver@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "reflect",
+      "purl": "pkg:golang/reflect@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/reflect@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-semver",
+      "purl": "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+      "version": "v0.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "version": "v0.0.0-20210104183010-2eb08e3e575f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubectl",
+      "purl": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=b4c3f12b0f973ad1",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pmezard/go-difflib",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "version": "v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/sys/cpu",
+      "purl": "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "usermode",
+      "purl": "pkg:rpm/redhat/usermode@1.114-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/usermode@1.114-4.el9?arch=x86_64",
+      "version": "1.114-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6fcf2ff19afca6b8a061136d7df6189faec5f15c",
+            "url": "git://pkgs.devel.redhat.com/rpms/usermode#6fcf2ff19afca6b8a061136d7df6189faec5f15c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1821463",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/usermode#6fcf2ff19afca6b8a061136d7df6189faec5f15c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "math/bits",
+      "purl": "pkg:golang/math/bits@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math/bits@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/povsister/scp",
+      "purl": "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+      "version": "v0.0.0-20210427074412-33febfd9f13e",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/xml",
+      "purl": "pkg:golang/encoding/xml@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/xml@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic",
+      "purl": "pkg:golang/github.com/google/gnostic@v0.5.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic@v0.5.7",
+      "version": "v0.5.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/chacha8rand",
+      "purl": "pkg:golang/internal/chacha8rand@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/chacha8rand@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libnghttp2",
+      "purl": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=x86_64",
+      "version": "1.43.0-5.el9_4.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3c2e4449d7e195f89fc8f2d9c566b05a2e315dae",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#3c2e4449d7e195f89fc8f2d9c566b05a2e315dae"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2996729",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#3c2e4449d7e195f89fc8f2d9c566b05a2e315dae",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "version": "v1.1.14",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/operator-framework/operator-lifecycle-manager",
+      "purl": "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "version": "v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libdnf-plugin-subscription-manager",
+      "purl": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "pygobject",
+      "purl": "pkg:pypi/pygobject@3.40.1",
+      "type": "library",
+      "author": "James Henstridge <james@daa.com.au>",
+      "bom-ref": "pkg:pypi/pygobject@3.40.1",
+      "version": "3.40.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GNU LGPL"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/PyGObject-3.40.1.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "version": "v0.5.9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=1f351b9d12dd5e8b",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=807835609b958430",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "go/ast",
+      "purl": "pkg:golang/go/ast@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/ast@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libassuan",
+      "purl": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "version": "2.5.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5b185f851a42718727fee9efcf42ba525a59a8bb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689887",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "version": "v1.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/node-api",
+      "purl": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-libdnf",
+      "purl": "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+      "version": "0.69.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e5984c195dca639c24fa8a25263d2faf9419e97d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134146",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-pip-wheel",
+      "purl": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+      "version": "21.2.3-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f3400cce6a9da840f21eb4cfd81a0c2ca38eb185",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#f3400cce6a9da840f21eb4cfd81a0c2ca38eb185"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2906206",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#f3400cce6a9da840f21eb4cfd81a0c2ca38eb185",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:pypi/rpm@4.16.1.3",
+      "type": "library",
+      "author": "UNKNOWN <rpm-maint@lists.rpm.org>",
+      "bom-ref": "pkg:pypi/rpm@4.16.1.3",
+      "version": "4.16.1.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "GNU General Public License v2"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/rpm-4.16.1.3-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "systemd-libs",
+      "purl": "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=x86_64",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "syscall",
+      "purl": "pkg:golang/syscall@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/syscall@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "version": "5a6340b3-6229229e",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "version": "v1.5.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig/v3",
+      "purl": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "version": "v3.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/renameio/v2",
+      "purl": "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+      "version": "v2.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "version": "v0.3.16",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "yajl",
+      "purl": "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=x86_64",
+      "version": "2.1.0-22.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3b4891fe107c68e6e41550e4be2a5c9ad4f870a6",
+            "url": "git://pkgs.devel.redhat.com/rpms/yajl#3b4891fe107c68e6e41550e4be2a5c9ad4f870a6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2592251",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/yajl#3b4891fe107c68e6e41550e4be2a5c9ad4f870a6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsepol",
+      "purl": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=x86_64",
+      "version": "3.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d568b2713a4280fad93a660b66d5047296c3853f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#d568b2713a4280fad93a660b66d5047296c3853f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820602",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#d568b2713a4280fad93a660b66d5047296c3853f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/oserror",
+      "purl": "pkg:golang/internal/oserror@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/oserror@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/ecdh",
+      "purl": "pkg:golang/crypto/ecdh@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/ecdh@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "compress/bzip2",
+      "purl": "pkg:golang/compress/bzip2@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/bzip2@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/socket",
+      "purl": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "version": "v0.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go.mongodb.org/mongo-driver",
+      "purl": "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+      "version": "v1.8.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/insomniacslk/dhcp",
+      "purl": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "version": "v0.0.0-20230908212754-65c27093e38a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "net/http/internal",
+      "purl": "pkg:golang/net/http/internal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/internal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.22.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.22.0",
+      "version": "v0.22.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=848770ad63e2adc0",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/common",
+      "purl": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "version": "v0.44.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "compress/zlib",
+      "purl": "pkg:golang/compress/zlib@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/zlib@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libbpf",
+      "purl": "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=x86_64&epoch=2",
+      "version": "2:1.3.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 or BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "39db39a8f05a831c2cff398273dbc03597e85c8a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libbpf#39db39a8f05a831c2cff398273dbc03597e85c8a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2924610",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libbpf#39db39a8f05a831c2cff398273dbc03597e85c8a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/cryptobyte/asn1",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libsemanage",
+      "purl": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=x86_64",
+      "version": "3.6-2.1.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "96eef030fb0a0f4d27e17961dd585c8730df12e4",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#96eef030fb0a0f4d27e17961dd585c8730df12e4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3418014",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#96eef030fb0a0f4d27e17961dd585c8730df12e4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-six",
+      "purl": "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+      "version": "1.15.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7a3cef2bf49b31b0f9c2ecd4b05d34bdc214998c",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-six#7a3cef2bf49b31b0f9c2ecd4b05d34bdc214998c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1890817",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-six#7a3cef2bf49b31b0f9c2ecd4b05d34bdc214998c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/elliptic",
+      "purl": "pkg:golang/crypto/elliptic@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/elliptic@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libksba",
+      "purl": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=x86_64",
+      "version": "1.5.1-6.el9_1",
+      "licenses": [
+        {
+          "license": {
+            "name": "(LGPLv3+ or GPLv2+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7112a8f2afeccb3acd42cba9a99b4c2c8fe70306",
+            "url": "git://pkgs.devel.redhat.com/rpms/libksba#7112a8f2afeccb3acd42cba9a99b4c2c8fe70306"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2345715",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libksba#7112a8f2afeccb3acd42cba9a99b4c2c8fe70306",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/cespare/xxhash/v2",
+      "purl": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "version": "v2.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=b15f37518ae084d6",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/godebugs",
+      "purl": "pkg:golang/internal/godebugs@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/godebugs@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-controller-manager",
+      "purl": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/secure/bidirule",
+      "purl": "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/glog",
+      "purl": "pkg:golang/github.com/golang/glog",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/glog",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-cloud-what",
+      "purl": "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=x86_64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmnl",
+      "purl": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+      "version": "1.0.4-16.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e4e253af7af3650798d04664f7b96965ed5365ad",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libmnl#e4e253af7af3650798d04664f7b96965ed5365ad"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3049134",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libmnl#e4e253af7af3650798d04664f7b96965ed5365ad",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/buildcfg",
+      "purl": "pkg:golang/internal/buildcfg@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/buildcfg@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "purl": "pkg:golang/os@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager-rhsm-certificates",
+      "purl": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+      "version": "20220623-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "aa015c720c46b2548f962320f9b18de28c097691",
+            "url": "git://pkgs.devel.redhat.com/rpms/subscription-manager-rhsm-certificates#aa015c720c46b2548f962320f9b18de28c097691"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2061647",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/subscription-manager-rhsm-certificates#aa015c720c46b2548f962320f9b18de28c097691",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libattr",
+      "purl": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "version": "2.5.1-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+            "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688838",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/http2/hpack",
+      "purl": "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/bytealg",
+      "purl": "pkg:golang/internal/bytealg@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/bytealg@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "version": "fd431d51-4ae0493b",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/kubevirt",
+      "purl": "pkg:golang/kubevirt.io/kubevirt",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/kubevirt",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "net/url",
+      "purl": "pkg:golang/net/url@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/url@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/edwards25519/field",
+      "purl": "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.29.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.29.0",
+      "version": "v0.29.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/matttproud/golang_protobuf_extensions",
+      "purl": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "version": "v1.0.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/rogpeppe/go-internal",
+      "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "flag",
+      "purl": "pkg:golang/flag@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/flag@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "systemd-rpm-macros",
+      "purl": "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnfnetlink",
+      "purl": "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=x86_64",
+      "version": "1.0.1-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9ba3ebe2fec01b51fb3dbee7005578f6c9257add",
+            "url": "git://pkgs.devel.redhat.com/rpms/libnfnetlink#9ba3ebe2fec01b51fb3dbee7005578f6c9257add"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690058",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libnfnetlink#9ba3ebe2fec01b51fb3dbee7005578f6c9257add",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/matttproud/golang_protobuf_extensions",
+      "purl": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4?package-id=e4e1dce43844ff08",
+      "version": "v1.0.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-aggregator",
+      "purl": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+      "purl": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0?package-id=3f73b8c486d0a009",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.22.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.22.0?package-id=341ee6986e5d85c1",
+      "version": "v0.22.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.33.0",
+      "version": "v0.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubernetes-csi/external-snapshotter/client/v4",
+      "purl": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "version": "v4.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "go/token",
+      "purl": "pkg:golang/go/token@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/token@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libgcrypt",
+      "purl": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=x86_64",
+      "version": "1.10.0-10.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "06551d4cc2458fcbe36fe78ec1a5cdbc5dbbf914",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#06551d4cc2458fcbe36fe78ec1a5cdbc5dbbf914"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3567943",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#06551d4cc2458fcbe36fe78ec1a5cdbc5dbbf914",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "compress/flate",
+      "purl": "pkg:golang/compress/flate@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/flate@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "go/build",
+      "purl": "pkg:golang/go/build@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/build@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/api",
+      "purl": "pkg:golang/kubevirt.io/api",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/api",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kr/logfmt",
+      "purl": "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+      "version": "v0.0.0-20210122060352-19f9bcb100e6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "acl",
+      "purl": "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64",
+      "version": "2.3.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2709815",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/platform",
+      "purl": "pkg:golang/internal/platform@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/platform@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/randutil",
+      "purl": "pkg:golang/crypto/internal/randutil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/randutil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/log",
+      "purl": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/common",
+      "purl": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/common@v0.44.0?package-id=3a5f710d384a3dd9",
+      "version": "v0.44.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "html",
+      "purl": "pkg:golang/html@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/html@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-setuptools-wheel",
+      "purl": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+      "version": "53.0.0-12.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and (BSD or ASL 2.0)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e118582dafc46c5b61049eb79598ec15e88c3b7d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3754759",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=64880854c531d875",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/goos",
+      "purl": "pkg:golang/internal/goos@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goos@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=fa36e4581bae4e38",
+      "version": "v1.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-colorable",
+      "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "version": "v0.1.13",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/gob",
+      "purl": "pkg:golang/encoding/gob@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/gob@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_golang",
+      "purl": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "version": "v1.16.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=3f115ef0cb31e7b8",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/fmtsort",
+      "purl": "pkg:golang/internal/fmtsort@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/fmtsort@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "slices",
+      "purl": "pkg:golang/slices@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/slices@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=bbfbb1eba9b1b80e",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/mapstructure",
+      "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libcurl-minimal",
+      "purl": "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+      "version": "7.76.1-29.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80195397e7d61d156d731499be9884797b75dbb1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471237",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=9312f2882f8a9a02",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "crypto/aes",
+      "purl": "pkg:golang/crypto/aes@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/aes@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "pcre2",
+      "purl": "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=x86_64",
+      "version": "10.40-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "29947c528818ead0dfcd77753bd76a46d617d18a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2914968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libselinux",
+      "purl": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=x86_64",
+      "version": "3.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b604bc7c7288a43b90e0f88226ddff652b945e40",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#b604bc7c7288a43b90e0f88226ddff652b945e40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2821561",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#b604bc7c7288a43b90e0f88226ddff652b945e40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=66f62c4a3380d295",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "dbus-common",
+      "purl": "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcomps",
+      "purl": "pkg:pypi/libcomps@0.1.18",
+      "type": "library",
+      "author": "RPM Software Management <rpm-ecosystem@lists.rpm.org>",
+      "bom-ref": "pkg:pypi/libcomps@0.1.18",
+      "version": "0.1.18",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/libcomps-0.1.18-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "strconv",
+      "purl": "pkg:golang/strconv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/strconv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "bytes",
+      "purl": "pkg:golang/bytes@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/bytes@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/sha256",
+      "purl": "pkg:golang/crypto/sha256@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/sha256@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libnl3",
+      "purl": "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=x86_64",
+      "version": "3.9.0-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "23021690a101b6f1b14fd6b0d4fe318934dbb9c3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnl3#23021690a101b6f1b14fd6b0d4fe318934dbb9c3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2805134",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnl3#23021690a101b6f1b14fd6b0d4fe318934dbb9c3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=8fbdfdc32aa3f0c7",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-lib",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=45b68313e6b7649d",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "io",
+      "purl": "pkg:golang/io@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/io@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "langpacks-en",
+      "purl": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl",
+      "purl": "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+      "version": "1:3.0.7-29.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3880294",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v0.2.1",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "iniparse",
+      "purl": "pkg:pypi/iniparse@0.4",
+      "type": "library",
+      "author": "Paramjit Oberoi <param@cs.wisc.edu>",
+      "bom-ref": "pkg:pypi/iniparse@0.4",
+      "version": "0.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/iniparse-0.4-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "kmod-libs",
+      "purl": "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=x86_64",
+      "version": "28-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "36aca425e7d25f5daca7109dc963da87294cd1b5",
+            "url": "git://pkgs.devel.redhat.com/rpms/kmod#36aca425e7d25f5daca7109dc963da87294cd1b5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2512428",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/kmod#36aca425e7d25f5daca7109dc963da87294cd1b5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/cheggaaa/pb/v3",
+      "purl": "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+      "version": "v3.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig/v3",
+      "purl": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0?package-id=c5265481edb963f4#v3",
+      "version": "v3.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=6025e076d202b258",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gnutls",
+      "purl": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=x86_64",
+      "version": "3.8.3-4.el9_4.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b773160a90460399f962c17953398ff7f781803b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#b773160a90460399f962c17953398ff7f781803b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3821445",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#b773160a90460399f962c17953398ff7f781803b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/cipher",
+      "purl": "pkg:golang/crypto/cipher@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/cipher@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "debug/elf",
+      "purl": "pkg:golang/debug/elf@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/debug/elf@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/rsa",
+      "purl": "pkg:golang/crypto/rsa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/rsa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/diff",
+      "purl": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "version": "v0.0.0-20210226163009-20ebb0f2a09e",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/metrics",
+      "purl": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libffi",
+      "purl": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "version": "3.4.2-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6f484e5230669fffb71870ce41c386e01ab4e47d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467679",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nftables",
+      "purl": "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=x86_64&epoch=1",
+      "version": "1:1.0.9-1.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6bd061508fbd17f371f610037fe4b4b89d8cd95e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nftables#6bd061508fbd17f371f610037fe4b4b89d8cd95e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3693063",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nftables#6bd061508fbd17f371f610037fe4b4b89d8cd95e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=68f83d538edd1c62",
+      "version": "v1.1.1-0.20210330154013-f5de75959ad5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "iproute",
+      "purl": "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=x86_64",
+      "version": "6.2.0-6.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-or-later AND NIST-PD"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "50f71af59d28c401b90bb35a222dc94b3eb7cfae",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/iproute#50f71af59d28c401b90bb35a222dc94b3eb7cfae"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2950524",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/iproute#50f71af59d28c401b90bb35a222dc94b3eb7cfae",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+      "version": "v0.0.0-20210105115604-44119421ec6b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "container/heap",
+      "purl": "pkg:golang/container/heap@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/container/heap@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "mime/multipart",
+      "purl": "pkg:golang/mime/multipart@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/mime/multipart@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "mime/quotedprintable",
+      "purl": "pkg:golang/mime/quotedprintable@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/mime/quotedprintable@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/alias",
+      "purl": "pkg:golang/crypto/internal/alias@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/alias@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libdb",
+      "purl": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=x86_64",
+      "version": "5.3.28-53.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and LGPLv2 and Sleepycat"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "27038c5d3e75ae33c7281b39d1b15ce166a0c420",
+            "url": "git://pkgs.devel.redhat.com/rpms/libdb#27038c5d3e75ae33c7281b39d1b15ce166a0c420"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1806145",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libdb#27038c5d3e75ae33c7281b39d1b15ce166a0c420",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "encoding/hex",
+      "purl": "pkg:golang/encoding/hex@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/hex@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "audit-libs",
+      "purl": "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=x86_64",
+      "version": "3.1.2-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3d2d297e67e32b5ce4c2914cc64169fd0be4ace0",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#3d2d297e67e32b5ce4c2914cc64169fd0be4ace0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2769499",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#3d2d297e67e32b5ce4c2914cc64169fd0be4ace0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gobject-introspection",
+      "purl": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "version": "1.68.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5fa3808a6c90b0da8da9a85fad983244c13640ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2248264",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies",
+      "purl": "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+      "version": "20240202-1.git283706d.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a950d9ca3218bf47d75befa4639b7990b00c99eb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2889114",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/appengine",
+      "purl": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "version": "v1.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "internal/abi",
+      "purl": "pkg:golang/internal/abi@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/abi@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/tomb.v1",
+      "purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "version": "v1.0.0-20141024135613-dd632973f1e7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=38049f9b809b501e",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "ncurses-base",
+      "purl": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+      "version": "6.2-10.20210508.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "539ab619cec841979d6b46943d3f82c15b7a8467",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3759616",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=7f71bb3211c40e1e",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/parser",
+      "purl": "pkg:golang/go/parser@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/parser@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+      "version": "v0.0.0-20230503133300-8bbcb7ca7183",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "image/color",
+      "purl": "pkg:golang/image/color@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/color@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/chacha20",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/pprof",
+      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "version": "v0.0.0-20240424215950-a892ee059fd6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "context",
+      "purl": "pkg:golang/context@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/context@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=06ba511a601e36d7",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/http/internal/ascii",
+      "purl": "pkg:golang/net/http/internal/ascii@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/internal/ascii@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=874d616b5ffd59b7",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/nxadm/tail",
+      "purl": "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+      "version": "v0.0.0-20211216163028-4472660a31a6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "chardet",
+      "purl": "pkg:pypi/chardet@4.0.0",
+      "type": "library",
+      "author": "Mark Pilgrim <mark@diveintomark.org>",
+      "bom-ref": "pkg:pypi/chardet@4.0.0",
+      "version": "4.0.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPL"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/chardet-4.0.0.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d6c72ae7c47adf6d",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "cmp",
+      "purl": "pkg:golang/cmp@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/cmp@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/syscall/unix",
+      "purl": "pkg:golang/internal/syscall/unix@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/syscall/unix@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "rpm-build-libs",
+      "purl": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=x86_64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-isatty",
+      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "version": "v0.0.17",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.24.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.24.0",
+      "version": "v0.24.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/unsafeheader",
+      "purl": "pkg:golang/internal/unsafeheader@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/unsafeheader@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "path",
+      "purl": "pkg:golang/path@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/path@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.33.0?package-id=cb71f9386c7676b0",
+      "version": "v0.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "math",
+      "purl": "pkg:golang/math@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/cpu",
+      "purl": "pkg:golang/internal/cpu@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/cpu@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "fmt",
+      "purl": "pkg:golang/fmt@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/fmt@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog",
+      "purl": "pkg:golang/k8s.io/klog@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog@v0.4.0",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/cheggaaa/pb.v1",
+      "purl": "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+      "version": "v1.0.28",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/doc",
+      "purl": "pkg:golang/go/doc@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/doc@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libutempter",
+      "purl": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=x86_64",
+      "version": "1.2.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c269950567cdc8b12062724de07db72689bf55c",
+            "url": "git://pkgs.devel.redhat.com/rpms/libutempter#1c269950567cdc8b12062724de07db72689bf55c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690196",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libutempter#1c269950567cdc8b12062724de07db72689bf55c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "embed",
+      "purl": "pkg:golang/embed@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/embed@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=fd7a9516c0278d0e",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "internal/lazyregexp",
+      "purl": "pkg:golang/internal/lazyregexp@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/lazyregexp@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "librhsm",
+      "purl": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=x86_64",
+      "version": "0.0.3-7.el9_3.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25c62475abb565eb8ebef5f1df66a6c5eff74ccd",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#25c62475abb565eb8ebef5f1df66a6c5eff74ccd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2845494",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#25c62475abb565eb8ebef5f1df66a6c5eff74ccd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "grep",
+      "purl": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "version": "3.6-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7779e81140d7afaf33d2a97f4afdd682457f9697",
+            "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689607",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "path/filepath",
+      "purl": "pkg:golang/path/filepath@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/path/filepath@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cobra",
+      "purl": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/singleflight",
+      "purl": "pkg:golang/internal/singleflight@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/singleflight@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=7209f81d42d9fb42",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.3.0",
+      "version": "v0.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libmount",
+      "purl": "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log/slog",
+      "purl": "pkg:golang/log/slog@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/slog@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "debug/dwarf",
+      "purl": "pkg:golang/debug/dwarf@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/debug/dwarf@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/api",
+      "purl": "pkg:golang/kubevirt.io/api",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/api?package-id=8271ccebef8c7fbf",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/plugins",
+      "purl": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1?package-id=9ab03ca56b78d2bd",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/component-base",
+      "purl": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "purl": "pkg:golang/image@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "hash/crc32",
+      "purl": "pkg:golang/hash/crc32@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash/crc32@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "pcre",
+      "purl": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64",
+      "version": "8.44-3.el9.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1007ce35c0150110a7bcd4c1741380a726434e46",
+            "url": "git://pkgs.devel.redhat.com/rpms/pcre#1007ce35c0150110a7bcd4c1741380a726434e46"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691250",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pcre#1007ce35c0150110a7bcd4c1741380a726434e46",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "decorator",
+      "purl": "pkg:pypi/decorator@4.4.2",
+      "type": "library",
+      "author": "Michele Simionato <michele.simionato@gmail.com>",
+      "bom-ref": "pkg:pypi/decorator@4.4.2",
+      "version": "4.4.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "new BSD License"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/decorator-4.4.2-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/vsock",
+      "purl": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=cf3c5a20a21e8e64",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "os/exec",
+      "purl": "pkg:golang/os/exec@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os/exec@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/glog",
+      "purl": "pkg:golang/github.com/golang/glog@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/glog@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cli-runtime",
+      "purl": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiserver",
+      "purl": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/grafana/regexp",
+      "purl": "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "version": "v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "bzip2-libs",
+      "purl": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=x86_64",
+      "version": "1.0.8-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00ab1bac9f740f33a2dcc6ada500c802a28bb6b2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#00ab1bac9f740f33a2dcc6ada500c802a28bb6b2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3425109",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#00ab1bac9f740f33a2dcc6ada500c802a28bb6b2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/sha512",
+      "purl": "pkg:golang/crypto/sha512@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/sha512@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/node-api",
+      "purl": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/node-api@v0.30.0?package-id=69b6b0afb2bc8383",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libs",
+      "purl": "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=x86_64",
+      "version": "0.190-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03f1598bbe94308cc7655234a5dcf75092cd1968",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2817160",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/blang/semver",
+      "purl": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+      "version": "v3.5.1+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "hash/fnv",
+      "purl": "pkg:golang/hash/fnv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash/fnv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "go/scanner",
+      "purl": "pkg:golang/go/scanner@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/scanner@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=5af92f389a804379",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/testlog",
+      "purl": "pkg:golang/internal/testlog@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/testlog@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubelet",
+      "purl": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libarchive",
+      "purl": "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=x86_64",
+      "version": "3.5.3-4.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "64e0b899f452b7e78dde9b8df8e5ecd358f1c837",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#64e0b899f452b7e78dde9b8df8e5ecd358f1c837"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3807112",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#64e0b899f452b7e78dde9b8df8e5ecd358f1c837",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "text/template",
+      "purl": "pkg:golang/text/template@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/text/template@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "compress/gzip",
+      "purl": "pkg:golang/compress/gzip@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/gzip@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=64a952cc8f95048c",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog",
+      "purl": "pkg:golang/k8s.io/klog@v0.3.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog@v0.3.3",
+      "version": "v0.3.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=42ecb449d13ca189",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vim-minimal",
+      "purl": "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=x86_64&epoch=2",
+      "version": "2:8.2.2637-20.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Vim and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0efec05571fe5baab0ca0b22db499eb5c8d42af6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/vim#0efec05571fe5baab0ca0b22db499eb5c8d42af6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3849530",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/vim#0efec05571fe5baab0ca0b22db499eb5c8d42af6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtasn1",
+      "purl": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=x86_64",
+      "version": "4.16.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "425d04e73d45b52ff50b454e85e8c512cc8fe282",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtasn1#425d04e73d45b52ff50b454e85e8c512cc8fe282"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3617876",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtasn1#425d04e73d45b52ff50b454e85e8c512cc8fe282",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/library-go",
+      "purl": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "version": "v0.0.0-20211220195323-eca2c467c492",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "krb5-libs",
+      "purl": "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=x86_64",
+      "version": "1.21.1-2.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fb34142b8ed95c27cf052bbe556c0df07e04db51",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#fb34142b8ed95c27cf052bbe556c0df07e04db51"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3731292",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#fb34142b8ed95c27cf052bbe556c0df07e04db51",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-librepo",
+      "purl": "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=x86_64",
+      "version": "1.14.5-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "458f8b732e9d31cbe09323c87f796924ac30461c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797210",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cracklib-dicts",
+      "purl": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=x86_64",
+      "version": "2.9.6-27.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+            "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689047",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=c251c2070b6d837f",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mxk/go-flowrate",
+      "purl": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "version": "v0.0.0-20140419014527-cca7078d478f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "dnf",
+      "purl": "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-fips-provider",
+      "purl": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=x86_64",
+      "version": "3.0.7-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "74dea6ff6f98ab99d3a2b6aba58cd38346734b79",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#74dea6ff6f98ab99d3a2b6aba58cd38346734b79"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2922752",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#74dea6ff6f98ab99d3a2b6aba58cd38346734b79",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=a3f45ccc2eaef8aa",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-controller",
+      "purl": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-gobject-base",
+      "purl": "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=x86_64",
+      "version": "3.40.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79ff68bd91179f855796360827ad65f2a83577dc",
+            "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2049891",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcc",
+      "purl": "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=x86_64",
+      "version": "11.4.1-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498982",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "encoding/binary",
+      "purl": "pkg:golang/encoding/binary@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/binary@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/ecdsa",
+      "purl": "pkg:golang/crypto/ecdsa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/ecdsa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubectl",
+      "purl": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=75bca8ba1ca22c9b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubernetes-csi/external-snapshotter/client/v4",
+      "purl": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=45a8c7aac0e298e2#client/v4",
+      "version": "v4.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/poll",
+      "purl": "pkg:golang/internal/poll@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/poll@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.15",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.15",
+      "version": "v0.3.15",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e519b37240b7b6af",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "util-linux",
+      "purl": "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "io/fs",
+      "purl": "pkg:golang/io/fs@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/io/fs@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.23.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.23.0",
+      "version": "v0.23.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=0c548e794e085974",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-urllib3",
+      "purl": "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+      "version": "1.26.5-5.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b5a869c4fb0e5683a40c5007515de8ed8e9a182f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-urllib3#b5a869c4fb0e5683a40c5007515de8ed8e9a182f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3236012",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-urllib3#b5a869c4fb0e5683a40c5007515de8ed8e9a182f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "version": "v22.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog",
+      "purl": "pkg:golang/k8s.io/klog@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog@v0.4.0?package-id=a6cf3f8305ce0756",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/client-go",
+      "purl": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=ee6a4656125cefb2",
+      "version": "v0.0.0-20210112165513-ebc401615f47",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "./staging/src/kubevirt.io/client-go",
+      "purl": "pkg:golang/./staging/src#kubevirt.io/client-go",
+      "type": "library",
+      "bom-ref": "pkg:golang/./staging/src#kubevirt.io/client-go",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=92cbc10610ba936e",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=0610c737c3c00486",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=4f70a6c87f97190b",
+      "version": "v1.0.3-0.20210326190908-1c3f411f0417",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-dbus",
+      "purl": "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=x86_64",
+      "version": "1.2.18-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f3a764ea144cc2b6b80a1ebd2925c96b2d81653b",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus-python#f3a764ea144cc2b6b80a1ebd2925c96b2d81653b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus-python#f3a764ea144cc2b6b80a1ebd2925c96b2d81653b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/genproto/googleapis/rpc",
+      "purl": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "version": "v0.0.0-20230822172742-b8732ec3820d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "version": "v5.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "pcre2-syntax",
+      "purl": "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+      "version": "10.40-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "29947c528818ead0dfcd77753bd76a46d617d18a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2914968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/safefilepath",
+      "purl": "pkg:golang/internal/safefilepath@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/safefilepath@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=f3f74c8e52e58f96",
+      "version": "v0.3.16",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/md5",
+      "purl": "pkg:golang/crypto/md5@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/md5@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "ima-evm-utils",
+      "purl": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=x86_64",
+      "version": "1.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f8dae177fe0fdd6012a0f6b10dbb14b8bedd4c40",
+            "url": "git://pkgs.devel.redhat.com/rpms/ima-evm-utils#f8dae177fe0fdd6012a0f6b10dbb14b8bedd4c40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1825204",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ima-evm-utils#f8dae177fe0fdd6012a0f6b10dbb14b8bedd4c40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/pierrec/lz4/v4",
+      "purl": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "version": "v4.1.15",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "log/slog/internal/buffer",
+      "purl": "pkg:golang/log/slog/internal/buffer@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/slog/internal/buffer@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=4e434d83ac45a761#v5",
+      "version": "v5.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-pysocks",
+      "purl": "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+      "version": "1.7.1-12.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc8ec2cb464cfd2ed3729ebd577824893559ecbd",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-pysocks#dc8ec2cb464cfd2ed3729ebd577824893559ecbd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1891067",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-pysocks#dc8ec2cb464cfd2ed3729ebd577824893559ecbd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "popt",
+      "purl": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "version": "1.18-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+            "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691597",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "npth",
+      "purl": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "version": "1.6-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+            "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690792",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/wadey/gocovmerge",
+      "purl": "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+      "version": "v0.0.0-20160331181800-b5bfa59ec0ad",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=6bfd33acc02b178b",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/go-vnc",
+      "purl": "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+      "version": "v0.0.0-20150629162542-723ed9867aed",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "redhat-release",
+      "purl": "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=x86_64",
+      "version": "9.4-0.5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94af0111c38c9daaa9b97620cd8c6237de1d1315",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#94af0111c38c9daaa9b97620cd8c6237de1d1315"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3021565",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#94af0111c38c9daaa9b97620cd8c6237de1d1315",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-cli-plugin",
+      "purl": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sync",
+      "purl": "pkg:golang/sync@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/sync@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libuuid",
+      "purl": "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=78b5b822f572b90c",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=8c96dc44fcc58103",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-gpg",
+      "purl": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=x86_64",
+      "version": "1.15.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+            "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892040",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sync",
+      "purl": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/beorn7/perks",
+      "purl": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "version": "v1.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=7b9209a64c9c952b",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "tpm2-tss",
+      "purl": "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=x86_64",
+      "version": "3.2.2-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fda97b14b55a52fff507835adba9e6a9bf396f65",
+            "url": "git://pkgs.devel.redhat.com/rpms/tpm2-tss#fda97b14b55a52fff507835adba9e6a9bf396f65"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2577728",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/tpm2-tss#fda97b14b55a52fff507835adba9e6a9bf396f65",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3",
+      "purl": "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=x86_64",
+      "version": "3.9.18-3.el9_4.9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2e1b452fcf120e44a7613701e28dd40a7931fc59",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3828922",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=2e766a71ac55c8c1",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/hkdf",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "net/http/httputil",
+      "purl": "pkg:golang/net/http/httputil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/httputil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=264ee8e18d5b5c8a",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+      "version": "v0.0.0-20230501164219-8b0f38b5fd1f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/googleapis/gnostic",
+      "purl": "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+      "version": "v0.2.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "zlib",
+      "purl": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "version": "1.2.11-40.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Boost"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+            "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2495976",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-stack/stack",
+      "purl": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "version": "v1.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/goexperiment",
+      "purl": "pkg:golang/internal/goexperiment@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goexperiment@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glib2",
+      "purl": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=x86_64",
+      "version": "2.68.4-14.el9_4.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "14a7b9b0aeb14a071ad69f0c1c3779c0c31c03e3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#14a7b9b0aeb14a071ad69f0c1c3779c0c31c03e3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3857383",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#14a7b9b0aeb14a071ad69f0c1c3779c0c31c03e3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/sysinfo",
+      "purl": "pkg:golang/internal/sysinfo@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/sysinfo@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "mpfr",
+      "purl": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "version": "4.1.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "207ac3816285664c0c73fa4894dbdead53d1ca40",
+            "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690656",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/cryptobyte",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.1.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.5",
+      "version": "v1.1.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-dnf",
+      "purl": "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cli-runtime",
+      "purl": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0?package-id=372a4fd9b7953904",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libpwquality",
+      "purl": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=x86_64",
+      "version": "1.4.4-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d78e5ea6e840372c17fabdd2cc371c7105a69b4e",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpwquality#d78e5ea6e840372c17fabdd2cc371c7105a69b4e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690098",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpwquality#d78e5ea6e840372c17fabdd2cc371c7105a69b4e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=bcb125b3ee0ac2bf",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "p11-kit",
+      "purl": "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=x86_64",
+      "version": "0.25.3-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "af03cdd6b28123c3643c0874462f8aaa668be9e6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2792712",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ncurses-libs",
+      "purl": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=x86_64",
+      "version": "6.2-10.20210508.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "539ab619cec841979d6b46943d3f82c15b7a8467",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3759616",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=50971d92969aa29f",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "util-linux-core",
+      "purl": "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libvirt.org/go/libvirtxml",
+      "purl": "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+      "version": "v1.10000.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=deca7fef444579a8",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "text/template/parse",
+      "purl": "pkg:golang/text/template/parse@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/text/template/parse@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "psmisc",
+      "purl": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+      "version": "23.4-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4bb81408b08c44d02985b6af55bbd75260c6b3ed",
+            "url": "git://pkgs.devel.redhat.com/rpms/psmisc#4bb81408b08c44d02985b6af55bbd75260c6b3ed"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691630",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/psmisc#4bb81408b08c44d02985b6af55bbd75260c6b3ed",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/crypto",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+      "version": "v0.0.0-20220321153916-2c7772ba3064",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.14.0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=296003ccdd027f5f",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cloud-provider",
+      "purl": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0?package-id=213905a8e9bf9bca",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/version",
+      "purl": "pkg:golang/go/version@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/version@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=fd55bfb7c4801b59",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=d52596cce426463a",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/boring/sig",
+      "purl": "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-runewidth",
+      "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+      "version": "v0.0.13",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sync",
+      "purl": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.11.0?package-id=d30348b75bd8dbbe",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=x86_64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sed",
+      "purl": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "version": "4.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dad14ff8a62e967c0afb23d1d237a927d847e86e",
+            "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1692031",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/library-go",
+      "purl": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492?package-id=3ba9356bde827563",
+      "version": "v0.0.0-20211220195323-eca2c467c492",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubelet",
+      "purl": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubelet@v0.30.0?package-id=0d174a34ad4bac4b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "version": "v1.33.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+      "purl": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "version": "v0.68.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/types",
+      "purl": "pkg:golang/go/types@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/types@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/goterm",
+      "purl": "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+      "version": "v0.0.0-20190311235235-ce302be1d114",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "hash/adler32",
+      "purl": "pkg:golang/hash/adler32@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash/adler32@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=777844465b60ad81",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_model",
+      "purl": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/cni",
+      "purl": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/syscall",
+      "purl": "pkg:golang/runtime/internal/syscall@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/syscall@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gregjones/httpcache",
+      "purl": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+      "version": "v0.0.0-20190611155906-901d90724c79",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/log",
+      "purl": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=7349fb61f86b922a",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=4b04ea23556ed395",
+      "version": "v0.3.16",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glibc-common",
+      "purl": "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=x86_64",
+      "version": "2.34-100.el9_4.12",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676435",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "regexp",
+      "purl": "pkg:golang/regexp@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/regexp@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libverto",
+      "purl": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "version": "0.3.2-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690209",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "maps",
+      "purl": "pkg:golang/maps@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/maps@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/krolaw/dhcp4",
+      "purl": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "version": "v0.0.0-20180925202202-7cead472c414",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "net",
+      "purl": "pkg:golang/net@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "encoding/csv",
+      "purl": "pkg:golang/encoding/csv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/csv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=165ae9cdbab510ff",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "version": "v0.0.0-20191219222812-2987a591a72c",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "p11-kit-trust",
+      "purl": "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=x86_64",
+      "version": "0.25.3-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "af03cdd6b28123c3643c0874462f8aaa668be9e6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2792712",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "os/signal",
+      "purl": "pkg:golang/os/signal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os/signal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=37c32ab5198d2ad6",
+      "version": "v1.0.3-0.20210326190908-1c3f411f0417",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "net/mail",
+      "purl": "pkg:golang/net/mail@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/mail@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/goroot",
+      "purl": "pkg:golang/internal/goroot@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goroot@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/analysis",
+      "purl": "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/transform",
+      "purl": "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/internal/alias",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/inconshreveable/mousetrap",
+      "purl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "strings",
+      "purl": "pkg:golang/strings@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/strings@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/grpc",
+      "purl": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "version": "v1.58.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "go/build/constraint",
+      "purl": "pkg:golang/go/build/constraint@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/build/constraint@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=6676202d3cb12353",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "os/user",
+      "purl": "pkg:golang/os/user@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os/user@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/golang-crypto",
+      "purl": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "version": "v0.33.1-0.20250310193910-9003f682e581",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/dsa",
+      "purl": "pkg:golang/crypto/dsa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/dsa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=b1e90c3e1ac1f792",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/http/httptrace",
+      "purl": "pkg:golang/net/http/httptrace@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/httptrace@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "curl-minimal",
+      "purl": "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+      "version": "7.76.1-29.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80195397e7d61d156d731499be9884797b75dbb1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471237",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/procfs",
+      "purl": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0?package-id=05538c935c5bdc7f",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/client-go",
+      "purl": "pkg:golang/kubevirt.io/client-go@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/client-go@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=d49025084db5e534",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "log/slog/internal",
+      "purl": "pkg:golang/log/slog/internal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/slog/internal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/spec",
+      "purl": "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+      "version": "v0.20.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=30a0f7618c550bd4",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/http/httpproxy",
+      "purl": "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/insomniacslk/dhcp",
+      "purl": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a?package-id=f5ed66e6e2ff252b",
+      "version": "v0.0.0-20230908212754-65c27093e38a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "purl": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=x86_64",
+      "version": "2.34-100.el9_4.12",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676435",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c?package-id=569830e89dc03f1b",
+      "version": "v0.0.0-20191219222812-2987a591a72c",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "keyutils-libs",
+      "purl": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "version": "1.6.3-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+            "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2212253",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pysocks",
+      "purl": "pkg:pypi/pysocks@1.7.1",
+      "type": "library",
+      "author": "Anorov <anorov.vorona@gmail.com>",
+      "bom-ref": "pkg:pypi/pysocks@1.7.1",
+      "version": "1.7.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/PySocks-1.7.1-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "rootfiles",
+      "purl": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "version": "8.1-31.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30d4e6354acbcb23c1f2485151e08cc352871e75",
+            "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#30d4e6354acbcb23c1f2485151e08cc352871e75"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691770",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#30d4e6354acbcb23c1f2485151e08cc352871e75",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/x509",
+      "purl": "pkg:golang/crypto/x509@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/x509@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "go/printer",
+      "purl": "pkg:golang/go/printer@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/printer@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=d8c2f26e9986efc0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=875c60b36880d488",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/constant",
+      "purl": "pkg:golang/go/constant@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/constant@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=56fa540c52a6e225",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-apiserver",
+      "purl": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libcomps",
+      "purl": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=x86_64",
+      "version": "0.1.18-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1771556",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pam",
+      "purl": "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=x86_64",
+      "version": "1.5.1-24.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a62b752a294ae678f588bcb039a59078981341de",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pam#a62b752a294ae678f588bcb039a59078981341de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3807184",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pam#a62b752a294ae678f588bcb039a59078981341de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=c76606bb87a8c509",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "file-libs",
+      "purl": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "version": "5.39-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2800051",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+      "version": "v0.0.0-20190221213512-86fb29eff628",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/boring",
+      "purl": "pkg:golang/crypto/internal/boring@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/boring@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libgomp",
+      "purl": "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=x86_64",
+      "version": "11.4.1-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498982",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=c27f4e3f0f288cba",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@1.26.5",
+      "type": "library",
+      "author": "Andrey Petrov <andrey.petrov@shazow.net>",
+      "bom-ref": "pkg:pypi/urllib3@1.26.5",
+      "version": "1.26.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/urllib3-1.26.5-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "tzdata",
+      "purl": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "version": "2025b-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff671e79a03e80cf1c432e92fa02aff95d597a97",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3572007",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/itoa",
+      "purl": "pkg:golang/internal/itoa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/itoa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=cd25ddf836753eae",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "internal/zstd",
+      "purl": "pkg:golang/internal/zstd@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/zstd@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/native",
+      "purl": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "json-c",
+      "purl": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "version": "0.14-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "391500fb2a46f72180ba1353136c1b3327d71c55",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1728857",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "net/http/httptest",
+      "purl": "pkg:golang/net/http/httptest@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/httptest@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-requests",
+      "purl": "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+      "version": "2.25.1-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a4dc4a098af1480c6eded62b59f1e385c7b01058",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-requests#a4dc4a098af1480c6eded62b59f1e385c7b01058"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870541",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-requests#a4dc4a098af1480c6eded62b59f1e385c7b01058",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-idna",
+      "purl": "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+      "version": "2.10-7.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and Python and Unicode"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "112df0c7ea79f88a152381810b589b5bfa07e68b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-idna#112df0c7ea79f88a152381810b589b5bfa07e68b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3024021",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-idna#112df0c7ea79f88a152381810b589b5bfa07e68b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-toolsmith/astcopy",
+      "purl": "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_model",
+      "purl": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0?package-id=01a656f993da3d7b",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=426c1ef83fb90a34",
+      "version": "v1.1.1-0.20210330154013-f5de75959ad5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto",
+      "purl": "pkg:golang/crypto@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=1c5457c16104bad6#mountinfo",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=8f2230e2d588c340",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/evanphx/json-patch",
+      "purl": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "version": "v5.6.0+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-rpm",
+      "purl": "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=x86_64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "findutils",
+      "purl": "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=x86_64&epoch=1",
+      "version": "1:4.8.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "52a86f6303fb86be2412eeeb8df53ec3ee4c4b60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#52a86f6303fb86be2412eeeb8df53ec3ee4c4b60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2641338",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#52a86f6303fb86be2412eeeb8df53ec3ee4c4b60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/kubevirt",
+      "purl": "pkg:golang/kubevirt.io/kubevirt",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/kubevirt?package-id=7c29205f279961ea",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "encoding/base64",
+      "purl": "pkg:golang/encoding/base64@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/base64@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/csi-translation-lib",
+      "purl": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-systemd",
+      "purl": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=x86_64",
+      "version": "234-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bdb294f1932ff4b5a881daeea1375f1b93b7cf5b",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-systemd#bdb294f1932ff4b5a881daeea1375f1b93b7cf5b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691650",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-systemd#bdb294f1932ff4b5a881daeea1375f1b93b7cf5b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/go-ps",
+      "purl": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "version": "v0.0.0-20190716172923-621e5597135b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/des",
+      "purl": "pkg:golang/crypto/des@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/des@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=cdc588c277efc41e",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+      "purl": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+      "version": "v0.0.0-20191119172530-79f836b90111",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libfdisk",
+      "purl": "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gawk",
+      "purl": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "version": "5.1.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv2+ and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3830530bfc524ab9b89fafe76d58a388675ecc11",
+            "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1891122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=61ff33db308e1c87",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "xz-libs",
+      "purl": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "version": "5.2.5-8.el9_0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+            "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2032531",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/beorn7/perks",
+      "purl": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/beorn7/perks@v1.0.1?package-id=cf38e7467b415c45",
+      "version": "v1.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-querystring",
+      "purl": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=69c0335cd603cb43#v22",
+      "version": "v22.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=6b3967bbe5e4f770#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/http/httpguts",
+      "purl": "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/krolaw/dhcp4",
+      "purl": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414?package-id=1f03719fd30cb426",
+      "version": "v0.0.0-20180925202202-7cead472c414",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-setuptools",
+      "purl": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+      "version": "53.0.0-12.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and (BSD or ASL 2.0)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e118582dafc46c5b61049eb79598ec15e88c3b7d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3754759",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libvirt.org/go/libvirt",
+      "purl": "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+      "version": "v1.10000.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=392c78985b3ee866",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "filesystem",
+      "purl": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64",
+      "version": "3.16-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c7ae0c7b52a9e8a78431e06733a8f808418df283",
+            "url": "git://pkgs.devel.redhat.com/rpms/filesystem#c7ae0c7b52a9e8a78431e06733a8f808418df283"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689243",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/filesystem#c7ae0c7b52a9e8a78431e06733a8f808418df283",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "requests",
+      "purl": "pkg:pypi/requests@2.25.1",
+      "type": "library",
+      "author": "Kenneth Reitz <me@kennethreitz.org>",
+      "bom-ref": "pkg:pypi/requests@2.25.1",
+      "version": "2.25.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache 2.0"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/requests-2.25.1.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.14.0?package-id=a47e6c64839baca0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=507e16afff6e8cbf",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "yum",
+      "purl": "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bash",
+      "purl": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "version": "5.1.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80326284a249f523c3e2d14e0eed2dbaece63c4e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2910143",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=de8b89d7a225278d",
+      "version": "v0.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager",
+      "purl": "pkg:pypi/subscription-manager@1.29.40.1",
+      "type": "library",
+      "author": "Adrian Likins <alikins@redhat.com>",
+      "bom-ref": "pkg:pypi/subscription-manager@1.29.40.1",
+      "version": "1.29.40.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/subscription_manager-1.29.40.1-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-scheduler",
+      "purl": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0?package-id=c6f4b38d0e64a871",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=617dda993ef91b06",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/sha1",
+      "purl": "pkg:golang/crypto/sha1@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/sha1@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/tls",
+      "purl": "pkg:golang/crypto/tls@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/tls@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-apiserver",
+      "purl": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0?package-id=a7d282fdf5bcfc3a",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=28d221d2b95ef119",
+      "version": "v1.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=38a620e1191a8903",
+      "version": "v0.0.0-20210104183010-2eb08e3e575f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "mime",
+      "purl": "pkg:golang/mime@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/mime@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-font-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "readline",
+      "purl": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "version": "8.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be386f45be1322adf2bd79dd94c9904c4efa3d22",
+            "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691921",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-broker",
+      "purl": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=x86_64",
+      "version": "28-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "df7a36f938130717b6c201d8bf2ca8edf68719f6",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus-broker#df7a36f938130717b6c201d8bf2ca8edf68719f6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2130514",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus-broker#df7a36f938130717b6c201d8bf2ca8edf68719f6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "net/http",
+      "purl": "pkg:golang/net/http@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/c9s/goprocinfo",
+      "purl": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "version": "v0.0.0-20210130143923-c95fcf8c64a8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=7fd9e721114377fd",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libyaml",
+      "purl": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "version": "0.2.5-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70e1549fe5e56c95f1e23967e02c657d7af570ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690356",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sqlite-libs",
+      "purl": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=x86_64",
+      "version": "3.34.1-7.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b1dd0e13763f804a7e224ec726c7037b9fda6a0c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#b1dd0e13763f804a7e224ec726c7037b9fda6a0c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3767409",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#b1dd0e13763f804a7e224ec726c7037b9fda6a0c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log",
+      "purl": "pkg:golang/log@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=db29c54369441021",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-dnf-plugins-core",
+      "purl": "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+      "version": "4.3.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4f5d16cec79f81e1d37edd64ee4cdc2e8289d48b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf-plugins-core#4f5d16cec79f81e1d37edd64ee4cdc2e8289d48b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2850557",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf-plugins-core#4f5d16cec79f81e1d37edd64ee4cdc2e8289d48b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fonts-filesystem",
+      "purl": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "version": "1:2.0.5-7.el9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ac288ee82aa9655c3784dd2f59cedb3562638129",
+            "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1732053",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/unicode/norm",
+      "purl": "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libreport-filesystem",
+      "purl": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "version": "2.15.2-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4690267165817ccc06cb342d8ef955ae10b54c75",
+            "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1852394",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/metrics",
+      "purl": "pkg:golang/runtime/metrics@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/metrics@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/chacha20poly1305",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=bd15d762c1c6c3a1",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glibc",
+      "purl": "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=x86_64",
+      "version": "2.34-100.el9_4.12",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676435",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=abbe88d4dc25e60a",
+      "version": "v0.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-inotify",
+      "purl": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+      "version": "0.9.6-25.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bf5a869472d075a22ea709682b68d1343609c9af",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-inotify#bf5a869472d075a22ea709682b68d1343609c9af"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691386",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-inotify#bf5a869472d075a22ea709682b68d1343609c9af",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.22.12?package-id=0263aa6b4909132a",
+      "version": "go1.22.12",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "unicode/utf16",
+      "purl": "pkg:golang/unicode/utf16@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unicode/utf16@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=c8fd5af5f2696ffc",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=6871ce92eaf7233e",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=e5f84b4525280ceb",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "version": "v0.0.0-20240430033511-f0e62f92d13f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=ef4b943e758b9b6b",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cluster-bootstrap",
+      "purl": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "dnf-data",
+      "purl": "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=1651c6ba29f925e5",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "systemd",
+      "purl": "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=x86_64",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "setup",
+      "purl": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "version": "2.13.7-10.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2892761",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubevirt/monitoring/pkg/metrics/parser",
+      "purl": "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+      "version": "v0.0.0-20230627123556-81a891d4462a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "nettle",
+      "purl": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=x86_64",
+      "version": "3.9.1-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7e4a847c42da5300f4bac05df9a0fb140e0a2ed2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#7e4a847c42da5300f4bac05df9a0fb140e0a2ed2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2785925",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#7e4a847c42da5300f4bac05df9a0fb140e0a2ed2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=f3884188f09088ec#v5",
+      "version": "v5.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=9fca4ee62066efc2",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/nistec/fiat",
+      "purl": "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cluster-bootstrap",
+      "purl": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0?package-id=7c0f2e47ca097803",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/intern",
+      "purl": "pkg:golang/internal/intern@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/intern@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "errors",
+      "purl": "pkg:golang/errors@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/errors@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=79287922c4530134",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-gobject-base-noarch",
+      "purl": "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+      "version": "3.40.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79ff68bd91179f855796360827ad65f2a83577dc",
+            "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2049891",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hash",
+      "purl": "pkg:golang/hash@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=58fd55d3a3e68d9a",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=812518b1d5de5b6b",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libsigsegv",
+      "purl": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "version": "2.13-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b3dee05a0458f11a68b0f9a878aa676670814326",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690130",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/fatih/color",
+      "purl": "pkg:golang/github.com/fatih/color@v1.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fatih/color@v1.13.0",
+      "version": "v1.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/csi-translation-lib",
+      "purl": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0?package-id=e493ecdd6cef073d",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "idna",
+      "purl": "pkg:pypi/idna@2.10",
+      "type": "library",
+      "author": "Kim Davies <kim@cynosure.com.au>",
+      "bom-ref": "pkg:pypi/idna@2.10",
+      "version": "2.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-like"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/idna-2.10-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "image/internal/imageutil",
+      "purl": "pkg:golang/image/internal/imageutil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/internal/imageutil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-cli-plugin",
+      "purl": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0?package-id=b57f2d304a79c9d2",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gordonklaus/ineffassign",
+      "purl": "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+      "version": "v0.0.0-20210209182638-d0e41b2fc8ed",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/strfmt",
+      "purl": "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=0cf48c7c4e0c2225",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=5f3161d14fb9986b",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/rivo/uniseg",
+      "purl": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+      "version": "v0.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=2add8ed970e49e83",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=6ca8b50f74df1aba",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=9cd65210b34ae131",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d7e841647edf8bf8",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "container/list",
+      "purl": "pkg:golang/container/list@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/container/list@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "container/ring",
+      "purl": "pkg:golang/container/ring@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/container/ring@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "unicode",
+      "purl": "pkg:golang/unicode@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unicode@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.29.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.29.0?package-id=123dc6fd6dd76665",
+      "version": "v0.29.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "runtime",
+      "purl": "pkg:golang/runtime@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "systemd-python",
+      "purl": "pkg:pypi/systemd-python@234",
+      "type": "library",
+      "author": "systemd developers <systemd-devel@lists.freedesktop.org>",
+      "bom-ref": "pkg:pypi/systemd-python@234",
+      "version": "234",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/systemd_python-234-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "image/png",
+      "purl": "pkg:golang/image/png@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/png@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/btree",
+      "purl": "pkg:golang/github.com/google/btree@v1.1.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/btree@v1.1.3?package-id=d631efbb5e6884df",
+      "version": "v1.1.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/unicode/bidi",
+      "purl": "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "rpm-sign-libs",
+      "purl": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=x86_64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lz4-libs",
+      "purl": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "version": "1.9.3-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690509",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/code-generator",
+      "purl": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/code-generator@v0.30.0?package-id=c9d95bf42170291b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=fa2fc500853b500e",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "elfutils-default-yama-scope",
+      "purl": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+      "version": "0.190-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03f1598bbe94308cc7655234a5dcf75092cd1968",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2817160",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "go/doc/comment",
+      "purl": "pkg:golang/go/doc/comment@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/doc/comment@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/math",
+      "purl": "pkg:golang/runtime/internal/math@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/math@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo/v2",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "version": "v2.17.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=38f081dbc5ce4d6a",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=317d26dbf41e923a",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=20f072e6e3225e24",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "regexp/syntax",
+      "purl": "pkg:golang/regexp/syntax@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/regexp/syntax@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=a0115c013e649a4c",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libunistring",
+      "purl": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "version": "0.9.10-15.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690195",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/evanphx/json-patch",
+      "purl": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible?package-id=15ebdd24a0c721e7",
+      "version": "v5.6.0+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-decorator",
+      "purl": "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+      "version": "4.4.2-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc2368c1fe0e7914e6027cc70f05d59862dbf2ec",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-decorator#fc2368c1fe0e7914e6027cc70f05d59862dbf2ec"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691358",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-decorator#fc2368c1fe0e7914e6027cc70f05d59862dbf2ec",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-libs",
+      "purl": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "systemd-pam",
+      "purl": "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=x86_64",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=78d6e196699c60fb",
+      "version": "v1.1.14",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "internal/race",
+      "purl": "pkg:golang/internal/race@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/race@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/goversion",
+      "purl": "pkg:golang/internal/goversion@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goversion@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libcom_err",
+      "purl": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=x86_64",
+      "version": "1.46.5-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "55211469981d94577ec3da753afcdf2cc4d651ab",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#55211469981d94577ec3da753afcdf2cc4d651ab"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820207",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#55211469981d94577ec3da753afcdf2cc4d651ab",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/idna",
+      "purl": "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/appengine",
+      "purl": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=d183acc87e1fa62e",
+      "version": "v1.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=87c0cbf8954e0580",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/rc4",
+      "purl": "pkg:golang/crypto/rc4@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/rc4@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "cracklib",
+      "purl": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64",
+      "version": "2.9.6-27.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+            "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689047",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cri-api",
+      "purl": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=aabc29983e2a9841",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-controller-manager",
+      "purl": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0?package-id=0814f25a8e4531ce",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-aggregator",
+      "purl": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4bf18231eac48ba4",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/base32",
+      "purl": "pkg:golang/encoding/base32@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/base32@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libtirpc",
+      "purl": "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=x86_64",
+      "version": "1.3.3-8.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "SISSL and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bef7b741bc0541226473d5dae03ff0ab1df11b88",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#bef7b741bc0541226473d5dae03ff0ab1df11b88"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2966395",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#bef7b741bc0541226473d5dae03ff0ab1df11b88",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "text/tabwriter",
+      "purl": "pkg:golang/text/tabwriter@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/text/tabwriter@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cri-api",
+      "purl": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cri-api@v0.30.0?package-id=4de173f6a5765211",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/component-base",
+      "purl": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/component-base@v0.30.0?package-id=94800364440cc1a6",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "image/jpeg",
+      "purl": "pkg:golang/image/jpeg@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/jpeg@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=a1ff2ebea07a529d",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cobra",
+      "purl": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.7.0?package-id=3ba0797ce405770e",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "./staging/src/github.com/golang/glog",
+      "purl": "pkg:golang/./staging/src#github.com/golang/glog",
+      "type": "library",
+      "bom-ref": "pkg:golang/./staging/src#github.com/golang/glog",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "internal/coverage/rtcov",
+      "purl": "pkg:golang/internal/coverage/rtcov@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/coverage/rtcov@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gpg",
+      "purl": "pkg:pypi/gpg@1.15.1",
+      "type": "library",
+      "author": "The GnuPG hackers <gnupg-devel@gnupg.org>",
+      "bom-ref": "pkg:pypi/gpg@1.15.1",
+      "version": "1.15.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPL2.1+ (the library), GPL2+ (tests and examples)"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/gpg-1.15.1-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=dbb27eadf8364aee",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/groupcache",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=406cd2654be0fcc8",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=8899651b157fa55b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies-scripts",
+      "purl": "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+      "version": "20240202-1.git283706d.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a950d9ca3218bf47d75befa4639b7990b00c99eb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2889114",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/dns/dnsmessage",
+      "purl": "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=99619c8dbac171e6",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/metrics",
+      "purl": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/metrics@v0.30.0?package-id=e5a9c757e0ba76d0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/Masterminds/semver",
+      "purl": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+      "purl": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=41c9ffe89c4328dd#pkg/apis/monitoring",
+      "version": "v0.68.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e87736d4223a3553",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/gover",
+      "purl": "pkg:golang/internal/gover@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/gover@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=077b67d110fda982",
+      "version": "v0.0.0-20240430033511-f0e62f92d13f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "mvdan.cc/editorconfig",
+      "purl": "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+      "type": "library",
+      "bom-ref": "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+      "version": "v0.2.1-0.20231228180347-1925077f8eb2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/client-go",
+      "purl": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=332ab3a9d173ca98",
+      "version": "v0.0.0-20210112165513-ebc401615f47",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "openldap",
+      "purl": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=x86_64",
+      "version": "2.6.6-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "OLDAP-2.8"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "409b72030310df96b296a5dd8cf80f0a211cc038",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#409b72030310df96b296a5dd8cf80f0a211cc038"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2899087",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#409b72030310df96b296a5dd8cf80f0a211cc038",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ca-certificates",
+      "purl": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "version": "2025.2.80_v9.0.305-91.el9",
+      "licenses": [
+        {
+          "expression": "MIT AND GPL-2.0-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80abd67ad7d828eba9c44be633f42b67f21751b1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#80abd67ad7d828eba9c44be633f42b67f21751b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3864618",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#80abd67ad7d828eba9c44be633f42b67f21751b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=2f055f6cdf8e3fb1",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "json-glib",
+      "purl": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "version": "1.6.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d5548792bb86a77330957962541a936d9c391896",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1707185",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/pprof",
+      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6?package-id=0bc6f5896c6cb1a9",
+      "version": "v0.0.0-20240424215950-a892ee059fd6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=9de2c8dc0803d74e",
+      "version": "v0.0.0-20210104183010-2eb08e3e575f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=638aeba61e089e7d",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "numactl-libs",
+      "purl": "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=x86_64",
+      "version": "2.0.16-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4ace9e459353675439dae46e01102853d6c8f37d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/numactl#4ace9e459353675439dae46e01102853d6c8f37d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2692430",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/numactl#4ace9e459353675439dae46e01102853d6c8f37d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=8256c45ca06407ab",
+      "version": "v1.33.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/controller-runtime",
+      "purl": "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b135113b0301cc3e",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_golang",
+      "purl": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0?package-id=d58b9b0249e2d522",
+      "version": "v1.16.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "math/big",
+      "purl": "pkg:golang/math/big@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math/big@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=5df1a932dc364fae",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/seccomp/libseccomp-golang",
+      "purl": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "version": "v0.10.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-proxy",
+      "purl": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=49b478fdfd04f997",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=2f1b091e7ebc59e5#mountinfo",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/syscall/execenv",
+      "purl": "pkg:golang/internal/syscall/execenv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/syscall/execenv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gnupg2",
+      "purl": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "version": "2.3.3-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2481337",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager",
+      "purl": "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libseccomp",
+      "purl": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=x86_64",
+      "version": "2.5.2-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "81d3550e24896c1929fda36335626a6807df3922",
+            "url": "git://pkgs.devel.redhat.com/rpms/libseccomp#81d3550e24896c1929fda36335626a6807df3922"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1788033",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libseccomp#81d3550e24896c1929fda36335626a6807df3922",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "purl": "pkg:golang/golang.org/x/tools@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-proxy",
+      "purl": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0?package-id=da08354393870645",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/atomic",
+      "purl": "pkg:golang/runtime/internal/atomic@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/atomic@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/subtle",
+      "purl": "pkg:golang/crypto/subtle@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/subtle@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/native",
+      "purl": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/native@v1.1.0?package-id=6604c5cd4c4748cf",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "openssl-libs",
+      "purl": "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+      "version": "1:3.0.7-29.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3880294",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+      "version": "v2.6.1+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-stack/stack",
+      "purl": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-stack/stack@v1.8.0?package-id=48631dee752774c6",
+      "version": "v1.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/bisect",
+      "purl": "pkg:golang/internal/bisect@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/bisect@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libvirt-libs",
+      "purl": "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=x86_64",
+      "version": "10.0.0-6.19.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND OFL-1.1"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b48e93554655d865ca027aaceb12b91dc5dc6a5c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libvirt#b48e93554655d865ca027aaceb12b91dc5dc6a5c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3782117",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libvirt#b48e93554655d865ca027aaceb12b91dc5dc6a5c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libcomps",
+      "purl": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64",
+      "version": "0.1.18-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1771556",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/edwards25519",
+      "purl": "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=71cd8ab004151c77",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=e810f9b52b2fed54",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "dbus",
+      "purl": "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/c9s/goprocinfo",
+      "purl": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8?package-id=8753666bf11d11e8",
+      "version": "v0.0.0-20210130143923-c95fcf8c64a8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "alternatives",
+      "purl": "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=x86_64",
+      "version": "1.24-1.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2233412101349b53627f350497e1ac17dec36730",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#2233412101349b53627f350497e1ac17dec36730"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3267208",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#2233412101349b53627f350497e1ac17dec36730",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/u-root/uio",
+      "purl": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923?package-id=bf32666eb889d979",
+      "version": "v0.0.0-20230220225925-ffce2a382923",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libnetfilter_conntrack",
+      "purl": "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=x86_64",
+      "version": "1.0.9-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a8c7bd7fc24180e59c191a4d5a05a475afdcf17",
+            "url": "git://pkgs.devel.redhat.com/rpms/libnetfilter_conntrack#2a8c7bd7fc24180e59c191a4d5a05a475afdcf17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2296866",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libnetfilter_conntrack#2a8c7bd7fc24180e59c191a4d5a05a475afdcf17",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "go/internal/typeparams",
+      "purl": "pkg:golang/go/internal/typeparams@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/internal/typeparams@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "testing",
+      "purl": "pkg:golang/testing@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/testing@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl",
+      "purl": "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=x86_64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-github/v32",
+      "purl": "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+      "version": "v32.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=d06c6aae1204ae08#v22",
+      "version": "v22.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "tar",
+      "purl": "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=x86_64&epoch=2",
+      "version": "2:1.34-6.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a171e3d125646d2a953c247715ef2788c1829c1c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tar#a171e3d125646d2a953c247715ef2788c1829c1c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3229110",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tar#a171e3d125646d2a953c247715ef2788c1829c1c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/validate",
+      "purl": "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "io/ioutil",
+      "purl": "pkg:golang/io/ioutil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/io/ioutil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "procps-ng",
+      "purl": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+      "version": "3.3.17-14.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "277f9aaff8edd7603ea88dfe5e42cbb2d229a76f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/procps-ng#277f9aaff8edd7603ea88dfe5e42cbb2d229a76f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2865070",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/procps-ng#277f9aaff8edd7603ea88dfe5e42cbb2d229a76f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/VividCortex/ewma",
+      "purl": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=077a5e8ca27fa924",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "html/template",
+      "purl": "pkg:golang/html/template@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/html/template@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/common",
+      "purl": "pkg:golang/github.com/containers/common@v0.50.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/common@v0.50.1?package-id=e36d1d0f2ba91772",
+      "version": "v0.50.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libsolv",
+      "purl": "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=x86_64",
+      "version": "0.7.24-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9ab325a2961e60cb85d36bcd381102753a990bff",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsolv#9ab325a2961e60cb85d36bcd381102753a990bff"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2563465",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsolv#9ab325a2961e60cb85d36bcd381102753a990bff",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libblkid",
+      "purl": "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=x86_64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=ad5593f4e294dd87",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-dateutil",
+      "purl": "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+      "version": "1:2.8.1-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8f4fa349cd64e4143fc3b417b01a2ab1f433b40d",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-dateutil#8f4fa349cd64e4143fc3b417b01a2ab1f433b40d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2628796",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-dateutil#8f4fa349cd64e4143fc3b417b01a2ab1f433b40d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/debug",
+      "purl": "pkg:golang/runtime/debug@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/debug@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=c3d9773d12fa39a7",
+      "version": "v1.33.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/socket",
+      "purl": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=9e49a047878a9f7c",
+      "version": "v0.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/internal/poly1305",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cespare/xxhash/v2",
+      "purl": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0?package-id=d7fbb4f13b1bb601#v2",
+      "version": "v2.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/log",
+      "purl": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=429112dfb9428aeb",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "coreutils-single",
+      "purl": "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=x86_64",
+      "version": "8.32-35.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a5b35b64130afa26d91d771af474f947cc02a099",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#a5b35b64130afa26d91d771af474f947cc02a099"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2875684",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#a5b35b64130afa26d91d771af474f947cc02a099",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/pierrec/lz4/v4",
+      "purl": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15?package-id=8f6dd5f7ba6a62ec#v4",
+      "version": "v4.1.15",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=6619c43cfd07c933",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=59cd4b4e359e9754",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "./staging/src/kubevirt.io/api",
+      "purl": "pkg:golang/./staging/src#kubevirt.io/api",
+      "type": "library",
+      "bom-ref": "pkg:golang/./staging/src#kubevirt.io/api",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libssh-config",
+      "purl": "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+      "version": "0.10.4-13.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35756743d06f7dc2fde2d65495ae0d4866011d1b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3866387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxcrypt",
+      "purl": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "version": "4.4.18-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and BSD and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5ae2c88752320b1d81d70ae38259ce56b1c692de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690260",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gpgme",
+      "purl": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "version": "1.15.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+            "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892040",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/http/internal/testcert",
+      "purl": "pkg:golang/net/http/internal/testcert@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/internal/testcert@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pborman/uuid",
+      "purl": "pkg:golang/github.com/pborman/uuid@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pborman/uuid@v1.2.1",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-chardet",
+      "purl": "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+      "version": "4.0.0-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f8acd16e754d66fa555ae3facafdae9e6befdbb3",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-chardet#f8acd16e754d66fa555ae3facafdae9e6befdbb3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1894647",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-chardet#f8acd16e754d66fa555ae3facafdae9e6befdbb3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libs",
+      "purl": "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=x86_64",
+      "version": "3.9.18-3.el9_4.9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2e1b452fcf120e44a7613701e28dd40a7931fc59",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3828922",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=2510cbce9c179e69",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libevent",
+      "purl": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "version": "2.1.12-8.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3235991",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "purl": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "version": "v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/json",
+      "purl": "pkg:golang/encoding/json@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/json@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-aggregator",
+      "purl": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=70cc035eafb9fbd3",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=666b646207e276d6",
+      "version": "v1.1.14",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/errors",
+      "purl": "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+      "version": "v0.19.9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/reflectlite",
+      "purl": "pkg:golang/internal/reflectlite@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/reflectlite@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libstdc++",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=x86_64",
+      "version": "11.4.1-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498982",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/bigmod",
+      "purl": "pkg:golang/crypto/internal/bigmod@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/bigmod@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-hawkey",
+      "purl": "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=x86_64",
+      "version": "0.69.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e5984c195dca639c24fa8a25263d2faf9419e97d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134146",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/genproto/googleapis/rpc",
+      "purl": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d?package-id=3bb12d02cfa2e942#rpc",
+      "version": "v0.0.0-20230822172742-b8732ec3820d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-controller",
+      "purl": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-controller@v0.30.0?package-id=95847fe4258b57c0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/rand",
+      "purl": "pkg:golang/crypto/rand@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/rand@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo/v2",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2?package-id=709ca981edc6d5d6#v2",
+      "version": "v2.17.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/mod",
+      "purl": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "version": "v0.17.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=ab608fe96a3e5a01",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=13c8c846a4481335",
+      "version": "v0.0.0-20240430033511-f0e62f92d13f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "dmidecode",
+      "purl": "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=x86_64&epoch=1",
+      "version": "1:3.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3368d91ad91bcfd15a9e66b6f1bbbf18b7491c6e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dmidecode#3368d91ad91bcfd15a9e66b6f1bbbf18b7491c6e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2841778",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dmidecode#3368d91ad91bcfd15a9e66b6f1bbbf18b7491c6e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=dd84eb4f391fe51e",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "unicode/utf8",
+      "purl": "pkg:golang/unicode/utf8@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unicode/utf8@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/grpc",
+      "purl": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=1663864887e439eb",
+      "version": "v1.58.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=f1bc226b87c469d8",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/asn1",
+      "purl": "pkg:golang/encoding/asn1@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/asn1@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "sort",
+      "purl": "pkg:golang/sort@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/sort@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gzip",
+      "purl": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+      "version": "1.12-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "11df222a2dc5ce7dc943b1bce364d46ea97a535b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gzip#11df222a2dc5ce7dc943b1bce364d46ea97a535b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1982016",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gzip#11df222a2dc5ce7dc943b1bce364d46ea97a535b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=f951095dca4572e3",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "archive/tar",
+      "purl": "pkg:golang/archive/tar@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/archive/tar@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=3bccae874729638f",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=a8276711fb26ec2c#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gmp",
+      "purl": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "version": "1:6.2.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+            "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2625518",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/machadovilaca/operator-observability",
+      "purl": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20?package-id=ce832bdd3e643f49",
+      "version": "v0.0.20",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "six",
+      "purl": "pkg:pypi/six@1.15.0",
+      "type": "library",
+      "author": "Benjamin Peterson <benjamin@python.org>",
+      "bom-ref": "pkg:pypi/six@1.15.0",
+      "version": "1.15.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/six-1.15.0.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/runtime",
+      "purl": "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+      "version": "v0.19.24",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "log/internal",
+      "purl": "pkg:golang/log/internal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/internal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libxml2",
+      "purl": "pkg:rpm/redhat/libxml2@2.9.13-12.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxml2@2.9.13-12.el9_4?arch=x86_64",
+      "version": "2.9.13-12.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cf8bbf431c59982f13241352ffb134c8e7876e7c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#cf8bbf431c59982f13241352ffb134c8e7876e7c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3790734",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#cf8bbf431c59982f13241352ffb134c8e7876e7c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/asaskevich/govalidator",
+      "purl": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+      "version": "v0.0.0-20200907205600-7a23bdc65eef",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libidn2",
+      "purl": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "version": "2.3.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or LGPLv3+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c781354177446e1bb6a5b48d2113feaed50cc860",
+            "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "passwd",
+      "purl": "pkg:rpm/redhat/passwd@0.80-12.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/passwd@0.80-12.el9?arch=x86_64",
+      "version": "0.80-12.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPL+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc8f2d3ecfe371757ee51d81b0b9e4b7e3a8cdc5",
+            "url": "git://pkgs.devel.redhat.com/rpms/passwd#dc8f2d3ecfe371757ee51d81b0b9e4b7e3a8cdc5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691236",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/passwd#dc8f2d3ecfe371757ee51d81b0b9e4b7e3a8cdc5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdbm-libs",
+      "purl": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1",
+      "version": "1:1.19-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6bade26c052b6560b132f163484ee009c04e3cce",
+            "url": "git://pkgs.devel.redhat.com/rpms/gdbm#6bade26c052b6560b132f163484ee009c04e3cce"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689293",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gdbm#6bade26c052b6560b132f163484ee009c04e3cce",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=6d74c429f555275e",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libmodulemd",
+      "purl": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "version": "2.13.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d48969327abbcbfad2ab893639cfb7d22362223d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1695462",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm-libs",
+      "purl": "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=x86_64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "expvar",
+      "purl": "pkg:golang/expvar@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/expvar@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/loads",
+      "purl": "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gdb-gdbserver",
+      "purl": "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=x86_64",
+      "version": "10.2-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ and GPLv2+ with exceptions and GPL+ and LGPLv2+ and LGPLv3+ and BSD and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0cda5771bf25da9b298b20bf195cfb9b05928603",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdb#0cda5771bf25da9b298b20bf195cfb9b05928603"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2822968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdb#0cda5771bf25da9b298b20bf195cfb9b05928603",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/go-ps",
+      "purl": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b?package-id=b697414c821ee814",
+      "version": "v0.0.0-20190716172923-621e5597135b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "net/textproto",
+      "purl": "pkg:golang/net/textproto@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/textproto@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=5804e51cbc6df18a",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libuser",
+      "purl": "pkg:rpm/redhat/libuser@0.63-13.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuser@0.63-13.el9?arch=x86_64",
+      "version": "0.63-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "13af6ac62247268424d499b1889ee11afd7e150a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libuser#13af6ac62247268424d499b1889ee11afd7e150a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2590170",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libuser#13af6ac62247268424d499b1889ee11afd7e150a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+      "purl": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=62c158205e5c5cbc#pkg/apis/monitoring",
+      "version": "v0.68.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=c9e73a9ce3fca441",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "jansson",
+      "purl": "pkg:rpm/redhat/jansson@2.14-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/jansson@2.14-1.el9?arch=x86_64",
+      "version": "2.14-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4580a680e5f19adde10c25adad0a31f1d3dc1078",
+            "url": "git://pkgs.devel.redhat.com/rpms/jansson#4580a680e5f19adde10c25adad0a31f1d3dc1078"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1798464",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/jansson#4580a680e5f19adde10c25adad0a31f1d3dc1078",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua-libs",
+      "purl": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "version": "5.4.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d795270f6d1372b9636433ed1fb08b2439eed16",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467503",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=ed2a22c702bae008",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=3f70c1e082cb9132",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/sys",
+      "purl": "pkg:golang/runtime/internal/sys@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/sys@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "setuptools",
+      "purl": "pkg:pypi/setuptools@53.0.0",
+      "type": "library",
+      "author": "Python Packaging Authority <distutils-sig@python.org>",
+      "bom-ref": "pkg:pypi/setuptools@53.0.0",
+      "version": "53.0.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "UNKNOWN"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/setuptools-53.0.0.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiserver",
+      "purl": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiserver@v0.30.0?package-id=46f0784d88e673c3",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubernetes-csi/external-snapshotter/client/v4",
+      "purl": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=c379c7237a34dcc0#client/v4",
+      "version": "v4.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "iptables-libs",
+      "purl": "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=x86_64",
+      "version": "1.8.10-5.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and Artistic 2.0 and ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6eebdb82213f2bb74f3104414ce85d304151f2c7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/iptables#6eebdb82213f2bb74f3104414ce85d304151f2c7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3227256",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/iptables#6eebdb82213f2bb74f3104414ce85d304151f2c7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-subscription-manager-rhsm",
+      "purl": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=x86_64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "encoding/pem",
+      "purl": "pkg:golang/encoding/pem@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/pem@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "openssl-synthetic-test",
+      "purl": "pkg:rpm/redhat/openssl-synthetic-test@1.0?arch=x86_64",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "115adb1c831d3bd47e171c4d5d967a828cf0464e918f47c70ab57770f2f1d034"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/openssl-synthetic-test@1.0?arch=x86_64",
+      "version": "1.0",
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "description": "This package is a TEST package for testing trustify queries."
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:oci/virt-handler-rhel9@sha256%3A60bf81bdeafa73ba18d4ca19a211f9d6797fa517290a791c2fd5975ea92e73a9?arch=amd64&os=linux&tag=v4.17.35-2",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0",
+        "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+        "pkg:golang/k8s.io/client-go@v0.30.0",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=b6c9d8ea55ec3898",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+        "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+        "pkg:golang/time@go1.22.12",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+        "pkg:pypi/dbus-python@1.2.18",
+        "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+        "pkg:golang/internal/types/errors@go1.22.12",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+        "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+        "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=x86_64",
+        "pkg:golang/github.com/containers/common@v0.50.1",
+        "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+        "pkg:golang/k8s.io/kubectl@v0.30.0",
+        "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+        "pkg:golang/internal/godebug@go1.22.12",
+        "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=x86_64",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+        "pkg:pypi/python-dateutil@2.8.1",
+        "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+        "pkg:golang/kubevirt.io/client-go",
+        "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=x86_64",
+        "pkg:golang/crypto/hmac@go1.22.12",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+        "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=x86_64",
+        "pkg:golang/internal/goarch@go1.22.12",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+        "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+        "pkg:golang/math/rand@go1.22.12",
+        "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+        "pkg:pypi/pyinotify@0.9.6",
+        "pkg:golang/internal/saferio@go1.22.12",
+        "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+        "pkg:golang/unsafe@go1.22.12",
+        "pkg:golang/crypto/ed25519@go1.22.12",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1",
+        "pkg:golang/net/rpc@go1.22.12",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/bufio@go1.22.12",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+        "pkg:golang/internal/nettrace@go1.22.12",
+        "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0?package-id=6f1e377d494cf9f5",
+        "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+        "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+        "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+        "pkg:golang/github.com/moby/spdystream@v0.2.0",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64",
+        "pkg:golang/runtime/pprof@go1.22.12",
+        "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=x86_64",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0",
+        "pkg:golang/encoding@go1.22.12",
+        "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=2fae184f36a99a47",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=x86_64&epoch=2",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+        "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=x86_64",
+        "pkg:golang/crypto/x509/pkix@go1.22.12",
+        "pkg:golang/runtime/trace@go1.22.12",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=f970a3d674d44626",
+        "pkg:golang/github.com/google/btree@v1.1.3",
+        "pkg:rpm/redhat/expat@2.5.0-2.el9_4.2?arch=x86_64",
+        "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+        "pkg:golang/golang.org/x/sys@v0.30.0",
+        "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+        "pkg:golang/net/netip@go1.22.12",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=48602be9269bc897",
+        "pkg:golang/k8s.io/code-generator@v0.30.0",
+        "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/stdlib@1.22.12",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=18734635491c2975",
+        "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=x86_64",
+        "pkg:golang/k8s.io/client-go@v0.30.0?package-id=1b0cc1bbf3f8ed78",
+        "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+        "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+        "pkg:golang/github.com/go-kit/kit@v0.9.0",
+        "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+        "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/which@2.21-29.el9?arch=x86_64",
+        "pkg:golang/sync/atomic@go1.22.12",
+        "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+        "pkg:golang/crypto/internal/nistec@go1.22.12",
+        "pkg:golang/database/sql/driver@go1.22.12",
+        "pkg:golang/reflect@go1.22.12",
+        "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+        "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=b4c3f12b0f973ad1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+        "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+        "pkg:rpm/redhat/usermode@1.114-4.el9?arch=x86_64",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+        "pkg:golang/math/bits@go1.22.12",
+        "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+        "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+        "pkg:golang/encoding/xml@go1.22.12",
+        "pkg:golang/github.com/google/gnostic@v0.5.7",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/internal/chacha8rand@go1.22.12",
+        "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=x86_64",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+        "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+        "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:pypi/pygobject@3.40.1",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=1f351b9d12dd5e8b",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=807835609b958430",
+        "pkg:golang/go/ast@go1.22.12",
+        "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+        "pkg:golang/k8s.io/node-api@v0.30.0",
+        "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+        "pkg:pypi/rpm@4.16.1.3",
+        "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=x86_64",
+        "pkg:golang/syscall@go1.22.12",
+        "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+        "pkg:golang/github.com/golang/protobuf@v1.5.3",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+        "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+        "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+        "pkg:golang/github.com/imdario/mergo@v0.3.16",
+        "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=x86_64",
+        "pkg:golang/internal/oserror@go1.22.12",
+        "pkg:golang/crypto/ecdh@go1.22.12",
+        "pkg:golang/compress/bzip2@go1.22.12",
+        "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+        "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+        "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+        "pkg:golang/net/http/internal@go1.22.12",
+        "pkg:golang/golang.org/x/text@v0.22.0",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=848770ad63e2adc0",
+        "pkg:golang/github.com/prometheus/common@v0.44.0",
+        "pkg:golang/compress/zlib@go1.22.12",
+        "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=x86_64&epoch=2",
+        "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+        "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=x86_64",
+        "pkg:golang/github.com/google/uuid@v1.3.0",
+        "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+        "pkg:golang/crypto/elliptic@go1.22.12",
+        "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=x86_64",
+        "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=b15f37518ae084d6",
+        "pkg:golang/internal/godebugs@go1.22.12",
+        "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+        "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+        "pkg:golang/github.com/golang/glog",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0",
+        "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+        "pkg:golang/internal/buildcfg@go1.22.12",
+        "pkg:golang/os@go1.22.12",
+        "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+        "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+        "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+        "pkg:golang/internal/bytealg@go1.22.12",
+        "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+        "pkg:golang/kubevirt.io/kubevirt",
+        "pkg:golang/net/url@go1.22.12",
+        "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+        "pkg:golang/golang.org/x/term@v0.29.0",
+        "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+        "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+        "pkg:golang/flag@go1.22.12",
+        "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+        "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=x86_64",
+        "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4?package-id=e4e1dce43844ff08",
+        "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+        "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0?package-id=3f73b8c486d0a009",
+        "pkg:golang/golang.org/x/text@v0.22.0?package-id=341ee6986e5d85c1",
+        "pkg:golang/golang.org/x/net@v0.33.0",
+        "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+        "pkg:golang/go/token@go1.22.12",
+        "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=x86_64",
+        "pkg:golang/compress/flate@go1.22.12",
+        "pkg:golang/go/build@go1.22.12",
+        "pkg:golang/kubevirt.io/api",
+        "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+        "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64",
+        "pkg:golang/internal/platform@go1.22.12",
+        "pkg:golang/crypto/internal/randutil@go1.22.12",
+        "pkg:golang/github.com/go-kit/log@v0.2.1",
+        "pkg:golang/github.com/prometheus/common@v0.44.0?package-id=3a5f710d384a3dd9",
+        "pkg:golang/html@go1.22.12",
+        "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=64880854c531d875",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+        "pkg:golang/internal/goos@go1.22.12",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=fa36e4581bae4e38",
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+        "pkg:golang/encoding/gob@go1.22.12",
+        "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=3f115ef0cb31e7b8",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+        "pkg:golang/internal/fmtsort@go1.22.12",
+        "pkg:golang/slices@go1.22.12",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=bbfbb1eba9b1b80e",
+        "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+        "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=9312f2882f8a9a02",
+        "pkg:golang/crypto/aes@go1.22.12",
+        "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=x86_64",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=66f62c4a3380d295",
+        "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+        "pkg:pypi/libcomps@0.1.18",
+        "pkg:golang/strconv@go1.22.12",
+        "pkg:golang/bytes@go1.22.12",
+        "pkg:golang/crypto/sha256@go1.22.12",
+        "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=x86_64",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=8fbdfdc32aa3f0c7",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=45b68313e6b7649d",
+        "pkg:golang/io@go1.22.12",
+        "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+        "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+        "pkg:golang/github.com/go-logr/logr@v0.2.1",
+        "pkg:pypi/iniparse@0.4",
+        "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=x86_64",
+        "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+        "pkg:golang/github.com/go-task/slim-sprig@v3.0.0?package-id=c5265481edb963f4#v3",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=6025e076d202b258",
+        "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=x86_64",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+        "pkg:golang/crypto/cipher@go1.22.12",
+        "pkg:golang/debug/elf@go1.22.12",
+        "pkg:golang/crypto/rsa@go1.22.12",
+        "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+        "pkg:golang/k8s.io/metrics@v0.30.0",
+        "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=x86_64&epoch=1",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=68f83d538edd1c62",
+        "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=x86_64",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+        "pkg:golang/container/heap@go1.22.12",
+        "pkg:golang/mime/multipart@go1.22.12",
+        "pkg:golang/mime/quotedprintable@go1.22.12",
+        "pkg:golang/crypto/internal/alias@go1.22.12",
+        "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=x86_64",
+        "pkg:golang/encoding/hex@go1.22.12",
+        "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+        "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4",
+        "pkg:golang/google.golang.org/appengine@v1.6.8",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+        "pkg:golang/internal/abi@go1.22.12",
+        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=38049f9b809b501e",
+        "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=7f71bb3211c40e1e",
+        "pkg:golang/go/parser@go1.22.12",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+        "pkg:golang/github.com/google/uuid@v1.3.1",
+        "pkg:golang/github.com/pkg/errors@v0.9.1",
+        "pkg:golang/image/color@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+        "pkg:golang/context@go1.22.12",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=06ba511a601e36d7",
+        "pkg:golang/net/http/internal/ascii@go1.22.12",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=874d616b5ffd59b7",
+        "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+        "pkg:pypi/chardet@4.0.0",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d6c72ae7c47adf6d",
+        "pkg:golang/cmp@go1.22.12",
+        "pkg:golang/internal/syscall/unix@go1.22.12",
+        "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=x86_64",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+        "pkg:golang/golang.org/x/net@v0.24.0",
+        "pkg:golang/internal/unsafeheader@go1.22.12",
+        "pkg:golang/path@go1.22.12",
+        "pkg:golang/golang.org/x/net@v0.33.0?package-id=cb71f9386c7676b0",
+        "pkg:golang/math@go1.22.12",
+        "pkg:golang/internal/cpu@go1.22.12",
+        "pkg:golang/fmt@go1.22.12",
+        "pkg:golang/k8s.io/klog@v0.4.0",
+        "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+        "pkg:golang/go/doc@go1.22.12",
+        "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=x86_64",
+        "pkg:golang/embed@go1.22.12",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=fd7a9516c0278d0e",
+        "pkg:golang/internal/lazyregexp@go1.22.12",
+        "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=x86_64",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+        "pkg:golang/path/filepath@go1.22.12",
+        "pkg:golang/github.com/spf13/cobra@v1.7.0",
+        "pkg:golang/internal/singleflight@go1.22.12",
+        "pkg:golang/k8s.io/client-go@v0.30.0?package-id=7209f81d42d9fb42",
+        "pkg:golang/golang.org/x/time@v0.3.0",
+        "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=x86_64",
+        "pkg:golang/log/slog@go1.22.12",
+        "pkg:golang/debug/dwarf@go1.22.12",
+        "pkg:golang/kubevirt.io/api?package-id=8271ccebef8c7fbf",
+        "pkg:golang/github.com/containernetworking/plugins@v1.1.1?package-id=9ab03ca56b78d2bd",
+        "pkg:golang/k8s.io/component-base@v0.30.0",
+        "pkg:golang/golang.org/x/term@v0.19.0",
+        "pkg:golang/image@go1.22.12",
+        "pkg:golang/hash/crc32@go1.22.12",
+        "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64",
+        "pkg:pypi/decorator@4.4.2",
+        "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=cf3c5a20a21e8e64",
+        "pkg:golang/os/exec@go1.22.12",
+        "pkg:golang/github.com/golang/glog@v1.1.0",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+        "pkg:golang/k8s.io/apiserver@v0.30.0",
+        "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=x86_64",
+        "pkg:golang/crypto/sha512@go1.22.12",
+        "pkg:golang/k8s.io/node-api@v0.30.0?package-id=69b6b0afb2bc8383",
+        "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=x86_64",
+        "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+        "pkg:golang/hash/fnv@go1.22.12",
+        "pkg:golang/go/scanner@go1.22.12",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=5af92f389a804379",
+        "pkg:golang/internal/testlog@go1.22.12",
+        "pkg:golang/k8s.io/kubelet@v0.30.0",
+        "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=x86_64",
+        "pkg:golang/text/template@go1.22.12",
+        "pkg:golang/compress/gzip@go1.22.12",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=64a952cc8f95048c",
+        "pkg:golang/k8s.io/klog@v0.3.3",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=42ecb449d13ca189",
+        "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=x86_64&epoch=2",
+        "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=x86_64",
+        "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+        "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=x86_64",
+        "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+        "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=x86_64",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=c251c2070b6d837f",
+        "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+        "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+        "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=x86_64",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=a3f45ccc2eaef8aa",
+        "pkg:golang/k8s.io/sample-controller@v0.30.0",
+        "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=x86_64",
+        "pkg:golang/encoding/binary@go1.22.12",
+        "pkg:golang/crypto/ecdsa@go1.22.12",
+        "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=75bca8ba1ca22c9b",
+        "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=45a8c7aac0e298e2#client/v4",
+        "pkg:golang/internal/poll@go1.22.12",
+        "pkg:golang/github.com/imdario/mergo@v0.3.15",
+        "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e519b37240b7b6af",
+        "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=x86_64",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+        "pkg:golang/io/fs@go1.22.12",
+        "pkg:golang/golang.org/x/net@v0.23.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=0c548e794e085974",
+        "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+        "pkg:golang/k8s.io/klog@v0.4.0?package-id=a6cf3f8305ce0756",
+        "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=ee6a4656125cefb2",
+        "pkg:golang/./staging/src#kubevirt.io/client-go",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=92cbc10610ba936e",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=0610c737c3c00486",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=4f70a6c87f97190b",
+        "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=x86_64",
+        "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+        "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+        "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+        "pkg:golang/internal/safefilepath@go1.22.12",
+        "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=f3f74c8e52e58f96",
+        "pkg:golang/crypto/md5@go1.22.12",
+        "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=x86_64",
+        "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+        "pkg:golang/log/slog/internal/buffer@go1.22.12",
+        "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=4e434d83ac45a761#v5",
+        "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+        "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=6bfd33acc02b178b",
+        "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+        "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=x86_64",
+        "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+        "pkg:golang/sync@go1.22.12",
+        "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=x86_64",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=78b5b822f572b90c",
+        "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=8c96dc44fcc58103",
+        "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=x86_64",
+        "pkg:golang/golang.org/x/sync@v0.11.0",
+        "pkg:golang/github.com/beorn7/perks@v1.0.1",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=7b9209a64c9c952b",
+        "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=x86_64",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=2e766a71ac55c8c1",
+        "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+        "pkg:golang/net/http/httputil@go1.22.12",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=264ee8e18d5b5c8a",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+        "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+        "pkg:golang/github.com/go-stack/stack@v1.8.0",
+        "pkg:golang/internal/goexperiment@go1.22.12",
+        "pkg:golang/github.com/go-kit/kit@v0.13.0",
+        "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=x86_64",
+        "pkg:golang/internal/sysinfo@go1.22.12",
+        "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+        "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+        "pkg:golang/github.com/google/uuid@v1.1.5",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+        "pkg:golang/k8s.io/cli-runtime@v0.30.0?package-id=372a4fd9b7953904",
+        "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=x86_64",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=bcb125b3ee0ac2bf",
+        "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=x86_64",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=50971d92969aa29f",
+        "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=x86_64",
+        "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=deca7fef444579a8",
+        "pkg:golang/text/template/parse@go1.22.12",
+        "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+        "pkg:golang/golang.org/x/text@v0.14.0",
+        "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=296003ccdd027f5f",
+        "pkg:golang/k8s.io/cloud-provider@v0.30.0?package-id=213905a8e9bf9bca",
+        "pkg:golang/go/version@go1.22.12",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=fd55bfb7c4801b59",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=d52596cce426463a",
+        "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+        "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+        "pkg:golang/golang.org/x/sync@v0.11.0?package-id=d30348b75bd8dbbe",
+        "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=x86_64",
+        "pkg:golang/github.com/josharian/intern@v1.0.0",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+        "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492?package-id=3ba9356bde827563",
+        "pkg:golang/k8s.io/kubelet@v0.30.0?package-id=0d174a34ad4bac4b",
+        "pkg:golang/github.com/onsi/gomega@v1.33.1",
+        "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+        "pkg:golang/go/types@go1.22.12",
+        "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+        "pkg:golang/hash/adler32@go1.22.12",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=777844465b60ad81",
+        "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+        "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+        "pkg:golang/runtime/internal/syscall@go1.22.12",
+        "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+        "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=7349fb61f86b922a",
+        "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=4b04ea23556ed395",
+        "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=x86_64",
+        "pkg:golang/regexp@go1.22.12",
+        "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+        "pkg:golang/maps@go1.22.12",
+        "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+        "pkg:golang/net@go1.22.12",
+        "pkg:golang/encoding/csv@go1.22.12",
+        "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=165ae9cdbab510ff",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+        "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=x86_64",
+        "pkg:golang/os/signal@go1.22.12",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=37c32ab5198d2ad6",
+        "pkg:golang/net/mail@go1.22.12",
+        "pkg:golang/internal/goroot@go1.22.12",
+        "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+        "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+        "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+        "pkg:golang/strings@go1.22.12",
+        "pkg:golang/google.golang.org/grpc@v1.58.3",
+        "pkg:golang/go/build/constraint@go1.22.12",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=6676202d3cb12353",
+        "pkg:golang/os/user@go1.22.12",
+        "pkg:golang/k8s.io/api@v0.30.0",
+        "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+        "pkg:golang/crypto/dsa@go1.22.12",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=b1e90c3e1ac1f792",
+        "pkg:golang/net/http/httptrace@go1.22.12",
+        "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+        "pkg:golang/github.com/prometheus/procfs@v0.11.0?package-id=05538c935c5bdc7f",
+        "pkg:golang/kubevirt.io/client-go@v0.19.0",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=d49025084db5e534",
+        "pkg:golang/log/slog/internal@go1.22.12",
+        "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+        "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=30a0f7618c550bd4",
+        "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+        "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a?package-id=f5ed66e6e2ff252b",
+        "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=x86_64",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c?package-id=569830e89dc03f1b",
+        "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+        "pkg:pypi/pysocks@1.7.1",
+        "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+        "pkg:golang/crypto/x509@go1.22.12",
+        "pkg:golang/go/printer@go1.22.12",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=d8c2f26e9986efc0",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=875c60b36880d488",
+        "pkg:golang/golang.org/x/sys@v0.19.0",
+        "pkg:golang/go/constant@go1.22.12",
+        "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=56fa540c52a6e225",
+        "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+        "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=x86_64",
+        "pkg:golang/golang.org/x/sys@v0.30.0?package-id=c76606bb87a8c509",
+        "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+        "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+        "pkg:golang/crypto/internal/boring@go1.22.12",
+        "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=x86_64",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=c27f4e3f0f288cba",
+        "pkg:pypi/urllib3@1.26.5",
+        "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+        "pkg:golang/internal/itoa@go1.22.12",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=cd25ddf836753eae",
+        "pkg:golang/internal/zstd@go1.22.12",
+        "pkg:golang/github.com/josharian/native@v1.1.0",
+        "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+        "pkg:golang/net/http/httptest@go1.22.12",
+        "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+        "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+        "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+        "pkg:golang/github.com/prometheus/client_model@v0.4.0?package-id=01a656f993da3d7b",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=426c1ef83fb90a34",
+        "pkg:golang/crypto@go1.22.12",
+        "pkg:golang/github.com/moby/sys@v0.6.2?package-id=1c5457c16104bad6#mountinfo",
+        "pkg:golang/github.com/google/uuid@v1.3.1?package-id=8f2230e2d588c340",
+        "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+        "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=x86_64",
+        "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=x86_64&epoch=1",
+        "pkg:golang/kubevirt.io/kubevirt?package-id=7c29205f279961ea",
+        "pkg:golang/encoding/base64@go1.22.12",
+        "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+        "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=x86_64",
+        "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+        "pkg:golang/crypto/des@go1.22.12",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=cdc588c277efc41e",
+        "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+        "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=x86_64",
+        "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=61ff33db308e1c87",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+        "pkg:golang/github.com/beorn7/perks@v1.0.1?package-id=cf38e7467b415c45",
+        "pkg:golang/github.com/google/go-querystring@v1.0.0",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=69c0335cd603cb43#v22",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=6b3967bbe5e4f770#v3",
+        "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+        "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414?package-id=1f03719fd30cb426",
+        "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+        "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=392c78985b3ee866",
+        "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64",
+        "pkg:pypi/requests@2.25.1",
+        "pkg:golang/golang.org/x/text@v0.14.0?package-id=a47e6c64839baca0",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=507e16afff6e8cbf",
+        "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+        "pkg:golang/golang.org/x/time@v0.3.0?package-id=de8b89d7a225278d",
+        "pkg:pypi/subscription-manager@1.29.40.1",
+        "pkg:golang/k8s.io/kube-scheduler@v0.30.0?package-id=c6f4b38d0e64a871",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=617dda993ef91b06",
+        "pkg:golang/crypto/sha1@go1.22.12",
+        "pkg:golang/crypto/tls@go1.22.12",
+        "pkg:golang/k8s.io/sample-apiserver@v0.30.0?package-id=a7d282fdf5bcfc3a",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=28d221d2b95ef119",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=38a620e1191a8903",
+        "pkg:golang/mime@go1.22.12",
+        "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=x86_64",
+        "pkg:golang/net/http@go1.22.12",
+        "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=7fd9e721114377fd",
+        "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=x86_64",
+        "pkg:golang/log@go1.22.12",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=db29c54369441021",
+        "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+        "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+        "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+        "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+        "pkg:golang/runtime/metrics@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=bd15d762c1c6c3a1",
+        "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=x86_64",
+        "pkg:golang/golang.org/x/time@v0.3.0?package-id=abbe88d4dc25e60a",
+        "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+        "pkg:golang/stdlib@1.22.12?package-id=0263aa6b4909132a",
+        "pkg:golang/unicode/utf16@go1.22.12",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=c8fd5af5f2696ffc",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=6871ce92eaf7233e",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=e5f84b4525280ceb",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=ef4b943e758b9b6b",
+        "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+        "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+        "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=1651c6ba29f925e5",
+        "pkg:golang/github.com/golang/mock@v1.6.0",
+        "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=x86_64",
+        "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+        "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+        "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=x86_64",
+        "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=f3884188f09088ec#v5",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=9fca4ee62066efc2",
+        "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+        "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0?package-id=7c0f2e47ca097803",
+        "pkg:golang/internal/intern@go1.22.12",
+        "pkg:golang/errors@go1.22.12",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=79287922c4530134",
+        "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+        "pkg:golang/hash@go1.22.12",
+        "pkg:golang/github.com/golang/mock@v1.6.0?package-id=58fd55d3a3e68d9a",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=812518b1d5de5b6b",
+        "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+        "pkg:golang/github.com/fatih/color@v1.13.0",
+        "pkg:golang/k8s.io/csi-translation-lib@v0.30.0?package-id=e493ecdd6cef073d",
+        "pkg:pypi/idna@2.10",
+        "pkg:golang/image/internal/imageutil@go1.22.12",
+        "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0?package-id=b57f2d304a79c9d2",
+        "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+        "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=0cf48c7c4e0c2225",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=5f3161d14fb9986b",
+        "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=2add8ed970e49e83",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=6ca8b50f74df1aba",
+        "pkg:golang/k8s.io/api@v0.30.0?package-id=9cd65210b34ae131",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d7e841647edf8bf8",
+        "pkg:golang/container/list@go1.22.12",
+        "pkg:golang/container/ring@go1.22.12",
+        "pkg:golang/unicode@go1.22.12",
+        "pkg:golang/golang.org/x/term@v0.29.0?package-id=123dc6fd6dd76665",
+        "pkg:golang/runtime@go1.22.12",
+        "pkg:pypi/systemd-python@234",
+        "pkg:golang/image/png@go1.22.12",
+        "pkg:golang/github.com/google/btree@v1.1.3?package-id=d631efbb5e6884df",
+        "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+        "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=x86_64",
+        "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+        "pkg:golang/k8s.io/code-generator@v0.30.0?package-id=c9d95bf42170291b",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=fa2fc500853b500e",
+        "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+        "pkg:golang/go/doc/comment@go1.22.12",
+        "pkg:golang/runtime/internal/math@go1.22.12",
+        "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=38f081dbc5ce4d6a",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=317d26dbf41e923a",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=20f072e6e3225e24",
+        "pkg:golang/regexp/syntax@go1.22.12",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=a0115c013e649a4c",
+        "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+        "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible?package-id=15ebdd24a0c721e7",
+        "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+        "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=x86_64",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=78d6e196699c60fb",
+        "pkg:golang/internal/race@go1.22.12",
+        "pkg:golang/internal/goversion@go1.22.12",
+        "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=x86_64",
+        "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+        "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=d183acc87e1fa62e",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=87c0cbf8954e0580",
+        "pkg:golang/crypto/rc4@go1.22.12",
+        "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64",
+        "pkg:golang/k8s.io/cri-api@v0.30.0",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=aabc29983e2a9841",
+        "pkg:golang/k8s.io/kube-controller-manager@v0.30.0?package-id=0814f25a8e4531ce",
+        "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4bf18231eac48ba4",
+        "pkg:golang/encoding/base32@go1.22.12",
+        "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=x86_64",
+        "pkg:golang/text/tabwriter@go1.22.12",
+        "pkg:golang/k8s.io/cri-api@v0.30.0?package-id=4de173f6a5765211",
+        "pkg:golang/k8s.io/component-base@v0.30.0?package-id=94800364440cc1a6",
+        "pkg:golang/image/jpeg@go1.22.12",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=a1ff2ebea07a529d",
+        "pkg:golang/github.com/spf13/cobra@v1.7.0?package-id=3ba0797ce405770e",
+        "pkg:golang/./staging/src#github.com/golang/glog",
+        "pkg:golang/internal/coverage/rtcov@go1.22.12",
+        "pkg:pypi/gpg@1.15.1",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=dbb27eadf8364aee",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=406cd2654be0fcc8",
+        "pkg:golang/golang.org/x/sys@v0.30.0?package-id=8899651b157fa55b",
+        "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+        "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=99619c8dbac171e6",
+        "pkg:golang/k8s.io/metrics@v0.30.0?package-id=e5a9c757e0ba76d0",
+        "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+        "pkg:golang/golang.org/x/oauth2@v0.12.0",
+        "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=41c9ffe89c4328dd#pkg/apis/monitoring",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e87736d4223a3553",
+        "pkg:golang/internal/gover@go1.22.12",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=077b67d110fda982",
+        "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+        "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=332ab3a9d173ca98",
+        "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=2f055f6cdf8e3fb1",
+        "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6?package-id=0bc6f5896c6cb1a9",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=9de2c8dc0803d74e",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=638aeba61e089e7d",
+        "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=x86_64",
+        "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=8256c45ca06407ab",
+        "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b135113b0301cc3e",
+        "pkg:golang/github.com/prometheus/client_golang@v1.16.0?package-id=d58b9b0249e2d522",
+        "pkg:golang/math/big@go1.22.12",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=5df1a932dc364fae",
+        "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+        "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+        "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=49b478fdfd04f997",
+        "pkg:golang/github.com/moby/sys@v0.6.2?package-id=2f1b091e7ebc59e5#mountinfo",
+        "pkg:golang/internal/syscall/execenv@go1.22.12",
+        "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=x86_64",
+        "pkg:golang/golang.org/x/tools@v0.20.0",
+        "pkg:golang/k8s.io/kube-proxy@v0.30.0?package-id=da08354393870645",
+        "pkg:golang/runtime/internal/atomic@go1.22.12",
+        "pkg:golang/crypto/subtle@go1.22.12",
+        "pkg:golang/github.com/josharian/native@v1.1.0?package-id=6604c5cd4c4748cf",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+        "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+        "pkg:golang/github.com/go-stack/stack@v1.8.0?package-id=48631dee752774c6",
+        "pkg:golang/internal/bisect@go1.22.12",
+        "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64",
+        "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=71cd8ab004151c77",
+        "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=e810f9b52b2fed54",
+        "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=x86_64&epoch=1",
+        "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8?package-id=8753666bf11d11e8",
+        "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=x86_64",
+        "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923?package-id=bf32666eb889d979",
+        "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=x86_64",
+        "pkg:golang/go/internal/typeparams@go1.22.12",
+        "pkg:golang/testing@go1.22.12",
+        "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=x86_64",
+        "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=d06c6aae1204ae08#v22",
+        "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=x86_64&epoch=2",
+        "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+        "pkg:golang/io/ioutil@go1.22.12",
+        "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+        "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+        "pkg:golang/k8s.io/api@v0.30.0?package-id=077a5e8ca27fa924",
+        "pkg:golang/html/template@go1.22.12",
+        "pkg:golang/github.com/containers/common@v0.50.1?package-id=e36d1d0f2ba91772",
+        "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=x86_64",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=ad5593f4e294dd87",
+        "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+        "pkg:golang/runtime/debug@go1.22.12",
+        "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=c3d9773d12fa39a7",
+        "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=9e49a047878a9f7c",
+        "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+        "pkg:golang/github.com/cespare/xxhash@v2.2.0?package-id=d7fbb4f13b1bb601#v2",
+        "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=429112dfb9428aeb",
+        "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=x86_64",
+        "pkg:golang/github.com/pierrec/lz4@v4.1.15?package-id=8f6dd5f7ba6a62ec#v4",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=6619c43cfd07c933",
+        "pkg:golang/github.com/golang/mock@v1.6.0?package-id=59cd4b4e359e9754",
+        "pkg:golang/./staging/src#kubevirt.io/api",
+        "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+        "pkg:golang/net/http/internal/testcert@go1.22.12",
+        "pkg:golang/github.com/pborman/uuid@v1.2.1",
+        "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+        "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=x86_64",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=2510cbce9c179e69",
+        "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+        "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+        "pkg:golang/encoding/json@go1.22.12",
+        "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=70cc035eafb9fbd3",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=666b646207e276d6",
+        "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+        "pkg:golang/internal/reflectlite@go1.22.12",
+        "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=x86_64",
+        "pkg:golang/crypto/internal/bigmod@go1.22.12",
+        "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=x86_64",
+        "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d?package-id=3bb12d02cfa2e942#rpc",
+        "pkg:golang/k8s.io/sample-controller@v0.30.0?package-id=95847fe4258b57c0",
+        "pkg:golang/crypto/rand@go1.22.12",
+        "pkg:golang/github.com/onsi/ginkgo@v2.17.2?package-id=709ca981edc6d5d6#v2",
+        "pkg:golang/golang.org/x/mod@v0.17.0",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=ab608fe96a3e5a01",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=13c8c846a4481335",
+        "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=x86_64&epoch=1",
+        "pkg:golang/k8s.io/api@v0.30.0?package-id=dd84eb4f391fe51e",
+        "pkg:golang/unicode/utf8@go1.22.12",
+        "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=1663864887e439eb",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=f1bc226b87c469d8",
+        "pkg:golang/encoding/asn1@go1.22.12",
+        "pkg:golang/sort@go1.22.12",
+        "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=f951095dca4572e3",
+        "pkg:golang/archive/tar@go1.22.12",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=3bccae874729638f",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=a8276711fb26ec2c#v3",
+        "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+        "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20?package-id=ce832bdd3e643f49",
+        "pkg:pypi/six@1.15.0",
+        "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+        "pkg:golang/log/internal@go1.22.12",
+        "pkg:rpm/redhat/libxml2@2.9.13-12.el9_4?arch=x86_64",
+        "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+        "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/passwd@0.80-12.el9?arch=x86_64",
+        "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=6d74c429f555275e",
+        "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=x86_64",
+        "pkg:golang/expvar@go1.22.12",
+        "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+        "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=x86_64",
+        "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b?package-id=b697414c821ee814",
+        "pkg:golang/net/textproto@go1.22.12",
+        "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=5804e51cbc6df18a",
+        "pkg:rpm/redhat/libuser@0.63-13.el9?arch=x86_64",
+        "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=62c158205e5c5cbc#pkg/apis/monitoring",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=c9e73a9ce3fca441",
+        "pkg:rpm/redhat/jansson@2.14-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=ed2a22c702bae008",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=3f70c1e082cb9132",
+        "pkg:golang/runtime/internal/sys@go1.22.12",
+        "pkg:pypi/setuptools@53.0.0",
+        "pkg:golang/k8s.io/apiserver@v0.30.0?package-id=46f0784d88e673c3",
+        "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=c379c7237a34dcc0#client/v4",
+        "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=x86_64",
+        "pkg:golang/encoding/pem@go1.22.12",
+        "pkg:rpm/redhat/openssl-synthetic-test@1.0?arch=x86_64"
+      ]
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=b6c9d8ea55ec3898",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/time@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/dbus-python@1.2.18",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/types/errors@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/common@v0.50.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/godebug@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/python-dateutil@2.8.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/client-go",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/hmac@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goarch@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math/rand@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/pyinotify@0.9.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/saferio@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unsafe@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/ed25519@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/rpc@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/bufio@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/nettrace@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0?package-id=6f1e377d494cf9f5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/pprof@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=2fae184f36a99a47",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/x509/pkix@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/trace@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=f970a3d674d44626",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/btree@v1.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/expat@2.5.0-2.el9_4.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/netip@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=48602be9269bc897",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/stdlib@1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=18734635491c2975",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=1b0cc1bbf3f8ed78",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.9.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/which@2.21-29.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sync/atomic@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/nistec@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/database/sql/driver@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/reflect@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=b4c3f12b0f973ad1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/usermode@1.114-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math/bits@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/xml@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic@v0.5.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/chacha8rand@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/pygobject@3.40.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=1f351b9d12dd5e8b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=807835609b958430",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/ast@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/rpm@4.16.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/syscall@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/oserror@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/ecdh@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/bzip2@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/internal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.22.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=848770ad63e2adc0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/zlib@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/elliptic@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=b15f37518ae084d6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/godebugs@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/glog",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/buildcfg@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/bytealg@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/kubevirt",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/url@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.29.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/flag@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4?package-id=e4e1dce43844ff08",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0?package-id=3f73b8c486d0a009",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.22.0?package-id=341ee6986e5d85c1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.33.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/token@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/flate@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/build@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/api",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/platform@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/randutil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/common@v0.44.0?package-id=3a5f710d384a3dd9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/html@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=64880854c531d875",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goos@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=fa36e4581bae4e38",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/gob@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=3f115ef0cb31e7b8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/fmtsort@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/slices@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=bbfbb1eba9b1b80e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=9312f2882f8a9a02",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/aes@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=66f62c4a3380d295",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/libcomps@0.1.18",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/strconv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/bytes@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/sha256@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=8fbdfdc32aa3f0c7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=45b68313e6b7649d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/io@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v0.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/iniparse@0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0?package-id=c5265481edb963f4#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=6025e076d202b258",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/cipher@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/debug/elf@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/rsa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=68f83d538edd1c62",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/container/heap@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mime/multipart@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mime/quotedprintable@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/alias@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/hex@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/abi@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=38049f9b809b501e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=7f71bb3211c40e1e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/parser@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/color@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/context@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=06ba511a601e36d7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/internal/ascii@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=874d616b5ffd59b7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/chardet@4.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d6c72ae7c47adf6d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/cmp@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/syscall/unix@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.24.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/unsafeheader@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/path@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.33.0?package-id=cb71f9386c7676b0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/cpu@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/fmt@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog@v0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/doc@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/embed@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=fd7a9516c0278d0e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/lazyregexp@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/path/filepath@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/singleflight@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=7209f81d42d9fb42",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/slog@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/debug/dwarf@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/api?package-id=8271ccebef8c7fbf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1?package-id=9ab03ca56b78d2bd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash/crc32@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/decorator@4.4.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=cf3c5a20a21e8e64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os/exec@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/glog@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/sha512@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/node-api@v0.30.0?package-id=69b6b0afb2bc8383",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash/fnv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/scanner@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=5af92f389a804379",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/testlog@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/text/template@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/gzip@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=64a952cc8f95048c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog@v0.3.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=42ecb449d13ca189",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=c251c2070b6d837f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=a3f45ccc2eaef8aa",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/binary@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/ecdsa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=75bca8ba1ca22c9b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=45a8c7aac0e298e2#client/v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/poll@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.15",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e519b37240b7b6af",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/io/fs@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.23.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=0c548e794e085974",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog@v0.4.0?package-id=a6cf3f8305ce0756",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=ee6a4656125cefb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/./staging/src#kubevirt.io/client-go",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=92cbc10610ba936e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=0610c737c3c00486",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=4f70a6c87f97190b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/safefilepath@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=f3f74c8e52e58f96",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/md5@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/slog/internal/buffer@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=4e434d83ac45a761#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=6bfd33acc02b178b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sync@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=78b5b822f572b90c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=8c96dc44fcc58103",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=7b9209a64c9c952b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=2e766a71ac55c8c1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/httputil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=264ee8e18d5b5c8a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goexperiment@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/sysinfo@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.1.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0?package-id=372a4fd9b7953904",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=bcb125b3ee0ac2bf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=50971d92969aa29f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=deca7fef444579a8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/text/template/parse@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=296003ccdd027f5f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0?package-id=213905a8e9bf9bca",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/version@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=fd55bfb7c4801b59",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=d52596cce426463a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.11.0?package-id=d30348b75bd8dbbe",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492?package-id=3ba9356bde827563",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubelet@v0.30.0?package-id=0d174a34ad4bac4b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/types@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash/adler32@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=777844465b60ad81",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/syscall@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=7349fb61f86b922a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=4b04ea23556ed395",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/regexp@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/maps@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/csv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=165ae9cdbab510ff",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os/signal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=37c32ab5198d2ad6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/mail@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goroot@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/strings@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/build/constraint@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=6676202d3cb12353",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os/user@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/dsa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=b1e90c3e1ac1f792",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/httptrace@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0?package-id=05538c935c5bdc7f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/client-go@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=d49025084db5e534",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/slog/internal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=30a0f7618c550bd4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a?package-id=f5ed66e6e2ff252b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c?package-id=569830e89dc03f1b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/pysocks@1.7.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/x509@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/printer@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=d8c2f26e9986efc0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=875c60b36880d488",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/constant@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=56fa540c52a6e225",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=c76606bb87a8c509",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/boring@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=c27f4e3f0f288cba",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/urllib3@1.26.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/itoa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=cd25ddf836753eae",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/zstd@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/httptest@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0?package-id=01a656f993da3d7b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=426c1ef83fb90a34",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=1c5457c16104bad6#mountinfo",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=8f2230e2d588c340",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/kubevirt?package-id=7c29205f279961ea",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/base64@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/des@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=cdc588c277efc41e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=61ff33db308e1c87",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/beorn7/perks@v1.0.1?package-id=cf38e7467b415c45",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=69c0335cd603cb43#v22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=6b3967bbe5e4f770#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414?package-id=1f03719fd30cb426",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=392c78985b3ee866",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/requests@2.25.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.14.0?package-id=a47e6c64839baca0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=507e16afff6e8cbf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=de8b89d7a225278d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/subscription-manager@1.29.40.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0?package-id=c6f4b38d0e64a871",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=617dda993ef91b06",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/sha1@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/tls@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0?package-id=a7d282fdf5bcfc3a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=28d221d2b95ef119",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=38a620e1191a8903",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mime@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=7fd9e721114377fd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=db29c54369441021",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/metrics@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=bd15d762c1c6c3a1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=abbe88d4dc25e60a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/stdlib@1.22.12?package-id=0263aa6b4909132a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unicode/utf16@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=c8fd5af5f2696ffc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=6871ce92eaf7233e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=e5f84b4525280ceb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=ef4b943e758b9b6b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=1651c6ba29f925e5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=f3884188f09088ec#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=9fca4ee62066efc2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0?package-id=7c0f2e47ca097803",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/intern@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/errors@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=79287922c4530134",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=58fd55d3a3e68d9a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=812518b1d5de5b6b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fatih/color@v1.13.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0?package-id=e493ecdd6cef073d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/idna@2.10",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/internal/imageutil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0?package-id=b57f2d304a79c9d2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=0cf48c7c4e0c2225",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=5f3161d14fb9986b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=2add8ed970e49e83",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=6ca8b50f74df1aba",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=9cd65210b34ae131",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d7e841647edf8bf8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/container/list@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/container/ring@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unicode@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.29.0?package-id=123dc6fd6dd76665",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/systemd-python@234",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/png@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/btree@v1.1.3?package-id=d631efbb5e6884df",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/code-generator@v0.30.0?package-id=c9d95bf42170291b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=fa2fc500853b500e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/doc/comment@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/math@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=38f081dbc5ce4d6a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=317d26dbf41e923a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=20f072e6e3225e24",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/regexp/syntax@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=a0115c013e649a4c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible?package-id=15ebdd24a0c721e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=78d6e196699c60fb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/race@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goversion@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=d183acc87e1fa62e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=87c0cbf8954e0580",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/rc4@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=aabc29983e2a9841",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0?package-id=0814f25a8e4531ce",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4bf18231eac48ba4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/base32@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/text/tabwriter@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cri-api@v0.30.0?package-id=4de173f6a5765211",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/component-base@v0.30.0?package-id=94800364440cc1a6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/jpeg@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=a1ff2ebea07a529d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cobra@v1.7.0?package-id=3ba0797ce405770e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/./staging/src#github.com/golang/glog",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/coverage/rtcov@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/gpg@1.15.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=dbb27eadf8364aee",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=406cd2654be0fcc8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=8899651b157fa55b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=99619c8dbac171e6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/metrics@v0.30.0?package-id=e5a9c757e0ba76d0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=41c9ffe89c4328dd#pkg/apis/monitoring",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e87736d4223a3553",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/gover@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=077b67d110fda982",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=332ab3a9d173ca98",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=2f055f6cdf8e3fb1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6?package-id=0bc6f5896c6cb1a9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=9de2c8dc0803d74e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=638aeba61e089e7d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=8256c45ca06407ab",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b135113b0301cc3e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0?package-id=d58b9b0249e2d522",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math/big@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=5df1a932dc364fae",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=49b478fdfd04f997",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=2f1b091e7ebc59e5#mountinfo",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/syscall/execenv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0?package-id=da08354393870645",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/atomic@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/subtle@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/native@v1.1.0?package-id=6604c5cd4c4748cf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-stack/stack@v1.8.0?package-id=48631dee752774c6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/bisect@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=71cd8ab004151c77",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=e810f9b52b2fed54",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8?package-id=8753666bf11d11e8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923?package-id=bf32666eb889d979",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/internal/typeparams@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/testing@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=d06c6aae1204ae08#v22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/io/ioutil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=077a5e8ca27fa924",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/html/template@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/common@v0.50.1?package-id=e36d1d0f2ba91772",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=ad5593f4e294dd87",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/debug@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=c3d9773d12fa39a7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=9e49a047878a9f7c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0?package-id=d7fbb4f13b1bb601#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=429112dfb9428aeb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15?package-id=8f6dd5f7ba6a62ec#v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=6619c43cfd07c933",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=59cd4b4e359e9754",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/./staging/src#kubevirt.io/api",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/internal/testcert@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pborman/uuid@v1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=2510cbce9c179e69",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/json@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=70cc035eafb9fbd3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=666b646207e276d6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/reflectlite@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/bigmod@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d?package-id=3bb12d02cfa2e942#rpc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-controller@v0.30.0?package-id=95847fe4258b57c0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/rand@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2?package-id=709ca981edc6d5d6#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=ab608fe96a3e5a01",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=13c8c846a4481335",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=dd84eb4f391fe51e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unicode/utf8@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=1663864887e439eb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=f1bc226b87c469d8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/asn1@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sort@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=f951095dca4572e3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/archive/tar@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=3bccae874729638f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=a8276711fb26ec2c#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20?package-id=ce832bdd3e643f49",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/six@1.15.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/internal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxml2@2.9.13-12.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/passwd@0.80-12.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=6d74c429f555275e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/expvar@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b?package-id=b697414c821ee814",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/textproto@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=5804e51cbc6df18a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuser@0.63-13.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=62c158205e5c5cbc#pkg/apis/monitoring",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=c9e73a9ce3fca441",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/jansson@2.14-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=ed2a22c702bae008",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=3f70c1e082cb9132",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/sys@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/setuptools@53.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiserver@v0.30.0?package-id=46f0784d88e673c3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=c379c7237a34dcc0#client/v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/pem@go1.22.12",
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:8bb251fd-2b99-42d2-b7ce-f6e40bc23452"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/older/binary-2025-11-25-3E72AAC00183431.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/older/binary-2025-11-25-3E72AAC00183431.json
@@ -1,0 +1,26680 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "syft",
+          "type": "application",
+          "author": "anchore",
+          "version": "1.27.1"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/virt-handler-rhel9@sha256%3A7bf21edeec9b052e5d2f748f1db1799385507c8c7f43261ff3d989e80db4417b?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35-2",
+      "type": "container"
+    },
+    "timestamp": "2025-11-25T09:02:40Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156271"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/virt-handler-rhel9@sha256%3A7bf21edeec9b052e5d2f748f1db1799385507c8c7f43261ff3d989e80db4417b?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35-2",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7bf21edeec9b052e5d2f748f1db1799385507c8c7f43261ff3d989e80db4417b"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-handler-rhel9@sha256%3A7bf21edeec9b052e5d2f748f1db1799385507c8c7f43261ff3d989e80db4417b?arch=arm64&os=linux&tag=v4.17.35-2",
+      "version": "sha256:7bf21edeec9b052e5d2f748f1db1799385507c8c7f43261ff3d989e80db4417b",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3A7bf21edeec9b052e5d2f748f1db1799385507c8c7f43261ff3d989e80db4417b?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3A7bf21edeec9b052e5d2f748f1db1799385507c8c7f43261ff3d989e80db4417b?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3A7bf21edeec9b052e5d2f748f1db1799385507c8c7f43261ff3d989e80db4417b?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35-2"
+          }
+        ]
+      },
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ca697ecfa8b17e55a6534a66691a9f7d8079e14e",
+            "url": "https://pkgs.devel.redhat.com/git/containers/virt-handler#ca697ecfa8b17e55a6534a66691a9f7d8079e14e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:architecture",
+          "value": "aarch64"
+        },
+        {
+          "name": "sbomer:image:labels:build-date",
+          "value": "2025-11-20T15:25:12"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "virt-handler-rhel9-container"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.license_terms",
+          "value": "https://www.redhat.com/agreements"
+        },
+        {
+          "name": "sbomer:image:labels:cpe",
+          "value": "cpe:/a:redhat:rhel_eus:9.4::appstream"
+        },
+        {
+          "name": "sbomer:image:labels:description",
+          "value": "Virtualization handler for CNV"
+        },
+        {
+          "name": "sbomer:image:labels:distribution-scope",
+          "value": "public"
+        },
+        {
+          "name": "sbomer:image:labels:io.buildah.version",
+          "value": "1.33.12"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.description",
+          "value": "Virtualization handler for CNV"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.display-name",
+          "value": "virt-handler"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.tags",
+          "value": "cnv,kubevirt"
+        },
+        {
+          "name": "sbomer:image:labels:maintainer",
+          "value": "sgott@redhat.com,ibezukh@redhat.com,dhiller@redhat.com,jlejosne@redhat.com"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "container-native-virtualization/virt-handler-rhel9"
+        },
+        {
+          "name": "sbomer:image:labels:org.opencontainers.image.revision",
+          "value": "2ce6c4e1853a72beb38c539476edad8d5f73a171"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "2"
+        },
+        {
+          "name": "sbomer:image:labels:summary",
+          "value": "Virtualization handler"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-vcs-ref",
+          "value": "952f258d1f909636381bb2491c504618d3749a35"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-vcs-url",
+          "value": "https://github.com/kubevirt/kubevirt"
+        },
+        {
+          "name": "sbomer:image:labels:upstream-version",
+          "value": "1.3.1-283-g952f258d1f"
+        },
+        {
+          "name": "sbomer:image:labels:url",
+          "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/container-native-virtualization/virt-handler-rhel9/images/v4.17.35-2"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-ref",
+          "value": "ca697ecfa8b17e55a6534a66691a9f7d8079e14e"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:vendor",
+          "value": "Red Hat"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "v4.17.35"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3894652",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "https://pkgs.devel.redhat.com/git/containers/virt-handler#ca697ecfa8b17e55a6534a66691a9f7d8079e14e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "json-glib",
+      "purl": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=aarch64",
+      "version": "1.6.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d5548792bb86a77330957962541a936d9c391896",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1707185",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "./staging/src/kubevirt.io/client-go",
+      "purl": "pkg:golang/./staging/src#kubevirt.io/client-go",
+      "type": "library",
+      "bom-ref": "pkg:golang/./staging/src#kubevirt.io/client-go",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=b6c9d8ea55ec3898",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/vsock",
+      "purl": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "time",
+      "purl": "pkg:golang/time@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/time@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "dbus-python",
+      "purl": "pkg:pypi/dbus-python@1.2.18",
+      "type": "library",
+      "bom-ref": "pkg:pypi/dbus-python@1.2.18",
+      "version": "1.2.18",
+      "licenses": [
+        {
+          "license": {
+            "name": "Expat (MIT/X11)"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/dbus_python-1.2.18-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-scheduler",
+      "purl": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/types/errors",
+      "purl": "pkg:golang/internal/types/errors@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/types/errors@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/legacy-cloud-providers",
+      "purl": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/exp/typeparams",
+      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+      "version": "v0.0.0-20230203172020-98cc5a0785f9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+      "purl": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "version": "v0.68.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "cracklib",
+      "purl": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=aarch64",
+      "version": "2.9.6-27.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+            "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689047",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgomp",
+      "purl": "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=aarch64",
+      "version": "11.4.1-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498982",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/procfs",
+      "purl": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libutempter",
+      "purl": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=aarch64",
+      "version": "1.2.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c269950567cdc8b12062724de07db72689bf55c",
+            "url": "git://pkgs.devel.redhat.com/rpms/libutempter#1c269950567cdc8b12062724de07db72689bf55c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690196",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libutempter#1c269950567cdc8b12062724de07db72689bf55c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubectl",
+      "purl": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "basesystem",
+      "purl": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "version": "11-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+            "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688850",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/godebug",
+      "purl": "pkg:golang/internal/godebug@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/godebug@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libgpg-error",
+      "purl": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=aarch64",
+      "version": "1.42-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "55660568a38dad2e4a858df692830af766ad6532",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1818836",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.1",
+      "type": "library",
+      "author": "Gustavo Niemeyer <gustavo@niemeyer.net>",
+      "bom-ref": "pkg:pypi/python-dateutil@2.8.1",
+      "version": "2.8.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Dual License"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/python_dateutil-2.8.1-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-lib",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=aarch64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libuser",
+      "purl": "pkg:rpm/redhat/libuser@0.63-13.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuser@0.63-13.el9?arch=aarch64",
+      "version": "0.63-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "13af6ac62247268424d499b1889ee11afd7e150a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libuser#13af6ac62247268424d499b1889ee11afd7e150a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2590170",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libuser#13af6ac62247268424d499b1889ee11afd7e150a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b7c26aaef6d1c9b7",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "dejavu-sans-fonts",
+      "purl": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "version": "2.37-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bitstream Vera and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1479ec5203df4c3e577d1992b22c6976c142afa9",
+            "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688969",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/client-go",
+      "purl": "pkg:golang/kubevirt.io/client-go",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/client-go",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "./staging/src/github.com/golang/glog",
+      "purl": "pkg:golang/./staging/src#github.com/golang/glog",
+      "type": "library",
+      "bom-ref": "pkg:golang/./staging/src#github.com/golang/glog",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libsepol",
+      "purl": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=aarch64",
+      "version": "3.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d568b2713a4280fad93a660b66d5047296c3853f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#d568b2713a4280fad93a660b66d5047296c3853f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820602",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#d568b2713a4280fad93a660b66d5047296c3853f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sync",
+      "purl": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/hmac",
+      "purl": "pkg:golang/crypto/hmac@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/hmac@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubernetes-csi/external-snapshotter/client/v4",
+      "purl": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "version": "v4.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "psmisc",
+      "purl": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=aarch64",
+      "version": "23.4-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4bb81408b08c44d02985b6af55bbd75260c6b3ed",
+            "url": "git://pkgs.devel.redhat.com/rpms/psmisc#4bb81408b08c44d02985b6af55bbd75260c6b3ed"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691630",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/psmisc#4bb81408b08c44d02985b6af55bbd75260c6b3ed",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/goarch",
+      "purl": "pkg:golang/internal/goarch@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goarch@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/qe-tools",
+      "purl": "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+      "version": "v0.1.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "math/rand",
+      "purl": "pkg:golang/math/rand@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math/rand@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-iniparse",
+      "purl": "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+      "version": "0.4-45.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fa613c34fcc4661d8320d1eead334cb4a43d56be",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-iniparse#fa613c34fcc4661d8320d1eead334cb4a43d56be"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-iniparse#fa613c34fcc4661d8320d1eead334cb4a43d56be",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pyinotify",
+      "purl": "pkg:pypi/pyinotify@0.9.6",
+      "type": "library",
+      "author": "Sebastien Martini <seb@dbzteam.org>",
+      "bom-ref": "pkg:pypi/pyinotify@0.9.6",
+      "version": "0.9.6",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT License"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/pyinotify-0.9.6-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "internal/saferio",
+      "purl": "pkg:golang/internal/saferio@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/saferio@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "unsafe",
+      "purl": "pkg:golang/unsafe@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unsafe@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libdb",
+      "purl": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=aarch64",
+      "version": "5.3.28-53.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and LGPLv2 and Sleepycat"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "27038c5d3e75ae33c7281b39d1b15ce166a0c420",
+            "url": "git://pkgs.devel.redhat.com/rpms/libdb#27038c5d3e75ae33c7281b39d1b15ce166a0c420"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1806145",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libdb#27038c5d3e75ae33c7281b39d1b15ce166a0c420",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nettle",
+      "purl": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=aarch64",
+      "version": "3.9.1-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7e4a847c42da5300f4bac05df9a0fb140e0a2ed2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#7e4a847c42da5300f4bac05df9a0fb140e0a2ed2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2785925",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#7e4a847c42da5300f4bac05df9a0fb140e0a2ed2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/ed25519",
+      "purl": "pkg:golang/crypto/ed25519@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/ed25519@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "net/rpc",
+      "purl": "pkg:golang/net/rpc@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/rpc@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "bufio",
+      "purl": "pkg:golang/bufio@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/bufio@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/nettrace",
+      "purl": "pkg:golang/internal/nettrace@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/nettrace@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/legacy-cloud-providers",
+      "purl": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0?package-id=6f1e377d494cf9f5",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kisielk/errcheck",
+      "purl": "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+      "version": "v1.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "mpfr",
+      "purl": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=aarch64",
+      "version": "4.1.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "207ac3816285664c0c73fa4894dbdead53d1ca40",
+            "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690656",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "redhat-release",
+      "purl": "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=aarch64",
+      "version": "9.4-0.5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94af0111c38c9daaa9b97620cd8c6237de1d1315",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#94af0111c38c9daaa9b97620cd8c6237de1d1315"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3021565",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#94af0111c38c9daaa9b97620cd8c6237de1d1315",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/nunnatsa/ginkgolinter",
+      "purl": "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gawk",
+      "purl": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=aarch64",
+      "version": "5.1.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv2+ and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3830530bfc524ab9b89fafe76d58a388675ecc11",
+            "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1891122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/spdystream",
+      "purl": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "version": "v0.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/common",
+      "purl": "pkg:golang/github.com/containers/common@v0.50.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/common@v0.50.1",
+      "version": "v0.50.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "runtime/pprof",
+      "purl": "pkg:golang/runtime/pprof@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/pprof@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libmount",
+      "purl": "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=05e9b8a9427d6786",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "p11-kit",
+      "purl": "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=aarch64",
+      "version": "0.25.3-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "af03cdd6b28123c3643c0874462f8aaa668be9e6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2792712",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vim-minimal",
+      "purl": "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=aarch64&epoch=2",
+      "version": "2:8.2.2637-20.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Vim and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0efec05571fe5baab0ca0b22db499eb5c8d42af6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/vim#0efec05571fe5baab0ca0b22db499eb5c8d42af6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3849530",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/vim#0efec05571fe5baab0ca0b22db499eb5c8d42af6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "encoding",
+      "purl": "pkg:golang/encoding@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/plugins",
+      "purl": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-rpm",
+      "purl": "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=aarch64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=f63f44519d8bc924",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/boring/bbig",
+      "purl": "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/x509/pkix",
+      "purl": "pkg:golang/crypto/x509/pkix@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/x509/pkix@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "runtime/trace",
+      "purl": "pkg:golang/runtime/trace@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/trace@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=f970a3d674d44626",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "librepo",
+      "purl": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=aarch64",
+      "version": "1.14.5-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "458f8b732e9d31cbe09323c87f796924ac30461c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797210",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/plugins",
+      "purl": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1?package-id=599ab3f3550112ac",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=9b8e9f9b128703ca",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libnftnl",
+      "purl": "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=aarch64",
+      "version": "1.2.6-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d524ea7068ac80696b2688aab672500071f38ac",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnftnl#8d524ea7068ac80696b2688aab672500071f38ac"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3052789",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnftnl#8d524ea7068ac80696b2688aab672500071f38ac",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "mvdan.cc/sh/v3",
+      "purl": "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+      "version": "v3.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/netip",
+      "purl": "pkg:golang/net/netip@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/netip@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/code-generator",
+      "purl": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/u-root/uio",
+      "purl": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "version": "v0.0.0-20230220225925-ffce2a382923",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.22.12",
+      "version": "go1.22.12",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=18734635491c2975",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/kubevirt",
+      "purl": "pkg:golang/kubevirt.io/kubevirt",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/kubevirt",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cloud-provider",
+      "purl": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/goexpect",
+      "purl": "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+      "version": "v0.0.0-20190425035906-112704a48083",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.9.0",
+      "version": "v0.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sync/atomic",
+      "purl": "pkg:golang/sync/atomic@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/sync/atomic@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+      "purl": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/nistec",
+      "purl": "pkg:golang/crypto/internal/nistec@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/nistec@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libtasn1",
+      "purl": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=aarch64",
+      "version": "4.16.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "425d04e73d45b52ff50b454e85e8c512cc8fe282",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtasn1#425d04e73d45b52ff50b454e85e8c512cc8fe282"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3617876",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtasn1#425d04e73d45b52ff50b454e85e8c512cc8fe282",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "database/sql/driver",
+      "purl": "pkg:golang/database/sql/driver@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/database/sql/driver@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/machadovilaca/operator-observability",
+      "purl": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "version": "v0.0.20",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/c9s/goprocinfo",
+      "purl": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "version": "v0.0.0-20210130143923-c95fcf8c64a8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "reflect",
+      "purl": "pkg:golang/reflect@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/reflect@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libsmartcols",
+      "purl": "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-semver",
+      "purl": "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+      "version": "v0.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pmezard/go-difflib",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "version": "v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "alternatives",
+      "purl": "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=aarch64",
+      "version": "1.24-1.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2233412101349b53627f350497e1ac17dec36730",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#2233412101349b53627f350497e1ac17dec36730"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3267208",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#2233412101349b53627f350497e1ac17dec36730",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pam",
+      "purl": "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=aarch64",
+      "version": "1.5.1-24.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a62b752a294ae678f588bcb039a59078981341de",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pam#a62b752a294ae678f588bcb039a59078981341de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3807184",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pam#a62b752a294ae678f588bcb039a59078981341de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=aeac65a548510a6a#mountinfo",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/sys/cpu",
+      "purl": "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "math/bits",
+      "purl": "pkg:golang/math/bits@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math/bits@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/povsister/scp",
+      "purl": "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+      "version": "v0.0.0-20210427074412-33febfd9f13e",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/xml",
+      "purl": "pkg:golang/encoding/xml@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/xml@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic",
+      "purl": "pkg:golang/github.com/google/gnostic@v0.5.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic@v0.5.7",
+      "version": "v0.5.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/chacha8rand",
+      "purl": "pkg:golang/internal/chacha8rand@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/chacha8rand@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/insomniacslk/dhcp",
+      "purl": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "version": "v0.0.0-20230908212754-65c27093e38a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "version": "v1.1.14",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/operator-framework/operator-lifecycle-manager",
+      "purl": "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "version": "v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "pygobject",
+      "purl": "pkg:pypi/pygobject@3.40.1",
+      "type": "library",
+      "author": "James Henstridge <james@daa.com.au>",
+      "bom-ref": "pkg:pypi/pygobject@3.40.1",
+      "version": "3.40.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GNU LGPL"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/PyGObject-3.40.1.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "version": "v0.5.9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/ast",
+      "purl": "pkg:golang/go/ast@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/ast@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libxml2",
+      "purl": "pkg:rpm/redhat/libxml2@2.9.13-12.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxml2@2.9.13-12.el9_4?arch=aarch64",
+      "version": "2.9.13-12.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cf8bbf431c59982f13241352ffb134c8e7876e7c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#cf8bbf431c59982f13241352ffb134c8e7876e7c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3790734",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#cf8bbf431c59982f13241352ffb134c8e7876e7c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "version": "v1.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "ima-evm-utils",
+      "purl": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=aarch64",
+      "version": "1.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f8dae177fe0fdd6012a0f6b10dbb14b8bedd4c40",
+            "url": "git://pkgs.devel.redhat.com/rpms/ima-evm-utils#f8dae177fe0fdd6012a0f6b10dbb14b8bedd4c40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1825204",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ima-evm-utils#f8dae177fe0fdd6012a0f6b10dbb14b8bedd4c40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/common",
+      "purl": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "version": "v0.44.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/node-api",
+      "purl": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-pip-wheel",
+      "purl": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+      "version": "21.2.3-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f3400cce6a9da840f21eb4cfd81a0c2ca38eb185",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#f3400cce6a9da840f21eb4cfd81a0c2ca38eb185"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2906206",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#f3400cce6a9da840f21eb4cfd81a0c2ca38eb185",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "readline",
+      "purl": "pkg:rpm/redhat/readline@8.1-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=aarch64",
+      "version": "8.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be386f45be1322adf2bd79dd94c9904c4efa3d22",
+            "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691921",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:pypi/rpm@4.16.1.3",
+      "type": "library",
+      "author": "UNKNOWN <rpm-maint@lists.rpm.org>",
+      "bom-ref": "pkg:pypi/rpm@4.16.1.3",
+      "version": "4.16.1.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "GNU General Public License v2"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/rpm-4.16.1.3-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "syscall",
+      "purl": "pkg:golang/syscall@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/syscall@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "version": "5a6340b3-6229229e",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "version": "v1.5.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig/v3",
+      "purl": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "version": "v3.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/renameio/v2",
+      "purl": "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+      "version": "v2.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "version": "v0.3.16",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/oserror",
+      "purl": "pkg:golang/internal/oserror@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/oserror@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "bzip2-libs",
+      "purl": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=aarch64",
+      "version": "1.0.8-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00ab1bac9f740f33a2dcc6ada500c802a28bb6b2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#00ab1bac9f740f33a2dcc6ada500c802a28bb6b2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3425109",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#00ab1bac9f740f33a2dcc6ada500c802a28bb6b2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/ecdh",
+      "purl": "pkg:golang/crypto/ecdh@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/ecdh@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "compress/bzip2",
+      "purl": "pkg:golang/compress/bzip2@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/bzip2@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/socket",
+      "purl": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "version": "v0.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go.mongodb.org/mongo-driver",
+      "purl": "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+      "version": "v1.8.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gmp",
+      "purl": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=aarch64&epoch=1",
+      "version": "1:6.2.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+            "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2625518",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "net/http/internal",
+      "purl": "pkg:golang/net/http/internal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/internal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.22.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.22.0",
+      "version": "v0.22.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "compress/zlib",
+      "purl": "pkg:golang/compress/zlib@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/zlib@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/cryptobyte/asn1",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-six",
+      "purl": "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+      "version": "1.15.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7a3cef2bf49b31b0f9c2ecd4b05d34bdc214998c",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-six#7a3cef2bf49b31b0f9c2ecd4b05d34bdc214998c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1890817",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-six#7a3cef2bf49b31b0f9c2ecd4b05d34bdc214998c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libblkid",
+      "purl": "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/elliptic",
+      "purl": "pkg:golang/crypto/elliptic@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/elliptic@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cespare/xxhash/v2",
+      "purl": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "version": "v2.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/godebugs",
+      "purl": "pkg:golang/internal/godebugs@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/godebugs@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-controller-manager",
+      "purl": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/secure/bidirule",
+      "purl": "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/glog",
+      "purl": "pkg:golang/github.com/golang/glog",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/glog",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/buildcfg",
+      "purl": "pkg:golang/internal/buildcfg@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/buildcfg@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "purl": "pkg:golang/os@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager-rhsm-certificates",
+      "purl": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+      "version": "20220623-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "aa015c720c46b2548f962320f9b18de28c097691",
+            "url": "git://pkgs.devel.redhat.com/rpms/subscription-manager-rhsm-certificates#aa015c720c46b2548f962320f9b18de28c097691"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2061647",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/subscription-manager-rhsm-certificates#aa015c720c46b2548f962320f9b18de28c097691",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/http2/hpack",
+      "purl": "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/bytealg",
+      "purl": "pkg:golang/internal/bytealg@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/bytealg@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "version": "fd431d51-4ae0493b",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "net/url",
+      "purl": "pkg:golang/net/url@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/url@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "version": "v1.1.1-0.20210330154013-f5de75959ad5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/edwards25519/field",
+      "purl": "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.29.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.29.0",
+      "version": "v0.29.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/matttproud/golang_protobuf_extensions",
+      "purl": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "version": "v1.0.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.3.0",
+      "version": "v0.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/rogpeppe/go-internal",
+      "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "version": "v0.0.0-20210104183010-2eb08e3e575f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "dmidecode",
+      "purl": "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=aarch64&epoch=1",
+      "version": "1:3.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3368d91ad91bcfd15a9e66b6f1bbbf18b7491c6e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dmidecode#3368d91ad91bcfd15a9e66b6f1bbbf18b7491c6e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2841778",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dmidecode#3368d91ad91bcfd15a9e66b6f1bbbf18b7491c6e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "flag",
+      "purl": "pkg:golang/flag@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/flag@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "systemd-rpm-macros",
+      "purl": "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-aggregator",
+      "purl": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/token",
+      "purl": "pkg:golang/go/token@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/token@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "version": "v1.0.3-0.20210326190908-1c3f411f0417",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "compress/flate",
+      "purl": "pkg:golang/compress/flate@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/flate@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "go/build",
+      "purl": "pkg:golang/go/build@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/build@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/api",
+      "purl": "pkg:golang/kubevirt.io/api",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/api",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cobra",
+      "purl": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kr/logfmt",
+      "purl": "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+      "version": "v0.0.0-20210122060352-19f9bcb100e6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/platform",
+      "purl": "pkg:golang/internal/platform@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/platform@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.33.0",
+      "version": "v0.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/randutil",
+      "purl": "pkg:golang/crypto/internal/randutil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/randutil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "which",
+      "purl": "pkg:rpm/redhat/which@2.21-29.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/which@2.21-29.el9?arch=aarch64",
+      "version": "2.21-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dac12498cdc45059738012dbd5af70569b8b8100",
+            "url": "git://pkgs.devel.redhat.com/rpms/which#dac12498cdc45059738012dbd5af70569b8b8100"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2437620",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/which#dac12498cdc45059738012dbd5af70569b8b8100",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=aec23c0e1d75ee8a",
+      "version": "v1.0.3-0.20210326190908-1c3f411f0417",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "libmodulemd",
+      "purl": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=aarch64",
+      "version": "2.13.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d48969327abbcbfad2ab893639cfb7d22362223d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1695462",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnetfilter_conntrack",
+      "purl": "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=aarch64",
+      "version": "1.0.9-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a8c7bd7fc24180e59c191a4d5a05a475afdcf17",
+            "url": "git://pkgs.devel.redhat.com/rpms/libnetfilter_conntrack#2a8c7bd7fc24180e59c191a4d5a05a475afdcf17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2296866",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libnetfilter_conntrack#2a8c7bd7fc24180e59c191a4d5a05a475afdcf17",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/common",
+      "purl": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/common@v0.44.0?package-id=3a5f710d384a3dd9",
+      "version": "v0.44.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "html",
+      "purl": "pkg:golang/html@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/html@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-setuptools-wheel",
+      "purl": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+      "version": "53.0.0-12.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and (BSD or ASL 2.0)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e118582dafc46c5b61049eb79598ec15e88c3b7d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3754759",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=64880854c531d875",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=b024122f6e41d561",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "p11-kit-trust",
+      "purl": "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=aarch64",
+      "version": "0.25.3-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "af03cdd6b28123c3643c0874462f8aaa668be9e6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2792712",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#af03cdd6b28123c3643c0874462f8aaa668be9e6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "systemd-pam",
+      "purl": "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=aarch64",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/goos",
+      "purl": "pkg:golang/internal/goos@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goos@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-colorable",
+      "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "version": "v0.1.13",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/gob",
+      "purl": "pkg:golang/encoding/gob@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/gob@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_golang",
+      "purl": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "version": "v1.16.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "lz4-libs",
+      "purl": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=aarch64",
+      "version": "1.9.3-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690509",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=3f115ef0cb31e7b8",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/fmtsort",
+      "purl": "pkg:golang/internal/fmtsort@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/fmtsort@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pierrec/lz4/v4",
+      "purl": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "version": "v4.1.15",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/krolaw/dhcp4",
+      "purl": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "version": "v0.0.0-20180925202202-7cead472c414",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "slices",
+      "purl": "pkg:golang/slices@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/slices@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=8c45f6a8d1cca06d",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/mapstructure",
+      "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/aes",
+      "purl": "pkg:golang/crypto/aes@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/aes@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "rpm-libs",
+      "purl": "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=aarch64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-common",
+      "purl": "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcomps",
+      "purl": "pkg:pypi/libcomps@0.1.18",
+      "type": "library",
+      "author": "RPM Software Management <rpm-ecosystem@lists.rpm.org>",
+      "bom-ref": "pkg:pypi/libcomps@0.1.18",
+      "version": "0.1.18",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/libcomps-0.1.18-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "libfdisk",
+      "purl": "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "strconv",
+      "purl": "pkg:golang/strconv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/strconv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "bytes",
+      "purl": "pkg:golang/bytes@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/bytes@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/sha256",
+      "purl": "pkg:golang/crypto/sha256@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/sha256@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=ff4b8706a44511d7",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=45b68313e6b7649d",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "io",
+      "purl": "pkg:golang/io@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/io@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=2ccbb81b4bfbf67e",
+      "version": "v1.1.14",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/vsock",
+      "purl": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=97ce01b8d036cd18",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "langpacks-en",
+      "purl": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v0.2.1",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "iniparse",
+      "purl": "pkg:pypi/iniparse@0.4",
+      "type": "library",
+      "author": "Paramjit Oberoi <param@cs.wisc.edu>",
+      "bom-ref": "pkg:pypi/iniparse@0.4",
+      "version": "0.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/iniparse-0.4-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cheggaaa/pb/v3",
+      "purl": "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+      "version": "v3.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sqlite-libs",
+      "purl": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=aarch64",
+      "version": "3.34.1-7.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b1dd0e13763f804a7e224ec726c7037b9fda6a0c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#b1dd0e13763f804a7e224ec726c7037b9fda6a0c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3767409",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#b1dd0e13763f804a7e224ec726c7037b9fda6a0c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig/v3",
+      "purl": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0?package-id=c5265481edb963f4#v3",
+      "version": "v3.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libsemanage",
+      "purl": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=aarch64",
+      "version": "3.6-2.1.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "96eef030fb0a0f4d27e17961dd585c8730df12e4",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#96eef030fb0a0f4d27e17961dd585c8730df12e4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3418014",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#96eef030fb0a0f4d27e17961dd585c8730df12e4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnl3",
+      "purl": "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=aarch64",
+      "version": "3.9.0-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "23021690a101b6f1b14fd6b0d4fe318934dbb9c3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnl3#23021690a101b6f1b14fd6b0d4fe318934dbb9c3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2805134",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libnl3#23021690a101b6f1b14fd6b0d4fe318934dbb9c3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/cipher",
+      "purl": "pkg:golang/crypto/cipher@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/cipher@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "debug/elf",
+      "purl": "pkg:golang/debug/elf@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/debug/elf@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/rsa",
+      "purl": "pkg:golang/crypto/rsa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/rsa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/diff",
+      "purl": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "version": "v0.0.0-20210226163009-20ebb0f2a09e",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/metrics",
+      "purl": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+      "version": "v0.0.0-20210105115604-44119421ec6b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "container/heap",
+      "purl": "pkg:golang/container/heap@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/container/heap@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "mime/multipart",
+      "purl": "pkg:golang/mime/multipart@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/mime/multipart@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "mime/quotedprintable",
+      "purl": "pkg:golang/mime/quotedprintable@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/mime/quotedprintable@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/alias",
+      "purl": "pkg:golang/crypto/internal/alias@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/alias@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "encoding/hex",
+      "purl": "pkg:golang/encoding/hex@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/hex@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies",
+      "purl": "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+      "version": "20240202-1.git283706d.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a950d9ca3218bf47d75befa4639b7990b00c99eb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2889114",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/appengine",
+      "purl": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "version": "v1.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/abi",
+      "purl": "pkg:golang/internal/abi@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/abi@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.29.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.29.0?package-id=6367701eacddef15",
+      "version": "v0.29.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libbpf",
+      "purl": "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=aarch64&epoch=2",
+      "version": "2:1.3.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 or BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "39db39a8f05a831c2cff398273dbc03597e85c8a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libbpf#39db39a8f05a831c2cff398273dbc03597e85c8a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2924610",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libbpf#39db39a8f05a831c2cff398273dbc03597e85c8a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/tomb.v1",
+      "purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "version": "v1.0.0-20141024135613-dd632973f1e7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "ncurses-base",
+      "purl": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+      "version": "6.2-10.20210508.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "539ab619cec841979d6b46943d3f82c15b7a8467",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3759616",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=7f71bb3211c40e1e",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/parser",
+      "purl": "pkg:golang/go/parser@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/parser@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+      "version": "v0.0.0-20230503133300-8bbcb7ca7183",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-gobject-base",
+      "purl": "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=aarch64",
+      "version": "3.40.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79ff68bd91179f855796360827ad65f2a83577dc",
+            "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2049891",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e5133fb001ac7926",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-hawkey",
+      "purl": "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=aarch64",
+      "version": "0.69.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e5984c195dca639c24fa8a25263d2faf9419e97d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134146",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "image/color",
+      "purl": "pkg:golang/image/color@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/color@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "glib2",
+      "purl": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=aarch64",
+      "version": "2.68.4-14.el9_4.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "14a7b9b0aeb14a071ad69f0c1c3779c0c31c03e3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#14a7b9b0aeb14a071ad69f0c1c3779c0c31c03e3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3857383",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#14a7b9b0aeb14a071ad69f0c1c3779c0c31c03e3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/chacha20",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "dbus",
+      "purl": "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=aarch64&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/pprof",
+      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "version": "v0.0.0-20240424215950-a892ee059fd6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "context",
+      "purl": "pkg:golang/context@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/context@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=06ba511a601e36d7",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/http/internal/ascii",
+      "purl": "pkg:golang/net/http/internal/ascii@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/internal/ascii@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "librhsm",
+      "purl": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=aarch64",
+      "version": "0.0.3-7.el9_3.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25c62475abb565eb8ebef5f1df66a6c5eff74ccd",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#25c62475abb565eb8ebef5f1df66a6c5eff74ccd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2845494",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#25c62475abb565eb8ebef5f1df66a6c5eff74ccd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=874d616b5ffd59b7",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/nxadm/tail",
+      "purl": "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+      "version": "v0.0.0-20211216163028-4472660a31a6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.22.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.22.0?package-id=b0628cbb477d7801",
+      "version": "v0.22.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "chardet",
+      "purl": "pkg:pypi/chardet@4.0.0",
+      "type": "library",
+      "author": "Mark Pilgrim <mark@diveintomark.org>",
+      "bom-ref": "pkg:pypi/chardet@4.0.0",
+      "version": "4.0.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPL"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/chardet-4.0.0.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d6c72ae7c47adf6d",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "cmp",
+      "purl": "pkg:golang/cmp@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/cmp@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libcurl-minimal",
+      "purl": "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+      "version": "7.76.1-29.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80195397e7d61d156d731499be9884797b75dbb1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471237",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/syscall/unix",
+      "purl": "pkg:golang/internal/syscall/unix@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/syscall/unix@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "bash",
+      "purl": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=aarch64",
+      "version": "5.1.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80326284a249f523c3e2d14e0eed2dbaece63c4e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2910143",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-isatty",
+      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "version": "v0.0.17",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.24.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.24.0",
+      "version": "v0.24.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/unsafeheader",
+      "purl": "pkg:golang/internal/unsafeheader@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/unsafeheader@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "path",
+      "purl": "pkg:golang/path@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/path@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.33.0?package-id=cb71f9386c7676b0",
+      "version": "v0.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "iptables-libs",
+      "purl": "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=aarch64",
+      "version": "1.8.10-5.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and Artistic 2.0 and ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6eebdb82213f2bb74f3104414ce85d304151f2c7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/iptables#6eebdb82213f2bb74f3104414ce85d304151f2c7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3227256",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/iptables#6eebdb82213f2bb74f3104414ce85d304151f2c7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "math",
+      "purl": "pkg:golang/math@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "coreutils-single",
+      "purl": "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=aarch64",
+      "version": "8.32-35.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a5b35b64130afa26d91d771af474f947cc02a099",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#a5b35b64130afa26d91d771af474f947cc02a099"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2875684",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#a5b35b64130afa26d91d771af474f947cc02a099",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/cpu",
+      "purl": "pkg:golang/internal/cpu@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/cpu@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "fmt",
+      "purl": "pkg:golang/fmt@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/fmt@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "xz-libs",
+      "purl": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=aarch64",
+      "version": "5.2.5-8.el9_0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+            "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2032531",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog",
+      "purl": "pkg:golang/k8s.io/klog@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog@v0.4.0",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/cheggaaa/pb.v1",
+      "purl": "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+      "version": "v1.0.28",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=723cf855d020f756",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "krb5-libs",
+      "purl": "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=aarch64",
+      "version": "1.21.1-2.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fb34142b8ed95c27cf052bbe556c0df07e04db51",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#fb34142b8ed95c27cf052bbe556c0df07e04db51"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3731292",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#fb34142b8ed95c27cf052bbe556c0df07e04db51",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "go/doc",
+      "purl": "pkg:golang/go/doc@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/doc@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "dbus-broker",
+      "purl": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=aarch64",
+      "version": "28-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "df7a36f938130717b6c201d8bf2ca8edf68719f6",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus-broker#df7a36f938130717b6c201d8bf2ca8edf68719f6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2130514",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus-broker#df7a36f938130717b6c201d8bf2ca8edf68719f6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "embed",
+      "purl": "pkg:golang/embed@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/embed@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/lazyregexp",
+      "purl": "pkg:golang/internal/lazyregexp@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/lazyregexp@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=3d1a8018c3d8d52a",
+      "version": "v1.1.1-0.20210330154013-f5de75959ad5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "openssl-fips-provider",
+      "purl": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=aarch64",
+      "version": "3.0.7-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "74dea6ff6f98ab99d3a2b6aba58cd38346734b79",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#74dea6ff6f98ab99d3a2b6aba58cd38346734b79"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2922752",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#74dea6ff6f98ab99d3a2b6aba58cd38346734b79",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/library-go",
+      "purl": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "version": "v0.0.0-20211220195323-eca2c467c492",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "path/filepath",
+      "purl": "pkg:golang/path/filepath@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/path/filepath@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cobra",
+      "purl": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.7.0?package-id=ddac4fa55f03e408",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/singleflight",
+      "purl": "pkg:golang/internal/singleflight@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/singleflight@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=7209f81d42d9fb42",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=c63cc068a81d5b95",
+      "version": "v0.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "log/slog",
+      "purl": "pkg:golang/log/slog@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/slog@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "debug/dwarf",
+      "purl": "pkg:golang/debug/dwarf@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/debug/dwarf@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/api",
+      "purl": "pkg:golang/kubevirt.io/api",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/api?package-id=8271ccebef8c7fbf",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libcom_err",
+      "purl": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=aarch64",
+      "version": "1.46.5-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "55211469981d94577ec3da753afcdf2cc4d651ab",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#55211469981d94577ec3da753afcdf2cc4d651ab"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820207",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#55211469981d94577ec3da753afcdf2cc4d651ab",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/component-base",
+      "purl": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "purl": "pkg:golang/image@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "hash/crc32",
+      "purl": "pkg:golang/hash/crc32@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash/crc32@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libmnl",
+      "purl": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=aarch64",
+      "version": "1.0.4-16.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e4e253af7af3650798d04664f7b96965ed5365ad",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libmnl#e4e253af7af3650798d04664f7b96965ed5365ad"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3049134",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libmnl#e4e253af7af3650798d04664f7b96965ed5365ad",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/kubevirt",
+      "purl": "pkg:golang/kubevirt.io/kubevirt",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/kubevirt?package-id=30e262c5e31c0ee0",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "decorator",
+      "purl": "pkg:pypi/decorator@4.4.2",
+      "type": "library",
+      "author": "Michele Simionato <michele.simionato@gmail.com>",
+      "bom-ref": "pkg:pypi/decorator@4.4.2",
+      "version": "4.4.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "new BSD License"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/decorator-4.4.2-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "libxcrypt",
+      "purl": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=aarch64",
+      "version": "4.4.18-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and BSD and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5ae2c88752320b1d81d70ae38259ce56b1c692de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690260",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "os/exec",
+      "purl": "pkg:golang/os/exec@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os/exec@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/glog",
+      "purl": "pkg:golang/github.com/golang/glog@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/glog@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=44dea5fe0373ffc7",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libcap",
+      "purl": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=aarch64",
+      "version": "2.48-9.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "579dc340bc85f77708d4c04f72f9cc7c2ad16e27",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap#579dc340bc85f77708d4c04f72f9cc7c2ad16e27"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2590508",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap#579dc340bc85f77708d4c04f72f9cc7c2ad16e27",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcc",
+      "purl": "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=aarch64",
+      "version": "11.4.1-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498982",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/grpc",
+      "purl": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "version": "v1.58.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cli-runtime",
+      "purl": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiserver",
+      "purl": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/grafana/regexp",
+      "purl": "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "version": "v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/sha512",
+      "purl": "pkg:golang/crypto/sha512@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/sha512@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/node-api",
+      "purl": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/node-api@v0.30.0?package-id=69b6b0afb2bc8383",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libassuan",
+      "purl": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=aarch64",
+      "version": "2.5.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5b185f851a42718727fee9efcf42ba525a59a8bb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689887",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/blang/semver",
+      "purl": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+      "version": "v3.5.1+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "hash/fnv",
+      "purl": "pkg:golang/hash/fnv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash/fnv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "go/scanner",
+      "purl": "pkg:golang/go/scanner@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/scanner@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "file-libs",
+      "purl": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=aarch64",
+      "version": "5.39-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2800051",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=5af92f389a804379",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/testlog",
+      "purl": "pkg:golang/internal/testlog@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/testlog@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubelet",
+      "purl": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "text/template",
+      "purl": "pkg:golang/text/template@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/text/template@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "compress/gzip",
+      "purl": "pkg:golang/compress/gzip@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/compress/gzip@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=64a952cc8f95048c",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "purl": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=aarch64",
+      "version": "2.34-100.el9_4.12",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676435",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog",
+      "purl": "pkg:golang/k8s.io/klog@v0.3.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog@v0.3.3",
+      "version": "v0.3.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libseccomp",
+      "purl": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=aarch64",
+      "version": "2.5.2-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "81d3550e24896c1929fda36335626a6807df3922",
+            "url": "git://pkgs.devel.redhat.com/rpms/libseccomp#81d3550e24896c1929fda36335626a6807df3922"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1788033",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libseccomp#81d3550e24896c1929fda36335626a6807df3922",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=211a5c0c1a7524b9",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=42ecb449d13ca189",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libacl",
+      "purl": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=aarch64",
+      "version": "2.3.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2709815",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/library-go",
+      "purl": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492?package-id=fb57a5f09377d6b1",
+      "version": "v0.0.0-20211220195323-eca2c467c492",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libunistring",
+      "purl": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=aarch64",
+      "version": "0.9.10-15.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690195",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua-libs",
+      "purl": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=aarch64",
+      "version": "5.4.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d795270f6d1372b9636433ed1fb08b2439eed16",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467503",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnfnetlink",
+      "purl": "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=aarch64",
+      "version": "1.0.1-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9ba3ebe2fec01b51fb3dbee7005578f6c9257add",
+            "url": "git://pkgs.devel.redhat.com/rpms/libnfnetlink#9ba3ebe2fec01b51fb3dbee7005578f6c9257add"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690058",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libnfnetlink#9ba3ebe2fec01b51fb3dbee7005578f6c9257add",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tpm2-tss",
+      "purl": "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=aarch64",
+      "version": "3.2.2-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fda97b14b55a52fff507835adba9e6a9bf396f65",
+            "url": "git://pkgs.devel.redhat.com/rpms/tpm2-tss#fda97b14b55a52fff507835adba9e6a9bf396f65"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2577728",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/tpm2-tss#fda97b14b55a52fff507835adba9e6a9bf396f65",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=c251c2070b6d837f",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mxk/go-flowrate",
+      "purl": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "version": "v0.0.0-20140419014527-cca7078d478f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "dnf",
+      "purl": "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=a3f45ccc2eaef8aa",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libffi",
+      "purl": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=aarch64",
+      "version": "3.4.2-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6f484e5230669fffb71870ce41c386e01ab4e47d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467679",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-controller",
+      "purl": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/binary",
+      "purl": "pkg:golang/encoding/binary@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/binary@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/ecdsa",
+      "purl": "pkg:golang/crypto/ecdsa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/ecdsa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubectl",
+      "purl": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=75bca8ba1ca22c9b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubernetes-csi/external-snapshotter/client/v4",
+      "purl": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=45a8c7aac0e298e2#client/v4",
+      "version": "v4.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/poll",
+      "purl": "pkg:golang/internal/poll@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/poll@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.15",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.15",
+      "version": "v0.3.15",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=b5d6576591ff84ae",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=1a97d0dde17253ca",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e519b37240b7b6af",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glibc",
+      "purl": "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=aarch64",
+      "version": "2.34-100.el9_4.12",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676435",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "io/fs",
+      "purl": "pkg:golang/io/fs@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/io/fs@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.23.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.23.0",
+      "version": "v0.23.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=0c548e794e085974",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-urllib3",
+      "purl": "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+      "version": "1.26.5-5.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b5a869c4fb0e5683a40c5007515de8ed8e9a182f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-urllib3#b5a869c4fb0e5683a40c5007515de8ed8e9a182f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3236012",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-urllib3#b5a869c4fb0e5683a40c5007515de8ed8e9a182f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/log",
+      "purl": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "filesystem",
+      "purl": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=aarch64",
+      "version": "3.16-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c7ae0c7b52a9e8a78431e06733a8f808418df283",
+            "url": "git://pkgs.devel.redhat.com/rpms/filesystem#c7ae0c7b52a9e8a78431e06733a8f808418df283"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689243",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/filesystem#c7ae0c7b52a9e8a78431e06733a8f808418df283",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog",
+      "purl": "pkg:golang/k8s.io/klog@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog@v0.4.0?package-id=a6cf3f8305ce0756",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=f72df465d2f4ba73",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/client-go",
+      "purl": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "version": "v0.0.0-20210112165513-ebc401615f47",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=92cbc10610ba936e",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=4f70a6c87f97190b",
+      "version": "v1.0.3-0.20210326190908-1c3f411f0417",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libpwquality",
+      "purl": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=aarch64",
+      "version": "1.4.4-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d78e5ea6e840372c17fabdd2cc371c7105a69b4e",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpwquality#d78e5ea6e840372c17fabdd2cc371c7105a69b4e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690098",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpwquality#d78e5ea6e840372c17fabdd2cc371c7105a69b4e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=aarch64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre2-syntax",
+      "purl": "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+      "version": "10.40-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "29947c528818ead0dfcd77753bd76a46d617d18a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2914968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/safefilepath",
+      "purl": "pkg:golang/internal/safefilepath@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/safefilepath@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=dc0ee049f53c27e7",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/md5",
+      "purl": "pkg:golang/crypto/md5@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/md5@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libelf",
+      "purl": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=aarch64",
+      "version": "0.190-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03f1598bbe94308cc7655234a5dcf75092cd1968",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2817160",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "procps-ng",
+      "purl": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=aarch64",
+      "version": "3.3.17-14.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "277f9aaff8edd7603ea88dfe5e42cbb2d229a76f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/procps-ng#277f9aaff8edd7603ea88dfe5e42cbb2d229a76f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2865070",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/procps-ng#277f9aaff8edd7603ea88dfe5e42cbb2d229a76f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log/slog/internal/buffer",
+      "purl": "pkg:golang/log/slog/internal/buffer@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/slog/internal/buffer@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "version": "v5.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-pysocks",
+      "purl": "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+      "version": "1.7.1-12.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc8ec2cb464cfd2ed3729ebd577824893559ecbd",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-pysocks#dc8ec2cb464cfd2ed3729ebd577824893559ecbd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1891067",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-pysocks#dc8ec2cb464cfd2ed3729ebd577824893559ecbd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/wadey/gocovmerge",
+      "purl": "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+      "version": "v0.0.0-20160331181800-b5bfa59ec0ad",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=6bfd33acc02b178b",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/go-vnc",
+      "purl": "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+      "version": "v0.0.0-20150629162542-723ed9867aed",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libzstd",
+      "purl": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=aarch64",
+      "version": "1.5.1-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dcda9fe564e51b7222a5efca3b14840bcc341b44",
+            "url": "git://pkgs.devel.redhat.com/rpms/zstd#dcda9fe564e51b7222a5efca3b14840bcc341b44"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1879398",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zstd#dcda9fe564e51b7222a5efca3b14840bcc341b44",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-cli-plugin",
+      "purl": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libsigsegv",
+      "purl": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=aarch64",
+      "version": "2.13-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b3dee05a0458f11a68b0f9a878aa676670814326",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690130",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sync",
+      "purl": "pkg:golang/sync@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/sync@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "zlib",
+      "purl": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=aarch64",
+      "version": "1.2.11-40.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Boost"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+            "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2495976",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-librepo",
+      "purl": "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=aarch64",
+      "version": "1.14.5-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "458f8b732e9d31cbe09323c87f796924ac30461c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797210",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=c91ff645d6ce8388",
+      "version": "v0.0.0-20210104183010-2eb08e3e575f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "libuuid",
+      "purl": "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tar",
+      "purl": "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=aarch64&epoch=2",
+      "version": "2:1.34-6.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a171e3d125646d2a953c247715ef2788c1829c1c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tar#a171e3d125646d2a953c247715ef2788c1829c1c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3229110",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tar#a171e3d125646d2a953c247715ef2788c1829c1c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libarchive",
+      "purl": "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=aarch64",
+      "version": "3.5.3-4.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "64e0b899f452b7e78dde9b8df8e5ecd358f1c837",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#64e0b899f452b7e78dde9b8df8e5ecd358f1c837"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3807112",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#64e0b899f452b7e78dde9b8df8e5ecd358f1c837",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/beorn7/perks",
+      "purl": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "version": "v1.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=7b9209a64c9c952b",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=2e766a71ac55c8c1",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/hkdf",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "net/http/httputil",
+      "purl": "pkg:golang/net/http/httputil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/httputil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=264ee8e18d5b5c8a",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+      "version": "v0.0.0-20230501164219-8b0f38b5fd1f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/googleapis/gnostic",
+      "purl": "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+      "version": "v0.2.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-stack/stack",
+      "purl": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "version": "v1.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "ncurses-libs",
+      "purl": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=aarch64",
+      "version": "6.2-10.20210508.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "539ab619cec841979d6b46943d3f82c15b7a8467",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3759616",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#539ab619cec841979d6b46943d3f82c15b7a8467",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "curl-minimal",
+      "purl": "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+      "version": "7.76.1-29.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80195397e7d61d156d731499be9884797b75dbb1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471237",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#80195397e7d61d156d731499be9884797b75dbb1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/goexperiment",
+      "purl": "pkg:golang/internal/goexperiment@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goexperiment@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=647cefa32ef8dbed",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/sysinfo",
+      "purl": "pkg:golang/internal/sysinfo@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/sysinfo@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/cryptobyte",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.1.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.5",
+      "version": "v1.1.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libstdc++",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=aarch64",
+      "version": "11.4.1-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498982",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#7bbeaa1e20c503a3f30458b94c018c46cc64fac5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dnf",
+      "purl": "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-cloud-what",
+      "purl": "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=aarch64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cli-runtime",
+      "purl": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0?package-id=372a4fd9b7953904",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=bcb125b3ee0ac2bf",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "popt",
+      "purl": "pkg:rpm/redhat/popt@1.18-8.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=aarch64",
+      "version": "1.18-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+            "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691597",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3",
+      "purl": "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=aarch64",
+      "version": "3.9.18-3.el9_4.9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2e1b452fcf120e44a7613701e28dd40a7931fc59",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3828922",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "yajl",
+      "purl": "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=aarch64",
+      "version": "2.1.0-22.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3b4891fe107c68e6e41550e4be2a5c9ad4f870a6",
+            "url": "git://pkgs.devel.redhat.com/rpms/yajl#3b4891fe107c68e6e41550e4be2a5c9ad4f870a6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2592251",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/yajl#3b4891fe107c68e6e41550e4be2a5c9ad4f870a6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-gssapi",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=aarch64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libvirt.org/go/libvirtxml",
+      "purl": "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+      "version": "v1.10000.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/procfs",
+      "purl": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0?package-id=53509fccb635cdaf",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libverto",
+      "purl": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=aarch64",
+      "version": "0.3.2-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690209",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "text/template/parse",
+      "purl": "pkg:golang/text/template/parse@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/text/template/parse@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/crypto",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+      "version": "v0.0.0-20220321153916-2c7772ba3064",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.14.0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cloud-provider",
+      "purl": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0?package-id=213905a8e9bf9bca",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/version",
+      "purl": "pkg:golang/go/version@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/version@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=fd55bfb7c4801b59",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/boring/sig",
+      "purl": "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-runewidth",
+      "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+      "version": "v0.0.13",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sync",
+      "purl": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.11.0?package-id=d30348b75bd8dbbe",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubelet",
+      "purl": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubelet@v0.30.0?package-id=0d174a34ad4bac4b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+      "purl": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=b4f2daad5b1d001e#pkg/apis/monitoring",
+      "version": "v0.68.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/types",
+      "purl": "pkg:golang/go/types@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/types@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "audit-libs",
+      "purl": "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=aarch64",
+      "version": "3.1.2-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3d2d297e67e32b5ce4c2914cc64169fd0be4ace0",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#3d2d297e67e32b5ce4c2914cc64169fd0be4ace0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2769499",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#3d2d297e67e32b5ce4c2914cc64169fd0be4ace0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/goterm",
+      "purl": "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+      "version": "v0.0.0-20190311235235-ce302be1d114",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "hash/adler32",
+      "purl": "pkg:golang/hash/adler32@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash/adler32@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=777844465b60ad81",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_model",
+      "purl": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/cni",
+      "purl": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "rpm-build-libs",
+      "purl": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=aarch64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/syscall",
+      "purl": "pkg:golang/runtime/internal/syscall@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/syscall@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gregjones/httpcache",
+      "purl": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+      "version": "v0.0.0-20190611155906-901d90724c79",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/log",
+      "purl": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=7349fb61f86b922a",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=4b04ea23556ed395",
+      "version": "v0.3.16",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_model",
+      "purl": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0?package-id=ecb7f6c81f243c3b",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "regexp",
+      "purl": "pkg:golang/regexp@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/regexp@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "maps",
+      "purl": "pkg:golang/maps@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/maps@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "net",
+      "purl": "pkg:golang/net@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=e0646f8826c197e7",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "encoding/csv",
+      "purl": "pkg:golang/encoding/csv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/csv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=9cb7e0ef1a4f0772",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "gnupg2",
+      "purl": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=aarch64",
+      "version": "2.3.3-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2481337",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libdnf",
+      "purl": "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+      "version": "0.69.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e5984c195dca639c24fa8a25263d2faf9419e97d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134146",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "os/signal",
+      "purl": "pkg:golang/os/signal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os/signal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "net/mail",
+      "purl": "pkg:golang/net/mail@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/mail@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "internal/goroot",
+      "purl": "pkg:golang/internal/goroot@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goroot@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/analysis",
+      "purl": "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/transform",
+      "purl": "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/internal/alias",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=e0fc581ee7f4ac53",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/inconshreveable/mousetrap",
+      "purl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "strings",
+      "purl": "pkg:golang/strings@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/strings@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "go/build/constraint",
+      "purl": "pkg:golang/go/build/constraint@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/build/constraint@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-libs",
+      "purl": "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=aarch64",
+      "version": "3.9.18-3.el9_4.9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2e1b452fcf120e44a7613701e28dd40a7931fc59",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3828922",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2e1b452fcf120e44a7613701e28dd40a7931fc59",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "os/user",
+      "purl": "pkg:golang/os/user@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/os/user@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/golang-crypto",
+      "purl": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "version": "v0.33.1-0.20250310193910-9003f682e581",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/dsa",
+      "purl": "pkg:golang/crypto/dsa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/dsa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-subscription-manager-rhsm",
+      "purl": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=aarch64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=b1e90c3e1ac1f792",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/http/httptrace",
+      "purl": "pkg:golang/net/http/httptrace@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/httptrace@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/client-go",
+      "purl": "pkg:golang/kubevirt.io/client-go@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/client-go@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=d49025084db5e534",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "log/slog/internal",
+      "purl": "pkg:golang/log/slog/internal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/slog/internal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/spec",
+      "purl": "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+      "version": "v0.20.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/kit",
+      "purl": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=30a0f7618c550bd4",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/http/httpproxy",
+      "purl": "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/insomniacslk/dhcp",
+      "purl": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a?package-id=f5ed66e6e2ff252b",
+      "version": "v0.0.0-20230908212754-65c27093e38a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "version": "v0.0.0-20191219222812-2987a591a72c",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "pysocks",
+      "purl": "pkg:pypi/pysocks@1.7.1",
+      "type": "library",
+      "author": "Anorov <anorov.vorona@gmail.com>",
+      "bom-ref": "pkg:pypi/pysocks@1.7.1",
+      "version": "1.7.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/PySocks-1.7.1-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "rootfiles",
+      "purl": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "version": "8.1-31.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30d4e6354acbcb23c1f2485151e08cc352871e75",
+            "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#30d4e6354acbcb23c1f2485151e08cc352871e75"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691770",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#30d4e6354acbcb23c1f2485151e08cc352871e75",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/x509",
+      "purl": "pkg:golang/crypto/x509@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/x509@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/matttproud/golang_protobuf_extensions",
+      "purl": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4?package-id=3ef7d310780b1738",
+      "version": "v1.0.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "go/printer",
+      "purl": "pkg:golang/go/printer@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/printer@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=d8c2f26e9986efc0",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=875c60b36880d488",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/constant",
+      "purl": "pkg:golang/go/constant@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/constant@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=56fa540c52a6e225",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-apiserver",
+      "purl": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/beorn7/perks",
+      "purl": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/beorn7/perks@v1.0.1?package-id=d6fd5b144cc18be1",
+      "version": "v1.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+      "version": "v0.0.0-20190221213512-86fb29eff628",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "systemd-libs",
+      "purl": "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=aarch64",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/boring",
+      "purl": "pkg:golang/crypto/internal/boring@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/boring@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "./staging/src/kubevirt.io/api",
+      "purl": "pkg:golang/./staging/src#kubevirt.io/api",
+      "type": "library",
+      "bom-ref": "pkg:golang/./staging/src#kubevirt.io/api",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/api",
+      "purl": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c?package-id=6c31ceb0e3238027",
+      "version": "v0.0.0-20191219222812-2987a591a72c",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=c27f4e3f0f288cba",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@1.26.5",
+      "type": "library",
+      "author": "Andrey Petrov <andrey.petrov@shazow.net>",
+      "bom-ref": "pkg:pypi/urllib3@1.26.5",
+      "version": "1.26.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/urllib3-1.26.5-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "tzdata",
+      "purl": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "version": "2025b-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff671e79a03e80cf1c432e92fa02aff95d597a97",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3572007",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/itoa",
+      "purl": "pkg:golang/internal/itoa@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/itoa@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libtirpc",
+      "purl": "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=aarch64",
+      "version": "1.3.3-8.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "SISSL and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bef7b741bc0541226473d5dae03ff0ab1df11b88",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#bef7b741bc0541226473d5dae03ff0ab1df11b88"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2966395",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#bef7b741bc0541226473d5dae03ff0ab1df11b88",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/zstd",
+      "purl": "pkg:golang/internal/zstd@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/zstd@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "net/http/httptest",
+      "purl": "pkg:golang/net/http/httptest@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/httptest@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-requests",
+      "purl": "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+      "version": "2.25.1-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a4dc4a098af1480c6eded62b59f1e385c7b01058",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-requests#a4dc4a098af1480c6eded62b59f1e385c7b01058"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870541",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-requests#a4dc4a098af1480c6eded62b59f1e385c7b01058",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-idna",
+      "purl": "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+      "version": "2.10-7.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and Python and Unicode"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "112df0c7ea79f88a152381810b589b5bfa07e68b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-idna#112df0c7ea79f88a152381810b589b5bfa07e68b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3024021",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-idna#112df0c7ea79f88a152381810b589b5bfa07e68b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-toolsmith/astcopy",
+      "purl": "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "systemd",
+      "purl": "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=aarch64",
+      "version": "252-32.el9_4.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3858218",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#09033a0f48e9f8b4616097a9f37fd90eaf6bdd45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=426c1ef83fb90a34",
+      "version": "v1.1.1-0.20210330154013-f5de75959ad5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto",
+      "purl": "pkg:golang/crypto@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/evanphx/json-patch",
+      "purl": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "version": "v5.6.0+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/groupcache",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "encoding/base64",
+      "purl": "pkg:golang/encoding/base64@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/base64@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/csi-translation-lib",
+      "purl": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=4947e27687df8894",
+      "version": "v1.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/go-ps",
+      "purl": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "version": "v0.0.0-20190716172923-621e5597135b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=b5787214009aa9c8",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "crypto/des",
+      "purl": "pkg:golang/crypto/des@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/des@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=cdc588c277efc41e",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=ea627eb359d3ebbf",
+      "version": "v0.0.0-20240423183400-0849a56e8f22",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+      "purl": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+      "version": "v0.0.0-20191119172530-79f836b90111",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=61ff33db308e1c87",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-querystring",
+      "purl": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "version": "v22.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=6b3967bbe5e4f770#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "iproute",
+      "purl": "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=aarch64",
+      "version": "6.2.0-6.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-or-later AND NIST-PD"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "50f71af59d28c401b90bb35a222dc94b3eb7cfae",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/iproute#50f71af59d28c401b90bb35a222dc94b3eb7cfae"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2950524",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/iproute#50f71af59d28c401b90bb35a222dc94b3eb7cfae",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/http/httpguts",
+      "purl": "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/krolaw/dhcp4",
+      "purl": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414?package-id=1f03719fd30cb426",
+      "version": "v0.0.0-20180925202202-7cead472c414",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-setuptools",
+      "purl": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+      "version": "53.0.0-12.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and (BSD or ASL 2.0)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e118582dafc46c5b61049eb79598ec15e88c3b7d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3754759",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#e118582dafc46c5b61049eb79598ec15e88c3b7d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm-sign-libs",
+      "purl": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=aarch64",
+      "version": "4.16.1.3-29.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#8126eec7e031d6a082553fa4fd2dd1deab63a24e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libvirt.org/go/libvirt",
+      "purl": "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+      "version": "v1.10000.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+      "purl": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0?package-id=85656f3ce4c495dd",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=392c78985b3ee866",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "requests",
+      "purl": "pkg:pypi/requests@2.25.1",
+      "type": "library",
+      "author": "Kenneth Reitz <me@kennethreitz.org>",
+      "bom-ref": "pkg:pypi/requests@2.25.1",
+      "version": "2.25.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache 2.0"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/requests-2.25.1.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.14.0?package-id=a47e6c64839baca0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "glibc-common",
+      "purl": "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=aarch64",
+      "version": "2.34-100.el9_4.12",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676435",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#140b8f14c72dac807ac9a6bc062dc383b847ec0a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "yum",
+      "purl": "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=de8b89d7a225278d",
+      "version": "v0.3.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager",
+      "purl": "pkg:pypi/subscription-manager@1.29.40.1",
+      "type": "library",
+      "author": "Adrian Likins <alikins@redhat.com>",
+      "bom-ref": "pkg:pypi/subscription-manager@1.29.40.1",
+      "version": "1.29.40.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/subscription_manager-1.29.40.1-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-scheduler",
+      "purl": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0?package-id=c6f4b38d0e64a871",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libcomps",
+      "purl": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=aarch64",
+      "version": "0.1.18-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1771556",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-libs",
+      "purl": "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+      "version": "1:3.0.7-29.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3880294",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=617dda993ef91b06",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/sha1",
+      "purl": "pkg:golang/crypto/sha1@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/sha1@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/tls",
+      "purl": "pkg:golang/crypto/tls@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/tls@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-apiserver",
+      "purl": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0?package-id=a7d282fdf5bcfc3a",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "mime",
+      "purl": "pkg:golang/mime@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/mime@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-font-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "net/http",
+      "purl": "pkg:golang/net/http@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/c9s/goprocinfo",
+      "purl": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8?package-id=5324f65a18aa4075",
+      "version": "v0.0.0-20210130143923-c95fcf8c64a8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=7fd9e721114377fd",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=e91ba32bfe0dcfe9",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/client-go",
+      "purl": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=82dbb4bd95c1a6af",
+      "version": "v0.0.0-20210112165513-ebc401615f47",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "log",
+      "purl": "pkg:golang/log@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "util-linux-core",
+      "purl": "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dnf-plugins-core",
+      "purl": "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+      "version": "4.3.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4f5d16cec79f81e1d37edd64ee4cdc2e8289d48b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf-plugins-core#4f5d16cec79f81e1d37edd64ee4cdc2e8289d48b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2850557",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf-plugins-core#4f5d16cec79f81e1d37edd64ee4cdc2e8289d48b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fonts-filesystem",
+      "purl": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "version": "1:2.0.5-7.el9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ac288ee82aa9655c3784dd2f59cedb3562638129",
+            "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1732053",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/unicode/norm",
+      "purl": "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libreport-filesystem",
+      "purl": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "version": "2.15.2-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4690267165817ccc06cb342d8ef955ae10b54c75",
+            "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1852394",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/metrics",
+      "purl": "pkg:golang/runtime/metrics@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/metrics@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/chacha20poly1305",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=bd15d762c1c6c3a1",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=5b48db5542316992",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gdbm-libs",
+      "purl": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=aarch64&epoch=1",
+      "version": "1:1.19-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6bade26c052b6560b132f163484ee009c04e3cce",
+            "url": "git://pkgs.devel.redhat.com/rpms/gdbm#6bade26c052b6560b132f163484ee009c04e3cce"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689293",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gdbm#6bade26c052b6560b132f163484ee009c04e3cce",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-inotify",
+      "purl": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+      "version": "0.9.6-25.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bf5a869472d075a22ea709682b68d1343609c9af",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-inotify#bf5a869472d075a22ea709682b68d1343609c9af"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691386",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-inotify#bf5a869472d075a22ea709682b68d1343609c9af",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.22.12?package-id=0263aa6b4909132a",
+      "version": "go1.22.12",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "unicode/utf16",
+      "purl": "pkg:golang/unicode/utf16@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unicode/utf16@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=e5f84b4525280ceb",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=a40b75a240613ee9#v5",
+      "version": "v5.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "version": "v0.0.0-20240430033511-f0e62f92d13f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=ef4b943e758b9b6b",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cluster-bootstrap",
+      "purl": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "dnf-data",
+      "purl": "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+      "version": "4.14.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b018b10b74283f913cb231eeb0b89763906a9ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2752321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#8b018b10b74283f913cb231eeb0b89763906a9ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=1651c6ba29f925e5",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=3cfe059b9c8f0896",
+      "version": "v0.3.16",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "setup",
+      "purl": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "version": "2.13.7-10.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2892761",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubevirt/monitoring/pkg/metrics/parser",
+      "purl": "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+      "version": "v0.0.0-20230627123556-81a891d4462a",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "nftables",
+      "purl": "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=aarch64&epoch=1",
+      "version": "1:1.0.9-1.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6bd061508fbd17f371f610037fe4b4b89d8cd95e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nftables#6bd061508fbd17f371f610037fe4b4b89d8cd95e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3693063",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nftables#6bd061508fbd17f371f610037fe4b4b89d8cd95e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdb-gdbserver",
+      "purl": "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=aarch64",
+      "version": "10.2-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ and GPLv2+ with exceptions and GPL+ and LGPLv2+ and LGPLv3+ and BSD and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0cda5771bf25da9b298b20bf195cfb9b05928603",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdb#0cda5771bf25da9b298b20bf195cfb9b05928603"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2822968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdb#0cda5771bf25da9b298b20bf195cfb9b05928603",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/nistec/fiat",
+      "purl": "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "shadow-utils",
+      "purl": "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=aarch64&epoch=2",
+      "version": "2:4.9-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "183ec47a68eb739420b44e0d9db15ffb5c4e5753",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#183ec47a68eb739420b44e0d9db15ffb5c4e5753"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3303839",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#183ec47a68eb739420b44e0d9db15ffb5c4e5753",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=3a7a3480e12ba94a",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gzip",
+      "purl": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=aarch64",
+      "version": "1.12-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "11df222a2dc5ce7dc943b1bce364d46ea97a535b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gzip#11df222a2dc5ce7dc943b1bce364d46ea97a535b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1982016",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gzip#11df222a2dc5ce7dc943b1bce364d46ea97a535b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cluster-bootstrap",
+      "purl": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0?package-id=7c0f2e47ca097803",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/intern",
+      "purl": "pkg:golang/internal/intern@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/intern@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "errors",
+      "purl": "pkg:golang/errors@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/errors@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-aggregator",
+      "purl": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4ca57bd69d22480b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=79287922c4530134",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=6d74791bcbcea4ec",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "pcre2",
+      "purl": "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=aarch64",
+      "version": "10.40-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "29947c528818ead0dfcd77753bd76a46d617d18a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2914968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#29947c528818ead0dfcd77753bd76a46d617d18a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-gobject-base-noarch",
+      "purl": "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+      "version": "3.40.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79ff68bd91179f855796360827ad65f2a83577dc",
+            "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2049891",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#79ff68bd91179f855796360827ad65f2a83577dc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hash",
+      "purl": "pkg:golang/hash@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/hash@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/socket",
+      "purl": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=a8fb70acf7ce028c",
+      "version": "v0.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=58fd55d3a3e68d9a",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=812518b1d5de5b6b",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/fatih/color",
+      "purl": "pkg:golang/github.com/fatih/color@v1.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fatih/color@v1.13.0",
+      "version": "v1.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=44034bb305ad6df8#v5",
+      "version": "v5.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/csi-translation-lib",
+      "purl": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0?package-id=e493ecdd6cef073d",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "idna",
+      "purl": "pkg:pypi/idna@2.10",
+      "type": "library",
+      "author": "Kim Davies <kim@cynosure.com.au>",
+      "bom-ref": "pkg:pypi/idna@2.10",
+      "version": "2.10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-like"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/idna-2.10-py3.9.egg-info/PKG-INFO"
+        }
+      ]
+    },
+    {
+      "name": "image/internal/imageutil",
+      "purl": "pkg:golang/image/internal/imageutil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/internal/imageutil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-cli-plugin",
+      "purl": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0?package-id=b57f2d304a79c9d2",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gordonklaus/ineffassign",
+      "purl": "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+      "version": "v0.0.0-20210209182638-d0e41b2fc8ed",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/strfmt",
+      "purl": "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=0cf48c7c4e0c2225",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=5f3161d14fb9986b",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/rivo/uniseg",
+      "purl": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+      "version": "v0.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=9cd65210b34ae131",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "container/list",
+      "purl": "pkg:golang/container/list@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/container/list@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "version": "v1.33.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "container/ring",
+      "purl": "pkg:golang/container/ring@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/container/ring@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "unicode",
+      "purl": "pkg:golang/unicode@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unicode@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "runtime",
+      "purl": "pkg:golang/runtime@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-gpg",
+      "purl": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=aarch64",
+      "version": "1.15.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+            "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892040",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "systemd-python",
+      "purl": "pkg:pypi/systemd-python@234",
+      "type": "library",
+      "author": "systemd developers <systemd-devel@lists.freedesktop.org>",
+      "bom-ref": "pkg:pypi/systemd-python@234",
+      "version": "234",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/systemd_python-234-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "image/png",
+      "purl": "pkg:golang/image/png@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/png@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/btree",
+      "purl": "pkg:golang/github.com/google/btree@v1.1.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/btree@v1.1.3",
+      "version": "v1.1.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/text/unicode/bidi",
+      "purl": "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "virt-what",
+      "purl": "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=aarch64",
+      "version": "1.25-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc9eaee5d4f089206bd81208cc7e4448bdae8233",
+            "url": "git://pkgs.devel.redhat.com/rpms/virt-what#fc9eaee5d4f089206bd81208cc7e4448bdae8233"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2574109",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/virt-what#fc9eaee5d4f089206bd81208cc7e4448bdae8233",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/code-generator",
+      "purl": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/code-generator@v0.30.0?package-id=c9d95bf42170291b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=fa2fc500853b500e",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libsolv",
+      "purl": "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=aarch64",
+      "version": "0.7.24-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9ab325a2961e60cb85d36bcd381102753a990bff",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsolv#9ab325a2961e60cb85d36bcd381102753a990bff"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2563465",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsolv#9ab325a2961e60cb85d36bcd381102753a990bff",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cracklib-dicts",
+      "purl": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=aarch64",
+      "version": "2.9.6-27.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+            "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689047",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cracklib#2ca3203c1299197f88c3e06c5923195f0a8c8b90",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "elfutils-default-yama-scope",
+      "purl": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+      "version": "0.190-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03f1598bbe94308cc7655234a5dcf75092cd1968",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2817160",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "go/doc/comment",
+      "purl": "pkg:golang/go/doc/comment@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/doc/comment@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libdnf",
+      "purl": "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+      "version": "0.69.0-8.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e5984c195dca639c24fa8a25263d2faf9419e97d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134146",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#e5984c195dca639c24fa8a25263d2faf9419e97d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/math",
+      "purl": "pkg:golang/runtime/internal/math@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/math@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo/v2",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "version": "v2.17.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=38f081dbc5ce4d6a",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/go-ps",
+      "purl": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b?package-id=1264b58e962ebcac",
+      "version": "v0.0.0-20190716172923-621e5597135b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=317d26dbf41e923a",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=20f072e6e3225e24",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=b026cc4209959195",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libcap-ng",
+      "purl": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=aarch64",
+      "version": "0.8.2-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1888632",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=58a2f3ed700462d3",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "regexp/syntax",
+      "purl": "pkg:golang/regexp/syntax@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/regexp/syntax@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=a0115c013e649a4c",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/evanphx/json-patch",
+      "purl": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible?package-id=15ebdd24a0c721e7",
+      "version": "v5.6.0+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "passwd",
+      "purl": "pkg:rpm/redhat/passwd@0.80-12.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/passwd@0.80-12.el9?arch=aarch64",
+      "version": "0.80-12.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPL+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc8f2d3ecfe371757ee51d81b0b9e4b7e3a8cdc5",
+            "url": "git://pkgs.devel.redhat.com/rpms/passwd#dc8f2d3ecfe371757ee51d81b0b9e4b7e3a8cdc5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691236",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/passwd#dc8f2d3ecfe371757ee51d81b0b9e4b7e3a8cdc5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-decorator",
+      "purl": "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+      "version": "4.4.2-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc2368c1fe0e7914e6027cc70f05d59862dbf2ec",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-decorator#fc2368c1fe0e7914e6027cc70f05d59862dbf2ec"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691358",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-decorator#fc2368c1fe0e7914e6027cc70f05d59862dbf2ec",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sed",
+      "purl": "pkg:rpm/redhat/sed@4.8-9.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=aarch64",
+      "version": "4.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dad14ff8a62e967c0afb23d1d237a927d847e86e",
+            "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1692031",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl",
+      "purl": "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+      "version": "1:3.0.7-29.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3880294",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#4000c8f49c400db3c5b4e8ccdd9af6cc3d04da19",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/race",
+      "purl": "pkg:golang/internal/race@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/race@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_golang",
+      "purl": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0?package-id=802b60ddf07e5522",
+      "version": "v1.16.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "internal/goversion",
+      "purl": "pkg:golang/internal/goversion@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/goversion@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/idna",
+      "purl": "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/appengine",
+      "purl": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=d183acc87e1fa62e",
+      "version": "v1.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/btree",
+      "purl": "pkg:golang/github.com/google/btree@v1.1.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/btree@v1.1.3?package-id=2655799dd02f4564",
+      "version": "v1.1.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "python3-dbus",
+      "purl": "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=aarch64",
+      "version": "1.2.18-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f3a764ea144cc2b6b80a1ebd2925c96b2d81653b",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus-python#f3a764ea144cc2b6b80a1ebd2925c96b2d81653b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus-python#f3a764ea144cc2b6b80a1ebd2925c96b2d81653b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=87c0cbf8954e0580",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/rc4",
+      "purl": "pkg:golang/crypto/rc4@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/rc4@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cri-api",
+      "purl": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=aabc29983e2a9841",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-controller-manager",
+      "purl": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0?package-id=0814f25a8e4531ce",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-aggregator",
+      "purl": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4bf18231eac48ba4",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/base32",
+      "purl": "pkg:golang/encoding/base32@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/base32@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "text/tabwriter",
+      "purl": "pkg:golang/text/tabwriter@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/text/tabwriter@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/cri-api",
+      "purl": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/cri-api@v0.30.0?package-id=4de173f6a5765211",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/component-base",
+      "purl": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/component-base@v0.30.0?package-id=94800364440cc1a6",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "image/jpeg",
+      "purl": "pkg:golang/image/jpeg@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/image/jpeg@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libeconf",
+      "purl": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=aarch64",
+      "version": "0.4.1-3.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "aeb088c5c9095f978d2e8b5a06f3079b3b15c9a9",
+            "url": "git://pkgs.devel.redhat.com/rpms/libeconf#aeb088c5c9095f978d2e8b5a06f3079b3b15c9a9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2539463",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libeconf#aeb088c5c9095f978d2e8b5a06f3079b3b15c9a9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=a1ff2ebea07a529d",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/native",
+      "purl": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "internal/coverage/rtcov",
+      "purl": "pkg:golang/internal/coverage/rtcov@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/coverage/rtcov@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "usermode",
+      "purl": "pkg:rpm/redhat/usermode@1.114-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/usermode@1.114-4.el9?arch=aarch64",
+      "version": "1.114-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6fcf2ff19afca6b8a061136d7df6189faec5f15c",
+            "url": "git://pkgs.devel.redhat.com/rpms/usermode#6fcf2ff19afca6b8a061136d7df6189faec5f15c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1821463",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/usermode#6fcf2ff19afca6b8a061136d7df6189faec5f15c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gpg",
+      "purl": "pkg:pypi/gpg@1.15.1",
+      "type": "library",
+      "author": "The GnuPG hackers <gnupg-devel@gnupg.org>",
+      "bom-ref": "pkg:pypi/gpg@1.15.1",
+      "version": "1.15.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPL2.1+ (the library), GPL2+ (tests and examples)"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/gpg-1.15.1-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/groupcache",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=406cd2654be0fcc8",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "acl",
+      "purl": "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=aarch64",
+      "version": "2.3.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2709815",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=8899651b157fa55b",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies-scripts",
+      "purl": "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+      "version": "20240202-1.git283706d.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a950d9ca3218bf47d75befa4639b7990b00c99eb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2889114",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#a950d9ca3218bf47d75befa4639b7990b00c99eb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=34e50fc47ddb109c",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/net/dns/dnsmessage",
+      "purl": "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/metrics",
+      "purl": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/metrics@v0.30.0?package-id=e5a9c757e0ba76d0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=bd9cfde5eb7d49da",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/Masterminds/semver",
+      "purl": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=a6a4677db3654d87",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+      "purl": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=41c9ffe89c4328dd#pkg/apis/monitoring",
+      "version": "v0.68.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e87736d4223a3553",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/gover",
+      "purl": "pkg:golang/internal/gover@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/gover@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=077b67d110fda982",
+      "version": "v0.0.0-20240430033511-f0e62f92d13f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "mvdan.cc/editorconfig",
+      "purl": "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+      "type": "library",
+      "bom-ref": "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+      "version": "v0.2.1-0.20231228180347-1925077f8eb2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/client-go",
+      "purl": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=332ab3a9d173ca98",
+      "version": "v0.0.0-20210112165513-ebc401615f47",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libnghttp2",
+      "purl": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=aarch64",
+      "version": "1.43.0-5.el9_4.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3c2e4449d7e195f89fc8f2d9c566b05a2e315dae",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#3c2e4449d7e195f89fc8f2d9c566b05a2e315dae"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2996729",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#3c2e4449d7e195f89fc8f2d9c566b05a2e315dae",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=d3adc2bc60fefccb",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "ca-certificates",
+      "purl": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "version": "2025.2.80_v9.0.305-91.el9",
+      "licenses": [
+        {
+          "expression": "MIT AND GPL-2.0-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80abd67ad7d828eba9c44be633f42b67f21751b1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#80abd67ad7d828eba9c44be633f42b67f21751b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3864618",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#80abd67ad7d828eba9c44be633f42b67f21751b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=2f055f6cdf8e3fb1",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "npth",
+      "purl": "pkg:rpm/redhat/npth@1.6-8.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=aarch64",
+      "version": "1.6-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+            "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690792",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubectl",
+      "purl": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=747804ed972e87a1",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/pprof",
+      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6?package-id=0bc6f5896c6cb1a9",
+      "version": "v0.0.0-20240424215950-a892ee059fd6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=9de2c8dc0803d74e",
+      "version": "v0.0.0-20210104183010-2eb08e3e575f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=2e7c033a75be1ef6",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=8256c45ca06407ab",
+      "version": "v1.33.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/controller-runtime",
+      "purl": "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "jansson",
+      "purl": "pkg:rpm/redhat/jansson@2.14-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/jansson@2.14-1.el9?arch=aarch64",
+      "version": "2.14-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4580a680e5f19adde10c25adad0a31f1d3dc1078",
+            "url": "git://pkgs.devel.redhat.com/rpms/jansson#4580a680e5f19adde10c25adad0a31f1d3dc1078"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1798464",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/jansson#4580a680e5f19adde10c25adad0a31f1d3dc1078",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/websocket",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b135113b0301cc3e",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "math/big",
+      "purl": "pkg:golang/math/big@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/math/big@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/custom-resource-status",
+      "purl": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=5df1a932dc364fae",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/seccomp/libseccomp-golang",
+      "purl": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "version": "v0.10.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-proxy",
+      "purl": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=49b478fdfd04f997",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "findutils",
+      "purl": "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=aarch64&epoch=1",
+      "version": "1:4.8.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "52a86f6303fb86be2412eeeb8df53ec3ee4c4b60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#52a86f6303fb86be2412eeeb8df53ec3ee4c4b60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2641338",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#52a86f6303fb86be2412eeeb8df53ec3ee4c4b60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=2f1b091e7ebc59e5#mountinfo",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libgcrypt",
+      "purl": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=aarch64",
+      "version": "1.10.0-10.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "06551d4cc2458fcbe36fe78ec1a5cdbc5dbbf914",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#06551d4cc2458fcbe36fe78ec1a5cdbc5dbbf914"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3567943",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#06551d4cc2458fcbe36fe78ec1a5cdbc5dbbf914",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/syscall/execenv",
+      "purl": "pkg:golang/internal/syscall/execenv@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/syscall/execenv@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cespare/xxhash/v2",
+      "purl": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0?package-id=ff6ddf5ac62bb415#v2",
+      "version": "v2.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "purl": "pkg:golang/golang.org/x/tools@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.20.0",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-proxy",
+      "purl": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0?package-id=da08354393870645",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/atomic",
+      "purl": "pkg:golang/runtime/internal/atomic@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/atomic@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=14c598a63cb5e9db",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libyaml",
+      "purl": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=aarch64",
+      "version": "0.2.5-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70e1549fe5e56c95f1e23967e02c657d7af570ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690356",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=0f468cc3892f0124",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "json-c",
+      "purl": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=aarch64",
+      "version": "0.14-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "391500fb2a46f72180ba1353136c1b3327d71c55",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1728857",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto/subtle",
+      "purl": "pkg:golang/crypto/subtle@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/subtle@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "python3-libcomps",
+      "purl": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=aarch64",
+      "version": "0.1.18-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1771556",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcomps#fca592fd8b98384f1dec6b45cdbfde1cbdadf4de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/native",
+      "purl": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/native@v1.1.0?package-id=6604c5cd4c4748cf",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=14c57ecad0b43747",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=db67540c07b5beb9",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+      "version": "v2.6.1+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=db815b5d0b61f513",
+      "version": "v1.1.14",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-stack/stack",
+      "purl": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-stack/stack@v1.8.0?package-id=48631dee752774c6",
+      "version": "v1.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "internal/bisect",
+      "purl": "pkg:golang/internal/bisect@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/bisect@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/edwards25519",
+      "purl": "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=71cd8ab004151c77",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "go/internal/typeparams",
+      "purl": "pkg:golang/go/internal/typeparams@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/go/internal/typeparams@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "testing",
+      "purl": "pkg:golang/testing@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/testing@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-github/v32",
+      "purl": "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+      "version": "v32.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libattr",
+      "purl": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=aarch64",
+      "version": "2.5.1-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+            "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688838",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/validate",
+      "purl": "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "numactl-libs",
+      "purl": "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=aarch64",
+      "version": "2.0.16-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4ace9e459353675439dae46e01102853d6c8f37d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/numactl#4ace9e459353675439dae46e01102853d6c8f37d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2692430",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/numactl#4ace9e459353675439dae46e01102853d6c8f37d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "io/ioutil",
+      "purl": "pkg:golang/io/ioutil@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/io/ioutil@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/VividCortex/ewma",
+      "purl": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=077a5e8ca27fa924",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-systemd",
+      "purl": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=aarch64",
+      "version": "234-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bdb294f1932ff4b5a881daeea1375f1b93b7cf5b",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-systemd#bdb294f1932ff4b5a881daeea1375f1b93b7cf5b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691650",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-systemd#bdb294f1932ff4b5a881daeea1375f1b93b7cf5b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "html/template",
+      "purl": "pkg:golang/html/template@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/html/template@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/u-root/uio",
+      "purl": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923?package-id=a98cba5ae186c4f5",
+      "version": "v0.0.0-20230220225925-ffce2a382923",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=c774b777664a4bb0",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/common",
+      "purl": "pkg:golang/github.com/containers/common@v0.50.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/common@v0.50.1?package-id=e36d1d0f2ba91772",
+      "version": "v0.50.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libvirt-libs",
+      "purl": "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=aarch64",
+      "version": "10.0.0-6.19.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND OFL-1.1"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b48e93554655d865ca027aaceb12b91dc5dc6a5c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libvirt#b48e93554655d865ca027aaceb12b91dc5dc6a5c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3782117",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libvirt#b48e93554655d865ca027aaceb12b91dc5dc6a5c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dateutil",
+      "purl": "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+      "version": "1:2.8.1-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8f4fa349cd64e4143fc3b417b01a2ab1f433b40d",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-dateutil#8f4fa349cd64e4143fc3b417b01a2ab1f433b40d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2628796",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-dateutil#8f4fa349cd64e4143fc3b417b01a2ab1f433b40d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtime/debug",
+      "purl": "pkg:golang/runtime/debug@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/debug@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=c3d9773d12fa39a7",
+      "version": "v1.33.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "vendor/golang.org/x/crypto/internal/poly1305",
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-kit/log",
+      "purl": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=429112dfb9428aeb",
+      "version": "v0.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pierrec/lz4/v4",
+      "purl": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15?package-id=8f6dd5f7ba6a62ec#v4",
+      "version": "v4.1.15",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/controller-lifecycle-operator-sdk/api",
+      "purl": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=6619c43cfd07c933",
+      "version": "v0.0.0-20220329064328-f3cc58c6ed90",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libssh-config",
+      "purl": "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+      "version": "0.10.4-13.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35756743d06f7dc2fde2d65495ae0d4866011d1b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3866387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logfmt/logfmt",
+      "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/github.com/golang/glog/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "net/http/internal/testcert",
+      "purl": "pkg:golang/net/http/internal/testcert@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/http/internal/testcert@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pborman/uuid",
+      "purl": "pkg:golang/github.com/pborman/uuid@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pborman/uuid@v1.2.1",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/examples/listvms/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "python3-chardet",
+      "purl": "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+      "version": "4.0.0-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f8acd16e754d66fa555ae3facafdae9e6befdbb3",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-chardet#f8acd16e754d66fa555ae3facafdae9e6befdbb3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1894647",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-chardet#f8acd16e754d66fa555ae3facafdae9e6befdbb3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=5ce12f7eaebfe865",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=2510cbce9c179e69",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "purl": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "version": "v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "grep",
+      "purl": "pkg:rpm/redhat/grep@3.6-5.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=aarch64",
+      "version": "3.6-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7779e81140d7afaf33d2a97f4afdd682457f9697",
+            "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689607",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "encoding/json",
+      "purl": "pkg:golang/encoding/json@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/json@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libselinux",
+      "purl": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=aarch64",
+      "version": "3.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b604bc7c7288a43b90e0f88226ddff652b945e40",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#b604bc7c7288a43b90e0f88226ddff652b945e40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2821561",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#b604bc7c7288a43b90e0f88226ddff652b945e40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/errors",
+      "purl": "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+      "version": "v0.19.9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "expat",
+      "purl": "pkg:rpm/redhat/expat@2.5.0-2.el9_4.2?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/expat@2.5.0-2.el9_4.2?arch=aarch64",
+      "version": "2.5.0-2.el9_4.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "28121dc5b647cd04fc79c666986f5382e9f6b160",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#28121dc5b647cd04fc79c666986f5382e9f6b160"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3411400",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#28121dc5b647cd04fc79c666986f5382e9f6b160",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "internal/reflectlite",
+      "purl": "pkg:golang/internal/reflectlite@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/internal/reflectlite@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "crypto/internal/bigmod",
+      "purl": "pkg:golang/crypto/internal/bigmod@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/internal/bigmod@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/genproto/googleapis/rpc",
+      "purl": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "version": "v0.0.0-20230822172742-b8732ec3820d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/sample-controller",
+      "purl": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/sample-controller@v0.30.0?package-id=95847fe4258b57c0",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "crypto/rand",
+      "purl": "pkg:golang/crypto/rand@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/crypto/rand@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libevent",
+      "purl": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=aarch64",
+      "version": "2.1.12-8.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3235991",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/genproto/googleapis/rpc",
+      "purl": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d?package-id=454c35570125ce2f#rpc",
+      "version": "v0.0.0-20230822172742-b8732ec3820d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=f4fcb5b06080adbf",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo/v2",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2?package-id=709ca981edc6d5d6#v2",
+      "version": "v2.17.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/mod",
+      "purl": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "version": "v0.17.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl",
+      "purl": "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=aarch64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=fd7558abcd37e57d",
+      "version": "v0.0.0-20240430033511-f0e62f92d13f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=dd84eb4f391fe51e",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "unicode/utf8",
+      "purl": "pkg:golang/unicode/utf8@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/unicode/utf8@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "pcre",
+      "purl": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=aarch64",
+      "version": "8.44-3.el9.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1007ce35c0150110a7bcd4c1741380a726434e46",
+            "url": "git://pkgs.devel.redhat.com/rpms/pcre#1007ce35c0150110a7bcd4c1741380a726434e46"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691250",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pcre#1007ce35c0150110a7bcd4c1741380a726434e46",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/grpc",
+      "purl": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=1663864887e439eb",
+      "version": "v1.58.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=f1bc226b87c469d8",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "encoding/asn1",
+      "purl": "pkg:golang/encoding/asn1@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/asn1@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=5eee73adffd25455",
+      "version": "v1.9.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "gnutls",
+      "purl": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=aarch64",
+      "version": "3.8.3-4.el9_4.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b773160a90460399f962c17953398ff7f781803b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#b773160a90460399f962c17953398ff7f781803b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3821445",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#b773160a90460399f962c17953398ff7f781803b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sort",
+      "purl": "pkg:golang/sort@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/sort@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "keyutils-libs",
+      "purl": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=aarch64",
+      "version": "1.6.3-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+            "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2212253",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=f951095dca4572e3",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "archive/tar",
+      "purl": "pkg:golang/archive/tar@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/archive/tar@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=3bccae874729638f",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "kubevirt.io/containerized-data-importer-api",
+      "purl": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=892f25b58ba2cadb",
+      "version": "v1.58.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gobject-introspection",
+      "purl": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=aarch64",
+      "version": "1.68.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5fa3808a6c90b0da8da9a85fad983244c13640ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2248264",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=3cee09b2c9d8346a",
+      "version": "v0.20.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "libksba",
+      "purl": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=aarch64",
+      "version": "1.5.1-6.el9_1",
+      "licenses": [
+        {
+          "license": {
+            "name": "(LGPLv3+ or GPLv2+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7112a8f2afeccb3acd42cba9a99b4c2c8fe70306",
+            "url": "git://pkgs.devel.redhat.com/rpms/libksba#7112a8f2afeccb3acd42cba9a99b4c2c8fe70306"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2345715",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libksba#7112a8f2afeccb3acd42cba9a99b4c2c8fe70306",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=a8276711fb26ec2c#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libs",
+      "purl": "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=aarch64",
+      "version": "0.190-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03f1598bbe94308cc7655234a5dcf75092cd1968",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2817160",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#03f1598bbe94308cc7655234a5dcf75092cd1968",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/machadovilaca/operator-observability",
+      "purl": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20?package-id=ce832bdd3e643f49",
+      "version": "v0.0.20",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "six",
+      "purl": "pkg:pypi/six@1.15.0",
+      "type": "library",
+      "author": "Benjamin Peterson <benjamin@python.org>",
+      "bom-ref": "pkg:pypi/six@1.15.0",
+      "version": "1.15.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/six-1.15.0.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/runtime",
+      "purl": "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+      "version": "v0.19.24",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "log/internal",
+      "purl": "pkg:golang/log/internal@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/log/internal@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/asaskevich/govalidator",
+      "purl": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+      "version": "v0.0.0-20200907205600-7a23bdc65eef",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gpgme",
+      "purl": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=aarch64",
+      "version": "1.15.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+            "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892040",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openldap",
+      "purl": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=aarch64",
+      "version": "2.6.6-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "OLDAP-2.8"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "409b72030310df96b296a5dd8cf80f0a211cc038",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#409b72030310df96b296a5dd8cf80f0a211cc038"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2899087",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#409b72030310df96b296a5dd8cf80f0a211cc038",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager",
+      "purl": "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "expvar",
+      "purl": "pkg:golang/expvar@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/expvar@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "libidn2",
+      "purl": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=aarch64",
+      "version": "2.3.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or LGPLv3+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c781354177446e1bb6a5b48d2113feaed50cc860",
+            "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=67a13c4d057a96fd#v22",
+      "version": "v22.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-chroot"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/loads",
+      "purl": "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "libdnf-plugin-subscription-manager",
+      "purl": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+      "version": "1.29.40.1-1.el9_4",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3677803",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#e6f3e2e4389aba36fc00c31a4f278c1e183ed2c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kmod-libs",
+      "purl": "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=aarch64",
+      "version": "28-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "36aca425e7d25f5daca7109dc963da87294cd1b5",
+            "url": "git://pkgs.devel.redhat.com/rpms/kmod#36aca425e7d25f5daca7109dc963da87294cd1b5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2512428",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/kmod#36aca425e7d25f5daca7109dc963da87294cd1b5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libssh",
+      "purl": "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=aarch64",
+      "version": "0.10.4-13.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35756743d06f7dc2fde2d65495ae0d4866011d1b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3866387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#35756743d06f7dc2fde2d65495ae0d4866011d1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "net/textproto",
+      "purl": "pkg:golang/net/textproto@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/net/textproto@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=5804e51cbc6df18a",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "util-linux",
+      "purl": "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=aarch64",
+      "version": "2.37.4-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2896335",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#f7f62d4a14d30b46185fd71a6acad9bf2684c298",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=c9e73a9ce3fca441",
+      "version": "v2.120.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=ebbb976b0b9a6691",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=ed2a22c702bae008",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=3f70c1e082cb9132",
+      "version": "v4.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/api/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "runtime/internal/sys",
+      "purl": "pkg:golang/runtime/internal/sys@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/runtime/internal/sys@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    },
+    {
+      "name": "setuptools",
+      "purl": "pkg:pypi/setuptools@53.0.0",
+      "type": "library",
+      "author": "Python Packaging Authority <distutils-sig@python.org>",
+      "bom-ref": "pkg:pypi/setuptools@53.0.0",
+      "version": "53.0.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "UNKNOWN"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "python"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/setuptools-53.0.0.dist-info/METADATA"
+        }
+      ]
+    },
+    {
+      "name": "dbus-libs",
+      "purl": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=aarch64&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiserver",
+      "purl": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiserver@v0.30.0?package-id=46f0784d88e673c3",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kubernetes-csi/external-snapshotter/client/v4",
+      "purl": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=c379c7237a34dcc0#client/v4",
+      "version": "v4.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "app/staging/src/kubevirt.io/client-go/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=7338c535d9c880a0#v22",
+      "version": "v22.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/bin/virt-handler"
+        }
+      ]
+    },
+    {
+      "name": "encoding/pem",
+      "purl": "pkg:golang/encoding/pem@go1.22.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/encoding/pem@go1.22.12",
+      "version": "go1.22.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:oci/virt-handler-rhel9@sha256%3A7bf21edeec9b052e5d2f748f1db1799385507c8c7f43261ff3d989e80db4417b?arch=arm64&os=linux&tag=v4.17.35-2",
+      "dependsOn": [
+        "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=aarch64",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+        "pkg:golang/./staging/src#kubevirt.io/client-go",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=b6c9d8ea55ec3898",
+        "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+        "pkg:golang/time@go1.22.12",
+        "pkg:pypi/dbus-python@1.2.18",
+        "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+        "pkg:golang/internal/types/errors@go1.22.12",
+        "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+        "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+        "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=aarch64",
+        "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=aarch64",
+        "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+        "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=aarch64",
+        "pkg:golang/k8s.io/kubectl@v0.30.0",
+        "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+        "pkg:golang/internal/godebug@go1.22.12",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=aarch64",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+        "pkg:pypi/python-dateutil@2.8.1",
+        "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=aarch64",
+        "pkg:rpm/redhat/libuser@0.63-13.el9?arch=aarch64",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b7c26aaef6d1c9b7",
+        "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+        "pkg:golang/kubevirt.io/client-go",
+        "pkg:golang/./staging/src#github.com/golang/glog",
+        "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=aarch64",
+        "pkg:golang/golang.org/x/sync@v0.11.0",
+        "pkg:golang/crypto/hmac@go1.22.12",
+        "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+        "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=aarch64",
+        "pkg:golang/internal/goarch@go1.22.12",
+        "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+        "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+        "pkg:golang/math/rand@go1.22.12",
+        "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+        "pkg:pypi/pyinotify@0.9.6",
+        "pkg:golang/internal/saferio@go1.22.12",
+        "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0",
+        "pkg:golang/unsafe@go1.22.12",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+        "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=aarch64",
+        "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=aarch64",
+        "pkg:golang/crypto/ed25519@go1.22.12",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/net/rpc@go1.22.12",
+        "pkg:golang/bufio@go1.22.12",
+        "pkg:golang/internal/nettrace@go1.22.12",
+        "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0?package-id=6f1e377d494cf9f5",
+        "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+        "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=aarch64",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+        "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=aarch64",
+        "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+        "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=aarch64",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1",
+        "pkg:golang/github.com/moby/spdystream@v0.2.0",
+        "pkg:golang/github.com/containers/common@v0.50.1",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+        "pkg:golang/runtime/pprof@go1.22.12",
+        "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=aarch64",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=05e9b8a9427d6786",
+        "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=aarch64",
+        "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=aarch64&epoch=2",
+        "pkg:golang/encoding@go1.22.12",
+        "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+        "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=aarch64",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=f63f44519d8bc924",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+        "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+        "pkg:golang/crypto/x509/pkix@go1.22.12",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+        "pkg:golang/runtime/trace@go1.22.12",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=f970a3d674d44626",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+        "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=aarch64",
+        "pkg:golang/github.com/containernetworking/plugins@v1.1.1?package-id=599ab3f3550112ac",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=9b8e9f9b128703ca",
+        "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=aarch64",
+        "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+        "pkg:golang/net/netip@go1.22.12",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0",
+        "pkg:golang/k8s.io/code-generator@v0.30.0",
+        "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/stdlib@1.22.12",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+        "pkg:golang/github.com/go-kit/kit@v0.13.0",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=18734635491c2975",
+        "pkg:golang/k8s.io/client-go@v0.30.0",
+        "pkg:golang/kubevirt.io/kubevirt",
+        "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+        "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+        "pkg:golang/github.com/go-kit/kit@v0.9.0",
+        "pkg:golang/sync/atomic@go1.22.12",
+        "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+        "pkg:golang/crypto/internal/nistec@go1.22.12",
+        "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=aarch64",
+        "pkg:golang/database/sql/driver@go1.22.12",
+        "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+        "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+        "pkg:golang/reflect@go1.22.12",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=aarch64",
+        "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+        "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=aarch64",
+        "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=aarch64",
+        "pkg:golang/github.com/moby/sys@v0.6.2?package-id=aeac65a548510a6a#mountinfo",
+        "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+        "pkg:golang/math/bits@go1.22.12",
+        "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+        "pkg:golang/encoding/xml@go1.22.12",
+        "pkg:golang/github.com/google/gnostic@v0.5.7",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/internal/chacha8rand@go1.22.12",
+        "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+        "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:pypi/pygobject@3.40.1",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/go/ast@go1.22.12",
+        "pkg:rpm/redhat/libxml2@2.9.13-12.el9_4?arch=aarch64",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+        "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=aarch64",
+        "pkg:golang/github.com/prometheus/common@v0.44.0",
+        "pkg:golang/k8s.io/node-api@v0.30.0",
+        "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=aarch64",
+        "pkg:pypi/rpm@4.16.1.3",
+        "pkg:golang/syscall@go1.22.12",
+        "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+        "pkg:golang/github.com/golang/protobuf@v1.5.3",
+        "pkg:golang/github.com/google/uuid@v1.3.1",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+        "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+        "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+        "pkg:golang/github.com/imdario/mergo@v0.3.16",
+        "pkg:golang/internal/oserror@go1.22.12",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=aarch64",
+        "pkg:golang/crypto/ecdh@go1.22.12",
+        "pkg:golang/compress/bzip2@go1.22.12",
+        "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+        "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+        "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=aarch64&epoch=1",
+        "pkg:golang/net/http/internal@go1.22.12",
+        "pkg:golang/golang.org/x/text@v0.22.0",
+        "pkg:golang/compress/zlib@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+        "pkg:golang/github.com/google/uuid@v1.3.0",
+        "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+        "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=aarch64",
+        "pkg:golang/crypto/elliptic@go1.22.12",
+        "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/internal/godebugs@go1.22.12",
+        "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+        "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+        "pkg:golang/github.com/golang/glog",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0",
+        "pkg:golang/internal/buildcfg@go1.22.12",
+        "pkg:golang/os@go1.22.12",
+        "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+        "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+        "pkg:golang/internal/bytealg@go1.22.12",
+        "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+        "pkg:golang/net/url@go1.22.12",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+        "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+        "pkg:golang/golang.org/x/term@v0.29.0",
+        "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+        "pkg:golang/golang.org/x/time@v0.3.0",
+        "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+        "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=aarch64&epoch=1",
+        "pkg:golang/flag@go1.22.12",
+        "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+        "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+        "pkg:golang/go/token@go1.22.12",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+        "pkg:golang/compress/flate@go1.22.12",
+        "pkg:golang/go/build@go1.22.12",
+        "pkg:golang/kubevirt.io/api",
+        "pkg:golang/github.com/spf13/cobra@v1.7.0",
+        "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+        "pkg:golang/internal/platform@go1.22.12",
+        "pkg:golang/golang.org/x/net@v0.33.0",
+        "pkg:golang/crypto/internal/randutil@go1.22.12",
+        "pkg:rpm/redhat/which@2.21-29.el9?arch=aarch64",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=aec23c0e1d75ee8a",
+        "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=aarch64",
+        "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=aarch64",
+        "pkg:golang/github.com/prometheus/common@v0.44.0?package-id=3a5f710d384a3dd9",
+        "pkg:golang/html@go1.22.12",
+        "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=64880854c531d875",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=b024122f6e41d561",
+        "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=aarch64",
+        "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=aarch64",
+        "pkg:golang/internal/goos@go1.22.12",
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+        "pkg:golang/encoding/gob@go1.22.12",
+        "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+        "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=aarch64",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=3f115ef0cb31e7b8",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+        "pkg:golang/internal/fmtsort@go1.22.12",
+        "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+        "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+        "pkg:golang/slices@go1.22.12",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=8c45f6a8d1cca06d",
+        "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+        "pkg:golang/crypto/aes@go1.22.12",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+        "pkg:golang/golang.org/x/sys@v0.30.0",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=aarch64",
+        "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+        "pkg:pypi/libcomps@0.1.18",
+        "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=aarch64",
+        "pkg:golang/strconv@go1.22.12",
+        "pkg:golang/bytes@go1.22.12",
+        "pkg:golang/crypto/sha256@go1.22.12",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=ff4b8706a44511d7",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=45b68313e6b7649d",
+        "pkg:golang/io@go1.22.12",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=2ccbb81b4bfbf67e",
+        "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=97ce01b8d036cd18",
+        "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+        "pkg:golang/github.com/go-logr/logr@v0.2.1",
+        "pkg:pypi/iniparse@0.4",
+        "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=aarch64",
+        "pkg:golang/github.com/go-task/slim-sprig@v3.0.0?package-id=c5265481edb963f4#v3",
+        "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=aarch64",
+        "pkg:golang/crypto/cipher@go1.22.12",
+        "pkg:golang/debug/elf@go1.22.12",
+        "pkg:golang/crypto/rsa@go1.22.12",
+        "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+        "pkg:golang/k8s.io/metrics@v0.30.0",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+        "pkg:golang/container/heap@go1.22.12",
+        "pkg:golang/mime/multipart@go1.22.12",
+        "pkg:golang/mime/quotedprintable@go1.22.12",
+        "pkg:golang/crypto/internal/alias@go1.22.12",
+        "pkg:golang/encoding/hex@go1.22.12",
+        "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4",
+        "pkg:golang/google.golang.org/appengine@v1.6.8",
+        "pkg:golang/internal/abi@go1.22.12",
+        "pkg:golang/golang.org/x/term@v0.29.0?package-id=6367701eacddef15",
+        "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=aarch64&epoch=2",
+        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1",
+        "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=7f71bb3211c40e1e",
+        "pkg:golang/go/parser@go1.22.12",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+        "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=aarch64",
+        "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e5133fb001ac7926",
+        "pkg:golang/github.com/pkg/errors@v0.9.1",
+        "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=aarch64",
+        "pkg:golang/image/color@go1.22.12",
+        "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=aarch64",
+        "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+        "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=aarch64&epoch=1",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+        "pkg:golang/context@go1.22.12",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=06ba511a601e36d7",
+        "pkg:golang/net/http/internal/ascii@go1.22.12",
+        "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=aarch64",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=874d616b5ffd59b7",
+        "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+        "pkg:golang/golang.org/x/text@v0.22.0?package-id=b0628cbb477d7801",
+        "pkg:pypi/chardet@4.0.0",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d6c72ae7c47adf6d",
+        "pkg:golang/cmp@go1.22.12",
+        "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+        "pkg:golang/internal/syscall/unix@go1.22.12",
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=aarch64",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+        "pkg:golang/golang.org/x/net@v0.24.0",
+        "pkg:golang/internal/unsafeheader@go1.22.12",
+        "pkg:golang/path@go1.22.12",
+        "pkg:golang/golang.org/x/net@v0.33.0?package-id=cb71f9386c7676b0",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+        "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=aarch64",
+        "pkg:golang/math@go1.22.12",
+        "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=aarch64",
+        "pkg:golang/internal/cpu@go1.22.12",
+        "pkg:golang/fmt@go1.22.12",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=aarch64",
+        "pkg:golang/k8s.io/klog@v0.4.0",
+        "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=723cf855d020f756",
+        "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=aarch64",
+        "pkg:golang/go/doc@go1.22.12",
+        "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=aarch64",
+        "pkg:golang/embed@go1.22.12",
+        "pkg:golang/internal/lazyregexp@go1.22.12",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=3d1a8018c3d8d52a",
+        "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=aarch64",
+        "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+        "pkg:golang/path/filepath@go1.22.12",
+        "pkg:golang/github.com/spf13/cobra@v1.7.0?package-id=ddac4fa55f03e408",
+        "pkg:golang/internal/singleflight@go1.22.12",
+        "pkg:golang/k8s.io/client-go@v0.30.0?package-id=7209f81d42d9fb42",
+        "pkg:golang/golang.org/x/time@v0.3.0?package-id=c63cc068a81d5b95",
+        "pkg:golang/log/slog@go1.22.12",
+        "pkg:golang/debug/dwarf@go1.22.12",
+        "pkg:golang/kubevirt.io/api?package-id=8271ccebef8c7fbf",
+        "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=aarch64",
+        "pkg:golang/k8s.io/component-base@v0.30.0",
+        "pkg:golang/golang.org/x/term@v0.19.0",
+        "pkg:golang/image@go1.22.12",
+        "pkg:golang/hash/crc32@go1.22.12",
+        "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=aarch64",
+        "pkg:golang/kubevirt.io/kubevirt?package-id=30e262c5e31c0ee0",
+        "pkg:pypi/decorator@4.4.2",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=aarch64",
+        "pkg:golang/os/exec@go1.22.12",
+        "pkg:golang/github.com/golang/glog@v1.1.0",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=44dea5fe0373ffc7",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=aarch64",
+        "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=aarch64",
+        "pkg:golang/google.golang.org/grpc@v1.58.3",
+        "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+        "pkg:golang/k8s.io/apiserver@v0.30.0",
+        "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+        "pkg:golang/crypto/sha512@go1.22.12",
+        "pkg:golang/k8s.io/node-api@v0.30.0?package-id=69b6b0afb2bc8383",
+        "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=aarch64",
+        "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+        "pkg:golang/hash/fnv@go1.22.12",
+        "pkg:golang/go/scanner@go1.22.12",
+        "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=aarch64",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=5af92f389a804379",
+        "pkg:golang/internal/testlog@go1.22.12",
+        "pkg:golang/k8s.io/kubelet@v0.30.0",
+        "pkg:golang/text/template@go1.22.12",
+        "pkg:golang/compress/gzip@go1.22.12",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=64a952cc8f95048c",
+        "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=aarch64",
+        "pkg:golang/k8s.io/klog@v0.3.3",
+        "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=aarch64",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=211a5c0c1a7524b9",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=42ecb449d13ca189",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=aarch64",
+        "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492?package-id=fb57a5f09377d6b1",
+        "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=aarch64",
+        "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=aarch64",
+        "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=aarch64",
+        "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=aarch64",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=c251c2070b6d837f",
+        "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+        "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=a3f45ccc2eaef8aa",
+        "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=aarch64",
+        "pkg:golang/k8s.io/sample-controller@v0.30.0",
+        "pkg:golang/encoding/binary@go1.22.12",
+        "pkg:golang/crypto/ecdsa@go1.22.12",
+        "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=75bca8ba1ca22c9b",
+        "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=45a8c7aac0e298e2#client/v4",
+        "pkg:golang/internal/poll@go1.22.12",
+        "pkg:golang/github.com/imdario/mergo@v0.3.15",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=b5d6576591ff84ae",
+        "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=1a97d0dde17253ca",
+        "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e519b37240b7b6af",
+        "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=aarch64",
+        "pkg:golang/io/fs@go1.22.12",
+        "pkg:golang/golang.org/x/net@v0.23.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=0c548e794e085974",
+        "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+        "pkg:golang/github.com/go-kit/log@v0.2.1",
+        "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=aarch64",
+        "pkg:golang/k8s.io/klog@v0.4.0?package-id=a6cf3f8305ce0756",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=f72df465d2f4ba73",
+        "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=92cbc10610ba936e",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=4f70a6c87f97190b",
+        "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=aarch64",
+        "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=aarch64",
+        "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+        "pkg:golang/internal/safefilepath@go1.22.12",
+        "pkg:golang/k8s.io/api@v0.30.0",
+        "pkg:golang/k8s.io/client-go@v0.30.0?package-id=dc0ee049f53c27e7",
+        "pkg:golang/crypto/md5@go1.22.12",
+        "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=aarch64",
+        "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=aarch64",
+        "pkg:golang/log/slog/internal/buffer@go1.22.12",
+        "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+        "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+        "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=6bfd33acc02b178b",
+        "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=aarch64",
+        "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+        "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=aarch64",
+        "pkg:golang/sync@go1.22.12",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=aarch64",
+        "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=aarch64",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=c91ff645d6ce8388",
+        "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=aarch64",
+        "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=aarch64&epoch=2",
+        "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=aarch64",
+        "pkg:golang/github.com/beorn7/perks@v1.0.1",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=7b9209a64c9c952b",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=2e766a71ac55c8c1",
+        "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+        "pkg:golang/net/http/httputil@go1.22.12",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=264ee8e18d5b5c8a",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+        "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+        "pkg:golang/github.com/go-stack/stack@v1.8.0",
+        "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=aarch64",
+        "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+        "pkg:golang/internal/goexperiment@go1.22.12",
+        "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=647cefa32ef8dbed",
+        "pkg:golang/internal/sysinfo@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+        "pkg:golang/github.com/google/uuid@v1.1.5",
+        "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+        "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=aarch64",
+        "pkg:golang/k8s.io/cli-runtime@v0.30.0?package-id=372a4fd9b7953904",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=bcb125b3ee0ac2bf",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=aarch64",
+        "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=aarch64",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=aarch64",
+        "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=aarch64",
+        "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+        "pkg:golang/github.com/prometheus/procfs@v0.11.0?package-id=53509fccb635cdaf",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+        "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=aarch64",
+        "pkg:golang/text/template/parse@go1.22.12",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+        "pkg:golang/golang.org/x/text@v0.14.0",
+        "pkg:golang/k8s.io/cloud-provider@v0.30.0?package-id=213905a8e9bf9bca",
+        "pkg:golang/go/version@go1.22.12",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=fd55bfb7c4801b59",
+        "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+        "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+        "pkg:golang/golang.org/x/sync@v0.11.0?package-id=d30348b75bd8dbbe",
+        "pkg:golang/github.com/josharian/intern@v1.0.0",
+        "pkg:golang/k8s.io/kubelet@v0.30.0?package-id=0d174a34ad4bac4b",
+        "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=b4f2daad5b1d001e#pkg/apis/monitoring",
+        "pkg:golang/go/types@go1.22.12",
+        "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=aarch64",
+        "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+        "pkg:golang/hash/adler32@go1.22.12",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=777844465b60ad81",
+        "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+        "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+        "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=aarch64",
+        "pkg:golang/runtime/internal/syscall@go1.22.12",
+        "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+        "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=7349fb61f86b922a",
+        "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=4b04ea23556ed395",
+        "pkg:golang/github.com/prometheus/client_model@v0.4.0?package-id=ecb7f6c81f243c3b",
+        "pkg:golang/regexp@go1.22.12",
+        "pkg:golang/maps@go1.22.12",
+        "pkg:golang/net@go1.22.12",
+        "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=e0646f8826c197e7",
+        "pkg:golang/encoding/csv@go1.22.12",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=9cb7e0ef1a4f0772",
+        "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=aarch64",
+        "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+        "pkg:golang/os/signal@go1.22.12",
+        "pkg:golang/net/mail@go1.22.12",
+        "pkg:golang/internal/goroot@go1.22.12",
+        "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+        "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=e0fc581ee7f4ac53",
+        "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+        "pkg:golang/strings@go1.22.12",
+        "pkg:golang/go/build/constraint@go1.22.12",
+        "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=aarch64",
+        "pkg:golang/os/user@go1.22.12",
+        "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+        "pkg:golang/crypto/dsa@go1.22.12",
+        "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=aarch64",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=b1e90c3e1ac1f792",
+        "pkg:golang/net/http/httptrace@go1.22.12",
+        "pkg:golang/kubevirt.io/client-go@v0.19.0",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=d49025084db5e534",
+        "pkg:golang/log/slog/internal@go1.22.12",
+        "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+        "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=30a0f7618c550bd4",
+        "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+        "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a?package-id=f5ed66e6e2ff252b",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+        "pkg:pypi/pysocks@1.7.1",
+        "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+        "pkg:golang/crypto/x509@go1.22.12",
+        "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4?package-id=3ef7d310780b1738",
+        "pkg:golang/go/printer@go1.22.12",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=d8c2f26e9986efc0",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=875c60b36880d488",
+        "pkg:golang/golang.org/x/sys@v0.19.0",
+        "pkg:golang/go/constant@go1.22.12",
+        "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=56fa540c52a6e225",
+        "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+        "pkg:golang/github.com/beorn7/perks@v1.0.1?package-id=d6fd5b144cc18be1",
+        "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+        "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=aarch64",
+        "pkg:golang/crypto/internal/boring@go1.22.12",
+        "pkg:golang/./staging/src#kubevirt.io/api",
+        "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c?package-id=6c31ceb0e3238027",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=c27f4e3f0f288cba",
+        "pkg:pypi/urllib3@1.26.5",
+        "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+        "pkg:golang/internal/itoa@go1.22.12",
+        "pkg:golang/golang.org/x/oauth2@v0.12.0",
+        "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=aarch64",
+        "pkg:golang/internal/zstd@go1.22.12",
+        "pkg:golang/net/http/httptest@go1.22.12",
+        "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+        "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+        "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+        "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=aarch64",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=426c1ef83fb90a34",
+        "pkg:golang/crypto@go1.22.12",
+        "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/encoding/base64@go1.22.12",
+        "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=4947e27687df8894",
+        "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=b5787214009aa9c8",
+        "pkg:golang/crypto/des@go1.22.12",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=cdc588c277efc41e",
+        "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=ea627eb359d3ebbf",
+        "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=61ff33db308e1c87",
+        "pkg:golang/github.com/google/go-querystring@v1.0.0",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=6b3967bbe5e4f770#v3",
+        "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=aarch64",
+        "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+        "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414?package-id=1f03719fd30cb426",
+        "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+        "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=aarch64",
+        "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+        "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0?package-id=85656f3ce4c495dd",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=392c78985b3ee866",
+        "pkg:pypi/requests@2.25.1",
+        "pkg:golang/golang.org/x/text@v0.14.0?package-id=a47e6c64839baca0",
+        "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=aarch64",
+        "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+        "pkg:golang/golang.org/x/time@v0.3.0?package-id=de8b89d7a225278d",
+        "pkg:pypi/subscription-manager@1.29.40.1",
+        "pkg:golang/k8s.io/kube-scheduler@v0.30.0?package-id=c6f4b38d0e64a871",
+        "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=aarch64",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=617dda993ef91b06",
+        "pkg:golang/crypto/sha1@go1.22.12",
+        "pkg:golang/crypto/tls@go1.22.12",
+        "pkg:golang/k8s.io/sample-apiserver@v0.30.0?package-id=a7d282fdf5bcfc3a",
+        "pkg:golang/mime@go1.22.12",
+        "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+        "pkg:golang/net/http@go1.22.12",
+        "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8?package-id=5324f65a18aa4075",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=7fd9e721114377fd",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=e91ba32bfe0dcfe9",
+        "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=82dbb4bd95c1a6af",
+        "pkg:golang/log@go1.22.12",
+        "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=aarch64",
+        "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+        "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+        "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+        "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+        "pkg:golang/runtime/metrics@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=bd15d762c1c6c3a1",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=5b48db5542316992",
+        "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=aarch64&epoch=1",
+        "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+        "pkg:golang/stdlib@1.22.12?package-id=0263aa6b4909132a",
+        "pkg:golang/unicode/utf16@go1.22.12",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=e5f84b4525280ceb",
+        "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=a40b75a240613ee9#v5",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=ef4b943e758b9b6b",
+        "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+        "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+        "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=1651c6ba29f925e5",
+        "pkg:golang/github.com/golang/mock@v1.6.0",
+        "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=3cfe059b9c8f0896",
+        "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+        "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+        "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=aarch64&epoch=1",
+        "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=aarch64",
+        "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+        "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=aarch64&epoch=2",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=3a7a3480e12ba94a",
+        "pkg:rpm/redhat/gzip@1.12-1.el9?arch=aarch64",
+        "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0?package-id=7c0f2e47ca097803",
+        "pkg:golang/internal/intern@go1.22.12",
+        "pkg:golang/errors@go1.22.12",
+        "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4ca57bd69d22480b",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=79287922c4530134",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=6d74791bcbcea4ec",
+        "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=aarch64",
+        "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+        "pkg:golang/hash@go1.22.12",
+        "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=a8fb70acf7ce028c",
+        "pkg:golang/github.com/golang/mock@v1.6.0?package-id=58fd55d3a3e68d9a",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=812518b1d5de5b6b",
+        "pkg:golang/github.com/fatih/color@v1.13.0",
+        "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=44034bb305ad6df8#v5",
+        "pkg:golang/k8s.io/csi-translation-lib@v0.30.0?package-id=e493ecdd6cef073d",
+        "pkg:pypi/idna@2.10",
+        "pkg:golang/image/internal/imageutil@go1.22.12",
+        "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0?package-id=b57f2d304a79c9d2",
+        "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+        "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=0cf48c7c4e0c2225",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=5f3161d14fb9986b",
+        "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+        "pkg:golang/k8s.io/api@v0.30.0?package-id=9cd65210b34ae131",
+        "pkg:golang/container/list@go1.22.12",
+        "pkg:golang/github.com/onsi/gomega@v1.33.1",
+        "pkg:golang/container/ring@go1.22.12",
+        "pkg:golang/unicode@go1.22.12",
+        "pkg:golang/runtime@go1.22.12",
+        "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=aarch64",
+        "pkg:pypi/systemd-python@234",
+        "pkg:golang/image/png@go1.22.12",
+        "pkg:golang/github.com/google/btree@v1.1.3",
+        "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+        "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=aarch64",
+        "pkg:golang/k8s.io/code-generator@v0.30.0?package-id=c9d95bf42170291b",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=fa2fc500853b500e",
+        "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=aarch64",
+        "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=aarch64",
+        "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+        "pkg:golang/go/doc/comment@go1.22.12",
+        "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+        "pkg:golang/runtime/internal/math@go1.22.12",
+        "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=38f081dbc5ce4d6a",
+        "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b?package-id=1264b58e962ebcac",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=317d26dbf41e923a",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=20f072e6e3225e24",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=b026cc4209959195",
+        "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=aarch64",
+        "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=58a2f3ed700462d3",
+        "pkg:golang/regexp/syntax@go1.22.12",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=a0115c013e649a4c",
+        "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible?package-id=15ebdd24a0c721e7",
+        "pkg:rpm/redhat/passwd@0.80-12.el9?arch=aarch64",
+        "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=aarch64",
+        "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+        "pkg:golang/internal/race@go1.22.12",
+        "pkg:golang/github.com/prometheus/client_golang@v1.16.0?package-id=802b60ddf07e5522",
+        "pkg:golang/internal/goversion@go1.22.12",
+        "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+        "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=d183acc87e1fa62e",
+        "pkg:golang/github.com/google/btree@v1.1.3?package-id=2655799dd02f4564",
+        "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=aarch64",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=87c0cbf8954e0580",
+        "pkg:golang/crypto/rc4@go1.22.12",
+        "pkg:golang/k8s.io/cri-api@v0.30.0",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=aabc29983e2a9841",
+        "pkg:golang/k8s.io/kube-controller-manager@v0.30.0?package-id=0814f25a8e4531ce",
+        "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4bf18231eac48ba4",
+        "pkg:golang/encoding/base32@go1.22.12",
+        "pkg:golang/text/tabwriter@go1.22.12",
+        "pkg:golang/k8s.io/cri-api@v0.30.0?package-id=4de173f6a5765211",
+        "pkg:golang/k8s.io/component-base@v0.30.0?package-id=94800364440cc1a6",
+        "pkg:golang/image/jpeg@go1.22.12",
+        "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=aarch64",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=a1ff2ebea07a529d",
+        "pkg:golang/github.com/josharian/native@v1.1.0",
+        "pkg:golang/internal/coverage/rtcov@go1.22.12",
+        "pkg:rpm/redhat/usermode@1.114-4.el9?arch=aarch64",
+        "pkg:pypi/gpg@1.15.1",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=406cd2654be0fcc8",
+        "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=aarch64",
+        "pkg:golang/golang.org/x/sys@v0.30.0?package-id=8899651b157fa55b",
+        "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=34e50fc47ddb109c",
+        "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+        "pkg:golang/k8s.io/metrics@v0.30.0?package-id=e5a9c757e0ba76d0",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=bd9cfde5eb7d49da",
+        "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+        "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=a6a4677db3654d87",
+        "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=41c9ffe89c4328dd#pkg/apis/monitoring",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e87736d4223a3553",
+        "pkg:golang/internal/gover@go1.22.12",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=077b67d110fda982",
+        "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+        "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=332ab3a9d173ca98",
+        "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=aarch64",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=d3adc2bc60fefccb",
+        "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=2f055f6cdf8e3fb1",
+        "pkg:rpm/redhat/npth@1.6-8.el9?arch=aarch64",
+        "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=747804ed972e87a1",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6?package-id=0bc6f5896c6cb1a9",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=9de2c8dc0803d74e",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=2e7c033a75be1ef6",
+        "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=8256c45ca06407ab",
+        "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+        "pkg:rpm/redhat/jansson@2.14-1.el9?arch=aarch64",
+        "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b135113b0301cc3e",
+        "pkg:golang/math/big@go1.22.12",
+        "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=5df1a932dc364fae",
+        "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+        "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+        "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=49b478fdfd04f997",
+        "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=aarch64&epoch=1",
+        "pkg:golang/github.com/moby/sys@v0.6.2?package-id=2f1b091e7ebc59e5#mountinfo",
+        "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=aarch64",
+        "pkg:golang/internal/syscall/execenv@go1.22.12",
+        "pkg:golang/github.com/cespare/xxhash@v2.2.0?package-id=ff6ddf5ac62bb415#v2",
+        "pkg:golang/golang.org/x/tools@v0.20.0",
+        "pkg:golang/k8s.io/kube-proxy@v0.30.0?package-id=da08354393870645",
+        "pkg:golang/runtime/internal/atomic@go1.22.12",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=14c598a63cb5e9db",
+        "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=aarch64",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=0f468cc3892f0124",
+        "pkg:rpm/redhat/json-c@0.14-11.el9?arch=aarch64",
+        "pkg:golang/crypto/subtle@go1.22.12",
+        "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=aarch64",
+        "pkg:golang/github.com/josharian/native@v1.1.0?package-id=6604c5cd4c4748cf",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=14c57ecad0b43747",
+        "pkg:golang/golang.org/x/sys@v0.30.0?package-id=db67540c07b5beb9",
+        "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=db815b5d0b61f513",
+        "pkg:golang/github.com/go-stack/stack@v1.8.0?package-id=48631dee752774c6",
+        "pkg:golang/internal/bisect@go1.22.12",
+        "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=71cd8ab004151c77",
+        "pkg:golang/go/internal/typeparams@go1.22.12",
+        "pkg:golang/testing@go1.22.12",
+        "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+        "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=aarch64",
+        "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+        "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=aarch64",
+        "pkg:golang/io/ioutil@go1.22.12",
+        "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+        "pkg:golang/k8s.io/api@v0.30.0?package-id=077a5e8ca27fa924",
+        "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=aarch64",
+        "pkg:golang/html/template@go1.22.12",
+        "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923?package-id=a98cba5ae186c4f5",
+        "pkg:golang/github.com/golang/mock@v1.6.0?package-id=c774b777664a4bb0",
+        "pkg:golang/github.com/containers/common@v0.50.1?package-id=e36d1d0f2ba91772",
+        "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+        "pkg:golang/runtime/debug@go1.22.12",
+        "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=c3d9773d12fa39a7",
+        "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+        "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=429112dfb9428aeb",
+        "pkg:golang/github.com/pierrec/lz4@v4.1.15?package-id=8f6dd5f7ba6a62ec#v4",
+        "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=6619c43cfd07c933",
+        "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+        "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+        "pkg:golang/net/http/internal/testcert@go1.22.12",
+        "pkg:golang/github.com/pborman/uuid@v1.2.1",
+        "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=5ce12f7eaebfe865",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=2510cbce9c179e69",
+        "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=aarch64",
+        "pkg:golang/encoding/json@go1.22.12",
+        "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=aarch64",
+        "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+        "pkg:rpm/redhat/expat@2.5.0-2.el9_4.2?arch=aarch64",
+        "pkg:golang/internal/reflectlite@go1.22.12",
+        "pkg:golang/crypto/internal/bigmod@go1.22.12",
+        "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+        "pkg:golang/k8s.io/sample-controller@v0.30.0?package-id=95847fe4258b57c0",
+        "pkg:golang/crypto/rand@go1.22.12",
+        "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=aarch64",
+        "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d?package-id=454c35570125ce2f#rpc",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=f4fcb5b06080adbf",
+        "pkg:golang/github.com/onsi/ginkgo@v2.17.2?package-id=709ca981edc6d5d6#v2",
+        "pkg:golang/golang.org/x/mod@v0.17.0",
+        "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=aarch64",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=fd7558abcd37e57d",
+        "pkg:golang/k8s.io/api@v0.30.0?package-id=dd84eb4f391fe51e",
+        "pkg:golang/unicode/utf8@go1.22.12",
+        "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=aarch64",
+        "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=1663864887e439eb",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=f1bc226b87c469d8",
+        "pkg:golang/encoding/asn1@go1.22.12",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=5eee73adffd25455",
+        "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=aarch64",
+        "pkg:golang/sort@go1.22.12",
+        "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=aarch64",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=f951095dca4572e3",
+        "pkg:golang/archive/tar@go1.22.12",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=3bccae874729638f",
+        "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=892f25b58ba2cadb",
+        "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=aarch64",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=3cee09b2c9d8346a",
+        "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=aarch64",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=a8276711fb26ec2c#v3",
+        "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=aarch64",
+        "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20?package-id=ce832bdd3e643f49",
+        "pkg:pypi/six@1.15.0",
+        "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+        "pkg:golang/log/internal@go1.22.12",
+        "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+        "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=aarch64",
+        "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=aarch64",
+        "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+        "pkg:golang/expvar@go1.22.12",
+        "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=aarch64",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=67a13c4d057a96fd#v22",
+        "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+        "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=aarch64",
+        "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=aarch64",
+        "pkg:golang/net/textproto@go1.22.12",
+        "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=5804e51cbc6df18a",
+        "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=aarch64",
+        "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=c9e73a9ce3fca441",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=ebbb976b0b9a6691",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=ed2a22c702bae008",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=3f70c1e082cb9132",
+        "pkg:golang/runtime/internal/sys@go1.22.12",
+        "pkg:pypi/setuptools@53.0.0",
+        "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=aarch64&epoch=1",
+        "pkg:golang/k8s.io/apiserver@v0.30.0?package-id=46f0784d88e673c3",
+        "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=c379c7237a34dcc0#client/v4",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=7338c535d9c880a0#v22",
+        "pkg:golang/encoding/pem@go1.22.12"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/sys@v0.6.2#mountinfo",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/./staging/src#kubevirt.io/client-go",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=b6c9d8ea55ec3898",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/time@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/dbus-python@1.2.18",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/types/errors@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/exp@v0.0.0-20230203172020-98cc5a0785f9#typeparams",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0#pkg/apis/monitoring",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgomp@11.4.1-4.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubectl@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/godebug@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/python-dateutil@2.8.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuser@0.63-13.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b7c26aaef6d1c9b7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/client-go",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/./staging/src#github.com/golang/glog",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/hmac@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0#client/v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goarch@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/qe-tools@v0.1.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math/rand@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-iniparse@0.4-45.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/pyinotify@0.9.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/saferio@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unsafe@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/ed25519@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/rpc@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/bufio@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/nettrace@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/legacy-cloud-providers@v0.30.0?package-id=6f1e377d494cf9f5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kisielk/errcheck@v1.6.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/redhat-release@9.4-0.5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/nunnatsa/ginkgolinter@v0.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/common@v0.50.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/pprof@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmount@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=05e9b8a9427d6786",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit@0.25.3-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/vim-minimal@8.2.2637-20.el9_4.1?arch=aarch64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-rpm@4.16.1.3-29.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=f63f44519d8bc924",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/boring/bbig@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/x509/pkix@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/trace@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=f970a3d674d44626",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containernetworking/plugins@v1.1.1?package-id=599ab3f3550112ac",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=9b8e9f9b128703ca",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnftnl@1.2.6-4.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mvdan.cc/sh/v3@v3.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/netip@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/code-generator@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/stdlib@1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.13.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=18734635491c2975",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/kubevirt",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/goexpect@v0.0.0-20190425035906-112704a48083",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.9.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sync/atomic@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/nistec@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/database/sql/driver@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/reflect@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsmartcols@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-semver@v0.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/alternatives@1.24-1.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pam@1.5.1-24.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=aeac65a548510a6a#mountinfo",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/sys/cpu@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math/bits@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/povsister/scp@v0.0.0-20210427074412-33febfd9f13e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/xml@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic@v0.5.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/chacha8rand@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20190128024246-5eb7ae5bdb7a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/pygobject@3.40.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/ast@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxml2@2.9.13-12.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/common@v0.44.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/node-api@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-8.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/rpm@4.16.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/syscall@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/renameio@v2.0.0#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.16",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/oserror@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/ecdh@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/bzip2@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.mongodb.org/mongo-driver@v1.8.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/internal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.22.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/zlib@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte/asn1@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-six@1.15.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libblkid@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/elliptic@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/godebugs@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/secure/bidirule@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/glog",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/buildcfg@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/http2/hpack@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/bytealg@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/url@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/edwards25519/field@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.29.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dmidecode@3.5-3.el9?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/flag@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-rpm-macros@252-32.el9_4.10?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/token@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/flate@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/build@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/api",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cobra@v1.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/logfmt@v0.0.0-20210122060352-19f9bcb100e6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/platform@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.33.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/randutil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/which@2.21-29.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=aec23c0e1d75ee8a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnetfilter_conntrack@1.0.9-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/common@v0.44.0?package-id=3a5f710d384a3dd9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/html@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9_4.2?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=64880854c531d875",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=b024122f6e41d561",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-pam@252-32.el9_4.10?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goos@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/gob@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=3f115ef0cb31e7b8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/fmtsort@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15#v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/slices@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=8c45f6a8d1cca06d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/aes@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-29.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-common@1.12.20-8.el9?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/libcomps@0.1.18",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libfdisk@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/strconv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/bytes@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/sha256@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=ff4b8706a44511d7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=45b68313e6b7649d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/io@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=2ccbb81b4bfbf67e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=97ce01b8d036cd18",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v0.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/iniparse@0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cheggaaa/pb@v3.1.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-task/slim-sprig@v3.0.0?package-id=c5265481edb963f4#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnl3@3.9.0-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/cipher@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/debug/elf@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/rsa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/metrics@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20210105115604-44119421ec6b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/container/heap@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mime/multipart@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mime/quotedprintable@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/alias@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/hex@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies@20240202-1.git283706d.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/abi@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.29.0?package-id=6367701eacddef15",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libbpf@1.3.0-2.el9?arch=aarch64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=7f71bb3211c40e1e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/parser@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20230503133300-8bbcb7ca7183",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gobject-base@3.40.1-6.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e5133fb001ac7926",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-hawkey@0.69.0-8.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/color@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus@1.12.20-8.el9?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/context@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=06ba511a601e36d7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/internal/ascii@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_3.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=874d616b5ffd59b7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/nxadm/tail@v0.0.0-20211216163028-4472660a31a6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.22.0?package-id=b0628cbb477d7801",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/chardet@4.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=d6c72ae7c47adf6d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/cmp@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/syscall/unix@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.24.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/unsafeheader@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/path@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.33.0?package-id=cb71f9386c7676b0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/iptables-libs@1.8.10-5.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/coreutils-single@8.32-35.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/cpu@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/fmt@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog@v0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/cheggaaa/pb.v1@v1.0.28",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=723cf855d020f756",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/krb5-libs@1.21.1-2.el9_4.2?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/doc@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/embed@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/lazyregexp@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=3d1a8018c3d8d52a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/path/filepath@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cobra@v1.7.0?package-id=ddac4fa55f03e408",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/singleflight@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=7209f81d42d9fb42",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=c63cc068a81d5b95",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/slog@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/debug/dwarf@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/api?package-id=8271ccebef8c7fbf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/component-base@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash/crc32@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/kubevirt?package-id=30e262c5e31c0ee0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/decorator@4.4.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os/exec@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/glog@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=44dea5fe0373ffc7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcc@11.4.1-4.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiserver@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/grafana/regexp@v0.0.0-20221122212121-6b5c0a4cb7fd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/sha512@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/node-api@v0.30.0?package-id=69b6b0afb2bc8383",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash/fnv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/scanner@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=5af92f389a804379",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/testlog@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubelet@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/text/template@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/compress/gzip@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=64a952cc8f95048c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-100.el9_4.12?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog@v0.3.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=211a5c0c1a7524b9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=42ecb449d13ca189",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/library-go@v0.0.0-20211220195323-eca2c467c492?package-id=fb57a5f09377d6b1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnfnetlink@1.0.1-21.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tpm2-tss@3.2.2-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=c251c2070b6d837f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=a3f45ccc2eaef8aa",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-controller@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/binary@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/ecdsa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=75bca8ba1ca22c9b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=45a8c7aac0e298e2#client/v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/poll@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.15",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=b5d6576591ff84ae",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.30.0?package-id=1a97d0dde17253ca",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.3.1?package-id=e519b37240b7b6af",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc@2.34-100.el9_4.12?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/io/fs@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.23.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=0c548e794e085974",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-urllib3@1.26.5-5.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/log@v0.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog@v0.4.0?package-id=a6cf3f8305ce0756",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=f72df465d2f4ba73",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=92cbc10610ba936e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.0.3-0.20210326190908-1c3f411f0417?package-id=4f70a6c87f97190b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm@4.16.1.3-29.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2-syntax@10.40-5.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/safefilepath@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.30.0?package-id=dc0ee049f53c27e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/md5@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/slog/internal/buffer@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/godbus/dbus@v5.1.0#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pysocks@1.7.1-12.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=6bfd33acc02b178b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-vnc@v0.0.0-20150629162542-723ed9867aed",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sync@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-librepo@1.14.5-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=c91ff645d6ce8388",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuuid@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tar@1.34-6.el9_4.1?arch=aarch64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=7b9209a64c9c952b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=2e766a71ac55c8c1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/hkdf@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/httputil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=264ee8e18d5b5c8a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/googleapis/gnostic@v0.2.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-stack/stack@v1.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/curl-minimal@7.76.1-29.el9_4.2?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goexperiment@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=647cefa32ef8dbed",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/sysinfo@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/cryptobyte@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.1.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B@11.4.1-4.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-cloud-what@1.29.40.1-1.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cli-runtime@v0.30.0?package-id=372a4fd9b7953904",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=bcb125b3ee0ac2bf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3@3.9.18-3.el9_4.9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/yajl@2.1.0-22.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-gssapi@2.1.27-21.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/libvirt.org/go/libvirtxml@v1.10000.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/procfs@v0.11.0?package-id=53509fccb635cdaf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/text/template/parse@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20220321153916-2c7772ba3064",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cloud-provider@v0.30.0?package-id=213905a8e9bf9bca",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/version@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=fd55bfb7c4801b59",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/boring/sig@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.13",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.11.0?package-id=d30348b75bd8dbbe",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubelet@v0.30.0?package-id=0d174a34ad4bac4b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=b4f2daad5b1d001e#pkg/apis/monitoring",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/types@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/audit-libs@3.1.2-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/goterm@v0.0.0-20190311235235-ce302be1d114",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash/adler32@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=777844465b60ad81",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-29.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/syscall@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=7349fb61f86b922a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=4b04ea23556ed395",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_model@v0.4.0?package-id=ecb7f6c81f243c3b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/regexp@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/maps@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=e0646f8826c197e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/csv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=9cb7e0ef1a4f0772",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os/signal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/mail@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goroot@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/analysis@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/transform@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/internal/alias@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4?package-id=e0fc581ee7f4ac53",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/strings@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/build/constraint@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libs@3.9.18-3.el9_4.9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/os/user@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/dsa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.29.40.1-1.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=b1e90c3e1ac1f792",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/httptrace@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/client-go@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=d49025084db5e534",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/slog/internal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/spec@v0.20.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/kit@v0.13.0?package-id=30a0f7618c550bd4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/http/httpproxy@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/insomniacslk/dhcp@v0.0.0-20230908212754-65c27093e38a?package-id=f5ed66e6e2ff252b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/pysocks@1.7.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/x509@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/matttproud/golang_protobuf_extensions@v1.0.4?package-id=3ef7d310780b1738",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/printer@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0?package-id=d8c2f26e9986efc0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=875c60b36880d488",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/constant@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=56fa540c52a6e225",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/beorn7/perks@v1.0.1?package-id=d6fd5b144cc18be1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.0.0-20190221213512-86fb29eff628",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-libs@252-32.el9_4.10?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/boring@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/./staging/src#kubevirt.io/api",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/api@v0.0.0-20191219222812-2987a591a72c?package-id=6c31ceb0e3238027",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=c27f4e3f0f288cba",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/urllib3@1.26.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/itoa@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.12.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtirpc@1.3.3-8.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/zstd@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/httptest@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-requests@2.25.1-8.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-idna@2.10-7.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-toolsmith/astcopy@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd@252-32.el9_4.10?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210330154013-f5de75959ad5?package-id=426c1ef83fb90a34",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/base64@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=4947e27687df8894",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=b5787214009aa9c8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/des@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=cdc588c277efc41e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20240423183400-0849a56e8f22?package-id=ea627eb359d3ebbf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20191119172530-79f836b90111",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=61ff33db308e1c87",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0#v22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=6b3967bbe5e4f770#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/iproute@6.2.0-6.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/http/httpguts@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/krolaw/dhcp4@v0.0.0-20180925202202-7cead472c414?package-id=1f03719fd30cb426",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9_4.2?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-29.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/libvirt.org/go/libvirt@v1.10000.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.3.0?package-id=85656f3ce4c495dd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=392c78985b3ee866",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/requests@2.25.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.14.0?package-id=a47e6c64839baca0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-common@2.34-100.el9_4.12?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/yum@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.3.0?package-id=de8b89d7a225278d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/subscription-manager@1.29.40.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-scheduler@v0.30.0?package-id=c6f4b38d0e64a871",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-libs@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=617dda993ef91b06",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/sha1@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/tls@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-apiserver@v0.30.0?package-id=a7d282fdf5bcfc3a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mime@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/c9s/goprocinfo@v0.0.0-20210130143923-c95fcf8c64a8?package-id=5324f65a18aa4075",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=7fd9e721114377fd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=e91ba32bfe0dcfe9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=82dbb4bd95c1a6af",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/util-linux-core@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf-plugins-core@4.3.0-13.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/unicode/norm@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/metrics@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/chacha20poly1305@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc?package-id=bd15d762c1c6c3a1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=5b48db5542316992",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/stdlib@1.22.12?package-id=0263aa6b4909132a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unicode/utf16@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=e5f84b4525280ceb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=a40b75a240613ee9#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=ef4b943e758b9b6b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-data@4.14.0-9.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=1651c6ba29f925e5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.16?package-id=3cfe059b9c8f0896",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubevirt/monitoring@v0.0.0-20230627123556-81a891d4462a#pkg/metrics/parser",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nftables@1.0.9-1.el9_4.1?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdb-gdbserver@10.2-13.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/nistec/fiat@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/shadow-utils@4.9-8.el9_4.1?arch=aarch64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=3a7a3480e12ba94a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cluster-bootstrap@v0.30.0?package-id=7c0f2e47ca097803",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/intern@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/errors@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4ca57bd69d22480b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822?package-id=79287922c4530134",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=6d74791bcbcea4ec",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2@10.40-5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gobject-base-noarch@3.40.1-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/hash@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=a8fb70acf7ce028c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=58fd55d3a3e68d9a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=812518b1d5de5b6b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fatih/color@v1.13.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/godbus/dbus@v5.1.0?package-id=44034bb305ad6df8#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/csi-translation-lib@v0.30.0?package-id=e493ecdd6cef073d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/idna@2.10",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/internal/imageutil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-cli-plugin@v0.30.0?package-id=b57f2d304a79c9d2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gordonklaus/ineffassign@v0.0.0-20210209182638-d0e41b2fc8ed",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/strfmt@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=0cf48c7c4e0c2225",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1?package-id=5f3161d14fb9986b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=9cd65210b34ae131",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/container/list@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.33.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/container/ring@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unicode@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/systemd-python@234",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/png@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/btree@v1.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/text/unicode/bidi@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/virt-what@1.25-5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/code-generator@v0.30.0?package-id=c9d95bf42170291b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=fa2fc500853b500e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsolv@0.7.24-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/doc/comment@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf@0.69.0-8.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/math@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd?package-id=38f081dbc5ce4d6a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-ps@v0.0.0-20190716172923-621e5597135b?package-id=1264b58e962ebcac",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=317d26dbf41e923a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=20f072e6e3225e24",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=b026cc4209959195",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cilium/ebpf@v0.7.0?package-id=58a2f3ed700462d3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/regexp/syntax@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8?package-id=a0115c013e649a4c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible?package-id=15ebdd24a0c721e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/passwd@0.80-12.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-decorator@4.4.2-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl@3.0.7-29.el9_4.1?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/race@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_golang@v1.16.0?package-id=802b60ddf07e5522",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/goversion@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/idna@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=d183acc87e1fa62e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/btree@v1.1.3?package-id=2655799dd02f4564",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dbus@1.2.18-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=87c0cbf8954e0580",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/rc4@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cri-api@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=aabc29983e2a9841",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-controller-manager@v0.30.0?package-id=0814f25a8e4531ce",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-aggregator@v0.30.0?package-id=4bf18231eac48ba4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/base32@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/text/tabwriter@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/cri-api@v0.30.0?package-id=4de173f6a5765211",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/component-base@v0.30.0?package-id=94800364440cc1a6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/image/jpeg@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=a1ff2ebea07a529d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/native@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/coverage/rtcov@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/usermode@1.114-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/gpg@1.15.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=406cd2654be0fcc8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=8899651b157fa55b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies-scripts@20240202-1.git283706d.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=34e50fc47ddb109c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/net/dns/dnsmessage@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/metrics@v0.30.0?package-id=e5a9c757e0ba76d0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=bd9cfde5eb7d49da",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=a6a4677db3654d87",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus-operator/prometheus-operator@v0.68.0?package-id=41c9ffe89c4328dd#pkg/apis/monitoring",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e87736d4223a3553",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/gover@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=077b67d110fda982",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/mvdan.cc/editorconfig@v0.2.1-0.20231228180347-1925077f8eb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/client-go@v0.0.0-20210112165513-ebc401615f47?package-id=332ab3a9d173ca98",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_4.3?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=d3adc2bc60fefccb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=2f055f6cdf8e3fb1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kubectl@v0.30.0?package-id=747804ed972e87a1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20240424215950-a892ee059fd6?package-id=0bc6f5896c6cb1a9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20210104183010-2eb08e3e575f?package-id=9de2c8dc0803d74e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=2e7c033a75be1ef6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=8256c45ca06407ab",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/controller-runtime@v0.6.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/jansson@2.14-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.5.0?package-id=b135113b0301cc3e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/math/big@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/openshift/custom-resource-status@v1.1.2?package-id=5df1a932dc364fae",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.12.0?package-id=49b478fdfd04f997",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/findutils@4.8.0-6.el9?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/sys@v0.6.2?package-id=2f1b091e7ebc59e5#mountinfo",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/syscall/execenv@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0?package-id=ff6ddf5ac62bb415#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-proxy@v0.30.0?package-id=da08354393870645",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/atomic@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=14c598a63cb5e9db",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=0f468cc3892f0124",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/subtle@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/native@v1.1.0?package-id=6604c5cd4c4748cf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=14c57ecad0b43747",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=db67540c07b5beb9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v2.6.1%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/opencontainers/runc@v1.1.14?package-id=db815b5d0b61f513",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-stack/stack@v1.8.0?package-id=48631dee752774c6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/bisect@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/edwards25519@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=71cd8ab004151c77",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go/internal/typeparams@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/testing@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-github@v32.0.0#v32",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/validate@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/numactl-libs@2.0.16-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/io/ioutil@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=077a5e8ca27fa924",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/html/template@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230220225925-ffce2a382923?package-id=a98cba5ae186c4f5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0?package-id=c774b777664a4bb0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/common@v0.50.1?package-id=e36d1d0f2ba91772",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libvirt-libs@10.0.0-6.19.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dateutil@2.8.1-7.el9?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/debug@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.33.1?package-id=c3d9773d12fa39a7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-kit/log@v0.2.1?package-id=429112dfb9428aeb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pierrec/lz4@v4.1.15?package-id=8f6dd5f7ba6a62ec#v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/controller-lifecycle-operator-sdk/api@v0.0.0-20220329064328-f3cc58c6ed90?package-id=6619c43cfd07c933",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libssh-config@0.10.4-13.el9_4.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/http/internal/testcert@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pborman/uuid@v1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-chardet@4.0.0-5.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=5ce12f7eaebfe865",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=2510cbce9c179e69",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/json@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/errors@v0.19.9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/expat@2.5.0-2.el9_4.2?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/internal/reflectlite@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/internal/bigmod@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d#rpc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/sample-controller@v0.30.0?package-id=95847fe4258b57c0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/crypto/rand@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230822172742-b8732ec3820d?package-id=454c35570125ce2f#rpc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=f4fcb5b06080adbf",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo@v2.17.2?package-id=709ca981edc6d5d6#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl@2.1.27-21.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240430033511-f0e62f92d13f?package-id=fd7558abcd37e57d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.30.0?package-id=dd84eb4f391fe51e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/unicode/utf8@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=1663864887e439eb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.30.0?package-id=f1bc226b87c469d8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/asn1@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.0?package-id=5eee73adffd25455",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4.4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sort@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=f951095dca4572e3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/archive/tar@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=3bccae874729638f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/kubevirt.io/containerized-data-importer-api@v1.58.0?package-id=892f25b58ba2cadb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.20.0?package-id=3cee09b2c9d8346a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0?package-id=a8276711fb26ec2c#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libs@0.190-2.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/machadovilaca/operator-observability@v0.0.20?package-id=ce832bdd3e643f49",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/six@1.15.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/runtime@v0.19.24",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/log/internal@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20200907205600-7a23bdc65eef",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/expvar@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=67a13c4d057a96fd#v22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/loads@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.40.1-1.el9_4?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/kmod-libs@28-9.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libssh@0.10.4-13.el9_4.1?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/net/textproto@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=5804e51cbc6df18a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/util-linux@2.37.4-18.el9?arch=aarch64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.120.1?package-id=c9e73a9ce3fca441",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=ebbb976b0b9a6691",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=ed2a22c702bae008",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1?package-id=3f70c1e082cb9132",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/runtime/internal/sys@go1.22.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:pypi/setuptools@53.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=aarch64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiserver@v0.30.0?package-id=46f0784d88e673c3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubernetes-csi/external-snapshotter@v4.2.0?package-id=c379c7237a34dcc0#client/v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.0?package-id=7338c535d9c880a0#v22",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/encoding/pem@go1.22.12",
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:e62dea98-2427-459e-bc0e-4d0f9d4f7f03"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/older/image-index-2025-11-25-CBE2989E64414F5.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/older/image-index-2025-11-25-CBE2989E64414F5.json
@@ -1,0 +1,156 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [
+        {
+          "name": "SBOMer",
+          "version": "f1c3bca6",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+                "acknowledgement": "declared"
+              }
+            }
+          ],
+          "provider": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          },
+          "externalReferences": [
+            {
+              "url": "https://github.com/project-ncl/sbomer",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/container-native-virtualization-virt-handler-rhel9@sha256%3Ae4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35-2",
+      "type": "container",
+      "description": "Image index manifest of pkg:oci/container-native-virtualization-virt-handler-rhel9@sha256%3Ae4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da"
+    },
+    "timestamp": "2025-11-25T09:03:29Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156271"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/container-native-virtualization-virt-handler-rhel9@sha256%3Ae4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35-2",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da"
+        }
+      ],
+      "bom-ref": "virt-handler-rhel9-container_image-index",
+      "version": "sha256:e4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/container-native-virtualization-virt-handler-rhel9@sha256%3Ae4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/container-native-virtualization-virt-handler-rhel9@sha256%3Ae4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/container-native-virtualization-virt-handler-rhel9@sha256%3Ae4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "pedigree": {
+        "variants": [
+          {
+            "name": "container-native-virtualization/virt-handler-rhel9",
+            "purl": "pkg:oci/virt-handler-rhel9@sha256%3A60bf81bdeafa73ba18d4ca19a211f9d6797fa517290a791c2fd5975ea92e73a9?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35-2",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "60bf81bdeafa73ba18d4ca19a211f9d6797fa517290a791c2fd5975ea92e73a9"
+              }
+            ],
+            "bom-ref": "virt-handler-rhel9-container_amd64",
+            "version": "sha256:60bf81bdeafa73ba18d4ca19a211f9d6797fa517290a791c2fd5975ea92e73a9",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          },
+          {
+            "name": "container-native-virtualization/virt-handler-rhel9",
+            "purl": "pkg:oci/virt-handler-rhel9@sha256%3A7bf21edeec9b052e5d2f748f1db1799385507c8c7f43261ff3d989e80db4417b?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35-2",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "7bf21edeec9b052e5d2f748f1db1799385507c8c7f43261ff3d989e80db4417b"
+              }
+            ],
+            "bom-ref": "virt-handler-rhel9-container_arm64",
+            "version": "sha256:7bf21edeec9b052e5d2f748f1db1799385507c8c7f43261ff3d989e80db4417b",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "virt-handler-rhel9-container"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "container-native-virtualization/virt-handler-rhel9"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "2"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "v4.17.35"
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:642378ff-11b2-38a8-83b5-a9a51fe89269"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/older/product-2025-11-25-D05BF995974542F.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/cnv-4.17/older/product-2025-11-25-D05BF995974542F.json
@@ -1,0 +1,2004 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [
+        {
+          "name": "SBOMer",
+          "version": "f1c3bca6",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+                "acknowledgement": "declared"
+              }
+            }
+          ],
+          "provider": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          },
+          "externalReferences": [
+            {
+              "url": "https://github.com/project-ncl/sbomer",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "RHEL-9-CNV-4.17",
+      "type": "framework",
+      "bom-ref": "RHEL-9-CNV-4.17",
+      "version": "RHEL-9-CNV-4.17",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:container_native_virtualization:4.17::el9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-11-25T11:21:36Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156271"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "container-native-virtualization/virt-artifacts-server-rhel9",
+      "purl": "pkg:oci/virt-artifacts-server-rhel9@sha256%3A180df7149d1eae6114df9e9be4c5777296498e3455a91484fae57c98bd5420ad",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "180df7149d1eae6114df9e9be4c5777296498e3455a91484fae57c98bd5420ad"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-artifacts-server-rhel9@sha256%3A180df7149d1eae6114df9e9be4c5777296498e3455a91484fae57c98bd5420ad",
+      "version": "sha256:180df7149d1eae6114df9e9be4c5777296498e3455a91484fae57c98bd5420ad",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-artifacts-server-rhel9@sha256%3A180df7149d1eae6114df9e9be4c5777296498e3455a91484fae57c98bd5420ad?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-artifacts-server-rhel9&tag=v4.17.35-1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-artifacts-server-rhel9@sha256%3A180df7149d1eae6114df9e9be4c5777296498e3455a91484fae57c98bd5420ad?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-artifacts-server-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-artifacts-server-rhel9@sha256%3A180df7149d1eae6114df9e9be4c5777296498e3455a91484fae57c98bd5420ad?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-artifacts-server-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/cnv-must-gather-rhel9",
+      "purl": "pkg:oci/cnv-must-gather-rhel9@sha256%3Afd7dd914c2083a0811316a42b6c648804d46b74c331698b9f297a3c0c6d1e4b9",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fd7dd914c2083a0811316a42b6c648804d46b74c331698b9f297a3c0c6d1e4b9"
+        }
+      ],
+      "bom-ref": "pkg:oci/cnv-must-gather-rhel9@sha256%3Afd7dd914c2083a0811316a42b6c648804d46b74c331698b9f297a3c0c6d1e4b9",
+      "version": "sha256:fd7dd914c2083a0811316a42b6c648804d46b74c331698b9f297a3c0c6d1e4b9",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cnv-must-gather-rhel9@sha256%3Afd7dd914c2083a0811316a42b6c648804d46b74c331698b9f297a3c0c6d1e4b9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcnv-must-gather-rhel9&tag=v4.17.35-1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cnv-must-gather-rhel9@sha256%3Afd7dd914c2083a0811316a42b6c648804d46b74c331698b9f297a3c0c6d1e4b9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcnv-must-gather-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cnv-must-gather-rhel9@sha256%3Afd7dd914c2083a0811316a42b6c648804d46b74c331698b9f297a3c0c6d1e4b9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcnv-must-gather-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/ovs-cni-plugin-rhel9",
+      "purl": "pkg:oci/ovs-cni-plugin-rhel9@sha256%3A2a068a744b162cd890966c5adf21db11024dabc31cf709402a6a47a905b50bb8",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2a068a744b162cd890966c5adf21db11024dabc31cf709402a6a47a905b50bb8"
+        }
+      ],
+      "bom-ref": "pkg:oci/ovs-cni-plugin-rhel9@sha256%3A2a068a744b162cd890966c5adf21db11024dabc31cf709402a6a47a905b50bb8",
+      "version": "sha256:2a068a744b162cd890966c5adf21db11024dabc31cf709402a6a47a905b50bb8",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/ovs-cni-plugin-rhel9@sha256%3A2a068a744b162cd890966c5adf21db11024dabc31cf709402a6a47a905b50bb8?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fovs-cni-plugin-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/ovs-cni-plugin-rhel9@sha256%3A2a068a744b162cd890966c5adf21db11024dabc31cf709402a6a47a905b50bb8?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fovs-cni-plugin-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/ovs-cni-plugin-rhel9@sha256%3A2a068a744b162cd890966c5adf21db11024dabc31cf709402a6a47a905b50bb8?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fovs-cni-plugin-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/bridge-marker-rhel9",
+      "purl": "pkg:oci/bridge-marker-rhel9@sha256%3A540201cffb476d8a8d80a340d907ef824377bd65593422ca783db735493d5bdd",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "540201cffb476d8a8d80a340d907ef824377bd65593422ca783db735493d5bdd"
+        }
+      ],
+      "bom-ref": "pkg:oci/bridge-marker-rhel9@sha256%3A540201cffb476d8a8d80a340d907ef824377bd65593422ca783db735493d5bdd",
+      "version": "sha256:540201cffb476d8a8d80a340d907ef824377bd65593422ca783db735493d5bdd",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/bridge-marker-rhel9@sha256%3A540201cffb476d8a8d80a340d907ef824377bd65593422ca783db735493d5bdd?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fbridge-marker-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/bridge-marker-rhel9@sha256%3A540201cffb476d8a8d80a340d907ef824377bd65593422ca783db735493d5bdd?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fbridge-marker-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/bridge-marker-rhel9@sha256%3A540201cffb476d8a8d80a340d907ef824377bd65593422ca783db735493d5bdd?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fbridge-marker-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-api-rhel9",
+      "purl": "pkg:oci/virt-api-rhel9@sha256%3A2680962c55d63273ec3aeeec447d5246dec0a484c18a02fe56dd29a58fb25bd5",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2680962c55d63273ec3aeeec447d5246dec0a484c18a02fe56dd29a58fb25bd5"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-api-rhel9@sha256%3A2680962c55d63273ec3aeeec447d5246dec0a484c18a02fe56dd29a58fb25bd5",
+      "version": "sha256:2680962c55d63273ec3aeeec447d5246dec0a484c18a02fe56dd29a58fb25bd5",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-api-rhel9@sha256%3A2680962c55d63273ec3aeeec447d5246dec0a484c18a02fe56dd29a58fb25bd5?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-api-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-api-rhel9@sha256%3A2680962c55d63273ec3aeeec447d5246dec0a484c18a02fe56dd29a58fb25bd5?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-api-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-api-rhel9@sha256%3A2680962c55d63273ec3aeeec447d5246dec0a484c18a02fe56dd29a58fb25bd5?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-api-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-ipam-controller-rhel9",
+      "purl": "pkg:oci/kubevirt-ipam-controller-rhel9@sha256%3A09881b8d3853a3db01379500ba1adc75d993b68000fe3591326a74c574035882",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "09881b8d3853a3db01379500ba1adc75d993b68000fe3591326a74c574035882"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-ipam-controller-rhel9@sha256%3A09881b8d3853a3db01379500ba1adc75d993b68000fe3591326a74c574035882",
+      "version": "sha256:09881b8d3853a3db01379500ba1adc75d993b68000fe3591326a74c574035882",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-ipam-controller-rhel9@sha256%3A09881b8d3853a3db01379500ba1adc75d993b68000fe3591326a74c574035882?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-ipam-controller-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-ipam-controller-rhel9@sha256%3A09881b8d3853a3db01379500ba1adc75d993b68000fe3591326a74c574035882?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-ipam-controller-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-ipam-controller-rhel9@sha256%3A09881b8d3853a3db01379500ba1adc75d993b68000fe3591326a74c574035882?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-ipam-controller-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-controller-rhel9",
+      "purl": "pkg:oci/virt-controller-rhel9@sha256%3A4f2760b8b18888ed24ab402070bb517e445fa24dd9ae5904b5c1ce758a8a4993",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4f2760b8b18888ed24ab402070bb517e445fa24dd9ae5904b5c1ce758a8a4993"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-controller-rhel9@sha256%3A4f2760b8b18888ed24ab402070bb517e445fa24dd9ae5904b5c1ce758a8a4993",
+      "version": "sha256:4f2760b8b18888ed24ab402070bb517e445fa24dd9ae5904b5c1ce758a8a4993",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-controller-rhel9@sha256%3A4f2760b8b18888ed24ab402070bb517e445fa24dd9ae5904b5c1ce758a8a4993?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-controller-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-controller-rhel9@sha256%3A4f2760b8b18888ed24ab402070bb517e445fa24dd9ae5904b5c1ce758a8a4993?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-controller-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-controller-rhel9@sha256%3A4f2760b8b18888ed24ab402070bb517e445fa24dd9ae5904b5c1ce758a8a4993?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-controller-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-uploadproxy-rhel9",
+      "purl": "pkg:oci/virt-cdi-uploadproxy-rhel9@sha256%3A15264188a5cd3ac275789b79fe0738b545a263c06b462ecfa5b135c360d29624",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "15264188a5cd3ac275789b79fe0738b545a263c06b462ecfa5b135c360d29624"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-uploadproxy-rhel9@sha256%3A15264188a5cd3ac275789b79fe0738b545a263c06b462ecfa5b135c360d29624",
+      "version": "sha256:15264188a5cd3ac275789b79fe0738b545a263c06b462ecfa5b135c360d29624",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-uploadproxy-rhel9@sha256%3A15264188a5cd3ac275789b79fe0738b545a263c06b462ecfa5b135c360d29624?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-uploadproxy-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-uploadproxy-rhel9@sha256%3A15264188a5cd3ac275789b79fe0738b545a263c06b462ecfa5b135c360d29624?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-uploadproxy-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-uploadproxy-rhel9@sha256%3A15264188a5cd3ac275789b79fe0738b545a263c06b462ecfa5b135c360d29624?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-uploadproxy-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-operator-rhel9",
+      "purl": "pkg:oci/virt-operator-rhel9@sha256%3Aa774009a12b4ea3328df7b1009de3e27aecb4719cbca17e0828ad8f6a4d14f97",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a774009a12b4ea3328df7b1009de3e27aecb4719cbca17e0828ad8f6a4d14f97"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-operator-rhel9@sha256%3Aa774009a12b4ea3328df7b1009de3e27aecb4719cbca17e0828ad8f6a4d14f97",
+      "version": "sha256:a774009a12b4ea3328df7b1009de3e27aecb4719cbca17e0828ad8f6a4d14f97",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-operator-rhel9@sha256%3Aa774009a12b4ea3328df7b1009de3e27aecb4719cbca17e0828ad8f6a4d14f97?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-operator-rhel9&tag=v4.17.35-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-operator-rhel9@sha256%3Aa774009a12b4ea3328df7b1009de3e27aecb4719cbca17e0828ad8f6a4d14f97?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-operator-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-operator-rhel9@sha256%3Aa774009a12b4ea3328df7b1009de3e27aecb4719cbca17e0828ad8f6a4d14f97?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-cloner-rhel9",
+      "purl": "pkg:oci/virt-cdi-cloner-rhel9@sha256%3Adc17158fbde5eb3bb29dc125b5db33123c204d840c31cfbca73ef5a54440a7e6",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dc17158fbde5eb3bb29dc125b5db33123c204d840c31cfbca73ef5a54440a7e6"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-cloner-rhel9@sha256%3Adc17158fbde5eb3bb29dc125b5db33123c204d840c31cfbca73ef5a54440a7e6",
+      "version": "sha256:dc17158fbde5eb3bb29dc125b5db33123c204d840c31cfbca73ef5a54440a7e6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-cloner-rhel9@sha256%3Adc17158fbde5eb3bb29dc125b5db33123c204d840c31cfbca73ef5a54440a7e6?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-cloner-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-cloner-rhel9@sha256%3Adc17158fbde5eb3bb29dc125b5db33123c204d840c31cfbca73ef5a54440a7e6?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-cloner-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-cloner-rhel9@sha256%3Adc17158fbde5eb3bb29dc125b5db33123c204d840c31cfbca73ef5a54440a7e6?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-cloner-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-template-validator-rhel9",
+      "purl": "pkg:oci/kubevirt-template-validator-rhel9@sha256%3A68b0b9adaa2a83b1b80a16e57ee930aec5f7f051a2e78198c8a60ea270faf1f0",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "68b0b9adaa2a83b1b80a16e57ee930aec5f7f051a2e78198c8a60ea270faf1f0"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-template-validator-rhel9@sha256%3A68b0b9adaa2a83b1b80a16e57ee930aec5f7f051a2e78198c8a60ea270faf1f0",
+      "version": "sha256:68b0b9adaa2a83b1b80a16e57ee930aec5f7f051a2e78198c8a60ea270faf1f0",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-template-validator-rhel9@sha256%3A68b0b9adaa2a83b1b80a16e57ee930aec5f7f051a2e78198c8a60ea270faf1f0?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-template-validator-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-template-validator-rhel9@sha256%3A68b0b9adaa2a83b1b80a16e57ee930aec5f7f051a2e78198c8a60ea270faf1f0?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-template-validator-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-template-validator-rhel9@sha256%3A68b0b9adaa2a83b1b80a16e57ee930aec5f7f051a2e78198c8a60ea270faf1f0?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-template-validator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-handler-rhel9",
+      "purl": "pkg:oci/virt-handler-rhel9@sha256%3Ae4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-handler-rhel9@sha256%3Ae4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da",
+      "version": "sha256:e4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3Ae4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3Ae4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-handler-rhel9@sha256%3Ae4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-handler-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/cluster-network-addons-operator-rhel9",
+      "purl": "pkg:oci/cluster-network-addons-operator-rhel9@sha256%3A5d2390a55695a9373d34f85f972e6454d4511f80f335f4e9f31e7dec7fb87bca",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5d2390a55695a9373d34f85f972e6454d4511f80f335f4e9f31e7dec7fb87bca"
+        }
+      ],
+      "bom-ref": "pkg:oci/cluster-network-addons-operator-rhel9@sha256%3A5d2390a55695a9373d34f85f972e6454d4511f80f335f4e9f31e7dec7fb87bca",
+      "version": "sha256:5d2390a55695a9373d34f85f972e6454d4511f80f335f4e9f31e7dec7fb87bca",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cluster-network-addons-operator-rhel9@sha256%3A5d2390a55695a9373d34f85f972e6454d4511f80f335f4e9f31e7dec7fb87bca?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcluster-network-addons-operator-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cluster-network-addons-operator-rhel9@sha256%3A5d2390a55695a9373d34f85f972e6454d4511f80f335f4e9f31e7dec7fb87bca?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcluster-network-addons-operator-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cluster-network-addons-operator-rhel9@sha256%3A5d2390a55695a9373d34f85f972e6454d4511f80f335f4e9f31e7dec7fb87bca?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcluster-network-addons-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-apiserver-rhel9",
+      "purl": "pkg:oci/virt-cdi-apiserver-rhel9@sha256%3A6abc764e7a3deebf6933a4afd420243a32e2db42f6d62bd4c1a226b1fec65171",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6abc764e7a3deebf6933a4afd420243a32e2db42f6d62bd4c1a226b1fec65171"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-apiserver-rhel9@sha256%3A6abc764e7a3deebf6933a4afd420243a32e2db42f6d62bd4c1a226b1fec65171",
+      "version": "sha256:6abc764e7a3deebf6933a4afd420243a32e2db42f6d62bd4c1a226b1fec65171",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-apiserver-rhel9@sha256%3A6abc764e7a3deebf6933a4afd420243a32e2db42f6d62bd4c1a226b1fec65171?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-apiserver-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-apiserver-rhel9@sha256%3A6abc764e7a3deebf6933a4afd420243a32e2db42f6d62bd4c1a226b1fec65171?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-apiserver-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-apiserver-rhel9@sha256%3A6abc764e7a3deebf6933a4afd420243a32e2db42f6d62bd4c1a226b1fec65171?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-apiserver-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubemacpool-rhel9",
+      "purl": "pkg:oci/kubemacpool-rhel9@sha256%3Afb9110ca46371970548f2801eadbd9696b58419002e19f6929760ad54dcc1ecb",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fb9110ca46371970548f2801eadbd9696b58419002e19f6929760ad54dcc1ecb"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubemacpool-rhel9@sha256%3Afb9110ca46371970548f2801eadbd9696b58419002e19f6929760ad54dcc1ecb",
+      "version": "sha256:fb9110ca46371970548f2801eadbd9696b58419002e19f6929760ad54dcc1ecb",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubemacpool-rhel9@sha256%3Afb9110ca46371970548f2801eadbd9696b58419002e19f6929760ad54dcc1ecb?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubemacpool-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubemacpool-rhel9@sha256%3Afb9110ca46371970548f2801eadbd9696b58419002e19f6929760ad54dcc1ecb?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubemacpool-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubemacpool-rhel9@sha256%3Afb9110ca46371970548f2801eadbd9696b58419002e19f6929760ad54dcc1ecb?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubemacpool-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/hostpath-csi-driver-rhel9",
+      "purl": "pkg:oci/hostpath-csi-driver-rhel9@sha256%3A4be6a390bce53a27c677b442ed767f6dc7460dfbf8cf46b0b6a0feed06cd9f93",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4be6a390bce53a27c677b442ed767f6dc7460dfbf8cf46b0b6a0feed06cd9f93"
+        }
+      ],
+      "bom-ref": "pkg:oci/hostpath-csi-driver-rhel9@sha256%3A4be6a390bce53a27c677b442ed767f6dc7460dfbf8cf46b0b6a0feed06cd9f93",
+      "version": "sha256:4be6a390bce53a27c677b442ed767f6dc7460dfbf8cf46b0b6a0feed06cd9f93",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-csi-driver-rhel9@sha256%3A4be6a390bce53a27c677b442ed767f6dc7460dfbf8cf46b0b6a0feed06cd9f93?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-csi-driver-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-csi-driver-rhel9@sha256%3A4be6a390bce53a27c677b442ed767f6dc7460dfbf8cf46b0b6a0feed06cd9f93?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-csi-driver-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-csi-driver-rhel9@sha256%3A4be6a390bce53a27c677b442ed767f6dc7460dfbf8cf46b0b6a0feed06cd9f93?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-csi-driver-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-uploadserver-rhel9",
+      "purl": "pkg:oci/virt-cdi-uploadserver-rhel9@sha256%3A9cfeb2bb6e1ef117e437d388c0dc4aa24c53ce496c3996dee7cddad1eb5cbce3",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9cfeb2bb6e1ef117e437d388c0dc4aa24c53ce496c3996dee7cddad1eb5cbce3"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-uploadserver-rhel9@sha256%3A9cfeb2bb6e1ef117e437d388c0dc4aa24c53ce496c3996dee7cddad1eb5cbce3",
+      "version": "sha256:9cfeb2bb6e1ef117e437d388c0dc4aa24c53ce496c3996dee7cddad1eb5cbce3",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-uploadserver-rhel9@sha256%3A9cfeb2bb6e1ef117e437d388c0dc4aa24c53ce496c3996dee7cddad1eb5cbce3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-uploadserver-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-uploadserver-rhel9@sha256%3A9cfeb2bb6e1ef117e437d388c0dc4aa24c53ce496c3996dee7cddad1eb5cbce3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-uploadserver-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-uploadserver-rhel9@sha256%3A9cfeb2bb6e1ef117e437d388c0dc4aa24c53ce496c3996dee7cddad1eb5cbce3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-uploadserver-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/multus-dynamic-networks-rhel9",
+      "purl": "pkg:oci/multus-dynamic-networks-rhel9@sha256%3Abe43f4cbfa7c892fd152e06a04ee8b82af9613e5dee44b8ca279ab0e2c659663",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "be43f4cbfa7c892fd152e06a04ee8b82af9613e5dee44b8ca279ab0e2c659663"
+        }
+      ],
+      "bom-ref": "pkg:oci/multus-dynamic-networks-rhel9@sha256%3Abe43f4cbfa7c892fd152e06a04ee8b82af9613e5dee44b8ca279ab0e2c659663",
+      "version": "sha256:be43f4cbfa7c892fd152e06a04ee8b82af9613e5dee44b8ca279ab0e2c659663",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/multus-dynamic-networks-rhel9@sha256%3Abe43f4cbfa7c892fd152e06a04ee8b82af9613e5dee44b8ca279ab0e2c659663?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fmultus-dynamic-networks-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/multus-dynamic-networks-rhel9@sha256%3Abe43f4cbfa7c892fd152e06a04ee8b82af9613e5dee44b8ca279ab0e2c659663?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fmultus-dynamic-networks-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/multus-dynamic-networks-rhel9@sha256%3Abe43f4cbfa7c892fd152e06a04ee8b82af9613e5dee44b8ca279ab0e2c659663?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fmultus-dynamic-networks-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-launcher-rhel9",
+      "purl": "pkg:oci/virt-launcher-rhel9@sha256%3Aee4b4a5104c0d119f062d61ce2832a815094a9cb18ad53b4d984e207734cf6c3",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ee4b4a5104c0d119f062d61ce2832a815094a9cb18ad53b4d984e207734cf6c3"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-launcher-rhel9@sha256%3Aee4b4a5104c0d119f062d61ce2832a815094a9cb18ad53b4d984e207734cf6c3",
+      "version": "sha256:ee4b4a5104c0d119f062d61ce2832a815094a9cb18ad53b4d984e207734cf6c3",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-launcher-rhel9@sha256%3Aee4b4a5104c0d119f062d61ce2832a815094a9cb18ad53b4d984e207734cf6c3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-launcher-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-launcher-rhel9@sha256%3Aee4b4a5104c0d119f062d61ce2832a815094a9cb18ad53b4d984e207734cf6c3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-launcher-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-launcher-rhel9@sha256%3Aee4b4a5104c0d119f062d61ce2832a815094a9cb18ad53b4d984e207734cf6c3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-launcher-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-common-instancetypes-rhel9",
+      "purl": "pkg:oci/kubevirt-common-instancetypes-rhel9@sha256%3A59de0374db75b0b98a4070eead6a300d88ca8406006845afe4ae6830af88951e",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "59de0374db75b0b98a4070eead6a300d88ca8406006845afe4ae6830af88951e"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-common-instancetypes-rhel9@sha256%3A59de0374db75b0b98a4070eead6a300d88ca8406006845afe4ae6830af88951e",
+      "version": "sha256:59de0374db75b0b98a4070eead6a300d88ca8406006845afe4ae6830af88951e",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-common-instancetypes-rhel9@sha256%3A59de0374db75b0b98a4070eead6a300d88ca8406006845afe4ae6830af88951e?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-common-instancetypes-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-common-instancetypes-rhel9@sha256%3A59de0374db75b0b98a4070eead6a300d88ca8406006845afe4ae6830af88951e?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-common-instancetypes-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-common-instancetypes-rhel9@sha256%3A59de0374db75b0b98a4070eead6a300d88ca8406006845afe4ae6830af88951e?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-common-instancetypes-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/libguestfs-tools-rhel9",
+      "purl": "pkg:oci/libguestfs-tools-rhel9@sha256%3Acbf7dbb73ceb1da835df2ee1d3060a3aa3dc21cd9454580ce6931aebfa9ad2f9",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cbf7dbb73ceb1da835df2ee1d3060a3aa3dc21cd9454580ce6931aebfa9ad2f9"
+        }
+      ],
+      "bom-ref": "pkg:oci/libguestfs-tools-rhel9@sha256%3Acbf7dbb73ceb1da835df2ee1d3060a3aa3dc21cd9454580ce6931aebfa9ad2f9",
+      "version": "sha256:cbf7dbb73ceb1da835df2ee1d3060a3aa3dc21cd9454580ce6931aebfa9ad2f9",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/libguestfs-tools-rhel9@sha256%3Acbf7dbb73ceb1da835df2ee1d3060a3aa3dc21cd9454580ce6931aebfa9ad2f9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Flibguestfs-tools-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/libguestfs-tools-rhel9@sha256%3Acbf7dbb73ceb1da835df2ee1d3060a3aa3dc21cd9454580ce6931aebfa9ad2f9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Flibguestfs-tools-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/libguestfs-tools-rhel9@sha256%3Acbf7dbb73ceb1da835df2ee1d3060a3aa3dc21cd9454580ce6931aebfa9ad2f9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Flibguestfs-tools-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-ssp-operator-rhel9",
+      "purl": "pkg:oci/kubevirt-ssp-operator-rhel9@sha256%3Aa6374363cc63c8752c26432e21647de53df1b93bbddad743388f3e7d2eb4405c",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a6374363cc63c8752c26432e21647de53df1b93bbddad743388f3e7d2eb4405c"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-ssp-operator-rhel9@sha256%3Aa6374363cc63c8752c26432e21647de53df1b93bbddad743388f3e7d2eb4405c",
+      "version": "sha256:a6374363cc63c8752c26432e21647de53df1b93bbddad743388f3e7d2eb4405c",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-ssp-operator-rhel9@sha256%3Aa6374363cc63c8752c26432e21647de53df1b93bbddad743388f3e7d2eb4405c?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-ssp-operator-rhel9&tag=v4.17.35-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-ssp-operator-rhel9@sha256%3Aa6374363cc63c8752c26432e21647de53df1b93bbddad743388f3e7d2eb4405c?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-ssp-operator-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-ssp-operator-rhel9@sha256%3Aa6374363cc63c8752c26432e21647de53df1b93bbddad743388f3e7d2eb4405c?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-ssp-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/aaq-server-rhel9",
+      "purl": "pkg:oci/aaq-server-rhel9@sha256%3A08f12a6b3e0e58de3ab58e58f84824eb1c02c44fb27966d21ad3f8aabd86a5fd",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "08f12a6b3e0e58de3ab58e58f84824eb1c02c44fb27966d21ad3f8aabd86a5fd"
+        }
+      ],
+      "bom-ref": "pkg:oci/aaq-server-rhel9@sha256%3A08f12a6b3e0e58de3ab58e58f84824eb1c02c44fb27966d21ad3f8aabd86a5fd",
+      "version": "sha256:08f12a6b3e0e58de3ab58e58f84824eb1c02c44fb27966d21ad3f8aabd86a5fd",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-server-rhel9@sha256%3A08f12a6b3e0e58de3ab58e58f84824eb1c02c44fb27966d21ad3f8aabd86a5fd?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-server-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-server-rhel9@sha256%3A08f12a6b3e0e58de3ab58e58f84824eb1c02c44fb27966d21ad3f8aabd86a5fd?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-server-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-server-rhel9@sha256%3A08f12a6b3e0e58de3ab58e58f84824eb1c02c44fb27966d21ad3f8aabd86a5fd?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-server-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/aaq-operator-rhel9",
+      "purl": "pkg:oci/aaq-operator-rhel9@sha256%3A16a66b5852e85ed6ee31c4d5ad3296ff3c5508e0ff8a05457c687e11b3245e32",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "16a66b5852e85ed6ee31c4d5ad3296ff3c5508e0ff8a05457c687e11b3245e32"
+        }
+      ],
+      "bom-ref": "pkg:oci/aaq-operator-rhel9@sha256%3A16a66b5852e85ed6ee31c4d5ad3296ff3c5508e0ff8a05457c687e11b3245e32",
+      "version": "sha256:16a66b5852e85ed6ee31c4d5ad3296ff3c5508e0ff8a05457c687e11b3245e32",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-operator-rhel9@sha256%3A16a66b5852e85ed6ee31c4d5ad3296ff3c5508e0ff8a05457c687e11b3245e32?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-operator-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-operator-rhel9@sha256%3A16a66b5852e85ed6ee31c4d5ad3296ff3c5508e0ff8a05457c687e11b3245e32?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-operator-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-operator-rhel9@sha256%3A16a66b5852e85ed6ee31c4d5ad3296ff3c5508e0ff8a05457c687e11b3245e32?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubesecondarydns-rhel9",
+      "purl": "pkg:oci/kubesecondarydns-rhel9@sha256%3A9fec79a7630162943ad9ab7bd091654652c12d81d7727b793f9afe5b7a0f9715",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9fec79a7630162943ad9ab7bd091654652c12d81d7727b793f9afe5b7a0f9715"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubesecondarydns-rhel9@sha256%3A9fec79a7630162943ad9ab7bd091654652c12d81d7727b793f9afe5b7a0f9715",
+      "version": "sha256:9fec79a7630162943ad9ab7bd091654652c12d81d7727b793f9afe5b7a0f9715",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubesecondarydns-rhel9@sha256%3A9fec79a7630162943ad9ab7bd091654652c12d81d7727b793f9afe5b7a0f9715?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubesecondarydns-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubesecondarydns-rhel9@sha256%3A9fec79a7630162943ad9ab7bd091654652c12d81d7727b793f9afe5b7a0f9715?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubesecondarydns-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubesecondarydns-rhel9@sha256%3A9fec79a7630162943ad9ab7bd091654652c12d81d7727b793f9afe5b7a0f9715?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubesecondarydns-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/cnv-containernetworking-plugins-rhel9",
+      "purl": "pkg:oci/cnv-containernetworking-plugins-rhel9@sha256%3A8fa483942880c19a090488033eb0ddb7d9013bc94f4f3f884f3e5812bccf4c63",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8fa483942880c19a090488033eb0ddb7d9013bc94f4f3f884f3e5812bccf4c63"
+        }
+      ],
+      "bom-ref": "pkg:oci/cnv-containernetworking-plugins-rhel9@sha256%3A8fa483942880c19a090488033eb0ddb7d9013bc94f4f3f884f3e5812bccf4c63",
+      "version": "sha256:8fa483942880c19a090488033eb0ddb7d9013bc94f4f3f884f3e5812bccf4c63",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cnv-containernetworking-plugins-rhel9@sha256%3A8fa483942880c19a090488033eb0ddb7d9013bc94f4f3f884f3e5812bccf4c63?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcnv-containernetworking-plugins-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cnv-containernetworking-plugins-rhel9@sha256%3A8fa483942880c19a090488033eb0ddb7d9013bc94f4f3f884f3e5812bccf4c63?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcnv-containernetworking-plugins-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/cnv-containernetworking-plugins-rhel9@sha256%3A8fa483942880c19a090488033eb0ddb7d9013bc94f4f3f884f3e5812bccf4c63?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fcnv-containernetworking-plugins-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-importer-rhel9",
+      "purl": "pkg:oci/virt-cdi-importer-rhel9@sha256%3A63a90ed0f470d4045490cafc66859ab6fa4996d38c8779715fb22e716e8c4924",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "63a90ed0f470d4045490cafc66859ab6fa4996d38c8779715fb22e716e8c4924"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-importer-rhel9@sha256%3A63a90ed0f470d4045490cafc66859ab6fa4996d38c8779715fb22e716e8c4924",
+      "version": "sha256:63a90ed0f470d4045490cafc66859ab6fa4996d38c8779715fb22e716e8c4924",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-importer-rhel9@sha256%3A63a90ed0f470d4045490cafc66859ab6fa4996d38c8779715fb22e716e8c4924?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-importer-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-importer-rhel9@sha256%3A63a90ed0f470d4045490cafc66859ab6fa4996d38c8779715fb22e716e8c4924?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-importer-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-importer-rhel9@sha256%3A63a90ed0f470d4045490cafc66859ab6fa4996d38c8779715fb22e716e8c4924?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-importer-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/wasp-agent-rhel9",
+      "purl": "pkg:oci/wasp-agent-rhel9@sha256%3A23f71dd83abe64d5131d3990f7f86c90eaf90e19d5c118e581654df2efa74ea5",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "23f71dd83abe64d5131d3990f7f86c90eaf90e19d5c118e581654df2efa74ea5"
+        }
+      ],
+      "bom-ref": "pkg:oci/wasp-agent-rhel9@sha256%3A23f71dd83abe64d5131d3990f7f86c90eaf90e19d5c118e581654df2efa74ea5",
+      "version": "sha256:23f71dd83abe64d5131d3990f7f86c90eaf90e19d5c118e581654df2efa74ea5",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/wasp-agent-rhel9@sha256%3A23f71dd83abe64d5131d3990f7f86c90eaf90e19d5c118e581654df2efa74ea5?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fwasp-agent-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/wasp-agent-rhel9@sha256%3A23f71dd83abe64d5131d3990f7f86c90eaf90e19d5c118e581654df2efa74ea5?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fwasp-agent-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/wasp-agent-rhel9@sha256%3A23f71dd83abe64d5131d3990f7f86c90eaf90e19d5c118e581654df2efa74ea5?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fwasp-agent-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/passt-network-binding-plugin-cni-rhel9",
+      "purl": "pkg:oci/passt-network-binding-plugin-cni-rhel9@sha256%3A6246fab77de49b0b46537651d107981706f6bc47a8069410aca5a9885095ebd7",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6246fab77de49b0b46537651d107981706f6bc47a8069410aca5a9885095ebd7"
+        }
+      ],
+      "bom-ref": "pkg:oci/passt-network-binding-plugin-cni-rhel9@sha256%3A6246fab77de49b0b46537651d107981706f6bc47a8069410aca5a9885095ebd7",
+      "version": "sha256:6246fab77de49b0b46537651d107981706f6bc47a8069410aca5a9885095ebd7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/passt-network-binding-plugin-cni-rhel9@sha256%3A6246fab77de49b0b46537651d107981706f6bc47a8069410aca5a9885095ebd7?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpasst-network-binding-plugin-cni-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/passt-network-binding-plugin-cni-rhel9@sha256%3A6246fab77de49b0b46537651d107981706f6bc47a8069410aca5a9885095ebd7?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpasst-network-binding-plugin-cni-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/passt-network-binding-plugin-cni-rhel9@sha256%3A6246fab77de49b0b46537651d107981706f6bc47a8069410aca5a9885095ebd7?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpasst-network-binding-plugin-cni-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-exportserver-rhel9",
+      "purl": "pkg:oci/virt-exportserver-rhel9@sha256%3A0c3267c8dae79cd9fccecd0681e063f738974a2a9ffbb7e013640a3a218dcef9",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0c3267c8dae79cd9fccecd0681e063f738974a2a9ffbb7e013640a3a218dcef9"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-exportserver-rhel9@sha256%3A0c3267c8dae79cd9fccecd0681e063f738974a2a9ffbb7e013640a3a218dcef9",
+      "version": "sha256:0c3267c8dae79cd9fccecd0681e063f738974a2a9ffbb7e013640a3a218dcef9",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-exportserver-rhel9@sha256%3A0c3267c8dae79cd9fccecd0681e063f738974a2a9ffbb7e013640a3a218dcef9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-exportserver-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-exportserver-rhel9@sha256%3A0c3267c8dae79cd9fccecd0681e063f738974a2a9ffbb7e013640a3a218dcef9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-exportserver-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-exportserver-rhel9@sha256%3A0c3267c8dae79cd9fccecd0681e063f738974a2a9ffbb7e013640a3a218dcef9?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-exportserver-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/vm-network-latency-checkup-rhel9",
+      "purl": "pkg:oci/vm-network-latency-checkup-rhel9@sha256%3A3d96bd657ede3b57725af013a73c3f1f026bc0ee01f0d710dc0ceda39b66abfc",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3d96bd657ede3b57725af013a73c3f1f026bc0ee01f0d710dc0ceda39b66abfc"
+        }
+      ],
+      "bom-ref": "pkg:oci/vm-network-latency-checkup-rhel9@sha256%3A3d96bd657ede3b57725af013a73c3f1f026bc0ee01f0d710dc0ceda39b66abfc",
+      "version": "sha256:3d96bd657ede3b57725af013a73c3f1f026bc0ee01f0d710dc0ceda39b66abfc",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/vm-network-latency-checkup-rhel9@sha256%3A3d96bd657ede3b57725af013a73c3f1f026bc0ee01f0d710dc0ceda39b66abfc?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvm-network-latency-checkup-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/vm-network-latency-checkup-rhel9@sha256%3A3d96bd657ede3b57725af013a73c3f1f026bc0ee01f0d710dc0ceda39b66abfc?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvm-network-latency-checkup-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/vm-network-latency-checkup-rhel9@sha256%3A3d96bd657ede3b57725af013a73c3f1f026bc0ee01f0d710dc0ceda39b66abfc?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvm-network-latency-checkup-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-operator-rhel9",
+      "purl": "pkg:oci/virt-cdi-operator-rhel9@sha256%3A18eacd9da3787f4796fe25bcb2f08008221403df14910cef67bd74030f02d37a",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "18eacd9da3787f4796fe25bcb2f08008221403df14910cef67bd74030f02d37a"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-operator-rhel9@sha256%3A18eacd9da3787f4796fe25bcb2f08008221403df14910cef67bd74030f02d37a",
+      "version": "sha256:18eacd9da3787f4796fe25bcb2f08008221403df14910cef67bd74030f02d37a",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-operator-rhel9@sha256%3A18eacd9da3787f4796fe25bcb2f08008221403df14910cef67bd74030f02d37a?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-operator-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-operator-rhel9@sha256%3A18eacd9da3787f4796fe25bcb2f08008221403df14910cef67bd74030f02d37a?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-operator-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-operator-rhel9@sha256%3A18eacd9da3787f4796fe25bcb2f08008221403df14910cef67bd74030f02d37a?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/hostpath-provisioner-operator-rhel9",
+      "purl": "pkg:oci/hostpath-provisioner-operator-rhel9@sha256%3A4f855fe67de01c37482a94c3b66d520a608b951f26cd0791772c79426c8365e3",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4f855fe67de01c37482a94c3b66d520a608b951f26cd0791772c79426c8365e3"
+        }
+      ],
+      "bom-ref": "pkg:oci/hostpath-provisioner-operator-rhel9@sha256%3A4f855fe67de01c37482a94c3b66d520a608b951f26cd0791772c79426c8365e3",
+      "version": "sha256:4f855fe67de01c37482a94c3b66d520a608b951f26cd0791772c79426c8365e3",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-provisioner-operator-rhel9@sha256%3A4f855fe67de01c37482a94c3b66d520a608b951f26cd0791772c79426c8365e3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-provisioner-operator-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-provisioner-operator-rhel9@sha256%3A4f855fe67de01c37482a94c3b66d520a608b951f26cd0791772c79426c8365e3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-provisioner-operator-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-provisioner-operator-rhel9@sha256%3A4f855fe67de01c37482a94c3b66d520a608b951f26cd0791772c79426c8365e3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-provisioner-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/vm-console-proxy-rhel9",
+      "purl": "pkg:oci/vm-console-proxy-rhel9@sha256%3A860bfbebe8d372a945183ac746634a019220e041279f5beb2b7ab45e2778c675",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "860bfbebe8d372a945183ac746634a019220e041279f5beb2b7ab45e2778c675"
+        }
+      ],
+      "bom-ref": "pkg:oci/vm-console-proxy-rhel9@sha256%3A860bfbebe8d372a945183ac746634a019220e041279f5beb2b7ab45e2778c675",
+      "version": "sha256:860bfbebe8d372a945183ac746634a019220e041279f5beb2b7ab45e2778c675",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/vm-console-proxy-rhel9@sha256%3A860bfbebe8d372a945183ac746634a019220e041279f5beb2b7ab45e2778c675?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvm-console-proxy-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/vm-console-proxy-rhel9@sha256%3A860bfbebe8d372a945183ac746634a019220e041279f5beb2b7ab45e2778c675?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvm-console-proxy-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/vm-console-proxy-rhel9@sha256%3A860bfbebe8d372a945183ac746634a019220e041279f5beb2b7ab45e2778c675?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvm-console-proxy-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/hostpath-provisioner-rhel9",
+      "purl": "pkg:oci/hostpath-provisioner-rhel9@sha256%3Aaed313a5e5da26aa209f6b3909625fdda987526bbd9ad73096f60e5c6449d384",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "aed313a5e5da26aa209f6b3909625fdda987526bbd9ad73096f60e5c6449d384"
+        }
+      ],
+      "bom-ref": "pkg:oci/hostpath-provisioner-rhel9@sha256%3Aaed313a5e5da26aa209f6b3909625fdda987526bbd9ad73096f60e5c6449d384",
+      "version": "sha256:aed313a5e5da26aa209f6b3909625fdda987526bbd9ad73096f60e5c6449d384",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-provisioner-rhel9@sha256%3Aaed313a5e5da26aa209f6b3909625fdda987526bbd9ad73096f60e5c6449d384?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-provisioner-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-provisioner-rhel9@sha256%3Aaed313a5e5da26aa209f6b3909625fdda987526bbd9ad73096f60e5c6449d384?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-provisioner-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hostpath-provisioner-rhel9@sha256%3Aaed313a5e5da26aa209f6b3909625fdda987526bbd9ad73096f60e5c6449d384?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhostpath-provisioner-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/passt-network-binding-plugin-sidecar-rhel9",
+      "purl": "pkg:oci/passt-network-binding-plugin-sidecar-rhel9@sha256%3Aa4adb00a5b1f8f0a0920e1c34a37f0d34fec064f2479e4302663a535769cd190",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a4adb00a5b1f8f0a0920e1c34a37f0d34fec064f2479e4302663a535769cd190"
+        }
+      ],
+      "bom-ref": "pkg:oci/passt-network-binding-plugin-sidecar-rhel9@sha256%3Aa4adb00a5b1f8f0a0920e1c34a37f0d34fec064f2479e4302663a535769cd190",
+      "version": "sha256:a4adb00a5b1f8f0a0920e1c34a37f0d34fec064f2479e4302663a535769cd190",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/passt-network-binding-plugin-sidecar-rhel9@sha256%3Aa4adb00a5b1f8f0a0920e1c34a37f0d34fec064f2479e4302663a535769cd190?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpasst-network-binding-plugin-sidecar-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/passt-network-binding-plugin-sidecar-rhel9@sha256%3Aa4adb00a5b1f8f0a0920e1c34a37f0d34fec064f2479e4302663a535769cd190?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpasst-network-binding-plugin-sidecar-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/passt-network-binding-plugin-sidecar-rhel9@sha256%3Aa4adb00a5b1f8f0a0920e1c34a37f0d34fec064f2479e4302663a535769cd190?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpasst-network-binding-plugin-sidecar-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virtio-win-rhel9",
+      "purl": "pkg:oci/virtio-win-rhel9@sha256%3Aad45b7d4e6ac2de819158e343be56fc2602f6ead3a9f86ca2cfc382bd75f8bfe",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ad45b7d4e6ac2de819158e343be56fc2602f6ead3a9f86ca2cfc382bd75f8bfe"
+        }
+      ],
+      "bom-ref": "pkg:oci/virtio-win-rhel9@sha256%3Aad45b7d4e6ac2de819158e343be56fc2602f6ead3a9f86ca2cfc382bd75f8bfe",
+      "version": "sha256:ad45b7d4e6ac2de819158e343be56fc2602f6ead3a9f86ca2cfc382bd75f8bfe",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virtio-win-rhel9@sha256%3Aad45b7d4e6ac2de819158e343be56fc2602f6ead3a9f86ca2cfc382bd75f8bfe?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirtio-win-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virtio-win-rhel9@sha256%3Aad45b7d4e6ac2de819158e343be56fc2602f6ead3a9f86ca2cfc382bd75f8bfe?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirtio-win-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virtio-win-rhel9@sha256%3Aad45b7d4e6ac2de819158e343be56fc2602f6ead3a9f86ca2cfc382bd75f8bfe?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirtio-win-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-apiserver-proxy-rhel9",
+      "purl": "pkg:oci/kubevirt-apiserver-proxy-rhel9@sha256%3A50983f969f5c8f61f9aeb68e02193227525ec82fcc34fe71a4c804c190b476fc",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "50983f969f5c8f61f9aeb68e02193227525ec82fcc34fe71a4c804c190b476fc"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-apiserver-proxy-rhel9@sha256%3A50983f969f5c8f61f9aeb68e02193227525ec82fcc34fe71a4c804c190b476fc",
+      "version": "sha256:50983f969f5c8f61f9aeb68e02193227525ec82fcc34fe71a4c804c190b476fc",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-apiserver-proxy-rhel9@sha256%3A50983f969f5c8f61f9aeb68e02193227525ec82fcc34fe71a4c804c190b476fc?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-apiserver-proxy-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-apiserver-proxy-rhel9@sha256%3A50983f969f5c8f61f9aeb68e02193227525ec82fcc34fe71a4c804c190b476fc?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-apiserver-proxy-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-apiserver-proxy-rhel9@sha256%3A50983f969f5c8f61f9aeb68e02193227525ec82fcc34fe71a4c804c190b476fc?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-apiserver-proxy-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-cdi-controller-rhel9",
+      "purl": "pkg:oci/virt-cdi-controller-rhel9@sha256%3A46d9b90b8e579903f861000daf25077364c890a27684ad6823031141735a48b7",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "46d9b90b8e579903f861000daf25077364c890a27684ad6823031141735a48b7"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-cdi-controller-rhel9@sha256%3A46d9b90b8e579903f861000daf25077364c890a27684ad6823031141735a48b7",
+      "version": "sha256:46d9b90b8e579903f861000daf25077364c890a27684ad6823031141735a48b7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-controller-rhel9@sha256%3A46d9b90b8e579903f861000daf25077364c890a27684ad6823031141735a48b7?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-controller-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-controller-rhel9@sha256%3A46d9b90b8e579903f861000daf25077364c890a27684ad6823031141735a48b7?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-controller-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-cdi-controller-rhel9@sha256%3A46d9b90b8e579903f861000daf25077364c890a27684ad6823031141735a48b7?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-cdi-controller-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/virt-exportproxy-rhel9",
+      "purl": "pkg:oci/virt-exportproxy-rhel9@sha256%3Ad0bb30ab8429e42a5162f317c6c56d893307dfb67b8a70c29f33dcd92b6a65b0",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d0bb30ab8429e42a5162f317c6c56d893307dfb67b8a70c29f33dcd92b6a65b0"
+        }
+      ],
+      "bom-ref": "pkg:oci/virt-exportproxy-rhel9@sha256%3Ad0bb30ab8429e42a5162f317c6c56d893307dfb67b8a70c29f33dcd92b6a65b0",
+      "version": "sha256:d0bb30ab8429e42a5162f317c6c56d893307dfb67b8a70c29f33dcd92b6a65b0",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-exportproxy-rhel9@sha256%3Ad0bb30ab8429e42a5162f317c6c56d893307dfb67b8a70c29f33dcd92b6a65b0?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-exportproxy-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-exportproxy-rhel9@sha256%3Ad0bb30ab8429e42a5162f317c6c56d893307dfb67b8a70c29f33dcd92b6a65b0?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-exportproxy-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/virt-exportproxy-rhel9@sha256%3Ad0bb30ab8429e42a5162f317c6c56d893307dfb67b8a70c29f33dcd92b6a65b0?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fvirt-exportproxy-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/hyperconverged-cluster-operator-rhel9",
+      "purl": "pkg:oci/hyperconverged-cluster-operator-rhel9@sha256%3Abc1548bff47233e5243e2c2c067eb949b0770b98284ac79d6a052b48a6848da3",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bc1548bff47233e5243e2c2c067eb949b0770b98284ac79d6a052b48a6848da3"
+        }
+      ],
+      "bom-ref": "pkg:oci/hyperconverged-cluster-operator-rhel9@sha256%3Abc1548bff47233e5243e2c2c067eb949b0770b98284ac79d6a052b48a6848da3",
+      "version": "sha256:bc1548bff47233e5243e2c2c067eb949b0770b98284ac79d6a052b48a6848da3",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hyperconverged-cluster-operator-rhel9@sha256%3Abc1548bff47233e5243e2c2c067eb949b0770b98284ac79d6a052b48a6848da3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhyperconverged-cluster-operator-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hyperconverged-cluster-operator-rhel9@sha256%3Abc1548bff47233e5243e2c2c067eb949b0770b98284ac79d6a052b48a6848da3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhyperconverged-cluster-operator-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hyperconverged-cluster-operator-rhel9@sha256%3Abc1548bff47233e5243e2c2c067eb949b0770b98284ac79d6a052b48a6848da3?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhyperconverged-cluster-operator-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-realtime-checkup-rhel9",
+      "purl": "pkg:oci/kubevirt-realtime-checkup-rhel9@sha256%3A5684b0620359dbd14157a9e3e3b8e2e9505c5b3992607a75e2392f48e45938bb",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5684b0620359dbd14157a9e3e3b8e2e9505c5b3992607a75e2392f48e45938bb"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-realtime-checkup-rhel9@sha256%3A5684b0620359dbd14157a9e3e3b8e2e9505c5b3992607a75e2392f48e45938bb",
+      "version": "sha256:5684b0620359dbd14157a9e3e3b8e2e9505c5b3992607a75e2392f48e45938bb",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-realtime-checkup-rhel9@sha256%3A5684b0620359dbd14157a9e3e3b8e2e9505c5b3992607a75e2392f48e45938bb?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-realtime-checkup-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-realtime-checkup-rhel9@sha256%3A5684b0620359dbd14157a9e3e3b8e2e9505c5b3992607a75e2392f48e45938bb?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-realtime-checkup-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-realtime-checkup-rhel9@sha256%3A5684b0620359dbd14157a9e3e3b8e2e9505c5b3992607a75e2392f48e45938bb?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-realtime-checkup-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/aaq-controller-rhel9",
+      "purl": "pkg:oci/aaq-controller-rhel9@sha256%3Ad5b08f598bc2ad948d3b47c280e42d102d3dd9925b2addf6ce35b9c879bf7969",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d5b08f598bc2ad948d3b47c280e42d102d3dd9925b2addf6ce35b9c879bf7969"
+        }
+      ],
+      "bom-ref": "pkg:oci/aaq-controller-rhel9@sha256%3Ad5b08f598bc2ad948d3b47c280e42d102d3dd9925b2addf6ce35b9c879bf7969",
+      "version": "sha256:d5b08f598bc2ad948d3b47c280e42d102d3dd9925b2addf6ce35b9c879bf7969",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-controller-rhel9@sha256%3Ad5b08f598bc2ad948d3b47c280e42d102d3dd9925b2addf6ce35b9c879bf7969?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-controller-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-controller-rhel9@sha256%3Ad5b08f598bc2ad948d3b47c280e42d102d3dd9925b2addf6ce35b9c879bf7969?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-controller-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/aaq-controller-rhel9@sha256%3Ad5b08f598bc2ad948d3b47c280e42d102d3dd9925b2addf6ce35b9c879bf7969?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Faaq-controller-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-tekton-tasks-disk-virt-customize-rhel9",
+      "purl": "pkg:oci/kubevirt-tekton-tasks-disk-virt-customize-rhel9@sha256%3Aa9e274420db32fa53e4f47af5d03a305a6b85faac3d994e729318d502a4f5471",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a9e274420db32fa53e4f47af5d03a305a6b85faac3d994e729318d502a4f5471"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-tekton-tasks-disk-virt-customize-rhel9@sha256%3Aa9e274420db32fa53e4f47af5d03a305a6b85faac3d994e729318d502a4f5471",
+      "version": "sha256:a9e274420db32fa53e4f47af5d03a305a6b85faac3d994e729318d502a4f5471",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-tekton-tasks-disk-virt-customize-rhel9@sha256%3Aa9e274420db32fa53e4f47af5d03a305a6b85faac3d994e729318d502a4f5471?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-tekton-tasks-disk-virt-customize-rhel9&tag=v4.17.35-3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-tekton-tasks-disk-virt-customize-rhel9@sha256%3Aa9e274420db32fa53e4f47af5d03a305a6b85faac3d994e729318d502a4f5471?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-tekton-tasks-disk-virt-customize-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-tekton-tasks-disk-virt-customize-rhel9@sha256%3Aa9e274420db32fa53e4f47af5d03a305a6b85faac3d994e729318d502a4f5471?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-tekton-tasks-disk-virt-customize-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/pr-helper-rhel9",
+      "purl": "pkg:oci/pr-helper-rhel9@sha256%3A26be2f8e5dd0859a03a88bcb59d9642ed6f900e378a598886f186042ab108e43",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "26be2f8e5dd0859a03a88bcb59d9642ed6f900e378a598886f186042ab108e43"
+        }
+      ],
+      "bom-ref": "pkg:oci/pr-helper-rhel9@sha256%3A26be2f8e5dd0859a03a88bcb59d9642ed6f900e378a598886f186042ab108e43",
+      "version": "sha256:26be2f8e5dd0859a03a88bcb59d9642ed6f900e378a598886f186042ab108e43",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/pr-helper-rhel9@sha256%3A26be2f8e5dd0859a03a88bcb59d9642ed6f900e378a598886f186042ab108e43?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpr-helper-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/pr-helper-rhel9@sha256%3A26be2f8e5dd0859a03a88bcb59d9642ed6f900e378a598886f186042ab108e43?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpr-helper-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/pr-helper-rhel9@sha256%3A26be2f8e5dd0859a03a88bcb59d9642ed6f900e378a598886f186042ab108e43?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fpr-helper-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-tekton-tasks-create-datavolume-rhel9",
+      "purl": "pkg:oci/kubevirt-tekton-tasks-create-datavolume-rhel9@sha256%3Add208ea58e0b85391f7736b1db26acbb39de00679a13ec6ad21e46f08f1491c1",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dd208ea58e0b85391f7736b1db26acbb39de00679a13ec6ad21e46f08f1491c1"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-tekton-tasks-create-datavolume-rhel9@sha256%3Add208ea58e0b85391f7736b1db26acbb39de00679a13ec6ad21e46f08f1491c1",
+      "version": "sha256:dd208ea58e0b85391f7736b1db26acbb39de00679a13ec6ad21e46f08f1491c1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-tekton-tasks-create-datavolume-rhel9@sha256%3Add208ea58e0b85391f7736b1db26acbb39de00679a13ec6ad21e46f08f1491c1?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-tekton-tasks-create-datavolume-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-tekton-tasks-create-datavolume-rhel9@sha256%3Add208ea58e0b85391f7736b1db26acbb39de00679a13ec6ad21e46f08f1491c1?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-tekton-tasks-create-datavolume-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-tekton-tasks-create-datavolume-rhel9@sha256%3Add208ea58e0b85391f7736b1db26acbb39de00679a13ec6ad21e46f08f1491c1?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-tekton-tasks-create-datavolume-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-dpdk-checkup-rhel9",
+      "purl": "pkg:oci/kubevirt-dpdk-checkup-rhel9@sha256%3Af8a8c5f736b357b6c4b6b6c5b508f0dd5925f7421f5127bb33e73b619ffc7556",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f8a8c5f736b357b6c4b6b6c5b508f0dd5925f7421f5127bb33e73b619ffc7556"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-dpdk-checkup-rhel9@sha256%3Af8a8c5f736b357b6c4b6b6c5b508f0dd5925f7421f5127bb33e73b619ffc7556",
+      "version": "sha256:f8a8c5f736b357b6c4b6b6c5b508f0dd5925f7421f5127bb33e73b619ffc7556",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-dpdk-checkup-rhel9@sha256%3Af8a8c5f736b357b6c4b6b6c5b508f0dd5925f7421f5127bb33e73b619ffc7556?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-dpdk-checkup-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-dpdk-checkup-rhel9@sha256%3Af8a8c5f736b357b6c4b6b6c5b508f0dd5925f7421f5127bb33e73b619ffc7556?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-dpdk-checkup-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-dpdk-checkup-rhel9@sha256%3Af8a8c5f736b357b6c4b6b6c5b508f0dd5925f7421f5127bb33e73b619ffc7556?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-dpdk-checkup-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/hyperconverged-cluster-webhook-rhel9",
+      "purl": "pkg:oci/hyperconverged-cluster-webhook-rhel9@sha256%3A73058a3ef3a24c76d4be5e2f3f436ecfa7595ba1b520f2e8ff1b7d377a53582c",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "73058a3ef3a24c76d4be5e2f3f436ecfa7595ba1b520f2e8ff1b7d377a53582c"
+        }
+      ],
+      "bom-ref": "pkg:oci/hyperconverged-cluster-webhook-rhel9@sha256%3A73058a3ef3a24c76d4be5e2f3f436ecfa7595ba1b520f2e8ff1b7d377a53582c",
+      "version": "sha256:73058a3ef3a24c76d4be5e2f3f436ecfa7595ba1b520f2e8ff1b7d377a53582c",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hyperconverged-cluster-webhook-rhel9@sha256%3A73058a3ef3a24c76d4be5e2f3f436ecfa7595ba1b520f2e8ff1b7d377a53582c?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhyperconverged-cluster-webhook-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hyperconverged-cluster-webhook-rhel9@sha256%3A73058a3ef3a24c76d4be5e2f3f436ecfa7595ba1b520f2e8ff1b7d377a53582c?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhyperconverged-cluster-webhook-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hyperconverged-cluster-webhook-rhel9@sha256%3A73058a3ef3a24c76d4be5e2f3f436ecfa7595ba1b520f2e8ff1b7d377a53582c?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhyperconverged-cluster-webhook-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-storage-checkup-rhel9",
+      "purl": "pkg:oci/kubevirt-storage-checkup-rhel9@sha256%3A8c48433e5a50ef19e0f9b45cf53334a3e4a94a4b301c7ab440c3ac77d4c75569",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8c48433e5a50ef19e0f9b45cf53334a3e4a94a4b301c7ab440c3ac77d4c75569"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-storage-checkup-rhel9@sha256%3A8c48433e5a50ef19e0f9b45cf53334a3e4a94a4b301c7ab440c3ac77d4c75569",
+      "version": "sha256:8c48433e5a50ef19e0f9b45cf53334a3e4a94a4b301c7ab440c3ac77d4c75569",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-storage-checkup-rhel9@sha256%3A8c48433e5a50ef19e0f9b45cf53334a3e4a94a4b301c7ab440c3ac77d4c75569?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-storage-checkup-rhel9&tag=v4.17.35-2"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-storage-checkup-rhel9@sha256%3A8c48433e5a50ef19e0f9b45cf53334a3e4a94a4b301c7ab440c3ac77d4c75569?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-storage-checkup-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-storage-checkup-rhel9@sha256%3A8c48433e5a50ef19e0f9b45cf53334a3e4a94a4b301c7ab440c3ac77d4c75569?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-storage-checkup-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/sidecar-shim-rhel9",
+      "purl": "pkg:oci/sidecar-shim-rhel9@sha256%3Ab5bcc19e0d6e589c0e4b9caf4d02d1e70788c5a56959cf4433e06e1eebcad6b2",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b5bcc19e0d6e589c0e4b9caf4d02d1e70788c5a56959cf4433e06e1eebcad6b2"
+        }
+      ],
+      "bom-ref": "pkg:oci/sidecar-shim-rhel9@sha256%3Ab5bcc19e0d6e589c0e4b9caf4d02d1e70788c5a56959cf4433e06e1eebcad6b2",
+      "version": "sha256:b5bcc19e0d6e589c0e4b9caf4d02d1e70788c5a56959cf4433e06e1eebcad6b2",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/sidecar-shim-rhel9@sha256%3Ab5bcc19e0d6e589c0e4b9caf4d02d1e70788c5a56959cf4433e06e1eebcad6b2?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fsidecar-shim-rhel9&tag=v4.17.35-12"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/sidecar-shim-rhel9@sha256%3Ab5bcc19e0d6e589c0e4b9caf4d02d1e70788c5a56959cf4433e06e1eebcad6b2?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fsidecar-shim-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/sidecar-shim-rhel9@sha256%3Ab5bcc19e0d6e589c0e4b9caf4d02d1e70788c5a56959cf4433e06e1eebcad6b2?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fsidecar-shim-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/kubevirt-console-plugin-rhel9",
+      "purl": "pkg:oci/kubevirt-console-plugin-rhel9@sha256%3A6a26811cae8abc6d6a2eb55ef116b500db2762fbef46663690749d30cd32e026",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6a26811cae8abc6d6a2eb55ef116b500db2762fbef46663690749d30cd32e026"
+        }
+      ],
+      "bom-ref": "pkg:oci/kubevirt-console-plugin-rhel9@sha256%3A6a26811cae8abc6d6a2eb55ef116b500db2762fbef46663690749d30cd32e026",
+      "version": "sha256:6a26811cae8abc6d6a2eb55ef116b500db2762fbef46663690749d30cd32e026",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-console-plugin-rhel9@sha256%3A6a26811cae8abc6d6a2eb55ef116b500db2762fbef46663690749d30cd32e026?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-console-plugin-rhel9&tag=v4.17.35-14"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-console-plugin-rhel9@sha256%3A6a26811cae8abc6d6a2eb55ef116b500db2762fbef46663690749d30cd32e026?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-console-plugin-rhel9&tag=v4.17.35"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/kubevirt-console-plugin-rhel9@sha256%3A6a26811cae8abc6d6a2eb55ef116b500db2762fbef46663690749d30cd32e026?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fkubevirt-console-plugin-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "container-native-virtualization/hco-bundle-registry",
+      "purl": "pkg:oci/hco-bundle-registry-rhel9@sha256%3Ab9c0a82dc63355e28a8902a669b88f2d7cac351c603670ae896d28f762143e85",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b9c0a82dc63355e28a8902a669b88f2d7cac351c603670ae896d28f762143e85"
+        }
+      ],
+      "bom-ref": "pkg:oci/hco-bundle-registry-rhel9@sha256%3Ab9c0a82dc63355e28a8902a669b88f2d7cac351c603670ae896d28f762143e85",
+      "version": "sha256:b9c0a82dc63355e28a8902a669b88f2d7cac351c603670ae896d28f762143e85",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hco-bundle-registry-rhel9@sha256%3Ab9c0a82dc63355e28a8902a669b88f2d7cac351c603670ae896d28f762143e85?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhco-bundle-registry-rhel9&tag=v4.17.35.rhel9-5"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hco-bundle-registry-rhel9@sha256%3Ab9c0a82dc63355e28a8902a669b88f2d7cac351c603670ae896d28f762143e85?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhco-bundle-registry-rhel9&tag=v4.17.35.rhel9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/hco-bundle-registry-rhel9@sha256%3Ab9c0a82dc63355e28a8902a669b88f2d7cac351c603670ae896d28f762143e85?repository_url=registry.access.redhat.com%2Fcontainer-native-virtualization%2Fhco-bundle-registry-rhel9&tag=v4.17"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "RHEL-9-CNV-4.17",
+      "provides": [
+        "pkg:oci/virt-artifacts-server-rhel9@sha256%3A180df7149d1eae6114df9e9be4c5777296498e3455a91484fae57c98bd5420ad",
+        "pkg:oci/cnv-must-gather-rhel9@sha256%3Afd7dd914c2083a0811316a42b6c648804d46b74c331698b9f297a3c0c6d1e4b9",
+        "pkg:oci/ovs-cni-plugin-rhel9@sha256%3A2a068a744b162cd890966c5adf21db11024dabc31cf709402a6a47a905b50bb8",
+        "pkg:oci/bridge-marker-rhel9@sha256%3A540201cffb476d8a8d80a340d907ef824377bd65593422ca783db735493d5bdd",
+        "pkg:oci/virt-api-rhel9@sha256%3A2680962c55d63273ec3aeeec447d5246dec0a484c18a02fe56dd29a58fb25bd5",
+        "pkg:oci/kubevirt-ipam-controller-rhel9@sha256%3A09881b8d3853a3db01379500ba1adc75d993b68000fe3591326a74c574035882",
+        "pkg:oci/virt-controller-rhel9@sha256%3A4f2760b8b18888ed24ab402070bb517e445fa24dd9ae5904b5c1ce758a8a4993",
+        "pkg:oci/virt-cdi-uploadproxy-rhel9@sha256%3A15264188a5cd3ac275789b79fe0738b545a263c06b462ecfa5b135c360d29624",
+        "pkg:oci/virt-operator-rhel9@sha256%3Aa774009a12b4ea3328df7b1009de3e27aecb4719cbca17e0828ad8f6a4d14f97",
+        "pkg:oci/virt-cdi-cloner-rhel9@sha256%3Adc17158fbde5eb3bb29dc125b5db33123c204d840c31cfbca73ef5a54440a7e6",
+        "pkg:oci/kubevirt-template-validator-rhel9@sha256%3A68b0b9adaa2a83b1b80a16e57ee930aec5f7f051a2e78198c8a60ea270faf1f0",
+        "pkg:oci/virt-handler-rhel9@sha256%3Ae4b6258044b661e3c2a1178492a48780aa0f0baec62e97529e8c644c8c8941da",
+        "pkg:oci/cluster-network-addons-operator-rhel9@sha256%3A5d2390a55695a9373d34f85f972e6454d4511f80f335f4e9f31e7dec7fb87bca",
+        "pkg:oci/virt-cdi-apiserver-rhel9@sha256%3A6abc764e7a3deebf6933a4afd420243a32e2db42f6d62bd4c1a226b1fec65171",
+        "pkg:oci/kubemacpool-rhel9@sha256%3Afb9110ca46371970548f2801eadbd9696b58419002e19f6929760ad54dcc1ecb",
+        "pkg:oci/hostpath-csi-driver-rhel9@sha256%3A4be6a390bce53a27c677b442ed767f6dc7460dfbf8cf46b0b6a0feed06cd9f93",
+        "pkg:oci/virt-cdi-uploadserver-rhel9@sha256%3A9cfeb2bb6e1ef117e437d388c0dc4aa24c53ce496c3996dee7cddad1eb5cbce3",
+        "pkg:oci/multus-dynamic-networks-rhel9@sha256%3Abe43f4cbfa7c892fd152e06a04ee8b82af9613e5dee44b8ca279ab0e2c659663",
+        "pkg:oci/virt-launcher-rhel9@sha256%3Aee4b4a5104c0d119f062d61ce2832a815094a9cb18ad53b4d984e207734cf6c3",
+        "pkg:oci/kubevirt-common-instancetypes-rhel9@sha256%3A59de0374db75b0b98a4070eead6a300d88ca8406006845afe4ae6830af88951e",
+        "pkg:oci/libguestfs-tools-rhel9@sha256%3Acbf7dbb73ceb1da835df2ee1d3060a3aa3dc21cd9454580ce6931aebfa9ad2f9",
+        "pkg:oci/kubevirt-ssp-operator-rhel9@sha256%3Aa6374363cc63c8752c26432e21647de53df1b93bbddad743388f3e7d2eb4405c",
+        "pkg:oci/aaq-server-rhel9@sha256%3A08f12a6b3e0e58de3ab58e58f84824eb1c02c44fb27966d21ad3f8aabd86a5fd",
+        "pkg:oci/aaq-operator-rhel9@sha256%3A16a66b5852e85ed6ee31c4d5ad3296ff3c5508e0ff8a05457c687e11b3245e32",
+        "pkg:oci/kubesecondarydns-rhel9@sha256%3A9fec79a7630162943ad9ab7bd091654652c12d81d7727b793f9afe5b7a0f9715",
+        "pkg:oci/cnv-containernetworking-plugins-rhel9@sha256%3A8fa483942880c19a090488033eb0ddb7d9013bc94f4f3f884f3e5812bccf4c63",
+        "pkg:oci/virt-cdi-importer-rhel9@sha256%3A63a90ed0f470d4045490cafc66859ab6fa4996d38c8779715fb22e716e8c4924",
+        "pkg:oci/wasp-agent-rhel9@sha256%3A23f71dd83abe64d5131d3990f7f86c90eaf90e19d5c118e581654df2efa74ea5",
+        "pkg:oci/passt-network-binding-plugin-cni-rhel9@sha256%3A6246fab77de49b0b46537651d107981706f6bc47a8069410aca5a9885095ebd7",
+        "pkg:oci/virt-exportserver-rhel9@sha256%3A0c3267c8dae79cd9fccecd0681e063f738974a2a9ffbb7e013640a3a218dcef9",
+        "pkg:oci/vm-network-latency-checkup-rhel9@sha256%3A3d96bd657ede3b57725af013a73c3f1f026bc0ee01f0d710dc0ceda39b66abfc",
+        "pkg:oci/virt-cdi-operator-rhel9@sha256%3A18eacd9da3787f4796fe25bcb2f08008221403df14910cef67bd74030f02d37a",
+        "pkg:oci/hostpath-provisioner-operator-rhel9@sha256%3A4f855fe67de01c37482a94c3b66d520a608b951f26cd0791772c79426c8365e3",
+        "pkg:oci/vm-console-proxy-rhel9@sha256%3A860bfbebe8d372a945183ac746634a019220e041279f5beb2b7ab45e2778c675",
+        "pkg:oci/hostpath-provisioner-rhel9@sha256%3Aaed313a5e5da26aa209f6b3909625fdda987526bbd9ad73096f60e5c6449d384",
+        "pkg:oci/passt-network-binding-plugin-sidecar-rhel9@sha256%3Aa4adb00a5b1f8f0a0920e1c34a37f0d34fec064f2479e4302663a535769cd190",
+        "pkg:oci/virtio-win-rhel9@sha256%3Aad45b7d4e6ac2de819158e343be56fc2602f6ead3a9f86ca2cfc382bd75f8bfe",
+        "pkg:oci/kubevirt-apiserver-proxy-rhel9@sha256%3A50983f969f5c8f61f9aeb68e02193227525ec82fcc34fe71a4c804c190b476fc",
+        "pkg:oci/virt-cdi-controller-rhel9@sha256%3A46d9b90b8e579903f861000daf25077364c890a27684ad6823031141735a48b7",
+        "pkg:oci/virt-exportproxy-rhel9@sha256%3Ad0bb30ab8429e42a5162f317c6c56d893307dfb67b8a70c29f33dcd92b6a65b0",
+        "pkg:oci/hyperconverged-cluster-operator-rhel9@sha256%3Abc1548bff47233e5243e2c2c067eb949b0770b98284ac79d6a052b48a6848da3",
+        "pkg:oci/kubevirt-realtime-checkup-rhel9@sha256%3A5684b0620359dbd14157a9e3e3b8e2e9505c5b3992607a75e2392f48e45938bb",
+        "pkg:oci/aaq-controller-rhel9@sha256%3Ad5b08f598bc2ad948d3b47c280e42d102d3dd9925b2addf6ce35b9c879bf7969",
+        "pkg:oci/kubevirt-tekton-tasks-disk-virt-customize-rhel9@sha256%3Aa9e274420db32fa53e4f47af5d03a305a6b85faac3d994e729318d502a4f5471",
+        "pkg:oci/pr-helper-rhel9@sha256%3A26be2f8e5dd0859a03a88bcb59d9642ed6f900e378a598886f186042ab108e43",
+        "pkg:oci/kubevirt-tekton-tasks-create-datavolume-rhel9@sha256%3Add208ea58e0b85391f7736b1db26acbb39de00679a13ec6ad21e46f08f1491c1",
+        "pkg:oci/kubevirt-dpdk-checkup-rhel9@sha256%3Af8a8c5f736b357b6c4b6b6c5b508f0dd5925f7421f5127bb33e73b619ffc7556",
+        "pkg:oci/hyperconverged-cluster-webhook-rhel9@sha256%3A73058a3ef3a24c76d4be5e2f3f436ecfa7595ba1b520f2e8ff1b7d377a53582c",
+        "pkg:oci/kubevirt-storage-checkup-rhel9@sha256%3A8c48433e5a50ef19e0f9b45cf53334a3e4a94a4b301c7ab440c3ac77d4c75569",
+        "pkg:oci/sidecar-shim-rhel9@sha256%3Ab5bcc19e0d6e589c0e4b9caf4d02d1e70788c5a56959cf4433e06e1eebcad6b2",
+        "pkg:oci/kubevirt-console-plugin-rhel9@sha256%3A6a26811cae8abc6d6a2eb55ef116b500db2762fbef46663690749d30cd32e026",
+        "pkg:oci/hco-bundle-registry-rhel9@sha256%3Ab9c0a82dc63355e28a8902a669b88f2d7cac351c603670ae896d28f762143e85"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:0f6d40f2-9c19-3b25-bf8a-115ab6e482f7"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/middleware/quarkus-3.20/latest/product-2025-12-01-EDA6638AD2F4451.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/middleware/quarkus-3.20/latest/product-2025-12-01-EDA6638AD2F4451.json
@@ -1,0 +1,126 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [
+        {
+          "name": "SBOMer",
+          "version": "f1c3bca6",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+                "acknowledgement": "declared"
+              }
+            }
+          ],
+          "provider": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          },
+          "externalReferences": [
+            {
+              "url": "https://github.com/project-ncl/sbomer",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "Red Hat build of Quarkus",
+      "type": "framework",
+      "bom-ref": "Red Hat build of Quarkus 3.20.4",
+      "version": "Red Hat build of Quarkus 3.20.4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:quarkus:3.20::el8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-12-01T21:02:54Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156615"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "quarkus-bom",
+      "purl": "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.20.4.redhat-00001?type=pom",
+      "type": "framework",
+      "group": "com.redhat.quarkus.platform",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "bbb0e61b448302933f0524191848535b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3b24deeb47b22083384e2035ed377d06ba9044f7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "72f15dcdb75fc8af9b27d2e3f77a2d9c65e2b869aa836c4acec378757989619f"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.20.4.redhat-00001?type=pom",
+      "version": "3.20.4.redhat-00001",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.20.4.redhat-00001?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=pom"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "description": "Red Hat Build of Quarkus - Kubernetes Native Java stack tailored for OpenJDK HotSpot and GraalVM"
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "Red Hat build of Quarkus 3.20.4",
+      "provides": [
+        "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.20.4.redhat-00001?type=pom"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:929c65c6-3bc0-3a8b-b0e5-6c8fbed1c91a"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/middleware/quarkus-3.20/older/product-2025-10-14-28954C62C811417.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/middleware/quarkus-3.20/older/product-2025-10-14-28954C62C811417.json
@@ -1,0 +1,126 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [
+        {
+          "name": "SBOMer",
+          "version": "1b2dba8d",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+                "acknowledgement": "declared"
+              }
+            }
+          ],
+          "provider": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          },
+          "externalReferences": [
+            {
+              "url": "https://github.com/project-ncl/sbomer",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "Red Hat build of Quarkus",
+      "type": "framework",
+      "bom-ref": "Red Hat build of Quarkus 3.20.3",
+      "version": "Red Hat build of Quarkus 3.20.3",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:quarkus:3.20::el8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-10-14T13:01:32Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "155081"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "quarkus-bom",
+      "purl": "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.20.3.redhat-00006?type=pom",
+      "type": "framework",
+      "group": "com.redhat.quarkus.platform",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "908169e859d77c0ffc1f7840041f5671"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9515775ed9057b36497ebfa6453b7505006131ae"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "df1fa05231622b4c99ae09cdf8fe03bca590c2b5a419bf4f3bd70b9e83940d8d"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.20.3.redhat-00006?type=pom",
+      "version": "3.20.3.redhat-00006",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.20.3.redhat-00006?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=pom"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "description": "Red Hat Build of Quarkus - Kubernetes Native Java stack tailored for OpenJDK HotSpot and GraalVM"
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "Red Hat build of Quarkus 3.20.3",
+      "provides": [
+        "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.20.3.redhat-00006?type=pom"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:8085c479-c438-35a4-93e9-f30eab5a0791"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/webkit2gtk3/latest/product-2025-12-08-A9F140D67EB2408.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/webkit2gtk3/latest/product-2025-12-08-A9F140D67EB2408.json
@@ -1,0 +1,145 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [
+        {
+          "name": "SBOMer",
+          "version": "f1c3bca6",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+                "acknowledgement": "declared"
+              }
+            }
+          ],
+          "provider": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          },
+          "externalReferences": [
+            {
+              "url": "https://github.com/project-ncl/sbomer",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "Red Hat Enterprise Linux 9",
+      "type": "operating-system",
+      "bom-ref": "RHEL-9.7.0.Z.MAIN",
+      "version": "RHEL-9.7.0.Z.MAIN",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:enterprise_linux:9.7::appstream"
+          },
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:enterprise_linux:9::appstream"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-12-08T01:59:46Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156970"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "51c73dd55fdf1c0ab25e3230772a499cc1c1225cadc9173381e5e1fc3b601491"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "RHEL-9.7.0.Z.MAIN",
+      "provides": [
+        "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:4f53daaa-1877-3446-b562-7464aca1847c"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/webkit2gtk3/latest/rpm-2025-12-05-3705CE313B0F437.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/webkit2gtk3/latest/rpm-2025-12-05-3705CE313B0F437.json
@@ -1,0 +1,2440 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "rpm-manifest-generator",
+          "type": "application",
+          "version": "0.0.1",
+          "manufacturer": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          }
+        }
+      ]
+    },
+    "licenses": [
+      {
+        "expression": "LGPL-2.0-only"
+      }
+    ],
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "51c73dd55fdf1c0ab25e3230772a499cc1c1225cadc9173381e5e1fc3b601491"
+        }
+      ],
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "ab75a0d1fd07a06e33a7d399ed67883f"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "743d3ed55c73f922f60baa863fbe8c0fb903c24baba979144ec600c685341be4"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3."
+    },
+    "timestamp": "2025-12-05T10:31:24Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156970"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "51c73dd55fdf1c0ab25e3230772a499cc1c1225cadc9173381e5e1fc3b601491"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "pedigree": {
+        "ancestors": [
+          {
+            "name": "webkitgtk",
+            "purl": "pkg:generic/webkitgtk@2.50.3?download_url=https://pkgs.devel.redhat.com/repo/rpms/webkit2gtk3/webkitgtk-2.50.3.tar.xz/sha512/32bebcb99464490ce36116c19e1da40269a7d22bed499056d80a0ad49843defc938203cf3450c122d7ee7aaa87203b265437db400e938e96af30d71f36cef2cf/webkitgtk-2.50.3.tar.xz&checksum=SHA-512:32bebcb99464490ce36116c19e1da40269a7d22bed499056d80a0ad49843defc938203cf3450c122d7ee7aaa87203b265437db400e938e96af30d71f36cef2cf",
+            "type": "library",
+            "hashes": [
+              {
+                "alg": "SHA-512",
+                "content": "32bebcb99464490ce36116c19e1da40269a7d22bed499056d80a0ad49843defc938203cf3450c122d7ee7aaa87203b265437db400e938e96af30d71f36cef2cf"
+              }
+            ],
+            "bom-ref": "pkg:generic/webkitgtk@2.50.3?download_url=https://pkgs.devel.redhat.com/repo/rpms/webkit2gtk3/webkitgtk-2.50.3.tar.xz/sha512/32bebcb99464490ce36116c19e1da40269a7d22bed499056d80a0ad49843defc938203cf3450c122d7ee7aaa87203b265437db400e938e96af30d71f36cef2cf/webkitgtk-2.50.3.tar.xz&checksum=SHA-512:32bebcb99464490ce36116c19e1da40269a7d22bed499056d80a0ad49843defc938203cf3450c122d7ee7aaa87203b265437db400e938e96af30d71f36cef2cf",
+            "version": "2.50.3",
+            "evidence": {
+              "identity": [
+                {
+                  "field": "purl",
+                  "concludedValue": "pkg:generic/webkitgtk@2.50.3?download_url=https://pkgs.devel.redhat.com/repo/rpms/webkit2gtk3/webkitgtk-2.50.3.tar.xz/sha512/32bebcb99464490ce36116c19e1da40269a7d22bed499056d80a0ad49843defc938203cf3450c122d7ee7aaa87203b265437db400e938e96af30d71f36cef2cf/webkitgtk-2.50.3.tar.xz&checksum=SHA-512:32bebcb99464490ce36116c19e1da40269a7d22bed499056d80a0ad49843defc938203cf3450c122d7ee7aaa87203b265437db400e938e96af30d71f36cef2cf"
+                }
+              ]
+            },
+            "pedigree": {
+              "ancestors": [
+                {
+                  "name": "webkitgtk",
+                  "purl": "pkg:generic/webkitgtk@2.50.3?download_url=https://webkitgtk.org/releases/webkitgtk-2.50.3.tar.xz&checksum=SHA-256:70a006b4695bb6b2e157e801f5a0d029f4110f050c6f0882decd8a3bf594d54f",
+                  "type": "library",
+                  "hashes": [
+                    {
+                      "alg": "SHA-256",
+                      "content": "70a006b4695bb6b2e157e801f5a0d029f4110f050c6f0882decd8a3bf594d54f"
+                    }
+                  ],
+                  "bom-ref": "pkg:generic/webkitgtk@2.50.3?download_url=https://webkitgtk.org/releases/webkitgtk-2.50.3.tar.xz&checksum=SHA-256:70a006b4695bb6b2e157e801f5a0d029f4110f050c6f0882decd8a3bf594d54f",
+                  "version": "2.50.3",
+                  "evidence": {
+                    "identity": [
+                      {
+                        "field": "purl",
+                        "concludedValue": "pkg:generic/webkitgtk@2.50.3?download_url=https://webkitgtk.org/releases/webkitgtk-2.50.3.tar.xz&checksum=SHA-256:70a006b4695bb6b2e157e801f5a0d029f4110f050c6f0882decd8a3bf594d54f"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "webkitgtk",
+            "purl": "pkg:generic/webkitgtk@2.50.3?download_url=https://pkgs.devel.redhat.com/repo/rpms/webkit2gtk3/webkitgtk-2.50.3.tar.xz.asc/sha512/635998799265ae125ad5ba6e45f939a33f465719756397d125f340818bf35b31d6924dbf91a762201f1f06741c92d2599515f1e28e5d4bdc2a3f16ae678b7aff/webkitgtk-2.50.3.tar.xz.asc&checksum=SHA-512:635998799265ae125ad5ba6e45f939a33f465719756397d125f340818bf35b31d6924dbf91a762201f1f06741c92d2599515f1e28e5d4bdc2a3f16ae678b7aff",
+            "type": "library",
+            "hashes": [
+              {
+                "alg": "SHA-512",
+                "content": "635998799265ae125ad5ba6e45f939a33f465719756397d125f340818bf35b31d6924dbf91a762201f1f06741c92d2599515f1e28e5d4bdc2a3f16ae678b7aff"
+              }
+            ],
+            "bom-ref": "pkg:generic/webkitgtk@2.50.3?download_url=https://pkgs.devel.redhat.com/repo/rpms/webkit2gtk3/webkitgtk-2.50.3.tar.xz.asc/sha512/635998799265ae125ad5ba6e45f939a33f465719756397d125f340818bf35b31d6924dbf91a762201f1f06741c92d2599515f1e28e5d4bdc2a3f16ae678b7aff/webkitgtk-2.50.3.tar.xz.asc&checksum=SHA-512:635998799265ae125ad5ba6e45f939a33f465719756397d125f340818bf35b31d6924dbf91a762201f1f06741c92d2599515f1e28e5d4bdc2a3f16ae678b7aff",
+            "version": "2.50.3",
+            "evidence": {
+              "identity": [
+                {
+                  "field": "purl",
+                  "concludedValue": "pkg:generic/webkitgtk@2.50.3?download_url=https://pkgs.devel.redhat.com/repo/rpms/webkit2gtk3/webkitgtk-2.50.3.tar.xz.asc/sha512/635998799265ae125ad5ba6e45f939a33f465719756397d125f340818bf35b31d6924dbf91a762201f1f06741c92d2599515f1e28e5d4bdc2a3f16ae678b7aff/webkitgtk-2.50.3.tar.xz.asc&checksum=SHA-512:635998799265ae125ad5ba6e45f939a33f465719756397d125f340818bf35b31d6924dbf91a762201f1f06741c92d2599515f1e28e5d4bdc2a3f16ae678b7aff"
+                }
+              ]
+            },
+            "pedigree": {
+              "ancestors": [
+                {
+                  "name": "webkitgtk",
+                  "purl": "pkg:generic/webkitgtk@2.50.3?download_url=https://webkitgtk.org/releases/webkitgtk-2.50.3.tar.xz.asc&checksum=SHA-256:ce3c3de459b0a7748424ae1d3605d8a270cede0e40977f78b0dd436d8de805a9",
+                  "type": "library",
+                  "hashes": [
+                    {
+                      "alg": "SHA-256",
+                      "content": "ce3c3de459b0a7748424ae1d3605d8a270cede0e40977f78b0dd436d8de805a9"
+                    }
+                  ],
+                  "bom-ref": "pkg:generic/webkitgtk@2.50.3?download_url=https://webkitgtk.org/releases/webkitgtk-2.50.3.tar.xz.asc&checksum=SHA-256:ce3c3de459b0a7748424ae1d3605d8a270cede0e40977f78b0dd436d8de805a9",
+                  "version": "2.50.3",
+                  "evidence": {
+                    "identity": [
+                      {
+                        "field": "purl",
+                        "concludedValue": "pkg:generic/webkitgtk@2.50.3?download_url=https://webkitgtk.org/releases/webkitgtk-2.50.3.tar.xz.asc&checksum=SHA-256:ce3c3de459b0a7748424ae1d3605d8a270cede0e40977f78b0dd436d8de805a9"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "ab75a0d1fd07a06e33a7d399ed67883f"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "743d3ed55c73f922f60baa863fbe8c0fb903c24baba979144ec600c685341be4"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3.",
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3905951",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        }
+      ]
+    },
+    {
+      "name": "webkit2gtk3-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fa734e5fa4df841f39dde3b732fbba4d677d88059ffe9f9086a04500e9605e69"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=aarch64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "fbd30db0b5647274de5abcefccab5108"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "8d39888f4d6563988a4e7c3e51ffb537fbb15eea51aa34295f1daf0346bde1f8"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "79d43bbf9a016c9ff1ed6afa164ae9893502c1395a5829978aca906ed9e6e196"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=aarch64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "fe9a0e0d0ea7ebbd25ac84c54128ec71"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "6db3b9b6db3592f2f7a4746a431668415fb208f7b6e6556f1c886e00750d68bd"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d70433af1759455ad92cdbb361a5071cba8a35080759e78a3381873233f7bb18"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=aarch64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "30bf8f9cebb198db16ed62c64f04ed6d"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "5b0eae6747d9d92ca1978cfb73600e37c44ba5a8d4e107e293410501c7adab33"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d4c0b5470264463ebbb272b509636e71556a2ae34f57529cd98aa060f9b71568"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=aarch64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "c49e0b007fcde245ad4dbffafebf3076"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b20df74306c5b71ab82d0ec1f57a3828950c3c2977d4cf746ab8c9b3719c1386"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7fce03aa1f4cbccf792770bf2e25e653670e5fb711fd9ddd9b7fe4e69ae95168"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=aarch64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "fec03c114b21c81242f74632e62e5a30"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "4c4dbcd5fd49b8729e82f3da642c1d587b9b9f598ead9c5f89c3599839c1d5e3"
+        }
+      ],
+      "description": "This package contains JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c0ed33d92407718dc1f5d3727522461ac123a56a884f38e183f614c9986ecc6a"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=aarch64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "32a5d61ea42202924d6bbf57714d8f73"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "e3bbb96784e646e656a31722bc0aad637cc755eeed7bfc7812891dc3a2f6d30a"
+        }
+      ],
+      "description": "The webkit2gtk3-jsc-devel package contains libraries, build data, and header files for developing applications that use JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ce09bcb9afa6168803bb21ea29453cf219e2d9f0d7a78d532b099676657b58b7"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=aarch64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "7a992aa1ccade99fd75093a43f321ff6"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "364898a6867d82e18932342518ecee7b92c0215468a571c093ddcc2b45a7cce0"
+        }
+      ],
+      "description": "The webkit2gtk3-devel package contains libraries, build data, and header files for developing applications that use webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ea5526c971f9c1d14bb4c211bc4de9dcab3986b3a80ad397a1e076a5ef6a7736"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=aarch64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "5c4abc687d6056ce54b6ef0fd4cd1175"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "42cd86fdcf562094cbd8f2c90f673c5da53fdfb6f71396be01a7594f8eb47e55"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3."
+    },
+    {
+      "name": "webkit2gtk3-debugsource",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d7a8fac027797bb73b2b6cf181b013b6fd5c277a84e7dc5ee1d39d70580d9dc8"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=aarch64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "ce03f126d111eeaef03f778ea2b5a697"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "9d180eae2517d30bcf660ef1b7b5fab363587d60a02c6b9fad27ed503a295e0f"
+        }
+      ],
+      "description": "This package provides debug sources for package webkit2gtk3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e60d7d752ddadf87a78c04f5b37bbea43b9eb5a549a90fdb62ae2a7977faafaa"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=ppc64le",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "019193f8afe49a870686bd5e97fc9ed8"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "94bfff04cc9aeb3bade57d5e4121675c6df47344933a0c4be512559bde40fdb1"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "29c02a10fdd6e3075309f7c5fd8ba58c41eb581eae3f582783f84772e153c858"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=ppc64le",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "f053286fa10d6665735d274b99596da8"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "a51b2966d4b9c15d582027055b2c355b940405a871ae0358d1ed3b4d5abd5675"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3."
+    },
+    {
+      "name": "webkit2gtk3-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c191c22e3155ee11e0d975caa713c7cfec5a0ccdb7b08032e5534aa5f5648be4"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=ppc64le",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "f749bd4e6b0c26d0008032d031295ba6"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "c584bfc1807f7dccae87c2001c6fc5d4e2265a1b7089e35997fbda8d45afdee4"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5b59dd192340b5c69d7aadb6b3c67e37d06b4f326364e3e04b295f17ef120eec"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=ppc64le",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "50819658b742533fcee7a64b31b96df7"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "efc40e0382e2b47098162569b95010c5f4e89f767215f8d6e072f882f2baab01"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "378dc2c7321ba57f159ac6a519d7c0055bad6e3157b4b7deb94c456389b4bf08"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=ppc64le",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "2d9b09d9fc571928c264bf21aa02c933"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "f16b6ef0a3c07acecff82ab124a5ddc5c7e691a694374e3e30811a3d07743ea1"
+        }
+      ],
+      "description": "The webkit2gtk3-jsc-devel package contains libraries, build data, and header files for developing applications that use JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-jsc",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bef86698cdc807d9de937f9bbe720c997b37db84b7396f48b8d22a870b374796"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=ppc64le",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "8d1e83e06e2db2e9f9a8411aad945de9"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "88a74b1874c0fc0a2cbefd06502166fca5685dd148f3431a3ca9b65bd1ca4610"
+        }
+      ],
+      "description": "This package contains JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-debugsource",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c5069416e9730154388453722c02923f9f5f647b1f8a1415aef484e5c0d6dc04"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=ppc64le",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "84a956eeb5fdfa4986f81fdcad2548e5"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "a22f292f96728216cd611b6e5161a6c74cd51472fd387f46eef73cc916c024d9"
+        }
+      ],
+      "description": "This package provides debug sources for package webkit2gtk3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e637f1b6500cb46ad9a12c679d96f4d675b744a6e4059133d77bc7db141648cf"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=ppc64le",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "38349c3a6eacbd5b3ce6b86e94dec19c"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "7f1252b8b638964f8f2f328325039e6fa5631ac53a3736f26f4cce1c7330ce2f"
+        }
+      ],
+      "description": "The webkit2gtk3-devel package contains libraries, build data, and header files for developing applications that use webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5b96aae3e2ffd326e8e9bbf9078dbdfeb56e171ca35ee3cf51c8f0edd511caf9"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=ppc64le",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "8ca1be08317c737ebc7ca12517ae32bf"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "3ed2f7ebd966f3882662bfad3407d732e7623cac42491801d12570da6d3c09cf"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f9aada36bee80b46d0373963d590d8eacbf13919a06b9d21aeb2a2c9ab7c9d1a"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=i686",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "45c6ca08e8ed401d6915aed444a13604"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "2c43020d6a16d451cd76a88b6b281ecd6f9cbb30417f1136a270f022c1181f18"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "21afd7d28fd7f6f38760ef5601c828b02c5c5b960f7a79933cc39d60eebc134d"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=i686",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "7a8e1b7906c952e258e444f31d905ef7"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b23ec07572f43d050405a2fdbc7368b3a3273d877a3cd0b42f123d665318fb9a"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8a7d3e56300215380bfac85a6aaf4d374633c79790c29c79e3abde71bdeb1a17"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=i686",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "9cbcef6393dbfcb5038f0dd00825df39"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "cd7897c60f90f114571346a0d73493b6339e2504f94b0eda4b08c173488ffa1f"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3."
+    },
+    {
+      "name": "webkit2gtk3-debugsource",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "924df799cac7dec47e858855530dd1e35eff37d126e6fa7e4acdb4168fff7a69"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=i686",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "a0bd07e49ad2419388f65cba127b78a7"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "ebec4c719740fed4439844687a9dd84fa79705510eb3da6e824ca8b55045e8c0"
+        }
+      ],
+      "description": "This package provides debug sources for package webkit2gtk3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f63d7978116335238c88da6261a23dad141548fec95bd4c46604a69d7b6e63da"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=i686",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "bfa1d1efba24d88ec7ce72ca941c8cd2"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "bca419e54659643e461974d2dffbe560212d2fef2e7e516f45b2435c781d660b"
+        }
+      ],
+      "description": "This package contains JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8b937ed9a2a3d1504f0dc4d0be940930c66a5adde31561ea182cd3e0d0028158"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=i686",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "b74d98987fd842932866f1fccc09ca3e"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "941062fe9bec3c217f028c1ba0b3e6822a25cc5a999e65b01119be3c1e2004d0"
+        }
+      ],
+      "description": "The webkit2gtk3-devel package contains libraries, build data, and header files for developing applications that use webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e92dfddb361d4800c1c92f975ba3ef98954b278e09462d0f6a729ebd299453ec"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=i686",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "fb307083872ad2894ee5920a54732f4f"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "0bbbed24018bcc876cb0cc7cd6cf8debb5a44911b92b37254af6e607f757a7f5"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8217ee6b63c9d5ff70b3402320b46a1b47ea8d16b0c13553c16dd3d8b4c6a298"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=i686",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "d772cc5f1204b28a12d385c6baccb5a6"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "00764b88e717e91e1f2d05954e2ea3d998e48f319edeaa1266d496ede42723a0"
+        }
+      ],
+      "description": "The webkit2gtk3-jsc-devel package contains libraries, build data, and header files for developing applications that use JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6584c5c1a978fe458fd91cd406f511ccc40fc704a207a44d3c57be9cbea2e6f1"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=i686",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "b8c3c36f508c52234275f3d742b22904"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "48bfaf696d7a2cc03fda1afe244d6aeae38daa436add53373ea4f9850733ab42"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a996086c6f168d5ead346f5abcca27e76030c397457ce293d836e86203613749"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=x86_64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "0945c3848a6a8b71242f113c710b1950"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b21864383474811f48a60cdc84d78beedccdf3349a1cec0481e943202b0fb09a"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "828e684b9539826ee28a5f572ff9b5c528d3788e7fba6d0987bd187800970f08"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=x86_64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "4a078e6fd8f6da31b6f2f01cfdda55fc"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "10759abc9149146524ceba2c82a553235563d5d20984861c77bde64fdea2fcb4"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5ee878a1cb75bce6f9ed39e9121fb9e40219fee33ef3de86edf72ebf4456e467"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=x86_64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "d5cf4b80602e52f47a21add1b398dfba"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "bdf4fc2dd1b6248419d96eb4d2b9c40be5bfe1f0b657501ee582ac41a363832f"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c38081b11995c9c8a5a2b079dbe764c97abe09be420c82b0050f821a6a3b385c"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=x86_64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "b67a9d5a5b2184c259b78fef7d2f77de"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "6103cf286a4e7d9fd72f844dc25c784e6caf87ecb3c02a2344bd0e335fe2cd2c"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d51732cd9066608af03d978e01dc43b7b9071afda8dacbc300355cf680099469"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=x86_64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "d6b4a66399c1557d80b811118a6fd3fa"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "000a27757900b013ef2c4b92a7e6f88a3c55df68a07c15bd679dfa88b8423659"
+        }
+      ],
+      "description": "The webkit2gtk3-jsc-devel package contains libraries, build data, and header files for developing applications that use JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-jsc",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "125168b871b97056f81fd603aa563f0c9e18e7af46d3a9c4df55ba17fa748e0c"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=x86_64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "7a7f197fc8c4a6c6b7b19de9f907cd64"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "ed9d62fdab5c10ab4fb365849d29848941ad9af2c2844d47f9c5462c601092e9"
+        }
+      ],
+      "description": "This package contains JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5bc2f6b9f2bc7f0bea8d4dd0a21fd3aa47e6e707f1594634ca3b9eb9ba6b1f19"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=x86_64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "5d04ad7cbbe9d8866f8dbfb638575421"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "1b577cebbfaa77b27a2a7767f6a21986d11b27ecb59fc065c40b544d043bc80d"
+        }
+      ],
+      "description": "The webkit2gtk3-devel package contains libraries, build data, and header files for developing applications that use webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bbfd9e4c811b1cfc20dcf4e73169a502d0514570021664ed9b95a097f0aefedb"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=x86_64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "aa69d8a73acd4233501d61ac1bf84fbd"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "577d4d03013dfcaa5d4dac08d2cbc2aeff58b6be760c285afdd4e1fcfbe201cf"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3."
+    },
+    {
+      "name": "webkit2gtk3-debugsource",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "316b1ff09fc976a1f915d0d5b3dff1247a41565f718d2e721c86f07cf3f637d0"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=x86_64",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "62510ac400ee40a3a29fea19338f41d2"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "e29835ee5ee17c81cf683bedf725de0c528359db36cd02c9b06f573af511da21"
+        }
+      ],
+      "description": "This package provides debug sources for package webkit2gtk3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "717ee0c214ff6f20d413fb32e56779cd83ce04dcf6b5466865022e7c7939695b"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=s390x",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "ff64bd8fffb522b73d63454f53cf5c65"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "6c684f32950056861fc1f54db86fc7f7388615485df9afeaa10f191305367971"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5d77874fd070e99c44053e5728c036a4b2aeac50b3ca4dc1bcfe155556a1ea4b"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=s390x",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "f49869e58eafb3e2d2bb6ed8cb6225f8"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "24618d97059128ce23b907a584272b70d2013889b57fdd9473717c1fb3f2824f"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d265dd4e3e70b7f7a6ca2e423fb1fd7a7375acd87a8c1a0642d80d5ca2c41e31"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=s390x",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "b66a172e59ef1ed05e6969e9b174fcae"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b9e7c561fd9ee25cf869a21ddff053f5b94adb7182fc9c12093fd95c70621e9f"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4a50586cd6d524d269f692b787dda8cd643e713eeb0d427a745f6f15b8691a03"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=s390x",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "2e248dfb4b5e31f94429d9814e3571d1"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "899397949fc387fb834356622c62dd971feb604e8a43a63c6c48683cd52c863f"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5ac229a945f8a0114d5a48f6ef4baaf0a23dd98792e1d172420ac562fe9dc3a0"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=s390x",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "0efcdebd2ca6d53322dc7c032d6a32a8"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "836097112361a2500e17c95cbb3c8e16d6dcbdf7ef1ed9e3569f5e77afee9333"
+        }
+      ],
+      "description": "The webkit2gtk3-jsc-devel package contains libraries, build data, and header files for developing applications that use JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-jsc",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fa194a5c303b81c0133d31cc329884d44a8565cc4ad004bf2ca3454e40465516"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=s390x",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "d50148a15674272b4fc2a3452afecd6f"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "35faa6a11b03c42412e78565962a09b0990aad933b52914ed412f21962fd268a"
+        }
+      ],
+      "description": "This package contains JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "779d7a7747239b898ac1af9c84699242860bef076c854df04c7c8a27aebc57b5"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=s390x",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "eab5cbebb5080dee8e715338fb34e3ff"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "cb07e7ed2c517c2ea761c015c4a883f2e185359c4fad0f4d557e9587bfba8590"
+        }
+      ],
+      "description": "The webkit2gtk3-devel package contains libraries, build data, and header files for developing applications that use webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e40c26b9221fc48cd5f5adedda9d0197c58eb8300c036757dedea3cfec117b25"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=s390x",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "12b30e2938ae9fe98400dbd1d8ab2171"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "c64473e96250690d73c60f89651dbcf78969e9d1a19f1f05b88943caf683699b"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3."
+    },
+    {
+      "name": "webkit2gtk3-debugsource",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "770f2f1d0348f47c70abbd47e171c4d5d967a828cf0464e9157115adb1c831d3"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=s390x",
+      "version": "2.50.3-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-source-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "4405fa41c9104f1947c3130cb3e0ecc7"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "c2925bddd2fcf7c313614e6517c59b3f3dda7dbab713c2de1791606abb5605b5"
+        }
+      ],
+      "description": "This package provides debug sources for package webkit2gtk3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "openssl-synthetic-test",
+      "purl": "pkg:rpm/redhat/openssl-synthetic-test@1.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5d967a828cf0464e9157115adb1c831d3770f2f1d0348f47c70abbd47e171c4d"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/openssl-synthetic-test@1.1?arch=s390x",
+      "version": "1.1",
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "description": "This package is a TEST package for testing trustify queries."
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=src",
+      "provides": [
+        "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.3-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.3-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.3-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.3-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.3-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.3-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-devel@2.50.3-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3@2.50.3-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.3-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/openssl-synthetic-test@1.1?arch=s390x"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:e0ccfbd4-7a39-448c-9c2d-66e3afbeaf31"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/webkit2gtk3/older/product-2025-11-11-7764C2C0C91542B.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/webkit2gtk3/older/product-2025-11-11-7764C2C0C91542B.json
@@ -1,0 +1,145 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [
+        {
+          "name": "SBOMer",
+          "version": "a128392a",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+                "acknowledgement": "declared"
+              }
+            }
+          ],
+          "provider": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          },
+          "externalReferences": [
+            {
+              "url": "https://github.com/project-ncl/sbomer",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "Red Hat Enterprise Linux 9",
+      "type": "operating-system",
+      "bom-ref": "RHEL-9.7.0.Z.MAIN",
+      "version": "RHEL-9.7.0.Z.MAIN",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:enterprise_linux:9.7::appstream"
+          },
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:enterprise_linux:9::appstream"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-11-11T13:58:27Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "154820"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2a3145cc5f6f19edc00ade5d4759bad96a520b64f50f848efaa6be44d4b0c5ec"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "RHEL-9.7.0.Z.MAIN",
+      "provides": [
+        "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:d489e752-0cec-39a7-8c2f-251487e34018"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/webkit2gtk3/older/rpm-2025-10-14-CC595A02EB3545E.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/webkit2gtk3/older/rpm-2025-10-14-CC595A02EB3545E.json
@@ -1,0 +1,2440 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "rpm-manifest-generator",
+          "type": "application",
+          "version": "0.0.1",
+          "manufacturer": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          }
+        }
+      ]
+    },
+    "licenses": [
+      {
+        "expression": "LGPL-2.0-only"
+      }
+    ],
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2a3145cc5f6f19edc00ade5d4759bad96a520b64f50f848efaa6be44d4b0c5ec"
+        }
+      ],
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "cdc778b7a671077c574daca211f6a9b8"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "fb1bf908e11ac108efa38d463af986baf87764212f77724220d66eba76a5bd67"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3."
+    },
+    "timestamp": "2025-10-14T12:44:03Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "154820"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2a3145cc5f6f19edc00ade5d4759bad96a520b64f50f848efaa6be44d4b0c5ec"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "pedigree": {
+        "ancestors": [
+          {
+            "name": "webkitgtk",
+            "purl": "pkg:generic/webkitgtk@2.50.1?download_url=https://pkgs.devel.redhat.com/repo/rpms/webkit2gtk3/webkitgtk-2.50.1.tar.xz/sha512/4b7b6c5ae02f1dbcff26e7af4ee4e3cdd4435c61dfaf17c2981422358dea01cfba0ffe8c6f12c7864b6f1ee6c9906dfa64248bc95effed526e9ade3ad1292888/webkitgtk-2.50.1.tar.xz&checksum=SHA-512:4b7b6c5ae02f1dbcff26e7af4ee4e3cdd4435c61dfaf17c2981422358dea01cfba0ffe8c6f12c7864b6f1ee6c9906dfa64248bc95effed526e9ade3ad1292888",
+            "type": "library",
+            "hashes": [
+              {
+                "alg": "SHA-512",
+                "content": "4b7b6c5ae02f1dbcff26e7af4ee4e3cdd4435c61dfaf17c2981422358dea01cfba0ffe8c6f12c7864b6f1ee6c9906dfa64248bc95effed526e9ade3ad1292888"
+              }
+            ],
+            "bom-ref": "pkg:generic/webkitgtk@2.50.1?download_url=https://pkgs.devel.redhat.com/repo/rpms/webkit2gtk3/webkitgtk-2.50.1.tar.xz/sha512/4b7b6c5ae02f1dbcff26e7af4ee4e3cdd4435c61dfaf17c2981422358dea01cfba0ffe8c6f12c7864b6f1ee6c9906dfa64248bc95effed526e9ade3ad1292888/webkitgtk-2.50.1.tar.xz&checksum=SHA-512:4b7b6c5ae02f1dbcff26e7af4ee4e3cdd4435c61dfaf17c2981422358dea01cfba0ffe8c6f12c7864b6f1ee6c9906dfa64248bc95effed526e9ade3ad1292888",
+            "version": "2.50.1",
+            "evidence": {
+              "identity": [
+                {
+                  "field": "purl",
+                  "concludedValue": "pkg:generic/webkitgtk@2.50.1?download_url=https://pkgs.devel.redhat.com/repo/rpms/webkit2gtk3/webkitgtk-2.50.1.tar.xz/sha512/4b7b6c5ae02f1dbcff26e7af4ee4e3cdd4435c61dfaf17c2981422358dea01cfba0ffe8c6f12c7864b6f1ee6c9906dfa64248bc95effed526e9ade3ad1292888/webkitgtk-2.50.1.tar.xz&checksum=SHA-512:4b7b6c5ae02f1dbcff26e7af4ee4e3cdd4435c61dfaf17c2981422358dea01cfba0ffe8c6f12c7864b6f1ee6c9906dfa64248bc95effed526e9ade3ad1292888"
+                }
+              ]
+            },
+            "pedigree": {
+              "ancestors": [
+                {
+                  "name": "webkitgtk",
+                  "purl": "pkg:generic/webkitgtk@2.50.1?download_url=https://webkitgtk.org/releases/webkitgtk-2.50.1.tar.xz&checksum=SHA-256:33e912ee6e3cdb4b9803715f50686af85a60af47f1cf72a6acc6a2db1bb3d9fe",
+                  "type": "library",
+                  "hashes": [
+                    {
+                      "alg": "SHA-256",
+                      "content": "33e912ee6e3cdb4b9803715f50686af85a60af47f1cf72a6acc6a2db1bb3d9fe"
+                    }
+                  ],
+                  "bom-ref": "pkg:generic/webkitgtk@2.50.1?download_url=https://webkitgtk.org/releases/webkitgtk-2.50.1.tar.xz&checksum=SHA-256:33e912ee6e3cdb4b9803715f50686af85a60af47f1cf72a6acc6a2db1bb3d9fe",
+                  "version": "2.50.1",
+                  "evidence": {
+                    "identity": [
+                      {
+                        "field": "purl",
+                        "concludedValue": "pkg:generic/webkitgtk@2.50.1?download_url=https://webkitgtk.org/releases/webkitgtk-2.50.1.tar.xz&checksum=SHA-256:33e912ee6e3cdb4b9803715f50686af85a60af47f1cf72a6acc6a2db1bb3d9fe"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "webkitgtk",
+            "purl": "pkg:generic/webkitgtk@2.50.1?download_url=https://pkgs.devel.redhat.com/repo/rpms/webkit2gtk3/webkitgtk-2.50.1.tar.xz.asc/sha512/c430677ec8e147750f3dc69f2b6252da9bc9b4df61c0976213dea535be8973dc746b22137d508899d28095f58197e52ffa003ab2033b2c20a6c03d1a1b327e2c/webkitgtk-2.50.1.tar.xz.asc&checksum=SHA-512:c430677ec8e147750f3dc69f2b6252da9bc9b4df61c0976213dea535be8973dc746b22137d508899d28095f58197e52ffa003ab2033b2c20a6c03d1a1b327e2c",
+            "type": "library",
+            "hashes": [
+              {
+                "alg": "SHA-512",
+                "content": "c430677ec8e147750f3dc69f2b6252da9bc9b4df61c0976213dea535be8973dc746b22137d508899d28095f58197e52ffa003ab2033b2c20a6c03d1a1b327e2c"
+              }
+            ],
+            "bom-ref": "pkg:generic/webkitgtk@2.50.1?download_url=https://pkgs.devel.redhat.com/repo/rpms/webkit2gtk3/webkitgtk-2.50.1.tar.xz.asc/sha512/c430677ec8e147750f3dc69f2b6252da9bc9b4df61c0976213dea535be8973dc746b22137d508899d28095f58197e52ffa003ab2033b2c20a6c03d1a1b327e2c/webkitgtk-2.50.1.tar.xz.asc&checksum=SHA-512:c430677ec8e147750f3dc69f2b6252da9bc9b4df61c0976213dea535be8973dc746b22137d508899d28095f58197e52ffa003ab2033b2c20a6c03d1a1b327e2c",
+            "version": "2.50.1",
+            "evidence": {
+              "identity": [
+                {
+                  "field": "purl",
+                  "concludedValue": "pkg:generic/webkitgtk@2.50.1?download_url=https://pkgs.devel.redhat.com/repo/rpms/webkit2gtk3/webkitgtk-2.50.1.tar.xz.asc/sha512/c430677ec8e147750f3dc69f2b6252da9bc9b4df61c0976213dea535be8973dc746b22137d508899d28095f58197e52ffa003ab2033b2c20a6c03d1a1b327e2c/webkitgtk-2.50.1.tar.xz.asc&checksum=SHA-512:c430677ec8e147750f3dc69f2b6252da9bc9b4df61c0976213dea535be8973dc746b22137d508899d28095f58197e52ffa003ab2033b2c20a6c03d1a1b327e2c"
+                }
+              ]
+            },
+            "pedigree": {
+              "ancestors": [
+                {
+                  "name": "webkitgtk",
+                  "purl": "pkg:generic/webkitgtk@2.50.1?download_url=https://webkitgtk.org/releases/webkitgtk-2.50.1.tar.xz.asc&checksum=SHA-256:e7889df60fa2ec3857b9db0cf2dfa783222f0b7fb15a77602d2044f83a200961",
+                  "type": "library",
+                  "hashes": [
+                    {
+                      "alg": "SHA-256",
+                      "content": "e7889df60fa2ec3857b9db0cf2dfa783222f0b7fb15a77602d2044f83a200961"
+                    }
+                  ],
+                  "bom-ref": "pkg:generic/webkitgtk@2.50.1?download_url=https://webkitgtk.org/releases/webkitgtk-2.50.1.tar.xz.asc&checksum=SHA-256:e7889df60fa2ec3857b9db0cf2dfa783222f0b7fb15a77602d2044f83a200961",
+                  "version": "2.50.1",
+                  "evidence": {
+                    "identity": [
+                      {
+                        "field": "purl",
+                        "concludedValue": "pkg:generic/webkitgtk@2.50.1?download_url=https://webkitgtk.org/releases/webkitgtk-2.50.1.tar.xz.asc&checksum=SHA-256:e7889df60fa2ec3857b9db0cf2dfa783222f0b7fb15a77602d2044f83a200961"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "cdc778b7a671077c574daca211f6a9b8"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "fb1bf908e11ac108efa38d463af986baf87764212f77724220d66eba76a5bd67"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3.",
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3866846",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        }
+      ]
+    },
+    {
+      "name": "webkit2gtk3-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "17cf287004a9b9a0132a3945113bfc0d645f49682a756b61bd2de9b07ca8b9d4"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=aarch64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "4dd8148fb1cecfc603083f61541d59e1"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "280b7c7e04f8d3f65fa4a67dcbf8fbdb106621f9cab41308856217f427fd41fe"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7a7fd995de842f61bb4910ee2f150e358d0e985197d901cbee59d3d1d3910d51"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=aarch64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "f8d3697c0c6c3a931762e788f93a0305"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b3717508c6eff781c23ecda5730fef5f42e7a298a8c2d2a7b45c13a837cb7df0"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1a54c8c4484ff05a792e4a8713cc809662f59942d58430e850956f41b884f4d1"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=aarch64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "d18e8a321e797565e7785c9230fc9b97"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "d8e90491503613c3afb9fdaa95d9fdd8cc9b6421246879ca53c930b42f0ca025"
+        }
+      ],
+      "description": "The webkit2gtk3-jsc-devel package contains libraries, build data, and header files for developing applications that use JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-jsc",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b22d76da8230b1fa653bcccf2a497200505d9ee9e0318033165f7048668aec52"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=aarch64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "e46fd5019b1e5bee4296983da98843a0"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "d16d0629453c3d651f1853351bfbb4584f9e96224d4869777222847e7cf1fbb0"
+        }
+      ],
+      "description": "This package contains JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4a7e412903dec6eb5d9271f89db40707da6e67d7e770cdca221a50abab3fd88b"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=aarch64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "9cef6ec935b5f754be41256bdce406dc"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "8631787137aaf9a210b48217283bedd4d4da7c775ff663f7d46db054d91ec33b"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6c97242d0b42a1de22f6366d294eff7f7d670861175d8e4371f5c8740fda3bd8"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=aarch64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "6414fff8bbedfbb6480120d267474ae7"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "c8737c8552055ce05a2ecf134ce8d7ee5cafce004aa7f69ef311a0970a70e38b"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "40442d1e68e8e4b92401123387b42a4ad7abb68bf129a335dce17d5fe9d25a70"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=aarch64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "d5eb0cc93f87828894fdeaf4a95de072"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "06c14fcc79c52a796a9494c0ec6f5f23618422da99b0e6b01830b2cc81176244"
+        }
+      ],
+      "description": "The webkit2gtk3-devel package contains libraries, build data, and header files for developing applications that use webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bc2e153a940e8006f938be061051192cbb7e0d2a6581485a0c9e390fc8b9e0f6"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=aarch64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "b267362beb7e848238e8907dd91d179c"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "35ffa29ed0a6a9f916696d3d4548358ac99d769454ae66837c0fab495c4a6fd4"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3."
+    },
+    {
+      "name": "webkit2gtk3-debugsource",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "12612b652306909a5d1c34795026e31cd2e596bf7eaf252159d723db628d4bcd"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=aarch64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "508bc2cc6a414ebf28fc31420a62cfcd"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "894126af54e1e14c397e93fe985ab772356ceb5ae79cb57fbc88427e5b069071"
+        }
+      ],
+      "description": "This package provides debug sources for package webkit2gtk3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "66295026d72f8386d82a6bb065ed97b7ebe808ce93ad23293eaa8804619b9406"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=ppc64le",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "16554480383a5aebdc1a8db97a3e2978"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "aa48f4fb11a657d1b51d3b3f852cb8dad7d7e75d0fb92402fe46e91c9bb070ee"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "66ddfcb0aefad9d8b9219e98929e8b25773ecf11cefeb27de9d05e287258686d"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=ppc64le",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "b08ab30e210c1a5925aa8c2b5d48830d"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "8e18de350f3968d5821a2f1977fed28357ef2fbd0be4b4df518990d2948d097f"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "41774f01b3176e565121bdfc5cd8561408a6a7f2c88ef328e8bd2aa68d5b8ab6"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=ppc64le",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "5e0d835facae9e142bd4c220608de0ea"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b60a72cd80c3a8e010f5de2eef4dd8570a385691208d19248250c0f6395a9da9"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-debugsource",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "aa9bdf09c18f5e17ed9802a6760e7b02742790aacdb57090b9569f4026ae8870"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=ppc64le",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "26bec8878883e939aff27b31746dbfdb"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "f7901fc826fea0996a18c29ed927aa3df9de5c2f5c64dcfc41a8a9a944b402d4"
+        }
+      ],
+      "description": "This package provides debug sources for package webkit2gtk3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0f5097308c08703d7810641cc17cd4bdaf1d1fc364325b5d29e855f491da724c"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=ppc64le",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "44a3a1cac145ba558f27a09741f2af40"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "7e8f9fcfcdebc7b932d794e7307d8e473ed67c4b13177e56561db63d24111aa2"
+        }
+      ],
+      "description": "The webkit2gtk3-devel package contains libraries, build data, and header files for developing applications that use webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6aa7039354b5283a5fe96e38b66d05a31fc20b8f76481e2734e57098833f8382"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=ppc64le",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "ad93a9c6d727048f9a53466a277cff2e"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "3764ef1beba708864a89f00d547af9dc1f8322584872bac2d2ac817c990f538b"
+        }
+      ],
+      "description": "The webkit2gtk3-jsc-devel package contains libraries, build data, and header files for developing applications that use JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "62bc431355624b6b7c0a6fda686ffeff2c640b742f0d1dd60ac46d4b6b922a75"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=ppc64le",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "d14ea2940257f8eca37686fd96ec42eb"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "cbe9b623ef9b3c2de3b877e4972a7c055007383fa9be725216a944a7653b86c9"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3."
+    },
+    {
+      "name": "webkit2gtk3-jsc",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4a2c1b1df7211e2e582338ac6ab3e75b227ddb45873811cdc78dd2e076def0b4"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=ppc64le",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "3c8b018637b2d490a03cc5422a3eed2a"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "21e5bc5d40273e1b9f4d4d8f8c9683dbdd45ea3bad2c190b877541cedb09f780"
+        }
+      ],
+      "description": "This package contains JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0a6ff989bbb953c5a65f1bb2dfc5761f75cbb143f7f8906bae5d373e36761e1f"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=ppc64le",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "0660bcf1b3122a5d9b10435998841fd0"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b89080ac4840269d336a6932d13247afaa8fba1ffb4a80415cbd6f001dcddd86"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "75e1e0fc3e054c8f6e7d59017651fb137a37217a001ec8f177a519f7e6e3ceb7"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=i686",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "c0ce7e19645dc895923f92743b703225"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "f0af2b8bed26ccf939a24c86ae021557e8ab218ef9d7f270003a34189877c32c"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "299611113aaff3216e93094cb05d258d4e170b28a0c69af12cc99ea310f11355"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=i686",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "5d6df803aa7d8c2405c98c5b3e52038f"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "62e30e551291e59dc237e54af568a4c2b386bce29aacd5c01bd79d2b9e0c636c"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a18d3096cceaca6215757cda3123c76f2608ce9d2ddf1177d3b1512b01ebf972"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=i686",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "c6f90e94c711fdb3914eb72881ab2362"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "9f6c0fbbfcfdb229fadc37e3c4bddb4e7bdc82010e907a0f2a3da38fbe3e4149"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3."
+    },
+    {
+      "name": "webkit2gtk3-debugsource",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e996456d2d34ec10e6f05a37dc80ac371944db43f1929ac0aafec6ad60feb24b"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=i686",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "36edcda41623c290beaa5aaf076bc995"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "6c23980300e08d2208dbb91099889565dd6a720091141727772f758d2fd44acc"
+        }
+      ],
+      "description": "This package provides debug sources for package webkit2gtk3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0b6758d0379a302501b62195966c0f5a98378b4dfa88b1aaa7139090dc28beea"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=i686",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "e852ec3387b8b877ebae2276b2fc3835"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "2f6b95defc98ad916604893bec904f124844ba31e171d8aed4715aaefedb8165"
+        }
+      ],
+      "description": "This package contains JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c99b6bcdae37b8fdcf2f49f48cde46f6f2a9dc71032edf01af4eab617c7be20e"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=i686",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "8b8e3983fe45ffc6b2563ecc7eb8b594"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "23ae2a7741042d35a33266634073d4356b3d1600c86e7db8d7606e9f89c43080"
+        }
+      ],
+      "description": "The webkit2gtk3-devel package contains libraries, build data, and header files for developing applications that use webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2f1bcf892d71641af4300b47775f514c88aee182a99e26acf5de9aa2cd14f75e"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=i686",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "0db9f48d486408750681fd4770f866ed"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "3f9ce28e6221fd1e68d7f4f209504e50a4eb70c754245f8b0cf756b3fe71bbef"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5b63ce063e61eb1a066b849278d5f47b5b4aa268ef749de283f6db438ccff386"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=i686",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "02f98ec9cbb2b705ef5d2cd1abbac14e"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "e049ad85651abcbee80673163325eaea5f57d5f82ef11f878f9a7e33a66dd0c4"
+        }
+      ],
+      "description": "The webkit2gtk3-jsc-devel package contains libraries, build data, and header files for developing applications that use JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=i686",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "40d89779e9199d8a9b3d275e5916d545a2a3aa0f14b97211d7ac7ef13c0719e9"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=i686",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=i686"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "b3bd56bd36cc4944d17231362caaeda0"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b8f59bc07de4c5dd2e4581781c8d0d726d0507fbade376548030152a32aec525"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9859ca1331f0b5cb003366cefd9b28c530e15f69f3b5a2e193cc85407f2bb53e"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=x86_64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "64f3f4894b719ccdbbe0bdd9dfa8470d"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "57c53b034e675f54844695fb947720857d6c0c6f1887984679d6c7b2433b4863"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cfe09142109a580df5b4dc9f56ba74a494858affa130ba6fc4c7bcb58e805f3b"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=x86_64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "7f9c23b32d7262ec2c7c805614b5df8e"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "4c0f3588149ad30b854b5f51e069c2ac66b5861e0335539d9ee372722d88459c"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d4bb732b02ef3f3bd252e0f67f371701e0b5b441349bc5082770481e28512e01"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=x86_64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "0adba30ef742a536db78307f994d6cd5"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "0c3b7aa740ab77f1fe925bd563db39ab7a9b7f3031d707bb62f770f742a2c19a"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "15cfce620f26ec20f1326c5791ca49765e9c48ef25639c20d4947ceda5f861d1"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=x86_64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "251216dcf32f6c0f3a3ba059ea10dcbd"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b79cb3fa3eacb3e32747eb62e3a36933e21d3984233c71da32aa30f8964c8071"
+        }
+      ],
+      "description": "The webkit2gtk3-jsc-devel package contains libraries, build data, and header files for developing applications that use JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-jsc-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cb881110941a1aa64493fc796318dd5bf4a286aad754a7e5ede99f6e9263e0ad"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=x86_64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "e7e949debc10787efacd83459bf84125"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "411716271ac73d5a8e2dadc2b892ec98b3262b372f3d8adcef62c664d122727f"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0a4144630bfd3f2654bb8c1d2450319174fbf8bdd890e87852d76a13d76362b9"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=x86_64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "fb63e141e71793766672fd36216d97de"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "6937da7e26571fdb62d708a7bf4eb56303fc33b7047f8669628f0d2c49c69055"
+        }
+      ],
+      "description": "This package contains JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "58394c38b3ec1f6d4ff559490386da7ea89fcb59839078d61d9341fb27c85964"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=x86_64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "0afbb36a1068d3078d80ba382960018e"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "547b99b9f227fd7555d2fdff64bcec3f055e710da3606061faa8ab067d5eac48"
+        }
+      ],
+      "description": "The webkit2gtk3-devel package contains libraries, build data, and header files for developing applications that use webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0773f988b200a6302556a2ff41b479a369a9cf11f9e793333eb6248ffbca2e55"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=x86_64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "015e5911023372a598db7e4c6f1fd4be"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "9514b5caee3c51a16b5bdbd5951e9c9efd4018e50c6a3af811132bddf704b5c3"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3."
+    },
+    {
+      "name": "webkit2gtk3-debugsource",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3975558421bd4c125b7850a4f16c7ffe48a2e4846a593da439978dd4301b9166"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=x86_64",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "da5b21380b49e0086bfa34b6f4764aba"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "cbbbb19919d0107446b8b1deee1901278819a8e5de66a54e23c7cb77b4985051"
+        }
+      ],
+      "description": "This package provides debug sources for package webkit2gtk3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5be367ebb19623c2cfd4a61727e24d4438afb4b2f912a380b28ed6842af33515"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=s390x",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "c31370798ad6a218be4405d55b3762d5"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "4c31aa765b29d03a09e49ad030e0e88a651b2a23b9902c2b28c2ff474b21c4dd"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1a19a2057b0fd39cddc76af9abacef104c3695d7699692f36ffc0a6f86c5a58e"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=s390x",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "8ebc74b50d9bc6b449936157a9f6804d"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "165efef1b2f82b87a11ae49b80d02afd1ddd3371380840e51d8e811cc6961a12"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4fa902114937998bec5f00ba18c67854450a2cded0c5c6b399af78605523a850"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=s390x",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "70d1fcd8363a72b3a61cd530dc479b32"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "648fbf1d58a73f3c104c0b91eec177ec90ebb3397644a74283e0609c0f417ba9"
+        }
+      ],
+      "description": "The webkit2gtk3-devel package contains libraries, build data, and header files for developing applications that use webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-jsc-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9768d5feeb3839110054fc51b9fa80f59bff655cd99f1428b3ffb25623740d22"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=s390x",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "11c1d5873a6da2af219b377a8fdba314"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "4c919a86fe16cec27659fde43bc5563d74b1bdeef46172df20bb4990de5e9485"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel-debuginfo",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "93688eac15c79c32449c43cbc42e1ed316595e89ad83c84b9558b21ddd1751f8"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=s390x",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-debug-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "fbc596c22fd1331f1c4443dd7c620f02"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b441cc0f5030cded4bcbdd96601e212313289dc1ea3298e92c9486d80a6bcd72"
+        }
+      ],
+      "description": "This package provides debug information for package webkit2gtk3-jsc-devel. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "webkit2gtk3-jsc-devel",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "86f50815ed6d1ab62af52b64145e67b1de0fedd4a06610b945eb74ffd5f83dd6"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=s390x",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "8efc998ae783da9583195f6a6ca71ea4"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "2b272a5f52544bfd0e8ad661dcc51525fd2c830be3452afdab7335e88f3b9c69"
+        }
+      ],
+      "description": "The webkit2gtk3-jsc-devel package contains libraries, build data, and header files for developing applications that use JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3",
+      "purl": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b639b876fa2ed2568b70c65b4c93594269623f2f6dc08df30ea5e1bf70e1f220"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=s390x",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "d2f4d572123587720d910c39ad7b90fb"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "25734336a58f7d64f48d1a8b1f4b69f6732bea0bd04f7e895db273049a2144e5"
+        }
+      ],
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform. This package contains WebKit2 based WebKitGTK for GTK 3."
+    },
+    {
+      "name": "webkit2gtk3-jsc",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c5969a21c4278fb872764937446577800720979d429c11efde591cc2b2243394"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=s390x",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "cf4ed769f90122f2491483818919a770"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "d36915b37a515adb780ac4b77d888756b3c791a6d30026385588dcb60b061611"
+        }
+      ],
+      "description": "This package contains JavaScript engine from webkit2gtk3."
+    },
+    {
+      "name": "webkit2gtk3-debugsource",
+      "purl": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ff07054eeb36f933ca3ffb8dc82e72bc9a9d343563b790c6f6740a394d8dcc06"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=s390x",
+      "version": "2.50.1-1.el9_7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_7"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=s390x&repository_id=rhel-9-for-s390x-appstream-source-rpms__9"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "1f117a942f0ad89b548d8711ef2f7216"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "e165adb6f14d35638f60c4e1871de8e51dd8a5ca0fed2b46286074161ae51e45"
+        }
+      ],
+      "description": "This package provides debug sources for package webkit2gtk3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "openssl-synthetic-test",
+      "purl": "pkg:rpm/redhat/openssl-synthetic-test@1.0?arch=s390x&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_7",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8f47c70abbd47e171c4d5d967a828cf0464e9157115adb1c831d3770f2f1d034"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/openssl-synthetic-test@1.0?arch=s390x",
+      "version": "1.0",
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "description": "This package is a TEST package for testing trustify queries."
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=src",
+      "provides": [
+        "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=aarch64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=ppc64le",
+        "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=i686",
+        "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/webkit2gtk3-debuginfo@2.50.1-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-devel-debuginfo@2.50.1-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-devel@2.50.1-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-debuginfo@2.50.1-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel-debuginfo@2.50.1-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-jsc-devel@2.50.1-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3@2.50.1-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-jsc@2.50.1-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/webkit2gtk3-debugsource@2.50.1-1.el9_7?arch=s390x",
+        "pkg:rpm/redhat/openssl-synthetic-test@1.0?arch=s390x"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:21479570-cb4b-42ff-8d4d-d45cea101a65"
+}


### PR DESCRIPTION
added a more fully fledged test data set for rh latest tests.

## Summary by Sourcery

Add comprehensive RH latest filter test coverage for TC-3278 using new multi-product SBOM fixtures.

Documentation:
- Document the structure and intent of the new TC-3278 CycloneDX SBOM test dataset.

Tests:
- Add parametrized latest-filter integration test for RH variant resolution using TC-3278 data across CPE, name, and purl queries.