### PR TITLE
docs(terraform): OpenAPI callback for frontend client

### DIFF
--- a/docs/book/modules/admin/examples/trustify/sso.tf
+++ b/docs/book/modules/admin/examples/trustify/sso.tf
@@ -112,6 +112,7 @@ resource "aws_cognito_user_pool_client" "frontend" {
   callback_urls = [
     var.console-url,
     "${var.console-url}/",
+    "${var.console-url}/openapi/oauth-receiver.html",
   ]
   logout_urls = [
     "${var.console-url}/",


### PR DESCRIPTION
When using the OpenAPI (rapidoc) web interface,
for obtaining token it uses /openapi/oauth-receiver.html as target for callback redirect.
(As can be seen also in common/infrastructure/src/app/http.rs#L607)

While Cognito requires each callback page to be specified by full URL,
having just domain or top-level url (as in console-url) is not enough.

So this adds the openapi endpoint directly to allowed CallbackURLs for the fronted client.

## Summary by Sourcery

Enhancements:
- Add the OpenAPI OAuth receiver HTML endpoint to the allowed callback URLs for the frontend Cognito user pool client in the Terraform SSO example configuration.