### PR TITLE
latest: fix TC-3278 add more test data

### DIFF
--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/datagrid-datagrid-8/latest/binary-2025-12-04-62F0D268C8094C2.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/datagrid-datagrid-8/latest/binary-2025-12-04-62F0D268C8094C2.json
@@ -1,0 +1,27088 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "syft",
+          "type": "application",
+          "author": "anchore",
+          "version": "1.27.1"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "datagrid/datagrid-8",
+      "purl": "pkg:oci/datagrid-8@sha256%3A6a28608358b7af404b1f6699cad8ff338a8cc763214ade7d4ce6b8aab6125ecd?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1764765711",
+      "type": "container"
+    },
+    "timestamp": "2025-12-04T06:50:24Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156818"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "datagrid/datagrid-8",
+      "purl": "pkg:oci/datagrid-8@sha256%3A6a28608358b7af404b1f6699cad8ff338a8cc763214ade7d4ce6b8aab6125ecd?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1764765711",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6a28608358b7af404b1f6699cad8ff338a8cc763214ade7d4ce6b8aab6125ecd"
+        }
+      ],
+      "bom-ref": "pkg:oci/datagrid-8@sha256%3A6a28608358b7af404b1f6699cad8ff338a8cc763214ade7d4ce6b8aab6125ecd?arch=amd64&os=linux&tag=1.5-8.1764765711",
+      "version": "sha256:6a28608358b7af404b1f6699cad8ff338a8cc763214ade7d4ce6b8aab6125ecd",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-8@sha256%3A6a28608358b7af404b1f6699cad8ff338a8cc763214ade7d4ce6b8aab6125ecd?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1764765711"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-8@sha256%3A6a28608358b7af404b1f6699cad8ff338a8cc763214ade7d4ce6b8aab6125ecd?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5"
+          }
+        ]
+      },
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "56908efbd0acb84bbcbe0ac1a10ce922cff451d6",
+            "url": "https://pkgs.devel.redhat.com/git/containers/datagrid-8#56908efbd0acb84bbcbe0ac1a10ce922cff451d6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:architecture",
+          "value": "x86_64"
+        },
+        {
+          "name": "sbomer:image:labels:build-date",
+          "value": "2025-12-03T12:42:48"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "datagrid-8-rhel9-container"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.dev-mode",
+          "value": "DEBUG:true"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.dev-mode.port",
+          "value": "DEBUG_PORT:8787"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.license_terms",
+          "value": "https://www.redhat.com/agreements"
+        },
+        {
+          "name": "sbomer:image:labels:description",
+          "value": "Data Grid Server"
+        },
+        {
+          "name": "sbomer:image:labels:distribution-scope",
+          "value": "public"
+        },
+        {
+          "name": "sbomer:image:labels:io.buildah.version",
+          "value": "1.33.12"
+        },
+        {
+          "name": "sbomer:image:labels:io.cekit.version",
+          "value": "4.9.1"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.description",
+          "value": "Provides a scalable in-memory distributed database designed for fast access to large volumes of data."
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.display-name",
+          "value": "Data Grid 8.5"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.expose-services",
+          "value": "8080:http"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.s2i.scripts-url",
+          "value": "image:///usr/local/s2i"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.tags",
+          "value": "datagrid,java,jboss,xpaas"
+        },
+        {
+          "name": "sbomer:image:labels:maintainer",
+          "value": "remerson@redhat.com"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "datagrid/datagrid-8"
+        },
+        {
+          "name": "sbomer:image:labels:org.jboss.product",
+          "value": "datagrid"
+        },
+        {
+          "name": "sbomer:image:labels:org.jboss.product.datagrid.version",
+          "value": "8.5.5.GA"
+        },
+        {
+          "name": "sbomer:image:labels:org.jboss.product.openjdk.version",
+          "value": "21"
+        },
+        {
+          "name": "sbomer:image:labels:org.jboss.product.version",
+          "value": "8.5.5.GA"
+        },
+        {
+          "name": "sbomer:image:labels:org.opencontainers.image.documentation",
+          "value": "https://rh-openjdk.github.io/redhat-openjdk-containers/"
+        },
+        {
+          "name": "sbomer:image:labels:org.opencontainers.image.revision",
+          "value": "ubi9"
+        },
+        {
+          "name": "sbomer:image:labels:org.opencontainers.image.source",
+          "value": "https://github.com/rh-openjdk/redhat-openjdk-containers"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "8.1764765711"
+        },
+        {
+          "name": "sbomer:image:labels:summary",
+          "value": "Data Grid Server"
+        },
+        {
+          "name": "sbomer:image:labels:url",
+          "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/datagrid/datagrid-8/images/1.5-8.1764765711"
+        },
+        {
+          "name": "sbomer:image:labels:usage",
+          "value": "https://rh-openjdk.github.io/redhat-openjdk-containers/"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-ref",
+          "value": "56908efbd0acb84bbcbe0ac1a10ce922cff451d6"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:vendor",
+          "value": "Red Hat"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "1.5"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3904597",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "https://pkgs.devel.redhat.com/git/containers/datagrid-8#56908efbd0acb84bbcbe0ac1a10ce922cff451d6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "HdrHistogram",
+      "purl": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12.redhat-00005?type=jar",
+      "type": "library",
+      "group": "org.hdrhistogram",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c1caad7e00a8929ef9b621ff4a5fe97a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9babda04341092537cf08f258257ddb48eb10da2"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c981533d9c9ef603c8c5cc54e057845092fda91af8ec66ca1a06f778b857aaea"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12.redhat-00005?type=jar",
+      "version": "2.1.12.redhat-00005",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://creativecommons.org/publicdomain/zero/1.0/, https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "43fe40b92029f9bc8dc0c60892cd5b479e8819aa",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/HdrHistogram/HdrHistogram.git#2.1.12.redhat-00005"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/HdrHistogram-2.1.12.redhat-00005.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/HdrHistogram-2.1.12.redhat-00005.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9babda04341092537cf08f258257ddb48eb10da2"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12177243",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7HNRJQRKDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.3.9:1.0.6",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/HdrHistogram/HdrHistogram.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "LatencyUtils",
+      "purl": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3.redhat-00005?type=jar",
+      "type": "library",
+      "group": "org.latencyutils",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "74e6eef8656cc19496e61079b4d925b6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f1a15122edfee057a584cc867e2d1a82bd23eee3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "44693a35ca6d209a1a68c98f51556103e5b840e1d0f8288b86915d6b279ecfde"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3.redhat-00005?type=jar",
+      "version": "2.0.3.redhat-00005",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "name": "Public Domain, per Creative Commons CC0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a42a6a870eb135ff05b4caad90bd24c0f206540a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/LatencyUtils/LatencyUtils.git#2.0.3.redhat-00005"
+          },
+          {
+            "uid": "fa856f73028cd6f05d6f99477c13b248cfadc7f7",
+            "url": "https://github.com/LatencyUtils/LatencyUtils.git#LatencyUtils-2.0.3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/LatencyUtils-2.0.3.redhat-00005.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/LatencyUtils-2.0.3.redhat-00005.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f1a15122edfee057a584cc867e2d1a82bd23eee3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12177249",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7HNTNUC2DYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.3.9:1.0.6",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/LatencyUtils/LatencyUtils.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "aesh",
+      "purl": "pkg:maven/org.aesh/aesh@2.8.4.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.aesh",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "485bf701533babff79296e6fec37a4f0"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "616b3f8b80974394fe8fd734f61b8b0ee252d3fd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b7c14df584564f890a30b3d249c643a2052cd76b0c09ec81f91ef45626b85230"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.aesh/aesh@2.8.4.redhat-00001?type=jar",
+      "version": "2.8.4.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.apache.org/licenses/LICENSE-2.0",
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4a37197bf263b70de5173f531ae78056f965df4e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/aesh.git#2.8.4.redhat-00001"
+          },
+          {
+            "uid": "e0f2d1921e9d6d29c249f0028c4f10bd88a9dd20",
+            "url": "https://github.com/aeshell/aesh.git#e0f2d1921e9d6d29c249f0028c4f10bd88a9dd20"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/aesh-2.8.4.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/aesh-2.8.4.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "616b3f8b80974394fe8fd734f61b8b0ee252d3fd"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13873899",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BHIZVYWHBSIAG",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.3.9:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/aeshell/aesh.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "agroal-api",
+      "purl": "pkg:maven/io.agroal/agroal-api@2.4.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "io.agroal",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "47d6e8b75a5abcb73864ece30fb59163"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e57683d0cf8f7133697b33cd0bcc804be13a033e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3596e67341530b7f685ecc477ce3b73cd26978a8990ccd7d2e673f521a0506c3"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.agroal/agroal-api@2.4.0.redhat-00001?type=jar",
+      "version": "2.4.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "98f6b243e1fdf4ae3841a038ca641c30723a476e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/agroal/agroal.git#2.4.0.redhat-00001"
+          },
+          {
+            "uid": "a54f9e6f2edbff64450b0372d2f0247f823f7559",
+            "url": "https://github.com/agroal/agroal.git#2.4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/agroal-api-2.4.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/agroal-api-2.4.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e57683d0cf8f7133697b33cd0bcc804be13a033e"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12622356",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BBNBQIYM3EYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.3",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/agroal/agroal.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "agroal-pool",
+      "purl": "pkg:maven/io.agroal/agroal-pool@2.4.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "io.agroal",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d8d4e675337531dcb74f2aa163d70190"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4b7a58c10a043260bbf4222d1bd3044f63ce3f6c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "905dddb64716e78ec8d8e09e402a879b9596b0a1a6da45499913fc3eea4c52e6"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.agroal/agroal-pool@2.4.0.redhat-00001?type=jar",
+      "version": "2.4.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "98f6b243e1fdf4ae3841a038ca641c30723a476e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/agroal/agroal.git#2.4.0.redhat-00001"
+          },
+          {
+            "uid": "a54f9e6f2edbff64450b0372d2f0247f823f7559",
+            "url": "https://github.com/agroal/agroal.git#2.4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/agroal-pool-2.4.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/agroal-pool-2.4.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4b7a58c10a043260bbf4222d1bd3044f63ce3f6c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12622348",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BBNBQIYM3EYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.3",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/agroal/agroal.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "alsa-lib",
+      "purl": "pkg:rpm/redhat/alsa-lib@1.2.14-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/alsa-lib@1.2.14-1.el9?arch=x86_64",
+      "version": "1.2.14-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2bb67d5c1f5ba6cffeb75b1d503c031dc6245e00",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/alsa-lib#2bb67d5c1f5ba6cffeb75b1d503c031dc6245e00"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3720652",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/alsa-lib#2bb67d5c1f5ba6cffeb75b1d503c031dc6245e00",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "alternatives",
+      "purl": "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64",
+      "version": "1.24-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "083be09fc542a85ddbf9263d0616613ef5f23348",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#083be09fc542a85ddbf9263d0616613ef5f23348"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3269575",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#083be09fc542a85ddbf9263d0616613ef5f23348",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "antlr-runtime",
+      "purl": "pkg:maven/org.antlr/antlr-runtime@3.5.3.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.antlr",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d80f5b15a4627e916da9e1cfdd5ac3ba"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "89ed934e7299232021180827ba43fec5f02a7908"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fc60a333d05e1ec9b7edc1a5a903fc2e3149c942682ee0de48ee100d08b3bc8b"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.antlr/antlr-runtime@3.5.3.redhat-00001?type=jar",
+      "version": "3.5.3.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b51577f54b7934af40d3c3fe9999ee428afc1013",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/antlr/antlr3.git#3.5.3.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-objectfilter-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-objectfilter-15.0.19.Final-redhat-00001.jar:org.antlr:antlr-runtime"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/10584631",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/AZTFVRLIVUIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.6",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/antlr/antlr3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "audit-libs",
+      "purl": "pkg:rpm/redhat/audit-libs@3.1.5-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/audit-libs@3.1.5-7.el9?arch=x86_64",
+      "version": "3.1.5-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "935b145ca6e530c3df0b34882b5870502c85f0a8",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#935b145ca6e530c3df0b34882b5870502c85f0a8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3599839",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#935b145ca6e530c3df0b34882b5870502c85f0a8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "avahi-libs",
+      "purl": "pkg:rpm/redhat/avahi-libs@0.8-23.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/avahi-libs@0.8-23.el9?arch=x86_64",
+      "version": "0.8-23.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3bbe0d065fa0fe185ea381cd2b7ee3fa85658db3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/avahi#3bbe0d065fa0fe185ea381cd2b7ee3fa85658db3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3736646",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/avahi#3bbe0d065fa0fe185ea381cd2b7ee3fa85658db3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "basesystem",
+      "purl": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "version": "11-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+            "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688850",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bash",
+      "purl": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "version": "5.1.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80326284a249f523c3e2d14e0eed2dbaece63c4e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2910143",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bsdtar",
+      "purl": "pkg:rpm/redhat/bsdtar@3.5.3-6.el9_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bsdtar@3.5.3-6.el9_6?arch=x86_64",
+      "version": "3.5.3-6.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "476a518562a29e2fa60704cd358f8afffb8492c4",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#476a518562a29e2fa60704cd358f8afffb8492c4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3803996",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#476a518562a29e2fa60704cd358f8afffb8492c4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bzip2-libs",
+      "purl": "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64",
+      "version": "1.0.8-10.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc546512bf0d59d11d367828d43b5988da3a5d92",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#fc546512bf0d59d11d367828d43b5988da3a5d92"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3469717",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#fc546512bf0d59d11d367828d43b5988da3a5d92",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ca-certificates",
+      "purl": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "version": "2025.2.80_v9.0.305-91.el9",
+      "licenses": [
+        {
+          "expression": "MIT AND GPL-2.0-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80abd67ad7d828eba9c44be633f42b67f21751b1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#80abd67ad7d828eba9c44be633f42b67f21751b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3864618",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#80abd67ad7d828eba9c44be633f42b67f21751b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "caffeine",
+      "purl": "pkg:maven/com.github.ben-manes.caffeine/caffeine@3.1.8.redhat-00002?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fbd6ee5eccdc6885d8f526081cf5f30e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6fb7fa88c93a73f03e19ac3a48bf4d75562b7f14"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1e04f06f8d86b417ddf64312eb0bdd56e4942ba0a8e8fb3db958f1de7f0281b3"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.github.ben-manes.caffeine/caffeine@3.1.8.redhat-00002?type=jar",
+      "version": "3.1.8.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b5314d952a017252ae7e189b2112e8d0334f89b7",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/ben-manes/caffeine.git#3.1.8.redhat-00002"
+          },
+          {
+            "uid": "b0723da5976ebb52069f6b0cccfcf44186c3fdf3",
+            "url": "https://github.com/ben-manes/caffeine.git#v3.1.8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/caffeine-3.1.8.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/caffeine-3.1.8.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6fb7fa88c93a73f03e19ac3a48bf4d75562b7f14"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12150903",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7ENB5XM2DYAG",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j11-mvn3.9.2-gradle8.3-gcc-cpp-make:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/ben-manes/caffeine.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "commons-codec",
+      "purl": "pkg:maven/commons-codec/commons-codec@1.17.1.redhat-00001?type=jar",
+      "type": "library",
+      "group": "commons-codec",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2f5bff2bf6696d283e2869b0419ca451"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "26fff2e5416d83e7689903a31fa597193ed6d7c1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e8660def29c6ecc7561af978e105c3e402f8103350905ede0feec5011eb530b8"
+        }
+      ],
+      "bom-ref": "pkg:maven/commons-codec/commons-codec@1.17.1.redhat-00001?type=jar",
+      "version": "1.17.1.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0a70440e5a16b2a4713612ad36587d4327bb71dc",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/commons-codec.git#1.17.1.redhat-00001"
+          },
+          {
+            "uid": "965109705c5236b05011e1c45f47d991abfa521e",
+            "url": "https://github.com/apache/commons-codec#rel/commons-codec-1.17.1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/commons-codec-1.17.1.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/commons-codec-1.17.1.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "26fff2e5416d83e7689903a31fa597193ed6d7c1"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12915991",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2OHPU2VVAAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-oraclejdk8u192-mvn3.6.3-gcc-cpp-make:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/commons-codec",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "commons-compress",
+      "purl": "pkg:maven/org.apache.commons/commons-compress@1.27.1.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.apache.commons",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6a6a96076dd429f80856b5534a6a30d9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2cdf05602d7e9d907acb79a0951ec77535d69d66"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "eef292ee5dc65e8a05ce9ad9dc002d9cc20eb36929cafad08250893f661621bb"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.commons/commons-compress@1.27.1.redhat-00001?type=jar",
+      "version": "1.27.1.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8fd71117d111b4b168cb3e000b88a17612291f7a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/commons-compress.git#1.27.1.redhat-00001"
+          },
+          {
+            "uid": "8de4d85b09a5d60e03191c0d362797de253a3516",
+            "url": "https://github.com/apache/commons-compress.git#rel/commons-compress-1.27.1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/commons-compress-1.27.1.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/commons-compress-1.27.1.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "2cdf05602d7e9d907acb79a0951ec77535d69d66"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13055369",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BDKHVMG7GPYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/commons-compress.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "commons-io",
+      "purl": "pkg:maven/commons-io/commons-io@2.18.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "commons-io",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "98a8b92492fe0f745e3fbbea48c93aff"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1873c333376bce01dcc4fe00c8fdbb711de4aaae"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "70bd51e855f554df686eb20cdafdf812e215512dfdfeb376eb6ac861703df6ab"
+        }
+      ],
+      "bom-ref": "pkg:maven/commons-io/commons-io@2.18.0.redhat-00001?type=jar",
+      "version": "2.18.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "81bb90257f43e935b64638b2b61eb5aeeff11275",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/commons-io.git#2.18.0.redhat-00001"
+          },
+          {
+            "uid": "be0b1eaea246aba841510807484a6ddd6ee5fcdb",
+            "url": "https://github.com/apache/commons-io.git#rel/commons-io-2.18.0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/commons-io-2.18.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/commons-io-2.18.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "1873c333376bce01dcc4fe00c8fdbb711de4aaae"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13374352",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFJW6IBGMKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/commons-io.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "commons-lang3",
+      "purl": "pkg:maven/org.apache.commons/commons-lang3@3.18.0.redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.apache.commons",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1099218a260a3ee077785dc02577828a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "84dbe9df515799981a4881ee3a2a4a32e748c746"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0053c9d466df0b5bcb5ba7bf50a3755162f5ecbd61900196d1d17089c812f030"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.commons/commons-lang3@3.18.0.redhat-00002?type=jar",
+      "version": "3.18.0.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a11dead9f7309c377f5041b4c588a0a39e2f852a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/commons-lang.git#3.18.0.redhat-00002"
+          },
+          {
+            "uid": "5b59487808d0b86a94ad7a1ebd4c200e09b7be09",
+            "url": "https://github.com/apache/commons-lang.git#rel/commons-lang-3.18.0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/commons-lang3-3.18.0.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/commons-lang3-3.18.0.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "84dbe9df515799981a4881ee3a2a4a32e748c746"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14115530",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BIX2VBOPQSAAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/commons-lang.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "commons-math3",
+      "purl": "pkg:maven/org.apache.commons/commons-math3@3.6.1.redhat-00003?type=jar",
+      "type": "library",
+      "group": "org.apache.commons",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "93bcdd177c15c3397e9a0e1369e45032"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6c1e8b7dac8f2bd0169c7b011e8883a878c35060"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "208f2434634de0369bce68566eabfa7a49c37a0ded650a670b5f0da36f9e9ce9"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.commons/commons-math3@3.6.1.redhat-00003?type=jar",
+      "version": "3.6.1.redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ed37bf058a929f7d0440c79ba664c16e6127be53",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/commons-math.git#3.6.1.redhat-00003"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/commons-math3-3.6.1.redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/commons-math3-3.6.1.redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6c1e8b7dac8f2bd0169c7b011e8883a878c35060"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11190034",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A3OKQROB2MYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.0-gradle5.6.2:1.0.8",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/commons-math.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "copy-jdk-configs",
+      "purl": "pkg:rpm/redhat/copy-jdk-configs@4.0-3.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/copy-jdk-configs@4.0-3.el9?arch=noarch",
+      "version": "4.0-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "90e4cb8b7a3ba3d7ba7e88871bc8a6a3d9608b57",
+            "url": "git://pkgs.devel.redhat.com/rpms/copy-jdk-configs#90e4cb8b7a3ba3d7ba7e88871bc8a6a3d9608b57"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688937",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/copy-jdk-configs#90e4cb8b7a3ba3d7ba7e88871bc8a6a3d9608b57",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "coreutils-single",
+      "purl": "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64",
+      "version": "8.32-39.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8435cd1c7488661c55ad9df39743c3c53feeb582",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#8435cd1c7488661c55ad9df39743c3c53feeb582"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3429810",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#8435cd1c7488661c55ad9df39743c3c53feeb582",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies",
+      "purl": "pkg:rpm/redhat/crypto-policies@20250905-1.git377cc42.el9_7?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies@20250905-1.git377cc42.el9_7?arch=noarch",
+      "version": "20250905-1.git377cc42.el9_7",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7485840e2cbfcb1b084d9032e70c01baadd9a74",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#f7485840e2cbfcb1b084d9032e70c01baadd9a74"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3830898",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#f7485840e2cbfcb1b084d9032e70c01baadd9a74",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies-scripts",
+      "purl": "pkg:rpm/redhat/crypto-policies-scripts@20250905-1.git377cc42.el9_7?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies-scripts@20250905-1.git377cc42.el9_7?arch=noarch",
+      "version": "20250905-1.git377cc42.el9_7",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f7485840e2cbfcb1b084d9032e70c01baadd9a74",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#f7485840e2cbfcb1b084d9032e70c01baadd9a74"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3830898",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#f7485840e2cbfcb1b084d9032e70c01baadd9a74",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cups-libs",
+      "purl": "pkg:rpm/redhat/cups-libs@2.3.3op2-34.el9_7?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cups-libs@2.3.3op2-34.el9_7?arch=x86_64&epoch=1",
+      "version": "1:2.3.3op2-34.el9_7",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 and zlib"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5e93223eeb5f9339dc10c46a5eab714a4fd2d96b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/cups#5e93223eeb5f9339dc10c46a5eab714a4fd2d96b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3841136",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/cups#5e93223eeb5f9339dc10c46a5eab714a4fd2d96b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "curl-minimal",
+      "purl": "pkg:rpm/redhat/curl-minimal@7.76.1-34.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/curl-minimal@7.76.1-34.el9?arch=x86_64",
+      "version": "7.76.1-34.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9191ce624f0ca7590f3ff733b0d9374e7dc545fa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#9191ce624f0ca7590f3ff733b0d9374e7dc545fa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3708949",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#9191ce624f0ca7590f3ff733b0d9374e7dc545fa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-lib",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-22.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-22.el9?arch=x86_64",
+      "version": "2.1.27-22.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57d3073d4cb3434cf81053e6ba37d48562ab143e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/cyrus-sasl#57d3073d4cb3434cf81053e6ba37d48562ab143e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3578235",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/cyrus-sasl#57d3073d4cb3434cf81053e6ba37d48562ab143e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-libs",
+      "purl": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dejavu-sans-fonts",
+      "purl": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "version": "2.37-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bitstream Vera and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1479ec5203df4c3e577d1992b22c6976c142afa9",
+            "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688969",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dnf-data",
+      "purl": "pkg:rpm/redhat/dnf-data@4.14.0-31.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf-data@4.14.0-31.el9?arch=noarch",
+      "version": "4.14.0-31.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bac4aa45b59539817b721add70a8837d6b1423d8",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#bac4aa45b59539817b721add70a8837d6b1423d8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3719358",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#bac4aa45b59539817b721add70a8837d6b1423d8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libelf",
+      "purl": "pkg:rpm/redhat/elfutils-libelf@0.193-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libelf@0.193-1.el9?arch=x86_64",
+      "version": "0.193-1.el9",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-or-later OR LGPL-3.0-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ea323c7543bee364b5a38398e1ddd9903e8d4ef6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#ea323c7543bee364b5a38398e1ddd9903e8d4ef6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3630257",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#ea323c7543bee364b5a38398e1ddd9903e8d4ef6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "expat",
+      "purl": "pkg:rpm/redhat/expat@2.5.0-5.el9_7.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/expat@2.5.0-5.el9_7.1?arch=x86_64",
+      "version": "2.5.0-5.el9_7.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3e6642cf7af1b5be61b7207231d0fc5dfa510d13",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#3e6642cf7af1b5be61b7207231d0fc5dfa510d13"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3898237",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#3e6642cf7af1b5be61b7207231d0fc5dfa510d13",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "file",
+      "purl": "pkg:rpm/redhat/file@5.39-16.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/file@5.39-16.el9?arch=x86_64",
+      "version": "5.39-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2800051",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "file-libs",
+      "purl": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "version": "5.39-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2800051",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "filesystem",
+      "purl": "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64",
+      "version": "3.16-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a5b75452255bee32dd79cb51dea804d566ac9e30",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/filesystem#a5b75452255bee32dd79cb51dea804d566ac9e30"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134118",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/filesystem#a5b75452255bee32dd79cb51dea804d566ac9e30",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "findutils",
+      "purl": "pkg:rpm/redhat/findutils@4.8.0-7.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/findutils@4.8.0-7.el9?arch=x86_64&epoch=1",
+      "version": "1:4.8.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "575073254d61c01e14ae09af199e2e4b035191b3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#575073254d61c01e14ae09af199e2e4b035191b3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3154025",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#575073254d61c01e14ae09af199e2e4b035191b3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fonts-filesystem",
+      "purl": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "version": "1:2.0.5-7.el9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ac288ee82aa9655c3784dd2f59cedb3562638129",
+            "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1732053",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gawk",
+      "purl": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "version": "5.1.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv2+ and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3830530bfc524ab9b89fafe76d58a388675ecc11",
+            "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1891122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdbm-libs",
+      "purl": "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&epoch=1",
+      "version": "1:1.23-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1a66bb7ed77701afec99503ce9602021bc24092b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdbm#1a66bb7ed77701afec99503ce9602021bc24092b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2995292",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdbm#1a66bb7ed77701afec99503ce9602021bc24092b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glib2",
+      "purl": "pkg:rpm/redhat/glib2@2.68.4-18.el9_7?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glib2@2.68.4-18.el9_7?arch=x86_64",
+      "version": "2.68.4-18.el9_7",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "942a9794732fac94ba977dbc4e41534a5ff0ac62",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#942a9794732fac94ba977dbc4e41534a5ff0ac62"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3845143",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#942a9794732fac94ba977dbc4e41534a5ff0ac62",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc",
+      "purl": "pkg:rpm/redhat/glibc@2.34-231.el9_7.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc@2.34-231.el9_7.2?arch=x86_64",
+      "version": "2.34-231.el9_7.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "816c61b8558c2c34f1f2dd3cb447f9e5bfd127b7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#816c61b8558c2c34f1f2dd3cb447f9e5bfd127b7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3864593",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#816c61b8558c2c34f1f2dd3cb447f9e5bfd127b7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-common",
+      "purl": "pkg:rpm/redhat/glibc-common@2.34-231.el9_7.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-common@2.34-231.el9_7.2?arch=x86_64",
+      "version": "2.34-231.el9_7.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "816c61b8558c2c34f1f2dd3cb447f9e5bfd127b7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#816c61b8558c2c34f1f2dd3cb447f9e5bfd127b7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3864593",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#816c61b8558c2c34f1f2dd3cb447f9e5bfd127b7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "purl": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-231.el9_7.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-231.el9_7.2?arch=x86_64",
+      "version": "2.34-231.el9_7.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "816c61b8558c2c34f1f2dd3cb447f9e5bfd127b7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#816c61b8558c2c34f1f2dd3cb447f9e5bfd127b7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3864593",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#816c61b8558c2c34f1f2dd3cb447f9e5bfd127b7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gmp",
+      "purl": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "version": "1:6.2.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+            "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2625518",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gnupg2",
+      "purl": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "version": "2.3.3-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2481337",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gnutls",
+      "purl": "pkg:rpm/redhat/gnutls@3.8.3-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnutls@3.8.3-9.el9?arch=x86_64",
+      "version": "3.8.3-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e7d1c9cca47ee3a0424f5406b2b633f7a4e97a85",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#e7d1c9cca47ee3a0424f5406b2b633f7a4e97a85"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3790470",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#e7d1c9cca47ee3a0424f5406b2b633f7a4e97a85",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gobject-introspection",
+      "purl": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "version": "1.68.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5fa3808a6c90b0da8da9a85fad983244c13640ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2248264",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "version": "5a6340b3-6229229e",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "version": "fd431d51-4ae0493b",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "gpgme",
+      "purl": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "version": "1.15.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+            "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892040",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "grep",
+      "purl": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "version": "3.6-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7779e81140d7afaf33d2a97f4afdd682457f9697",
+            "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689607",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gzip",
+      "purl": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+      "version": "1.12-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "11df222a2dc5ce7dc943b1bce364d46ea97a535b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gzip#11df222a2dc5ce7dc943b1bce364d46ea97a535b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1982016",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gzip#11df222a2dc5ce7dc943b1bce364d46ea97a535b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hibernate-commons-annotations",
+      "purl": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@6.0.6.Final-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "49f9b7386c252e2d54169d3e507b3faf"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0b3608f5e7d9b30452833ae018d0f9946a5c62d3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "701d20a23a0f7d69f4ed480600442e21721419103fed55d8fe64758648a21383"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@6.0.6.Final-redhat-00001?type=jar",
+      "version": "6.0.6.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b6d38c8141c81799d9aae66802b32a71f6e3af42",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/hibernate/hibernate-commons-annotations.git#6.0.6.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hibernate-commons-annotations-6.0.6.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hibernate-commons-annotations-6.0.6.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0b3608f5e7d9b30452833ae018d0f9946a5c62d3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/9883909",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/AXIV7DVFWSYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.14-9-mvn3.8.4-gradle7.3.3:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/hibernate/hibernate-commons-annotations.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hibernate-search-backend-lucene",
+      "purl": "pkg:maven/org.hibernate.search/hibernate-search-backend-lucene@7.1.2.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.hibernate.search",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "70480e16d85200fc275b4ed223ea85c5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "dc2e03f2d42aaeb5d599bdfe5ab5f53a5b222a3e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c9baf07ad707038330061cc16ca669074736d4c1da889d0ec31fc12358bde9fc"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hibernate.search/hibernate-search-backend-lucene@7.1.2.Final-redhat-00002?type=jar",
+      "version": "7.1.2.Final-redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.opensource.org/licenses/LGPL-2.1",
+            "name": "GNU Lesser General Public License v2.1 or later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cb28def79b97bb1abc5c656959bcde657159dca5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/hibernate/hibernate-search.git#7.1.2.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hibernate-search-backend-lucene-7.1.2.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hibernate-search-backend-lucene-7.1.2.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "dc2e03f2d42aaeb5d599bdfe5ab5f53a5b222a3e"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387875",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNQPNQSUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/hibernate/hibernate-search.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hibernate-search-engine",
+      "purl": "pkg:maven/org.hibernate.search/hibernate-search-engine@7.1.2.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.hibernate.search",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1a83248562c6ffb645b3686bb9176ecc"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "53ffdb99e7aa3278627b051f2d50def61c576700"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "923c74a4ae2ca78ca018e93331ca584188a4336308bd39e539bec90c69aafa51"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hibernate.search/hibernate-search-engine@7.1.2.Final-redhat-00002?type=jar",
+      "version": "7.1.2.Final-redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.opensource.org/licenses/LGPL-2.1",
+            "name": "GNU Lesser General Public License v2.1 or later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cb28def79b97bb1abc5c656959bcde657159dca5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/hibernate/hibernate-search.git#7.1.2.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hibernate-search-engine-7.1.2.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hibernate-search-engine-7.1.2.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "53ffdb99e7aa3278627b051f2d50def61c576700"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387837",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNQPNQSUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/hibernate/hibernate-search.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hibernate-search-mapper-pojo-base",
+      "purl": "pkg:maven/org.hibernate.search/hibernate-search-mapper-pojo-base@7.1.2.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.hibernate.search",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ae0931de3be9696338f0b5cc93d792a8"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1cfea5f6af627804883ba8619320f62430b92087"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c1e6e4c10e988c37fbfecafcb157b8b24a90594c66819abed6efc9582a8c9969"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hibernate.search/hibernate-search-mapper-pojo-base@7.1.2.Final-redhat-00002?type=jar",
+      "version": "7.1.2.Final-redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.opensource.org/licenses/LGPL-2.1",
+            "name": "GNU Lesser General Public License v2.1 or later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cb28def79b97bb1abc5c656959bcde657159dca5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/hibernate/hibernate-search.git#7.1.2.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hibernate-search-mapper-pojo-base-7.1.2.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hibernate-search-mapper-pojo-base-7.1.2.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "1cfea5f6af627804883ba8619320f62430b92087"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387841",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNQPNQSUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/hibernate/hibernate-search.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hibernate-search-util-common",
+      "purl": "pkg:maven/org.hibernate.search/hibernate-search-util-common@7.1.2.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.hibernate.search",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "42b072cd94cae4d35c2636875791c838"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "22343bb88245197e8d60c41f8eb67a29d95630da"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "98b65530036e13db8bf4d3277c783d0171a5ddd3c3a825dc2788044e1c861143"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hibernate.search/hibernate-search-util-common@7.1.2.Final-redhat-00002?type=jar",
+      "version": "7.1.2.Final-redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.opensource.org/licenses/LGPL-2.1",
+            "name": "GNU Lesser General Public License v2.1 or later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cb28def79b97bb1abc5c656959bcde657159dca5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/hibernate/hibernate-search.git#7.1.2.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hibernate-search-util-common-7.1.2.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hibernate-search-util-common-7.1.2.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "22343bb88245197e8d60c41f8eb67a29d95630da"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387858",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNQPNQSUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/hibernate/hibernate-search.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hibernate-search-v5migrationhelper-engine",
+      "purl": "pkg:maven/org.hibernate.search/hibernate-search-v5migrationhelper-engine@7.1.2.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.hibernate.search",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "490a14aeb5fefba0bad4b591150975ab"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8575e0a0c0d04004c4ffa5b03d4d2b35b86306a6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5d2dedd844c7e6d3c181c64646ca8a43083e6c36c8f4b4e6ee971175e9753879"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hibernate.search/hibernate-search-v5migrationhelper-engine@7.1.2.Final-redhat-00002?type=jar",
+      "version": "7.1.2.Final-redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.opensource.org/licenses/LGPL-2.1",
+            "name": "GNU Lesser General Public License v2.1 or later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cb28def79b97bb1abc5c656959bcde657159dca5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/hibernate/hibernate-search.git#7.1.2.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hibernate-search-v5migrationhelper-engine-7.1.2.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hibernate-search-v5migrationhelper-engine-7.1.2.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8575e0a0c0d04004c4ffa5b03d4d2b35b86306a6"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387810",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNQPNQSUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/hibernate/hibernate-search.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hppc",
+      "purl": "pkg:maven/com.carrotsearch/hppc@0.9.1.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "000dd28c342dcbab651a132492a9eadd"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "aa699c05e5d94209416810bc417aeca3a31b74f9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "79ff752e2f14e309c13e9a43a161d8c207239759cabcfbaf44b8ec000c2ff2dd"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.carrotsearch/hppc@0.9.1.redhat-00001?type=jar",
+      "version": "0.9.1.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "93d10b39214a4a1774715ef1fcfb6b131d0178b3",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/carrotsearch/hppc.git#0.9.1.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hppc-0.9.1.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hppc-0.9.1.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "aa699c05e5d94209416810bc417aeca3a31b74f9"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12528357",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BAU5V4AJSMQAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.14-9-mvn3.8.4-gradle7.3.3:1.0.2",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/carrotsearch/hppc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-anchored-keys",
+      "purl": "pkg:maven/org.infinispan/infinispan-anchored-keys@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "53e4c1dfad1940d4aef7f66c69a68bb4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e14a003ba9725024702bb51558d142e05ab5842b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b839114b0305ed4a3b6728e0b4fc2679bcda912f3f0f2243b6c98ce1a5257335"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-anchored-keys@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-anchored-keys-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-anchored-keys-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e14a003ba9725024702bb51558d142e05ab5842b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277601",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-api",
+      "purl": "pkg:maven/org.infinispan/infinispan-api@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c825a3e6c2add8aad9f064119c60c5c7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9a268376e4fb58d5d09fec9c161609359653eff2"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6a479959e3417078fb058b14a7a0097f17e9c7ebf9f66d7179d2018894227cea"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-api@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-api-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-api-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9a268376e4fb58d5d09fec9c161609359653eff2"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277570",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-cachestore-jdbc",
+      "purl": "pkg:maven/org.infinispan/infinispan-cachestore-jdbc@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "51d889a5731e89a2329781b031c513c0"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "73c186c2cfea456f25df4d07afa12860184471b2"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "229293acd52813697290e9ea4860a85d0eb9a797f51a6fba60a0ef4dc44f1823"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-cachestore-jdbc@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-jdbc-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-jdbc-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "73c186c2cfea456f25df4d07afa12860184471b2"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277452",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-cachestore-jdbc-common",
+      "purl": "pkg:maven/org.infinispan/infinispan-cachestore-jdbc-common@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "567356d7b099fb19f5af86f9d582041a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "648fe83e77366dfb57c60ff1e3ad99a4e6182d73"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "70b63e4c6f393ff1f9ef90fc7f17fd3090b3f9751f7f64fdf7e9cac16be835fb"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-cachestore-jdbc-common@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-jdbc-common-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-jdbc-common-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "648fe83e77366dfb57c60ff1e3ad99a4e6182d73"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277672",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-cachestore-remote",
+      "purl": "pkg:maven/org.infinispan/infinispan-cachestore-remote@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "390b75850c286c3828747cb540cdd402"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "139eb8a05fc5441fa00d769675e7311edb6cb219"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "12ddab14ed26cb15190d13c38e672edae4a96abbfb35675a325b288c8f744305"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-cachestore-remote@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-remote-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-remote-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "139eb8a05fc5441fa00d769675e7311edb6cb219"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277810",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-cachestore-rocksdb",
+      "purl": "pkg:maven/org.infinispan/infinispan-cachestore-rocksdb@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "80e1e844d2edace8d0c3759e250a061b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f255ace6c46f4fefdfe9f8fe81df7bae527d4c21"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8276623759f96a7b48b7179518a2541453c7e1047c8557c3faf436b5577ced4f"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-cachestore-rocksdb@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-rocksdb-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-rocksdb-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f255ace6c46f4fefdfe9f8fe81df7bae527d4c21"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277825",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-cachestore-sql",
+      "purl": "pkg:maven/org.infinispan/infinispan-cachestore-sql@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a170fd723dde097780cf77a91a1f287e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "46a2110e69b3d053a5b8e5353ffa051ab2da17d5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f392e4f0b9fd184c5fb40406402f846ddeb8cd6c222e4a4e960c3cb3e9d456f2"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-cachestore-sql@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-sql-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-sql-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "46a2110e69b3d053a5b8e5353ffa051ab2da17d5"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277508",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-cli-client",
+      "purl": "pkg:maven/org.infinispan/infinispan-cli-client@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2c569818ed58106b36f6d476613db805"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "76e5d2a13573ae3673d4a5a00e9cc00dfb2c6378"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "65ddeb92e3c9ab3e79aafaa218f8c942f0ab38a71fa088caee2a6f3258b87cec"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-cli-client@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-cli-client-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-cli-client-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "76e5d2a13573ae3673d4a5a00e9cc00dfb2c6378"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277615",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-client-hotrod",
+      "purl": "pkg:maven/org.infinispan/infinispan-client-hotrod@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "abfc6d86a82ea1cd9d2bd01e46f132d5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bd1d7f9187f7f121e73fc68b8eecfc726af16b94"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "883a8624747ce9bca52ac3a2fabcab6e37e03b38b3dc2b006ef0ba532f1997d7"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-client-hotrod@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-client-hotrod-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-client-hotrod-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bd1d7f9187f7f121e73fc68b8eecfc726af16b94"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277799",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-client-rest",
+      "purl": "pkg:maven/org.infinispan/infinispan-client-rest@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9ff10f4f87fa4e747dc9a987653389bc"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "fb615ef234077cd298b5e42b1faf0a1a3e1ef810"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "625b9d15a00f400d64ac155a19830e4983f0fd5b2f9dcbb478a3a0e617e3da90"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-client-rest@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-client-rest-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-client-rest-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "fb615ef234077cd298b5e42b1faf0a1a3e1ef810"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277793",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-clustered-counter",
+      "purl": "pkg:maven/org.infinispan/infinispan-clustered-counter@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "55433d90b17adbec079929a9eba59ccd"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "652620ced40d314c48648423d0cb6ab8c68e0980"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0343af90c16c37123decea8ca70c39ae98fd15c95730d6ff76b80446b2692910"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-clustered-counter@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-clustered-counter-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-clustered-counter-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "652620ced40d314c48648423d0cb6ab8c68e0980"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277817",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-commons",
+      "purl": "pkg:maven/org.infinispan/infinispan-commons@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1df243c398fa4b33c0ea2edd7e0a3cb9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5f6e5feb0a612fbd36728845c3446bd4ad4309ee"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "84a7f7f0e5e7a5bc7772a5c4db0f4f8c705aa296488c15e2dd6690cd4502748f"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-commons@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-commons-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-commons-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5f6e5feb0a612fbd36728845c3446bd4ad4309ee"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277750",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-commons-graalvm",
+      "purl": "pkg:maven/org.infinispan/infinispan-commons-graalvm@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "eea5b4fc23e7b1e31271ece4617ce70e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "255e8e40b85696ca73bb1ac54a749f9144a1f87f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2883a20744877096e4d1e6a152f8a0b1505bc57d29521fdfe31806f7416cc2f8"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-commons-graalvm@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-commons-graalvm-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-commons-graalvm-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "255e8e40b85696ca73bb1ac54a749f9144a1f87f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277754",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-core",
+      "purl": "pkg:maven/org.infinispan/infinispan-core@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "58206d09879e0a3428a2322a18da8bf7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f188352b05b4e2a1eb7c88eea5d6151a505ff32f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "9de4d95a04890d3369c0b583edd4dca69715c400ee3c88398f07d73dab48be6e"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-core@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-core-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-core-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f188352b05b4e2a1eb7c88eea5d6151a505ff32f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277552",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-jboss-marshalling",
+      "purl": "pkg:maven/org.infinispan/infinispan-jboss-marshalling@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "69725b65d2719bcaf2c399388e1c6a42"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a5c6b69d421f977345c13221d74f99a9c37e1026"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4bbe43e5cfd1c7a6d0f0d11873db65e4cd8d8fe697ecd7fd3b8edf0191ffcca4"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-jboss-marshalling@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-jboss-marshalling-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-jboss-marshalling-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a5c6b69d421f977345c13221d74f99a9c37e1026"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277720",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-multimap",
+      "purl": "pkg:maven/org.infinispan/infinispan-multimap@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "005d72dc6ff851e80723c525a92d8d92"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ee541c3846d52c5aeee9aaf60e7cd41a094e9e3b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "83afa5e6842d07dc5853f1ec206dda4c940ef7aeb8aedf573b45cd09d27635fe"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-multimap@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-multimap-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-multimap-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ee541c3846d52c5aeee9aaf60e7cd41a094e9e3b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277563",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-objectfilter",
+      "purl": "pkg:maven/org.infinispan/infinispan-objectfilter@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "80321dfbba06604e2cc7d5a1b65af6ee"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a5d2268b2ba82a0f81ddf60d5a88bdca0969c58b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ecbe19ada05b24012bf2970f7b626c65b46ab3794f7a0eea764c3910700fa170"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-objectfilter@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-objectfilter-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-objectfilter-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a5d2268b2ba82a0f81ddf60d5a88bdca0969c58b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277822",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-query",
+      "purl": "pkg:maven/org.infinispan/infinispan-query@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e64b4ce2f0f73017fbe4d1532a2bb669"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "48cf4b3bb7eb4d29a7a43359de7cff08014424f7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "aeda9999cee0d0691fb72aa80f7744788dae0ef7814f01ca567bc71cb086e723"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-query@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-query-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-query-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "48cf4b3bb7eb4d29a7a43359de7cff08014424f7"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277621",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-query-core",
+      "purl": "pkg:maven/org.infinispan/infinispan-query-core@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6bdecf9627ebfd7ad4bd7aa715fd9af0"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5121236ee86bd2e97e89c6f1662ffebb2cf1c726"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "839d7060bffbef793979a461460dae397b848beeb76ebda5049088352773c328"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-query-core@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-query-core-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-query-core-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5121236ee86bd2e97e89c6f1662ffebb2cf1c726"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277712",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-query-dsl",
+      "purl": "pkg:maven/org.infinispan/infinispan-query-dsl@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7fdd8d81781f147f2b5a51c57ea5048a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1506d3661637ddfb7a0caaf4ec5a739e64147577"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4384fa60294a627734849bdeba50dfb0b737cbde4ffb82615d9ec3d4a036e39e"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-query-dsl@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-query-dsl-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-query-dsl-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "1506d3661637ddfb7a0caaf4ec5a739e64147577"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277638",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-remote-query-client",
+      "purl": "pkg:maven/org.infinispan/infinispan-remote-query-client@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7df8528aa1a42af4a821614aeed0c80a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c69f7e88966f925c1ff1f6469ae0969758d3f480"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2818c7109902cc0a5406f2ccf7e9393883c8b141050c319faf4d15715636b3c9"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-remote-query-client@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-remote-query-client-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-remote-query-client-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c69f7e88966f925c1ff1f6469ae0969758d3f480"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277572",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-remote-query-server",
+      "purl": "pkg:maven/org.infinispan/infinispan-remote-query-server@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "44b6fdc3cbc4dd8e4379ccdefd308163"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0011892a87e79f6a47e77caa0f570867d6ac2fce"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "241f340e46c3c35d7e3d0c9d91791b4a0e44688b3d8489ce4cefbb2be01e305d"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-remote-query-server@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-remote-query-server-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-remote-query-server-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0011892a87e79f6a47e77caa0f570867d6ac2fce"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277726",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-scripting",
+      "purl": "pkg:maven/org.infinispan/infinispan-scripting@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "83c42af96244e1a3e10b78243e628b12"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b465036a4270d4d8c93a37bd89df48657e379aa3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2c94308746c75026bff6e20b7737f0e35e6119f8849e9a126ecb9be5eab590b5"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-scripting@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-scripting-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-scripting-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b465036a4270d4d8c93a37bd89df48657e379aa3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277667",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-core",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-core@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ebfff9aa9eea101acaa6fd4937d52a66"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f2c35dbb068fd2b26fdd5305cd93a6f94f6c3654"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4682d5a29ccc60544fe81429d0e4e646be637a086d54409a17d211be80dd7fb9"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-core@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-core-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-core-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f2c35dbb068fd2b26fdd5305cd93a6f94f6c3654"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277557",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-hotrod",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-hotrod@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "cc1c0bf0c506f87069b75f07b087af17"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "602161be23ef73a4715f38f6fa2c23261c7a2c2e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4a2c502feb0396f770aa6485e96cd2899c5b7f4034920f8eb9e42fd19991ac12"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-hotrod@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-hotrod-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-hotrod-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "602161be23ef73a4715f38f6fa2c23261c7a2c2e"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277539",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-insights",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-insights@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b3c2cdaa0e171e3d131d229e8ab3bc55"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "87c7d683e3d17894cc957648f9f18f9636dce016"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c94e9968ffe2b0f22ca89f9fa56cde4a782f55e30528466f608911ec8014deba"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-insights@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-insights-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-insights-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "87c7d683e3d17894cc957648f9f18f9636dce016"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277498",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-memcached",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-memcached@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2b6de11ee8d3a28b293405894a0d6ca5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b43ef7d49af30f2754426c9460e2176b200e9567"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5a435f54fe1dbc4e20dd3cd5ee401b382df7deca7ee80ec9db48a145359aa94c"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-memcached@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-memcached-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-memcached-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b43ef7d49af30f2754426c9460e2176b200e9567"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277782",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-resp",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-resp@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "84f0b9d459413c8d4817218c8bc26698"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "925157066b72273ca4dab72b59bff2bff8923b30"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "800ff86489413eaa3c521454a12176c0f82b5497b9109470fb27370110276f83"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-resp@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-resp-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-resp-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "925157066b72273ca4dab72b59bff2bff8923b30"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277618",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-rest",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-rest@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6e78b2604d15723d852baeedc099ca5b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b2e87e7bdc6e615a0dc312edfca2c9dd14cd604d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7e2cddf84521dc3a71a3ca229a5a4e4a0fac8a9726fe09af5fab0e541989c98d"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-rest@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-rest-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-rest-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b2e87e7bdc6e615a0dc312edfca2c9dd14cd604d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277488",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-router",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-router@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "12482f189ec249f4e6e9f6fd0cc41590"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "615c6189c6895f312c1a87d370153a8063f5a851"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "62cc5ee9bd963c631a4c68b667ce25df341d31a86633ae0bbc45db2f282b52d9"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-router@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-router-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-router-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "615c6189c6895f312c1a87d370153a8063f5a851"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277519",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-runtime",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ab9a52f4210a249dd5c2233a1881aada"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6935cdbf4c3d7e5898937a5ee710d77ceb0c66e9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8a81e688d9736617cf9bdcbea1be1cafda0fbf04839d9743a8c0070a55e9ba09"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/boot/infinispan-server-runtime-15.0.19.Final-redhat-00001-loader.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/boot/infinispan-server-runtime-15.0.19.Final-redhat-00001-loader.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6401bb733782d0ab1af1fd60eb229615de46e72d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277553",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-runtime",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ab9a52f4210a249dd5c2233a1881aada"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6935cdbf4c3d7e5898937a5ee710d77ceb0c66e9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8a81e688d9736617cf9bdcbea1be1cafda0fbf04839d9743a8c0070a55e9ba09"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?package-id=c7ba178dee624963",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-runtime-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-runtime-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6935cdbf4c3d7e5898937a5ee710d77ceb0c66e9"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277553",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-tasks",
+      "purl": "pkg:maven/org.infinispan/infinispan-tasks@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6c5c25d103ce5251b53bd4006e8c073d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6d0f44508fbc6e5fa62eb3d2570baef47ceb6949"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ed44223a7c56a236f5f4092331e28bb78c497a9815c7d327f60345144b387728"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-tasks@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-tasks-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-tasks-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6d0f44508fbc6e5fa62eb3d2570baef47ceb6949"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277476",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-tasks-api",
+      "purl": "pkg:maven/org.infinispan/infinispan-tasks-api@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5ea9d9ce129d27e78c0a49c771d388d3"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ec0dbd08ac0f40e6b4cb94609a74fa5c5f865f9a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "91022893691c3962594db42daa8f723fa2b4967d44f96e9d097855f437f57bec"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-tasks-api@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-tasks-api-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-tasks-api-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ec0dbd08ac0f40e6b4cb94609a74fa5c5f865f9a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277567",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-tools",
+      "purl": "pkg:maven/org.infinispan/infinispan-tools@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "299990a70c302de2c32baa01f9ea7116"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "04f243baa64ed2d13f3dfa539ee7bc249c01a6ab"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c6564c352b2fe968db1160e7fc2bb39d3fe961a09085ff45d1623747205a3af1"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-tools@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-tools-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-tools-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "04f243baa64ed2d13f3dfa539ee7bc249c01a6ab"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277535",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "iproute",
+      "purl": "pkg:rpm/redhat/iproute@6.14.0-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/iproute@6.14.0-2.el9?arch=x86_64",
+      "version": "6.14.0-2.el9",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-or-later AND NIST-PD"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ab2e87b6c3238fd77c61475a379758afd9461343",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/iproute#ab2e87b6c3238fd77c61475a379758afd9461343"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3759662",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/iproute#ab2e87b6c3238fd77c61475a379758afd9461343",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jackson-annotations",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.16.2.redhat-00001?type=jar",
+      "type": "library",
+      "group": "com.fasterxml.jackson.core",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "27a42e46ae645fee05ddac950c45a5a5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8e2228d7b3749929372cc15831e17297ad867bee"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d5c21bee1725602457513dbea38a80fa1f70c5be4ad021c3020b639181faa22f"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.16.2.redhat-00001?type=jar",
+      "version": "2.16.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07d9737f2ac52781e85fe8f87665bdfc6e2e8bb2",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/FasterXML/jackson-annotations.git#2.16.2.redhat-00001"
+          },
+          {
+            "uid": "6a2d806e4aec3e481ac8e78532c31fb4cbf29ad7",
+            "url": "https://github.com/FasterXML/jackson-annotations.git#jackson-annotations-2.16.2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jackson-annotations-2.16.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jackson-annotations-2.16.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8e2228d7b3749929372cc15831e17297ad867bee"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12193632",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7IWFY5UCDYAW",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "jackson-core",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.16.2.redhat-00001?type=jar",
+      "type": "library",
+      "group": "com.fasterxml.jackson.core",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6805a7b54e86c4fb33ade33c7f91e32c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d4c277d701922aba2d8c4623dda1c0b372f7369f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "dca47d81aea8d6cf49d51ad401ca4b3dce370795405ae05e0dda577a6e829865"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.16.2.redhat-00001?type=jar",
+      "version": "2.16.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1db06f09b6d66ea3d644c9f8d94fbdf5e723b6b8",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/FasterXML/jackson-core.git#2.16.2.redhat-00001"
+          },
+          {
+            "uid": "4162dfc503bd97e6824b1d5baa6de7895d3b3367",
+            "url": "https://github.com/FasterXML/jackson-core.git#jackson-core-2.16.2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jackson-core-2.16.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jackson-core-2.16.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d4c277d701922aba2d8c4623dda1c0b372f7369f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12193635",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7IWFY5UCDYAC",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/FasterXML/jackson-core.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jackson-databind",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.16.2.redhat-00001?type=jar",
+      "type": "library",
+      "group": "com.fasterxml.jackson.core",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2342e0d9e400adc6e1d5a2d563db4915"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e7f0c14801bb0185fe03b0e96e2a8a6a085ec1b2"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "01c4fbfc79ce01a6bb3de18cd4365afd89fe0eb9f882ddcd760bef568507bb9a"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.16.2.redhat-00001?type=jar",
+      "version": "2.16.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5aa42b80313de58bda0c417f3f239d25df5ef21f",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/FasterXML/jackson-databind.git#2.16.2.redhat-00001"
+          },
+          {
+            "uid": "a04a0a1852acf9ab5a80d10631026d9814436114",
+            "url": "https://github.com/FasterXML/jackson-databind#jackson-databind-2.16.2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jackson-databind-2.16.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jackson-databind-2.16.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e7f0c14801bb0185fe03b0e96e2a8a6a085ec1b2"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12193640",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7IWFY5UCDYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/FasterXML/jackson-databind",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jackson-datatype-jdk8",
+      "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.16.2.redhat-00001?type=jar",
+      "type": "library",
+      "group": "com.fasterxml.jackson.datatype",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4def7c9df2ac61a9a202f8ce7069b8f7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e8999d4b9525fdd42dd9a333ba0a080a621968b4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "33840a5ecbc71b03a13d1abc898cd94cabb6ea821a02e8aacdc1b04ee26cbea8"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.16.2.redhat-00001?type=jar",
+      "version": "2.16.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f627019d10505cad34366c2838c651ad74cf4402",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/FasterXML/jackson-modules-java8.git#2.16.2.redhat-00001"
+          },
+          {
+            "uid": "7b02de1312210ac0cbc84ecb2b9be95fe2363ee1",
+            "url": "https://github.com/FasterXML/jackson-modules-java8.git#jackson-modules-java8-2.16.2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jackson-datatype-jdk8-2.16.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jackson-datatype-jdk8-2.16.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e8999d4b9525fdd42dd9a333ba0a080a621968b4"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12193706",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7IWFY5UCDYA4",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/FasterXML/jackson-modules-java8.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jackson-datatype-jsr310",
+      "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.16.2.redhat-00001?type=jar",
+      "type": "library",
+      "group": "com.fasterxml.jackson.datatype",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "426f076655d0b227f3308cc45444b0ad"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c53a960de8eba8d8f22a797f4a3a17610ce6f054"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8022d3e299120aa025ae6fa7ad1970d9cb707cfb722f1270c2e4c66f09d8ec1a"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.16.2.redhat-00001?type=jar",
+      "version": "2.16.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f627019d10505cad34366c2838c651ad74cf4402",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/FasterXML/jackson-modules-java8.git#2.16.2.redhat-00001"
+          },
+          {
+            "uid": "7b02de1312210ac0cbc84ecb2b9be95fe2363ee1",
+            "url": "https://github.com/FasterXML/jackson-modules-java8.git#jackson-modules-java8-2.16.2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jackson-datatype-jsr310-2.16.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jackson-datatype-jsr310-2.16.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c53a960de8eba8d8f22a797f4a3a17610ce6f054"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12193700",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7IWFY5UCDYA4",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/FasterXML/jackson-modules-java8.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jakarta.json",
+      "purl": "pkg:maven/org.glassfish/jakarta.json@2.0.1.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.glassfish",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "eb5182fa4e28a355cb7025a4496e09c1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "38bab560ff71c9e95c3d0e96ba95f81aca4ab9a4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a993fae280a191c7b47b49f862ffd587cf827f67e1ffea09a15b18c6e2bcc76e"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.glassfish/jakarta.json@2.0.1.redhat-00001?type=jar",
+      "version": "2.0.1.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://projects.eclipse.org/license/epl-2.0, https://projects.eclipse.org/license/secondary-gpl-2.0-cp"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a7225d9c6adac65abd71ff0dc03d85b98d52660d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jakartaee/jsonp-api.git#2.0.1.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jakarta.json-2.0.1.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jakarta.json-2.0.1.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "38bab560ff71c9e95c3d0e96ba95f81aca4ab9a4"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11555991",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A4RXCEYTNVIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mx-mvn3.6.0:1.1.2",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "jakarta.transaction-api",
+      "purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@2.0.1.redhat-00004?type=jar",
+      "type": "library",
+      "group": "jakarta.transaction",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e7e50a5c1b223a660b8b09151524dca4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bbaeb416b3b3690e450cfbc29956c2cd0cb14213"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "648ac5de6cf10b58c0aa1357d7e312c4fc5cceea5d62ded7fc9f587573cd9cbb"
+        }
+      ],
+      "bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@2.0.1.redhat-00004?type=jar",
+      "version": "2.0.1.redhat-00004",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d942df8b8a62d3ba0312ec74645a1255d47cb888",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/eclipse-ee4j/jta-api.git#2.0.1.redhat-00004"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jakarta.transaction-api-2.0.1.redhat-00004.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jakarta.transaction-api-2.0.1.redhat-00004.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bbaeb416b3b3690e450cfbc29956c2cd0cb14213"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11187040",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A3OFCG7JKMYBI",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.6.3:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/eclipse-ee4j/jta-api.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jandex",
+      "purl": "pkg:maven/io.smallrye/jandex@3.3.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "io.smallrye",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2057b4a3915c2c9253ff5ce191bfdf11"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9c54762010a098d04486f4755c6ae83e726ce261"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "49dcd14a72f873b8221bfb4f0cf030ea45915cb1b375928959c7aff1cca5eb82"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.smallrye/jandex@3.3.0.redhat-00001?type=jar",
+      "version": "3.3.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1949d05b7d0d775e86ec6207640f261e8a5ac9aa",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jandex.git#3.3.0.redhat-00001"
+          },
+          {
+            "uid": "6e33aa2cc1fac966d0b59e4caaaf3382e0d9e359",
+            "url": "https://github.com/wildfly/jandex.git#3.3.0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jandex-3.3.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jandex-3.3.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9c54762010a098d04486f4755c6ae83e726ce261"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13880051",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BHJSJIKGJSIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17.0.2-8-mx-mvn3.6.3:1.0.2",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly/jandex.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jansi",
+      "purl": "pkg:maven/org.fusesource.jansi/jansi@2.4.0.redhat-00003?type=jar",
+      "type": "library",
+      "group": "org.fusesource.jansi",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "26fecb24841f7a7a6549208eac257e33"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5f9b7d1cfd2db5bfa22defba8cd06c8f68fa3af3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bf7137baf3bfb1e9461b95e5bb8c0e0f8f77d8cfc181ff275ffdb3dd43406e98"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.fusesource.jansi/jansi@2.4.0.redhat-00003?type=jar",
+      "version": "2.4.0.redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f57067c429f217e4c46c368253808a7b54786d88",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jansi.git#2.4.0.redhat-00003"
+          },
+          {
+            "uid": "165d4e0617362fe9d05f626d2b4b290cbaa65c63",
+            "url": "https://github.com/fusesource/jansi.git#jansi-2.4.0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jansi-2.4.0.redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jansi-2.4.0.redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5f9b7d1cfd2db5bfa22defba8cd06c8f68fa3af3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12914508",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2NCQULNVAAC",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.6",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/fusesource/jansi.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "java-21-openjdk-headless",
+      "purl": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.9.0.10-1.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.9.0.10-1.el9?arch=x86_64&epoch=1",
+      "version": "1:21.0.9.0.10-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9458ff559c5320c0e3d483b54926fa0732b18d1e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#9458ff559c5320c0e3d483b54926fa0732b18d1e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3870615",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#9458ff559c5320c0e3d483b54926fa0732b18d1e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "javapackages-filesystem",
+      "purl": "pkg:rpm/redhat/javapackages-filesystem@6.4.0-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/javapackages-filesystem@6.4.0-1.el9?arch=noarch",
+      "version": "6.4.0-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "41385fffa364031f88363ac251bffe64df0243cd",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/javapackages-tools#41385fffa364031f88363ac251bffe64df0243cd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3452090",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/javapackages-tools#41385fffa364031f88363ac251bffe64df0243cd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jboss-logging",
+      "purl": "pkg:maven/org.jboss.logging/jboss-logging@3.6.1.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.jboss.logging",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "03d0985b7d7de558ab1adfc9e2066b4b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "94a50c9ff838417d1eda9db040d0e45e7997724c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "84fdeb83918eab86e6ef623efcd94470f47d1c73a9f8b13e70ed42b2e9ad6107"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.6.1.Final-redhat-00001?type=jar",
+      "version": "3.6.1.Final-redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://repository.jboss.org/licenses/apache-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3be6af5bc6cb005633d59bd86b407cc068e932f0",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jboss-logging/jboss-logging.git#3.6.1.Final-redhat-00001"
+          },
+          {
+            "uid": "086ff9fdd86892ea67ef748fea69a99f3a6bc57d",
+            "url": "https://github.com/jboss-logging/jboss-logging.git#086ff9fdd86892ea67ef748fea69a99f3a6bc57d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jboss-logging-3.6.1.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jboss-logging-3.6.1.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "94a50c9ff838417d1eda9db040d0e45e7997724c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13493016",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF3XU65QKVYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/jboss-logging/jboss-logging.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jboss-marshalling",
+      "purl": "pkg:maven/org.jboss.marshalling/jboss-marshalling@2.2.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.jboss.marshalling",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "dec1475b91d1eda42d7ca629a0ed6778"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b317093216eff6a016c7ba04d9df406a4ba8088d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5c1b40d20ee820cfc6974fb423926a0c98bb9d23b1af84d96e21cfff005abcbd"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jboss.marshalling/jboss-marshalling@2.2.2.Final-redhat-00001?type=jar",
+      "version": "2.2.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9f659bf7f5b5addf218338b2c5a7710a71e93547",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jboss-remoting/jboss-marshalling.git#2.2.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jboss-marshalling-2.2.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jboss-marshalling-2.2.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b317093216eff6a016c7ba04d9df406a4ba8088d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13504331",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5SEZTPKVYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.6.3-gradle7.2:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/jboss-remoting/jboss-marshalling.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jboss-marshalling-river",
+      "purl": "pkg:maven/org.jboss.marshalling/jboss-marshalling-river@2.2.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.jboss.marshalling",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9572df79d6bef317767704c0520d8b52"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b7dce2740881d5233198795003fc892b216caf9e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4d49f81655a9b2ab75ee27780b3ce6e22603a7fb6f8ab4d134daaf9eb14a4c9e"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jboss.marshalling/jboss-marshalling-river@2.2.2.Final-redhat-00001?type=jar",
+      "version": "2.2.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9f659bf7f5b5addf218338b2c5a7710a71e93547",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jboss-remoting/jboss-marshalling.git#2.2.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jboss-marshalling-river-2.2.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jboss-marshalling-river-2.2.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b7dce2740881d5233198795003fc892b216caf9e"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13504322",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5SEZTPKVYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.6.3-gradle7.2:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/jboss-remoting/jboss-marshalling.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jboss-threads",
+      "purl": "pkg:maven/org.jboss.threads/jboss-threads@3.6.1.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.jboss.threads",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "db73d984ca74bf77086482ecbf0829a3"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "08ffac37882606f5d28b991dfd807a5fa09c7e3a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4ed78159cbb176f5f5c65e3799469e4d1d55a4165e7de8bbc34f273c81831c4a"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.6.1.Final-redhat-00001?type=jar",
+      "version": "3.6.1.Final-redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6b988a6b56ddaecf174a5a87d858c3c4555fe339",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jbossas/jboss-threads.git#3.6.1.Final-redhat-00001"
+          },
+          {
+            "uid": "1e97bb4b9e8d5b9ea1963994428202b89cb3f49d",
+            "url": "https://github.com/jbossas/jboss-threads.git#3.6.1.Final"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jboss-threads-3.6.1.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jboss-threads-3.6.1.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "08ffac37882606f5d28b991dfd807a5fa09c7e3a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12432402",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BAC74JRX4FIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.2-13-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/jbossas/jboss-threads.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jcl-over-slf4j",
+      "purl": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32.redhat-00003?type=jar",
+      "type": "library",
+      "group": "org.slf4j",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ab84582a9a7e33505e7751f9735bc199"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8183f7d48345087e1dd3bf4ec947633e5489beee"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4dc5701b31d13eb1c6871fc9fbdc17d3ae45d00f79e139100d430e8db4491a4e"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32.redhat-00003?type=jar",
+      "version": "1.7.32.redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "236b1dcaa8f6126a85b2a76bc7eecaf14ca4b37e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/slf4j.git#1.7.32.redhat-00003"
+          },
+          {
+            "uid": "0d8774854f4ebb0807bcb69867c13f1e991fcde5",
+            "url": "https://github.com/qos-ch/slf4j#v_1.7.32"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jcl-over-slf4j-1.7.32.redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jcl-over-slf4j-1.7.32.redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8183f7d48345087e1dd3bf4ec947633e5489beee"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11961873",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6S3WUGZ2DYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/qos-ch/slf4j",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jctools-core",
+      "purl": "pkg:maven/org.jctools/jctools-core@4.0.1?type=jar",
+      "type": "library",
+      "group": "org.jctools",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2d892c2868d73b9f06166da8f8ee0c57"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e12d5984d45aee3976249400dae1bbcafcf5ff0a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b0bac296a02d65b509e6979360796be1cab97727a1d7bb15d069557d3f62ac2f"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jctools/jctools-core@4.0.1?type=jar",
+      "version": "4.0.1",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.txt",
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-trace-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-trace-1.32.0.redhat-00001.jar:org.jctools:jctools-core"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/9899288",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        }
+      ]
+    },
+    {
+      "name": "jctools-core",
+      "purl": "pkg:maven/org.jctools/jctools-core@4.0.5.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.jctools",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b1be5d5d1139c878b92894eb06ea84df"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a9a79bbd4227cfa897325341ad7ed099a91a068c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3cc2f0d9fbde68cc0540fe73ddc2f70fbb6b8bce505eca90429e8fb6f72692d5"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jctools/jctools-core@4.0.5.redhat-00001?type=jar",
+      "version": "4.0.5.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5a5f0fd1b32399597677c63e87b731dbefa7008b",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/JCTools/JCTools.git#4.0.5.redhat-00001"
+          },
+          {
+            "uid": "a17b56f09cc9ec7d773707578c89f3ca9c11f968",
+            "url": "https://github.com/JCTools/JCTools.git#v4.0.5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-common-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-common-4.1.121.Final-redhat-00003.jar:org.jctools:jctools-core"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12915867",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2OGRGINVAAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/JCTools/JCTools.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jgroups",
+      "purl": "pkg:maven/org.jgroups/jgroups@5.3.16.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.jgroups",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "752c1afd8e6e53ccf777d7e55c6cbaad"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "db07655e0f3d8b201853569785d36692c7fa8976"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1e2ff937dd3cd7a8ad4c5fd8681e49f58763cccbc5a58e110a5e57d8791d3da4"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jgroups/jgroups@5.3.16.Final-redhat-00001?type=jar",
+      "version": "5.3.16.Final-redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4d55f4475e58ef886c87f474a068cd457c2d2366",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/JGroups.git#5.3.16.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jgroups-5.3.16.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jgroups-5.3.16.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "db07655e0f3d8b201853569785d36692c7fa8976"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13873713",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BHIXKX7MZSIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.6.3:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/belaban/JGroups.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jmh-core",
+      "purl": "pkg:maven/org.openjdk.jmh/jmh-core@1.37.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.openjdk.jmh",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1b35c598339845bff90ccf623a836ea2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "99168e5edecf956855d73f1c7bd4e82a19e692bb"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "78b1e52a4316dafb0c5fcb96195808544d9cd3bcc07e53e3f0b22dd324c4bd7b"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.openjdk.jmh/jmh-core@1.37.0.redhat-00001?type=jar",
+      "version": "1.37.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5dcc17974b37a5ae70eed8aa17d9a934c4cc011a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/openjdk/codetools/jmh.git#1.37.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jmh-core-1.37.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jmh-core-1.37.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "99168e5edecf956855d73f1c7bd4e82a19e692bb"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12427354",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BACIJWSW4FIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "jopt-simple",
+      "purl": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4.redhat-00002?type=jar",
+      "type": "library",
+      "group": "net.sf.jopt-simple",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "674f8454633dfe0e94540bb3a012fc84"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "fddd9adc22c99b76a4783c52c9be72651ccbdabf"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bc82c10b1ca3892d0aea1b456d764e26e34c7ea0efa84988d59335d59d3c34f2"
+        }
+      ],
+      "bom-ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4.redhat-00002?type=jar",
+      "version": "5.0.4.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.opensource.org/licenses/mit-license.php"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cde43141d1ce63eebc3342cdc70bb7ba333082fa",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jopt-simple/jopt-simple.git#5.0.4.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jopt-simple-5.0.4.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jopt-simple-5.0.4.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "fddd9adc22c99b76a4783c52c9be72651ccbdabf"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/756791",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/12372",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.3.9:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/jopt-simple/jopt-simple.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jrt-fs",
+      "purl": "pkg:maven/jrt-fs/jrt-fs@21.0.9?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/jrt-fs/jrt-fs@21.0.9?type=jar",
+      "version": "21.0.9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/jvm/java-21-openjdk-21.0.9.0.10-1.el9.x86_64/lib/jrt-fs.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/lib/jvm/java-21-openjdk-21.0.9.0.10-1.el9.x86_64/lib/jrt-fs.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f2491dd7e8474fb42676ffdb38f5b96ab2fd4bff"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "json-c",
+      "purl": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "version": "0.14-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "391500fb2a46f72180ba1353136c1b3327d71c55",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1728857",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "json-glib",
+      "purl": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "version": "1.6.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d5548792bb86a77330957962541a936d9c391896",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1707185",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jspecify",
+      "purl": "pkg:maven/org.jspecify/jspecify@1.0.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1ff6383495b2f8bde95f9d88458e694e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5a6871bfc86a0081a43fb23926e480f1f62f1de7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d8a7744f6b81521b73d37c4f1ac16fc1041a6cea07dcbbb468fd68e96f036e8a"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jspecify/jspecify@1.0.0.redhat-00001?type=jar",
+      "version": "1.0.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6202bed29a3526385e179ec85cd15d198bd12f48",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jspecify/jspecify.git#1.0.0.redhat-00001"
+          },
+          {
+            "uid": "b2a10e14bb81c1b7cb6e488c112fe55cb2218d7d",
+            "url": "https://github.com/jspecify/jspecify#v1.0.0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jspecify-1.0.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jspecify-1.0.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5a6871bfc86a0081a43fb23926e480f1f62f1de7"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13268528",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BEKOPSUU5BAAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21-mvn3.8.6-gradle8.9:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/jspecify/jspecify",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "keyutils-libs",
+      "purl": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "version": "1.6.3-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+            "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2212253",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "krb5-libs",
+      "purl": "pkg:rpm/redhat/krb5-libs@1.21.1-8.el9_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/krb5-libs@1.21.1-8.el9_6?arch=x86_64",
+      "version": "1.21.1-8.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "08d251b9d687093e68ae8b88583777d062df7a77",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#08d251b9d687093e68ae8b88583777d062df7a77"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3632943",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#08d251b9d687093e68ae8b88583777d062df7a77",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-font-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "langpacks-en",
+      "purl": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lettuce-core",
+      "purl": "pkg:maven/io.lettuce/lettuce-core@6.5.4.RELEASE-redhat-00001?type=jar",
+      "type": "library",
+      "group": "io.lettuce",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6c5b68f4fa85722a44221e4a3dd3ad15"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ee8f2ed9d766cb004d116237e53d32efe54c3e44"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "863a9e8e74c6f3b57fc69f7cd106c10ffbbefd506107aba5bb1caa54fc52225d"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.lettuce/lettuce-core@6.5.4.RELEASE-redhat-00001?type=jar",
+      "version": "6.5.4.RELEASE-redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8ff18f83cf74bba23b945728b6816a3a6ae1791b",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/lettuce-io/lettuce-core.git#6.5.4.RELEASE-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lettuce-core-6.5.4.RELEASE-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lettuce-core-6.5.4.RELEASE-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ee8f2ed9d766cb004d116237e53d32efe54c3e44"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13488927",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF3BNQJQ2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/lettuce-io/lettuce-core.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libacl",
+      "purl": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "version": "2.3.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2709815",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libarchive",
+      "purl": "pkg:rpm/redhat/libarchive@3.5.3-6.el9_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libarchive@3.5.3-6.el9_6?arch=x86_64",
+      "version": "3.5.3-6.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "476a518562a29e2fa60704cd358f8afffb8492c4",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#476a518562a29e2fa60704cd358f8afffb8492c4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3803996",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#476a518562a29e2fa60704cd358f8afffb8492c4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libassuan",
+      "purl": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "version": "2.5.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5b185f851a42718727fee9efcf42ba525a59a8bb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689887",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libattr",
+      "purl": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "version": "2.5.1-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+            "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688838",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libblkid",
+      "purl": "pkg:rpm/redhat/libblkid@2.37.4-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libblkid@2.37.4-21.el9?arch=x86_64",
+      "version": "2.37.4-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471212",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libbpf",
+      "purl": "pkg:rpm/redhat/libbpf@1.5.0-2.el9?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libbpf@1.5.0-2.el9?arch=x86_64&epoch=2",
+      "version": "2:1.5.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 or BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6d0889dc26792f53ba920146bf71d5f9e8a0304b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libbpf#6d0889dc26792f53ba920146bf71d5f9e8a0304b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3745871",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libbpf#6d0889dc26792f53ba920146bf71d5f9e8a0304b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcap",
+      "purl": "pkg:rpm/redhat/libcap@2.48-10.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap@2.48-10.el9?arch=x86_64",
+      "version": "2.48-10.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ea0a33459038cacc1c4670395c71f8ad87321a81",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libcap#ea0a33459038cacc1c4670395c71f8ad87321a81"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3725567",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libcap#ea0a33459038cacc1c4670395c71f8ad87321a81",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcap-ng",
+      "purl": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "version": "0.8.2-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1888632",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcom_err",
+      "purl": "pkg:rpm/redhat/libcom_err@1.46.5-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcom_err@1.46.5-8.el9?arch=x86_64",
+      "version": "1.46.5-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e34b390a71fcb15e4efe3d40023b026aef6e37d5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#e34b390a71fcb15e4efe3d40023b026aef6e37d5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3730627",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#e34b390a71fcb15e4efe3d40023b026aef6e37d5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcurl-minimal",
+      "purl": "pkg:rpm/redhat/libcurl-minimal@7.76.1-34.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-34.el9?arch=x86_64",
+      "version": "7.76.1-34.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9191ce624f0ca7590f3ff733b0d9374e7dc545fa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#9191ce624f0ca7590f3ff733b0d9374e7dc545fa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3708949",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#9191ce624f0ca7590f3ff733b0d9374e7dc545fa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libdnf",
+      "purl": "pkg:rpm/redhat/libdnf@0.69.0-16.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf@0.69.0-16.el9?arch=x86_64",
+      "version": "0.69.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03cea2d0b596b367e21c1016de5959ce1a12394b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#03cea2d0b596b367e21c1016de5959ce1a12394b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3718605",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#03cea2d0b596b367e21c1016de5959ce1a12394b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libevent",
+      "purl": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "version": "2.1.12-8.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3235991",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libffi",
+      "purl": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "version": "3.4.2-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6f484e5230669fffb71870ce41c386e01ab4e47d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467679",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcc",
+      "purl": "pkg:rpm/redhat/libgcc@11.5.0-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcc@11.5.0-11.el9?arch=x86_64",
+      "version": "11.5.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8cb29d27fbc72dc1aa0fd305915264ff1bca8273",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#8cb29d27fbc72dc1aa0fd305915264ff1bca8273"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3779349",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#8cb29d27fbc72dc1aa0fd305915264ff1bca8273",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcrypt",
+      "purl": "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64",
+      "version": "1.10.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6cd6cde2ff10db934bd6b9be9ecdfe75edebb67a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#6cd6cde2ff10db934bd6b9be9ecdfe75edebb67a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3202712",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#6cd6cde2ff10db934bd6b9be9ecdfe75edebb67a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgpg-error",
+      "purl": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "version": "1.42-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "55660568a38dad2e4a858df692830af766ad6532",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1818836",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libidn2",
+      "purl": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "version": "2.3.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or LGPLv3+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c781354177446e1bb6a5b48d2113feaed50cc860",
+            "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libksba",
+      "purl": "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64",
+      "version": "1.5.1-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(LGPLv3+ or GPLv2+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ced1b2ff933b56b33f08882bb4e5ddba997afaa6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libksba#ced1b2ff933b56b33f08882bb4e5ddba997afaa6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3198143",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libksba#ced1b2ff933b56b33f08882bb4e5ddba997afaa6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmnl",
+      "purl": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+      "version": "1.0.4-16.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e4e253af7af3650798d04664f7b96965ed5365ad",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libmnl#e4e253af7af3650798d04664f7b96965ed5365ad"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3049134",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libmnl#e4e253af7af3650798d04664f7b96965ed5365ad",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmodulemd",
+      "purl": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "version": "2.13.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d48969327abbcbfad2ab893639cfb7d22362223d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1695462",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmount",
+      "purl": "pkg:rpm/redhat/libmount@2.37.4-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmount@2.37.4-21.el9?arch=x86_64",
+      "version": "2.37.4-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471212",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnghttp2",
+      "purl": "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64",
+      "version": "1.43.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79861abb0ea729bcf418eabaf5027b18ba623bf9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#79861abb0ea729bcf418eabaf5027b18ba623bf9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2996602",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#79861abb0ea729bcf418eabaf5027b18ba623bf9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpeas",
+      "purl": "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64",
+      "version": "1.30.0-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "14f3f166e32b0592b8a0289de0e7050df985f9a0",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpeas#14f3f166e32b0592b8a0289de0e7050df985f9a0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690090",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpeas#14f3f166e32b0592b8a0289de0e7050df985f9a0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "librepo",
+      "purl": "pkg:rpm/redhat/librepo@1.14.5-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librepo@1.14.5-3.el9?arch=x86_64",
+      "version": "1.14.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "52faea249f23790549bbf48ff300ffebf0fdc4f0",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#52faea249f23790549bbf48ff300ffebf0fdc4f0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3710957",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#52faea249f23790549bbf48ff300ffebf0fdc4f0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libreport-filesystem",
+      "purl": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "version": "2.15.2-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4690267165817ccc06cb342d8ef955ae10b54c75",
+            "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1852394",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "librhsm",
+      "purl": "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64",
+      "version": "0.0.3-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bf2220747d150d79be10852ee5e990f99d7f2a77",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#bf2220747d150d79be10852ee5e990f99d7f2a77"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2996611",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#bf2220747d150d79be10852ee5e990f99d7f2a77",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libselinux",
+      "purl": "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64",
+      "version": "3.6-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "46550b75ecf34b63df099f9f009381df9227ce88",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#46550b75ecf34b63df099f9f009381df9227ce88"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3485081",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#46550b75ecf34b63df099f9f009381df9227ce88",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsemanage",
+      "purl": "pkg:rpm/redhat/libsemanage@3.6-5.el9_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsemanage@3.6-5.el9_6?arch=x86_64",
+      "version": "3.6-5.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ef095b2e9bc119969f848f04b96582d8b85fe5b4",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#ef095b2e9bc119969f848f04b96582d8b85fe5b4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3533947",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#ef095b2e9bc119969f848f04b96582d8b85fe5b4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsepol",
+      "purl": "pkg:rpm/redhat/libsepol@3.6-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsepol@3.6-3.el9?arch=x86_64",
+      "version": "3.6-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6148e341d9aa8e8557fae791b7cbb6ce085bc6f2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#6148e341d9aa8e8557fae791b7cbb6ce085bc6f2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3569827",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#6148e341d9aa8e8557fae791b7cbb6ce085bc6f2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsigsegv",
+      "purl": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "version": "2.13-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b3dee05a0458f11a68b0f9a878aa676670814326",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690130",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsmartcols",
+      "purl": "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64",
+      "version": "2.37.4-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471212",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsolv",
+      "purl": "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64",
+      "version": "0.7.24-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "334959330f40393346bb399506b5c5081231109d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsolv#334959330f40393346bb399506b5c5081231109d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2995003",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsolv#334959330f40393346bb399506b5c5081231109d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libstdc++",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-11.el9?arch=x86_64",
+      "version": "11.5.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8cb29d27fbc72dc1aa0fd305915264ff1bca8273",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#8cb29d27fbc72dc1aa0fd305915264ff1bca8273"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3779349",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#8cb29d27fbc72dc1aa0fd305915264ff1bca8273",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtasn1",
+      "purl": "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64",
+      "version": "4.16.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "243192561fe59a99450308901f0ff2be9a39489b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtasn1#243192561fe59a99450308901f0ff2be9a39489b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3513775",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtasn1#243192561fe59a99450308901f0ff2be9a39489b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtirpc",
+      "purl": "pkg:rpm/redhat/libtirpc@1.3.3-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtirpc@1.3.3-9.el9?arch=x86_64",
+      "version": "1.3.3-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "SISSL and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "51b799b231540bcf17278cd04c8537a450015e45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#51b799b231540bcf17278cd04c8537a450015e45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3198130",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#51b799b231540bcf17278cd04c8537a450015e45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtool-ltdl",
+      "purl": "pkg:rpm/redhat/libtool-ltdl@2.4.6-46.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtool-ltdl@2.4.6-46.el9?arch=x86_64",
+      "version": "2.4.6-46.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7e2c1061c8fc1a80327da6afee4a76e61313a632",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtool#7e2c1061c8fc1a80327da6afee4a76e61313a632"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3103845",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtool#7e2c1061c8fc1a80327da6afee4a76e61313a632",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libunistring",
+      "purl": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "version": "0.9.10-15.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690195",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libusbx",
+      "purl": "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64",
+      "version": "1.0.26-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e369f619a0e615f4b86409c454308b316c0a78b7",
+            "url": "git://pkgs.devel.redhat.com/rpms/libusbx#e369f619a0e615f4b86409c454308b316c0a78b7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1986004",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libusbx#e369f619a0e615f4b86409c454308b316c0a78b7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libuuid",
+      "purl": "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64",
+      "version": "2.37.4-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471212",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libverto",
+      "purl": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "version": "0.3.2-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690209",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxcrypt",
+      "purl": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "version": "4.4.18-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and BSD and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5ae2c88752320b1d81d70ae38259ce56b1c692de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690260",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxml2",
+      "purl": "pkg:rpm/redhat/libxml2@2.9.13-14.el9_7?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxml2@2.9.13-14.el9_7?arch=x86_64",
+      "version": "2.9.13-14.el9_7",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a2cbd6eb444aabc667540db709da20ba86a2c344",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#a2cbd6eb444aabc667540db709da20ba86a2c344"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3889263",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#a2cbd6eb444aabc667540db709da20ba86a2c344",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libyaml",
+      "purl": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "version": "0.2.5-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70e1549fe5e56c95f1e23967e02c657d7af570ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690356",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libzstd",
+      "purl": "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64",
+      "version": "1.5.5-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "65ac97bcf256b0440e458769fae5d197fd761c18",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/zstd#65ac97bcf256b0440e458769fae5d197fd761c18"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3397534",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/zstd#65ac97bcf256b0440e458769fae5d197fd761c18",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "linux-x86_64",
+      "purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?classifier=linux-x86_64&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1873e21ebdb1c4d0cc86bd37286cba73"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a77641ba2c0f5503907982b988f05ed8e621ae2e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "024817cc0bafa0f319adce67a610eac1bdfb3f080abc0bd25755e25b248b3f23"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?classifier=linux-x86_64&type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-transport-native-epoll-linux-x86_64-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-transport-native-epoll-linux-x86_64-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a77641ba2c0f5503907982b988f05ed8e621ae2e"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213523",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lksctp-tools",
+      "purl": "pkg:rpm/redhat/lksctp-tools@1.0.19-3.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lksctp-tools@1.0.19-3.el9_4?arch=x86_64",
+      "version": "1.0.19-3.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2 and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5f86a83e1f7b663385b325c8e8b04d682ef8305e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/lksctp-tools#5f86a83e1f7b663385b325c8e8b04d682ef8305e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2952358",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/lksctp-tools#5f86a83e1f7b663385b325c8e8b04d682ef8305e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log4j-api",
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.23.1.redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.apache.logging.log4j",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "87e858f83f309f9b3ba93d90cef9d641"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "535ec57e0b5256ca7129e7907da5ae0d2ffec43d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ac20f30acd881cffc7e1c519d0dceb18fcfe123842d8b81030c1ffec47c46be2"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.23.1.redhat-00002?type=jar",
+      "version": "2.23.1.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "\"Apache-2.0\";link=\"https://www.apache.org/licenses/LICENSE-2.0.txt\""
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "17e0635b3452b00ecbea3de5c598ddf9e1032b25",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/logging-log4j2.git#2.23.1.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/log4j-api-2.23.1.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/log4j-api-2.23.1.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "535ec57e0b5256ca7129e7907da5ae0d2ffec43d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12924522",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC3HOPOWG2QAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.3:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/logging-log4j2.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log4j-core",
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.23.1.redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.apache.logging.log4j",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a9d35bd01faacd02714f29bdd9c3199e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "57f6d82821d7744f132d035c7dd03a5b4f991884"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5e24419060329207282989cd07d03f81fae8ecdfac5e97c20746d39d9cb74965"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-core@2.23.1.redhat-00002?type=jar",
+      "version": "2.23.1.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "\"Apache-2.0\";link=\"https://www.apache.org/licenses/LICENSE-2.0.txt\""
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "17e0635b3452b00ecbea3de5c598ddf9e1032b25",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/logging-log4j2.git#2.23.1.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/log4j-core-2.23.1.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/log4j-core-2.23.1.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "57f6d82821d7744f132d035c7dd03a5b4f991884"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12924538",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC3HOPOWG2QAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.3:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/logging-log4j2.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log4j-jul",
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-jul@2.23.1.redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.apache.logging.log4j",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fc146233710aba4ef3c4f5a65f2c9935"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4bbff75479f990c03856afc9433b24ec9c4a99ba"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "27dcce885a46a6d6784e2eb189b4c3cdb140146cad6348fc4527316728c12d4c"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-jul@2.23.1.redhat-00002?type=jar",
+      "version": "2.23.1.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "\"Apache-2.0\";link=\"https://www.apache.org/licenses/LICENSE-2.0.txt\""
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "17e0635b3452b00ecbea3de5c598ddf9e1032b25",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/logging-log4j2.git#2.23.1.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/log4j-jul-2.23.1.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/log4j-jul-2.23.1.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4bbff75479f990c03856afc9433b24ec9c4a99ba"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12924430",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC3HOPOWG2QAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.3:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/logging-log4j2.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log4j-slf4j-impl",
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-slf4j-impl@2.23.1.redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.apache.logging.log4j",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "14f11829a8da5be1eaac8e3b72f6ac08"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "94774073cf8f3ad1c9077bc23adba9898834b418"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "213f139d8d3a708e8ba991d89e30c97d3fe1f8d4bf81301c6d3a7130085934f7"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-slf4j-impl@2.23.1.redhat-00002?type=jar",
+      "version": "2.23.1.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "\"Apache-2.0\";link=\"https://www.apache.org/licenses/LICENSE-2.0.txt\""
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "17e0635b3452b00ecbea3de5c598ddf9e1032b25",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/logging-log4j2.git#2.23.1.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/log4j-slf4j-impl-2.23.1.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/log4j-slf4j-impl-2.23.1.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "94774073cf8f3ad1c9077bc23adba9898834b418"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12924448",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC3HOPOWG2QAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.3:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/logging-log4j2.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lsof",
+      "purl": "pkg:rpm/redhat/lsof@4.94.0-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lsof@4.94.0-3.el9?arch=x86_64",
+      "version": "4.94.0-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Sendmail and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d0869d4345af34a0bce8cc84050591ab617c71d6",
+            "url": "git://pkgs.devel.redhat.com/rpms/lsof#d0869d4345af34a0bce8cc84050591ab617c71d6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690479",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lsof#d0869d4345af34a0bce8cc84050591ab617c71d6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua",
+      "purl": "pkg:rpm/redhat/lua@5.4.4-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua@5.4.4-4.el9?arch=x86_64",
+      "version": "5.4.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d795270f6d1372b9636433ed1fb08b2439eed16",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467503",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua-libs",
+      "purl": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "version": "5.4.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d795270f6d1372b9636433ed1fb08b2439eed16",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467503",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua-posix",
+      "purl": "pkg:rpm/redhat/lua-posix@35.0-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua-posix@35.0-8.el9?arch=x86_64",
+      "version": "35.0-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b59d69c683695ed563b24353ca10c2fad1324c2d",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua-posix#b59d69c683695ed563b24353ca10c2fad1324c2d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1903570",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua-posix#b59d69c683695ed563b24353ca10c2fad1324c2d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-analysis-common",
+      "purl": "pkg:maven/org.apache.lucene/lucene-analysis-common@9.9.2.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3f15962f7df0425bd9feacaf273c7e26"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bc2ac3574503f75e72ee648ce242c4ea2a8747bf"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bd79f5325c0462086d31b492608a6cae8ecaa87b473b7ec9f2014a6321b6cb17"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-analysis-common@9.9.2.redhat-00001?type=jar",
+      "version": "9.9.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4d3d1b1a24b8f176709132426956a7b92c7c2675",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-analysis-common-9.9.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-analysis-common-9.9.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bc2ac3574503f75e72ee648ce242c4ea2a8747bf"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12533364",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BAZS6XU3TEYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-core",
+      "purl": "pkg:maven/org.apache.lucene/lucene-core@9.9.2.redhat-00002?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3748dbfbafca95cab6bf70fe80415757"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "43f6d6e0c1b8273cffe3b80418434e316cbb54b0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7182f5ce417d0510352caa06d90cdb8687b60ba0358b4cadde76413f3616bde8"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-core@9.9.2.redhat-00002?type=jar",
+      "version": "9.9.2.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fdf0bb102254f6589265e6ce8968a137fc18709e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-core-9.9.2.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-core-9.9.2.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "43f6d6e0c1b8273cffe3b80418434e316cbb54b0"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13502776",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5KYYHC2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-facet",
+      "purl": "pkg:maven/org.apache.lucene/lucene-facet@9.9.2.redhat-00002?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7fa3e701879d196d75ea1968343e32d8"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "33b163f42aeb809ffd6969c1b46b4612e28fb51b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c0692ec878ec2525a88ba37e7f11a74f541fe1cc6146119f59ebfcf0c3e5f036"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-facet@9.9.2.redhat-00002?type=jar",
+      "version": "9.9.2.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fdf0bb102254f6589265e6ce8968a137fc18709e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-facet-9.9.2.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-facet-9.9.2.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "33b163f42aeb809ffd6969c1b46b4612e28fb51b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13502692",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5KYYHC2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-highlighter",
+      "purl": "pkg:maven/org.apache.lucene/lucene-highlighter@9.9.2.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "675f677407d1b192a92d3dc9d3104cb1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3452e289096135cb4215166d4d43d02bed53419c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6beec6476108ced023d3ff25df8bfaa933fba5a2d62f3cacb03c3d35ab166bd8"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-highlighter@9.9.2.redhat-00001?type=jar",
+      "version": "9.9.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4d3d1b1a24b8f176709132426956a7b92c7c2675",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-highlighter-9.9.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-highlighter-9.9.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3452e289096135cb4215166d4d43d02bed53419c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12533423",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BAZS6XU3TEYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-join",
+      "purl": "pkg:maven/org.apache.lucene/lucene-join@9.9.2.redhat-00002?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b5f2de2fada558edfca15e553e41abbd"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "726bda128dd0bb832dce0d59893cca5b2ef1ea47"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0fc014310ca57df29de9de983b10ebc6eed23b25a13b944896d1a249fba7058d"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-join@9.9.2.redhat-00002?type=jar",
+      "version": "9.9.2.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fdf0bb102254f6589265e6ce8968a137fc18709e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-join-9.9.2.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-join-9.9.2.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "726bda128dd0bb832dce0d59893cca5b2ef1ea47"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13502697",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5KYYHC2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-queries",
+      "purl": "pkg:maven/org.apache.lucene/lucene-queries@9.9.2.redhat-00002?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8e67dbfb583dd501f7e3e6dd2e4ef0c9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "23f07f72903d6a04709c3314311a182b867a5c7b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2b7421ce3bf562d561393548ee7010e7967d1a3f80fe1b388b9e88c88e21e6a5"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-queries@9.9.2.redhat-00002?type=jar",
+      "version": "9.9.2.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fdf0bb102254f6589265e6ce8968a137fc18709e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-queries-9.9.2.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-queries-9.9.2.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "23f07f72903d6a04709c3314311a182b867a5c7b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13502749",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5KYYHC2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-queryparser",
+      "purl": "pkg:maven/org.apache.lucene/lucene-queryparser@9.9.2.redhat-00002?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "22789e8ecb6a32a0a5787c4fd4990a70"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "82260a94df2702eac7f85c565d02ed3b6d05d976"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b47b987de42892eb437e23ad13a60351161e1cb04e7529788d4c702b400883e3"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-queryparser@9.9.2.redhat-00002?type=jar",
+      "version": "9.9.2.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fdf0bb102254f6589265e6ce8968a137fc18709e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-queryparser-9.9.2.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-queryparser-9.9.2.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "82260a94df2702eac7f85c565d02ed3b6d05d976"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13502703",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5KYYHC2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lz4-libs",
+      "purl": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "version": "1.9.3-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690509",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "microdnf",
+      "purl": "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64",
+      "version": "3.9.1-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cc6603992b29365e456f8747a8d17c17b8dc45a4",
+            "url": "git://pkgs.devel.redhat.com/rpms/microdnf#cc6603992b29365e456f8747a8d17c17b8dc45a4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2324298",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/microdnf#cc6603992b29365e456f8747a8d17c17b8dc45a4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "micrometer-commons",
+      "purl": "pkg:maven/io.micrometer/micrometer-commons@1.12.13.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "676eb18381b7a88734edcdc2f371ac9d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6d62652a0510d24e09294a9ff9188e6bd7a35178"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "992fc34743feb471d6dcc6fca4304fea08d35b8c706a7130ea416d50dd604bc4"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.micrometer/micrometer-commons@1.12.13.redhat-00001?type=jar",
+      "version": "1.12.13.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cceb355b800195d01ed93bbc3f5d56bf4b8d43f5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/micrometer-metrics/micrometer.git#1.12.13.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/micrometer-commons-1.12.13.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/micrometer-commons-1.12.13.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6d62652a0510d24e09294a9ff9188e6bd7a35178"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387666",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNP2EUIMKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j11-mvn3.9.2-gradle8.3-gcc-cpp-make:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/micrometer-metrics/micrometer.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "micrometer-core",
+      "purl": "pkg:maven/io.micrometer/micrometer-core@1.12.13.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7072d2946ebb878a63f1ad4d6343fe83"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3ac5a2fbbc934bb8b88c7125e21c673f7d73fff4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f84e87477c46ef299ed86c8cb2670f76b6355d78ecfe8de0ea0b8507fc268764"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.micrometer/micrometer-core@1.12.13.redhat-00001?type=jar",
+      "version": "1.12.13.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cceb355b800195d01ed93bbc3f5d56bf4b8d43f5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/micrometer-metrics/micrometer.git#1.12.13.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/micrometer-core-1.12.13.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/micrometer-core-1.12.13.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3ac5a2fbbc934bb8b88c7125e21c673f7d73fff4"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387708",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNP2EUIMKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j11-mvn3.9.2-gradle8.3-gcc-cpp-make:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/micrometer-metrics/micrometer.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "micrometer-observation",
+      "purl": "pkg:maven/io.micrometer/micrometer-observation@1.12.13.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9d6e579f34cc07df1e82a6bc6f9d486d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "dc96515c3be42592a1affe51f6fbb12c289e59d9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "360ae16c3b2dcfcb6af5c9225cce7d5b1d30f65d79df6fdfd5840c9ba426c9e3"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.micrometer/micrometer-observation@1.12.13.redhat-00001?type=jar",
+      "version": "1.12.13.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cceb355b800195d01ed93bbc3f5d56bf4b8d43f5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/micrometer-metrics/micrometer.git#1.12.13.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/micrometer-observation-1.12.13.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/micrometer-observation-1.12.13.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "dc96515c3be42592a1affe51f6fbb12c289e59d9"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387644",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNP2EUIMKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j11-mvn3.9.2-gradle8.3-gcc-cpp-make:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/micrometer-metrics/micrometer.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "micrometer-registry-prometheus",
+      "purl": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.12.13.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "afa9e6c072cdd57e67e6acac5edbeaae"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "01e8afc73fee8eab8b069346f15415473fb322f4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ef08b6521a4305e7be92a1284ed5cc396717731dfa8f7b026e3f94d60bd9fda2"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.12.13.redhat-00001?type=jar",
+      "version": "1.12.13.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cceb355b800195d01ed93bbc3f5d56bf4b8d43f5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/micrometer-metrics/micrometer.git#1.12.13.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/micrometer-registry-prometheus-1.12.13.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/micrometer-registry-prometheus-1.12.13.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "01e8afc73fee8eab8b069346f15415473fb322f4"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387709",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNP2EUIMKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j11-mvn3.9.2-gradle8.3-gcc-cpp-make:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/micrometer-metrics/micrometer.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "mpfr",
+      "purl": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "version": "4.1.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "207ac3816285664c0c73fa4894dbdead53d1ca40",
+            "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690656",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ncurses-base",
+      "purl": "pkg:rpm/redhat/ncurses-base@6.2-12.20210508.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-base@6.2-12.20210508.el9?arch=noarch",
+      "version": "6.2-12.20210508.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b7beb462ec8a2bc97070b830ddda90f114621bd1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#b7beb462ec8a2bc97070b830ddda90f114621bd1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3719922",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#b7beb462ec8a2bc97070b830ddda90f114621bd1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ncurses-libs",
+      "purl": "pkg:rpm/redhat/ncurses-libs@6.2-12.20210508.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-libs@6.2-12.20210508.el9?arch=x86_64",
+      "version": "6.2-12.20210508.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b7beb462ec8a2bc97070b830ddda90f114621bd1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#b7beb462ec8a2bc97070b830ddda90f114621bd1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3719922",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#b7beb462ec8a2bc97070b830ddda90f114621bd1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nettle",
+      "purl": "pkg:rpm/redhat/nettle@3.10.1-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nettle@3.10.1-1.el9?arch=x86_64",
+      "version": "3.10.1-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5100403b46842ba5c03a944f6792a20fc763f6da",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#5100403b46842ba5c03a944f6792a20fc763f6da"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3510365",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#5100403b46842ba5c03a944f6792a20fc763f6da",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-buffer",
+      "purl": "pkg:maven/io.netty/netty-buffer@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a3ee3ed80856434488c6bfd887fc3199"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6c74eb2c6ff72797676cb4cfc12a21cf13f76196"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3c4cf0915a2248fba20f835a0a9e5203660eda5476b6a38d22c676fc50e267fe"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-buffer-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-buffer-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6c74eb2c6ff72797676cb4cfc12a21cf13f76196"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213625",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-codec",
+      "purl": "pkg:maven/io.netty/netty-codec@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "37c0c4d9c5f7ec732b7a1a082034d7fd"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2ca92bfb5d2470ec0a10f73024fee659b536ea3a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "813a455304335b76e1301e486154b795d320a75015141b01fce93effb672ebbd"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-codec@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-codec-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-codec-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "2ca92bfb5d2470ec0a10f73024fee659b536ea3a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213536",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-codec-dns",
+      "purl": "pkg:maven/io.netty/netty-codec-dns@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "04644e520c848c87d49ba82b4db5823b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0bce2bc72df4a29c8074afbdbe727fb80d3421d3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e6a45206760e94df8db41aa4672a99f30db4ef7ba90779df15eebbef634f2dc7"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-codec-dns@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-codec-dns-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-codec-dns-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0bce2bc72df4a29c8074afbdbe727fb80d3421d3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213498",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-codec-http",
+      "purl": "pkg:maven/io.netty/netty-codec-http@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2b46462fc555670956015b6709d19a3b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d224bc5f21d4c5b8ebfba32dc78981da47d179ca"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ed7368ec39e5dc59240265fbd8c3e3966be8c2f0652163d43a00f0f2b3df89ca"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-codec-http@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-codec-http-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-codec-http-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d224bc5f21d4c5b8ebfba32dc78981da47d179ca"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213522",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-codec-http2",
+      "purl": "pkg:maven/io.netty/netty-codec-http2@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d3d62afb86e37d417eb88b4138cce15f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "60b12338cfcd9c12f1e53a192ad812e3891d3d0d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ed99f05810f7e547a8a62a3aeb14b2fc98233fcf418e4dbe14f233f512c76ad7"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-codec-http2@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-codec-http2-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-codec-http2-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "60b12338cfcd9c12f1e53a192ad812e3891d3d0d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213574",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-common",
+      "purl": "pkg:maven/io.netty/netty-common@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7e459306d2633e4ad954414201046bc6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7ae9e3c1c232b5cb4c74bf9f9371052124de4995"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5b5d52a6297c98129c26c982ac3d1e34ad70c06bdc7a7a08705686b05b05e5a5"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-common@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-common-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-common-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "7ae9e3c1c232b5cb4c74bf9f9371052124de4995"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213657",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-handler",
+      "purl": "pkg:maven/io.netty/netty-handler@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8beb68a2b6672adec37f89ade370aa99"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a8c783a0cbfb4fb886f3ecb0431e4cb79971f0e8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "728c319fe094b5f864c1a9eacb5f731614b98e939dfb9a0b5445c82ad9396d97"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-handler@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-handler-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-handler-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a8c783a0cbfb4fb886f3ecb0431e4cb79971f0e8"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213662",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-resolver",
+      "purl": "pkg:maven/io.netty/netty-resolver@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "df3e5b746c9eed9160e7f0a4b748db73"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f660750dee3de43e3dbb423c701043e77b5d0bdc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1a47865145e1462c322df1bbff7c2502785eb8c39023e57fdc384ec467763f1f"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-resolver-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-resolver-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f660750dee3de43e3dbb423c701043e77b5d0bdc"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213592",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-resolver-dns",
+      "purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "12be67c9e9bd84312a84bb47aa8acb58"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "07a7ba61d3772e51bf758d160ba8b12912b7442a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "de7d9b706e50e6e51114854d2304e4a37f428687ae67cc4ca0f54374cb085831"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-resolver-dns-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-resolver-dns-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "07a7ba61d3772e51bf758d160ba8b12912b7442a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213529",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-transport",
+      "purl": "pkg:maven/io.netty/netty-transport@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6ddf22a2f5e0f402032dad0e56621521"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "dfea097c493faaf173d0f332583ac02e71590304"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2790c30762328bcc9840871d0762efecc6554d1f9fb9195e717c2e9a352a17f0"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-transport@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-transport-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-transport-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "dfea097c493faaf173d0f332583ac02e71590304"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213565",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-transport-classes-epoll",
+      "purl": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9659a2895b1c9091d078c7a2340e9f0c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d741dc4588ce5ad4f043e87e52bf9e70decf2796"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "05811c9f9eede1524a33f31cc1ba1276c71129314af83755f12087de4cf39905"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-transport-classes-epoll-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-transport-classes-epoll-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d741dc4588ce5ad4f043e87e52bf9e70decf2796"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213627",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-transport-native-epoll",
+      "purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d61bd0771b8378844ebde13a5b7a8eac"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "28a3b9deb3db1aa6ab35a1b101afd7f7d419c9fd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e6ca3015299f1d255b76b3a05a590b2aab3745bd889804f39e993b5dd6a81567"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-transport-native-epoll-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-transport-native-epoll-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "28a3b9deb3db1aa6ab35a1b101afd7f7d419c9fd"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213587",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-transport-native-epoll",
+      "purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d61bd0771b8378844ebde13a5b7a8eac"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "28a3b9deb3db1aa6ab35a1b101afd7f7d419c9fd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e6ca3015299f1d255b76b3a05a590b2aab3745bd889804f39e993b5dd6a81567"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?package-id=0eb6ce733297e359",
+      "version": "4.1.121.Final-redhat-00003",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-transport-native-epoll-linux-x86_64-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-transport-native-epoll-linux-x86_64-4.1.121.Final-redhat-00003.jar:io.netty:netty-transport-native-epoll"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213587",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-transport-native-unix-common",
+      "purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "bf57526c157ee1074f7ccd5f2df575a7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bc340f2f382216d39fc206662bd63ed398139b21"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6144169cfb3719a1eb65821647eac90e4178112a115bf4a5d92f7c5fa72098cb"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-transport-native-unix-common-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-transport-native-unix-common-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bc340f2f382216d39fc206662bd63ed398139b21"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213675",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "npth",
+      "purl": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "version": "1.6-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+            "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690792",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nspr",
+      "purl": "pkg:rpm/redhat/nspr@4.36.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nspr@4.36.0-4.el9_4?arch=x86_64",
+      "version": "4.36.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss",
+      "purl": "pkg:rpm/redhat/nss@3.112.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss@3.112.0-4.el9_4?arch=x86_64",
+      "version": "3.112.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-softokn",
+      "purl": "pkg:rpm/redhat/nss-softokn@3.112.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-softokn@3.112.0-4.el9_4?arch=x86_64",
+      "version": "3.112.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-softokn-freebl",
+      "purl": "pkg:rpm/redhat/nss-softokn-freebl@3.112.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-softokn-freebl@3.112.0-4.el9_4?arch=x86_64",
+      "version": "3.112.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-sysinit",
+      "purl": "pkg:rpm/redhat/nss-sysinit@3.112.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-sysinit@3.112.0-4.el9_4?arch=x86_64",
+      "version": "3.112.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-tools",
+      "purl": "pkg:rpm/redhat/nss-tools@3.112.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-tools@3.112.0-4.el9_4?arch=x86_64",
+      "version": "3.112.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-util",
+      "purl": "pkg:rpm/redhat/nss-util@3.112.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-util@3.112.0-4.el9_4?arch=x86_64",
+      "version": "3.112.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openldap",
+      "purl": "pkg:rpm/redhat/openldap@2.6.8-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openldap@2.6.8-4.el9?arch=x86_64",
+      "version": "2.6.8-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "OLDAP-2.8"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9025f0ac208ee130e00cd0a4df276ce3be00cc31",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#9025f0ac208ee130e00cd0a4df276ce3be00cc31"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3505959",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#9025f0ac208ee130e00cd0a4df276ce3be00cc31",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl",
+      "purl": "pkg:rpm/redhat/openssl@3.5.1-4.el9_7?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl@3.5.1-4.el9_7?arch=x86_64&epoch=1",
+      "version": "1:3.5.1-4.el9_7",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d605f4b436b9c61af2722b05a820af652541fa99",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#d605f4b436b9c61af2722b05a820af652541fa99"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3875452",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#d605f4b436b9c61af2722b05a820af652541fa99",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-fips-provider",
+      "purl": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-8.el9?arch=x86_64",
+      "version": "3.0.7-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fef496520ada48022df42487ce01f1ab042c196e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#fef496520ada48022df42487ce01f1ab042c196e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3764070",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#fef496520ada48022df42487ce01f1ab042c196e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-fips-provider-so",
+      "purl": "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-8.el9?arch=x86_64",
+      "version": "3.0.7-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fef496520ada48022df42487ce01f1ab042c196e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#fef496520ada48022df42487ce01f1ab042c196e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3764070",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#fef496520ada48022df42487ce01f1ab042c196e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-libs",
+      "purl": "pkg:rpm/redhat/openssl-libs@3.5.1-4.el9_7?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-libs@3.5.1-4.el9_7?arch=x86_64&epoch=1",
+      "version": "1:3.5.1-4.el9_7",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d605f4b436b9c61af2722b05a820af652541fa99",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#d605f4b436b9c61af2722b05a820af652541fa99"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3875452",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#d605f4b436b9c61af2722b05a820af652541fa99",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-api",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-api@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ec551ed4304bdc08248ff0014272446c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "217c88e8100f57669d0f3036a7fa9e804bce7ad0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4b2026442f89dfca07ce0ca84f0541b21f9efd190c749741cf6c883c50049e09"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-api@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-api-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-api-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "217c88e8100f57669d0f3036a7fa9e804bce7ad0"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897119",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-api-events",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-api-events@1.32.0.alpha-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b89aa9e43a063d1a49689f49754db1a7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ad7ed14186dbd2d3f54c3aa4436cd7e7323f4ebf"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f3a94473035b71317a95eb521c07fdd8f2715bc845c3bba69a4dfce61606ded9"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-api-events@1.32.0.alpha-redhat-00001?type=jar",
+      "version": "1.32.0.alpha-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-api-events-1.32.0.alpha-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-api-events-1.32.0.alpha-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ad7ed14186dbd2d3f54c3aa4436cd7e7323f4ebf"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897053",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-context",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-context@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "24e76e2756671979d163f136cc1314d1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c1d65ea72838a9c316051e3fc0b77ec00621af3b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d7f4dba88db21a6892d788a86683072b681f82e1f7f75babfe873a9f3ec88f06"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-context@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-context-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-context-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c1d65ea72838a9c316051e3fc0b77ec00621af3b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897044",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-exporter-common",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-exporter-common@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "662c1e332a93c3f10920cd010f15f2af"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e8dd933ea522db6980fa9b10272e3068e6601399"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "406cc33f84f3889948be9438f33a1add4ba5b811f98efe7b04b4ef377d8b8de4"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-common@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-common-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-common-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e8dd933ea522db6980fa9b10272e3068e6601399"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897085",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-exporter-otlp",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1ba37c5425a2581191f47ac0c85cd301"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f2297156863e931e8850ab85a8c0e6f0ffb48035"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ed6e0b4bcb7f99179b43e310ed96003c6ecc496da9c26ca690b57ac9982c019b"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-otlp-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-otlp-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f2297156863e931e8850ab85a8c0e6f0ffb48035"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897079",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-exporter-otlp-common",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp-common@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "095872d37b85c8da8b6022d2ad494767"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "eb9b8e71e3465e6b039ae5c11bf506a81d21f8da"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "19dbbac172f33d1f482b0d3dcd355c055b6a3679aa00458b039705088acd94cc"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp-common@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-otlp-common-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-otlp-common-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "eb9b8e71e3465e6b039ae5c11bf506a81d21f8da"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897103",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-exporter-sender-jdk",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-exporter-sender-jdk@1.32.0.alpha-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5d4c20077aa399dcddf486ae3eeca078"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5683cc88721f16a0a16349242aef45148d833041"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3a384ada023d160eb64205b447c1d4bd5162730916f00b25378863ba31badb38"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-sender-jdk@1.32.0.alpha-redhat-00001?type=jar",
+      "version": "1.32.0.alpha-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-sender-jdk-1.32.0.alpha-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-sender-jdk-1.32.0.alpha-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5683cc88721f16a0a16349242aef45148d833041"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897162",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "58d428756c21d9a8323bd61362113e30"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a92a3369fa2040d879317784e3bc57ad693ec40b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e32deef70a831e78800d24a0ce467e1f710ca3155611d76cdd028d42fc298cc5"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a92a3369fa2040d879317784e3bc57ad693ec40b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897093",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk-common",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "bcc0064144dd022905b6b149ba1667e2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5e8a203be43bcd8cc52c0809c2a6a00d67b73377"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fca8e3578766d5b30afc6e78dddc1761922c03ab3e2cb2c2978f6d3896f61665"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-common-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-common-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5e8a203be43bcd8cc52c0809c2a6a00d67b73377"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897086",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk-extension-autoconfigure",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "82114fa0fce937e5e96d06bfc4f036b9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ac9a1bd070ad1cc264d9e429bb7070020dae5168"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "14254c1da7065e08a626f7846e718704a242c18154194eeb4257fed3f09a6c1f"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-extension-autoconfigure-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-extension-autoconfigure-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ac9a1bd070ad1cc264d9e429bb7070020dae5168"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897158",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk-extension-autoconfigure-spi",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "57d161ec62e4a910fdf3b8ecbdca6120"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c1fa08f788e3576ddae8533897e7a68366b5546d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fa787c0203949e8dca613ac5bcd88e8186eabd59d30d88bb4a302bb21f0bdc3f"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-extension-autoconfigure-spi-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-extension-autoconfigure-spi-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c1fa08f788e3576ddae8533897e7a68366b5546d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897125",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk-logs",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6bc0a6924b321dae476234c3097f684f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1b2913fc9295b6ef11d22fdac4c03d0a0100bfa7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e0239e938201a04ab85ebca824a0f66bb5a63ab1f70350427c566f0619ea9c90"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-logs-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-logs-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "1b2913fc9295b6ef11d22fdac4c03d0a0100bfa7"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897147",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk-metrics",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "55bf83bac58ea19bc8fd737c23517fed"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d19285a43369a29cb7cc6c1206ed54e65cad666c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5d270dcead76b47cdd98e9bad15c5fc34b5e7163df0cc972f49483c8fda3fc79"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-metrics-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-metrics-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d19285a43369a29cb7cc6c1206ed54e65cad666c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897106",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk-trace",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "321deec9610688249804ca947bc61418"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e208fba515941eb3f90241dea76ae79dd77e33fe"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "227120f953c075702c8601afaf798b38d6eb2035671db5eb4176b5bd2327b6b9"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-trace-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-trace-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e208fba515941eb3f90241dea76ae79dd77e33fe"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897047",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "p11-kit",
+      "purl": "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64",
+      "version": "0.25.3-3.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3af459e136c2ab22bad5a3577540eae19c51e96c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#3af459e136c2ab22bad5a3577540eae19c51e96c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3361662",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#3af459e136c2ab22bad5a3577540eae19c51e96c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "p11-kit-trust",
+      "purl": "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64",
+      "version": "0.25.3-3.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3af459e136c2ab22bad5a3577540eae19c51e96c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#3af459e136c2ab22bad5a3577540eae19c51e96c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3361662",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#3af459e136c2ab22bad5a3577540eae19c51e96c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre",
+      "purl": "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64",
+      "version": "8.44-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d94c9b77e3a4ea15a6f946ef3c050bc09f6742a0",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre#d94c9b77e3a4ea15a6f946ef3c050bc09f6742a0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3009164",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre#d94c9b77e3a4ea15a6f946ef3c050bc09f6742a0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre2",
+      "purl": "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64",
+      "version": "10.40-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e9e4f078efd0299ed2dbda1c777a7c65f658",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#0715e9e4f078efd0299ed2dbda1c777a7c65f658"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3200608",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#0715e9e4f078efd0299ed2dbda1c777a7c65f658",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre2-syntax",
+      "purl": "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch",
+      "version": "10.40-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e9e4f078efd0299ed2dbda1c777a7c65f658",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#0715e9e4f078efd0299ed2dbda1c777a7c65f658"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3200608",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#0715e9e4f078efd0299ed2dbda1c777a7c65f658",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "popt",
+      "purl": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "version": "1.18-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+            "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691597",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "procps-ng",
+      "purl": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+      "version": "3.3.17-14.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "277f9aaff8edd7603ea88dfe5e42cbb2d229a76f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/procps-ng#277f9aaff8edd7603ea88dfe5e42cbb2d229a76f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2865070",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/procps-ng#277f9aaff8edd7603ea88dfe5e42cbb2d229a76f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "protostream",
+      "purl": "pkg:maven/org.infinispan.protostream/protostream@5.0.14.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.infinispan.protostream",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7e2feb510b5fbe1b4ed4b234bc829958"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "fefe468705bf1c2ff180169fac3e18350d4ae740"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5087f67250376e1199e512efdc562c30a9ac6b0b5c0955684beeba516ed71339"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan.protostream/protostream@5.0.14.Final-redhat-00002?type=jar",
+      "version": "5.0.14.Final-redhat-00002",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "04ff1c343f4cefc1e81e2af45ebd6dcc2d487818",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/protostream.git#5.0.14.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/protostream-5.0.14.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/protostream-5.0.14.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "fefe468705bf1c2ff180169fac3e18350d4ae740"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277114",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.2-13-mx7.4.1-mvn3.9.6-protobuf:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "protostream-types",
+      "purl": "pkg:maven/org.infinispan.protostream/protostream-types@5.0.14.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.infinispan.protostream",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6fde908b02566e3b10c0d4de092761a4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "549d53949825303f7c73cbd14b70a29c653710d3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f70a37d2b7d5dfbebb90612009adf4b04a5379219d7c01cc66f82a6db4aa79b7"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan.protostream/protostream-types@5.0.14.Final-redhat-00002?type=jar",
+      "version": "5.0.14.Final-redhat-00002",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "04ff1c343f4cefc1e81e2af45ebd6dcc2d487818",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/protostream.git#5.0.14.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/protostream-types-5.0.14.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/protostream-types-5.0.14.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "549d53949825303f7c73cbd14b70a29c653710d3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277140",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.2-13-mx7.4.1-mvn3.9.6-protobuf:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "psmisc",
+      "purl": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+      "version": "23.4-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4bb81408b08c44d02985b6af55bbd75260c6b3ed",
+            "url": "git://pkgs.devel.redhat.com/rpms/psmisc#4bb81408b08c44d02985b6af55bbd75260c6b3ed"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691630",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/psmisc#4bb81408b08c44d02985b6af55bbd75260c6b3ed",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3",
+      "purl": "pkg:rpm/redhat/python3@3.9.23-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3@3.9.23-2.el9?arch=x86_64",
+      "version": "3.9.23-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2ffb5a9419c33bffe2ccfba99b52085def7780c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2ffb5a9419c33bffe2ccfba99b52085def7780c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3810287",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2ffb5a9419c33bffe2ccfba99b52085def7780c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libs",
+      "purl": "pkg:rpm/redhat/python3-libs@3.9.23-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libs@3.9.23-2.el9?arch=x86_64",
+      "version": "3.9.23-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2ffb5a9419c33bffe2ccfba99b52085def7780c1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2ffb5a9419c33bffe2ccfba99b52085def7780c1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3810287",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#2ffb5a9419c33bffe2ccfba99b52085def7780c1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-pip-wheel",
+      "purl": "pkg:rpm/redhat/python3-pip-wheel@21.3.1-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pip-wheel@21.3.1-1.el9?arch=noarch",
+      "version": "21.3.1-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "26ebeb19b2a1b18c017935ddb5d83aa7e287dee9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#26ebeb19b2a1b18c017935ddb5d83aa7e287dee9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2974574",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#26ebeb19b2a1b18c017935ddb5d83aa7e287dee9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-setuptools-wheel",
+      "purl": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-15.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-15.el9?arch=noarch",
+      "version": "53.0.0-15.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and (BSD or ASL 2.0)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "959443984fae7aaa553cbc9b6011935de3ad0540",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#959443984fae7aaa553cbc9b6011935de3ad0540"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3702626",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#959443984fae7aaa553cbc9b6011935de3ad0540",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "reactive-streams",
+      "purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.4.redhat-00004?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9381c32c1d4745f9035c2cf9d0a83ff7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b1381212d6a040fd785014972e327af5dad39c7d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "75ab47d00be4dfc81fca99675de881abf76db1034ef926bd4c162dafa7a3fd8a"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.4.redhat-00004?type=jar",
+      "version": "1.0.4.redhat-00004",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b7a6b624adf4dc03a8c3d4d0acc771209d4f8f5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/reactive-streams/reactive-streams-jvm.git#1.0.4.redhat-00004"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/reactive-streams-1.0.4.redhat-00004.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/reactive-streams-1.0.4.redhat-00004.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b1381212d6a040fd785014972e327af5dad39c7d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347260",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGQDLWKMKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.6.0-gradle5.6.2:1.0.9",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/reactive-streams/reactive-streams-jvm.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "reactor-core",
+      "purl": "pkg:maven/io.projectreactor/reactor-core@3.6.6.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "95d34c69cd5c5322b03a26f9e43d733c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e2ca11478777b6a48327f84182bf4aa77f86b7ca"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "cccf053c2a9c883c7c02b747c41f7183dc565ec7697ee0a0e97c92b412f2ec4a"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.projectreactor/reactor-core@3.6.6.redhat-00001?type=jar",
+      "version": "3.6.6.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e0d7284c9dc6fa17905c1564df7af3dc3a3e63ed",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/reactor/reactor-core.git#3.6.6.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/reactor-core-3.6.6.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/reactor-core-3.6.6.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e2ca11478777b6a48327f84182bf4aa77f86b7ca"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13396154",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFPLEZYESTQAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j8-oraclejdk9-j11-j17-j21-mvn3.8.6-gradle8.5:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/reactor/reactor-core.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "readline",
+      "purl": "pkg:maven/org.aesh/readline@2.6.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.aesh",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e01ea83d38f320a2938b3f50eebe3309"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4ff63a5a560347142f3dca1a2ea9e0fd825b47d8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6a53971e15ba50aa59e46f3301090a256c405889921b17c241510afda30c9b14"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.aesh/readline@2.6.0.redhat-00001?type=jar",
+      "version": "2.6.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.apache.org/licenses/LICENSE-2.0",
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe8fb39a4dcf5d9a0d00c8afa1202f6b8c4b09f0",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/aeshell/aesh-readline.git#2.6.0.redhat-00001"
+          },
+          {
+            "uid": "d89da56200c476df7e7a6d9cd2edc036ef251399",
+            "url": "https://github.com/aeshell/aesh-readline#2.6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/readline-2.6.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/readline-2.6.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4ff63a5a560347142f3dca1a2ea9e0fd825b47d8"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12914520",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2NCQULNVAAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/aeshell/aesh-readline",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "readline",
+      "purl": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "version": "8.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be386f45be1322adf2bd79dd94c9904c4efa3d22",
+            "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691921",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "redhat-release",
+      "purl": "pkg:rpm/redhat/redhat-release@9.7-0.7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/redhat-release@9.7-0.7.el9?arch=x86_64",
+      "version": "9.7-0.7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d9b73610b6a4f10c3a24094463dd02af093c6d2d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#d9b73610b6a4f10c3a24094463dd02af093c6d2d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3871427",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#d9b73610b6a4f10c3a24094463dd02af093c6d2d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rootfiles",
+      "purl": "pkg:rpm/redhat/rootfiles@8.1-35.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rootfiles@8.1-35.el9?arch=noarch",
+      "version": "8.1-35.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "806bfbf2f1d1311e7bcf64ce074f16aef3160a40",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rootfiles#806bfbf2f1d1311e7bcf64ce074f16aef3160a40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3664307",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rootfiles#806bfbf2f1d1311e7bcf64ce074f16aef3160a40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:rpm/redhat/rpm@4.16.1.3-39.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm@4.16.1.3-39.el9?arch=x86_64",
+      "version": "4.16.1.3-39.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f9df24167a44cd21d66f39b528971fe7fcad36f5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#f9df24167a44cd21d66f39b528971fe7fcad36f5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3812521",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#f9df24167a44cd21d66f39b528971fe7fcad36f5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm-libs",
+      "purl": "pkg:rpm/redhat/rpm-libs@4.16.1.3-39.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-39.el9?arch=x86_64",
+      "version": "4.16.1.3-39.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f9df24167a44cd21d66f39b528971fe7fcad36f5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#f9df24167a44cd21d66f39b528971fe7fcad36f5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3812521",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#f9df24167a44cd21d66f39b528971fe7fcad36f5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rsync",
+      "purl": "pkg:rpm/redhat/rsync@3.2.5-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rsync@3.2.5-3.el9?arch=x86_64",
+      "version": "3.2.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7b368221c0e4ef50115cba7ccbbf5c00395151bf",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rsync#7b368221c0e4ef50115cba7ccbbf5c00395151bf"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3495179",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rsync#7b368221c0e4ef50115cba7ccbbf5c00395151bf",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtimes-java-api",
+      "purl": "pkg:maven/com.redhat.insights/runtimes-java-api@2.0.4.redhat-00003?type=jar",
+      "type": "library",
+      "group": "com.redhat.insights",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4a46b6b8023fe43fb67aac4682d70b09"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d2484f042607f75b3f2e20739c86ca4012fe652d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "92cc5f46095f2b6c55bb54bc7ea9292aa69ee4199b1947f3c3ed4db26e496a28"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.redhat.insights/runtimes-java-api@2.0.4.redhat-00003?type=jar",
+      "version": "2.0.4.redhat-00003",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "92747c701c13608adca5e6eb61e606ef1741d591",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/RedHatInsights/insights-ingress-java.git#2.0.4.redhat-00003"
+          },
+          {
+            "uid": "a5bd420016a21d545887b114c8a092d24f65e5cf",
+            "url": "https://github.com/RedHatInsights/insights-java-client.git#2.0.4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/runtimes-java-api-2.0.4.redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/runtimes-java-api-2.0.4.redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d2484f042607f75b3f2e20739c86ca4012fe652d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14082362",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BIRQ6NFD5OIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.6.3-golang1.24-gcc-make:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/RedHatInsights/insights-java-client.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtimes-java-core-runtime",
+      "purl": "pkg:maven/com.redhat.insights/runtimes-java-core-runtime@2.0.4.redhat-00003?type=jar",
+      "type": "library",
+      "group": "com.redhat.insights",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7e23e6d55e7732671d8b35d1224ee328"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "810406a363fc3baf0b01b8d3384fd8cb6099571f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "89b09e7d66503ffae5503369ac6ec555998187bce1ff5c6dd6b7f9431a213117"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.redhat.insights/runtimes-java-core-runtime@2.0.4.redhat-00003?type=jar",
+      "version": "2.0.4.redhat-00003",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "92747c701c13608adca5e6eb61e606ef1741d591",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/RedHatInsights/insights-ingress-java.git#2.0.4.redhat-00003"
+          },
+          {
+            "uid": "a5bd420016a21d545887b114c8a092d24f65e5cf",
+            "url": "https://github.com/RedHatInsights/insights-java-client.git#2.0.4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/runtimes-java-core-runtime-2.0.4.redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/runtimes-java-core-runtime-2.0.4.redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "810406a363fc3baf0b01b8d3384fd8cb6099571f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14082353",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BIRQ6NFD5OIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.6.3-golang1.24-gcc-make:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/RedHatInsights/insights-java-client.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rxjava",
+      "purl": "pkg:maven/io.reactivex.rxjava3/rxjava@3.1.10.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6e8e73ae153f7f6329fb95f12ce67987"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ac90da1798d2b98c7b98e8a5d4eb7a8075206210"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "78e0f778927cada89eedc51a7cc9282420b98b139dc3c736e47d4bdd7d6908cb"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.reactivex.rxjava3/rxjava@3.1.10.redhat-00001?type=jar",
+      "version": "3.1.10.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "045b1123ed7327c870e7667e3e1b059b5d5ad2b9",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/ReactiveX/RxJava.git#3.1.10.redhat-00001"
+          },
+          {
+            "uid": "ede5cfcb41a6a1c8f955d77d80883d5d08e843d9",
+            "url": "https://github.com/ReactiveX/RxJava.git#ede5cfcb41a6a1c8f955d77d80883d5d08e843d9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/rxjava-3.1.10.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/rxjava-3.1.10.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ac90da1798d2b98c7b98e8a5d4eb7a8075206210"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387911",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNRQZJP4KYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-gradle7.1.1:1.0.6",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/ReactiveX/RxJava.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sed",
+      "purl": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "version": "4.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dad14ff8a62e967c0afb23d1d237a927d847e86e",
+            "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1692031",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "setup",
+      "purl": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "version": "2.13.7-10.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2892761",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "shadow-utils",
+      "purl": "pkg:rpm/redhat/shadow-utils@4.9-15.el9?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/shadow-utils@4.9-15.el9?arch=x86_64&epoch=2",
+      "version": "2:4.9-15.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "34fb76751d88d6d9ae98cda57f96e8ff4dc03462",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#34fb76751d88d6d9ae98cda57f96e8ff4dc03462"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3786692",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#34fb76751d88d6d9ae98cda57f96e8ff4dc03462",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "simpleclient",
+      "purl": "pkg:maven/io.prometheus/simpleclient@0.16.0.redhat-00008?type=jar",
+      "type": "library",
+      "group": "io.prometheus",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7428be73e58996a7719f6bb97dfb6723"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "98d7d29199dd01d91093e49b109ed7cb1341d7f6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "16f467422ae4a4ba7b93391403afff75470bc2c4340bd00f2b4e3731ca10ccac"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.prometheus/simpleclient@0.16.0.redhat-00008?type=jar",
+      "version": "0.16.0.redhat-00008",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "51dec6cef4f589cca814f01311bc68c48f36967a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/prometheus/client_java.git#0.16.0.redhat-00008"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/simpleclient-0.16.0.redhat-00008.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/simpleclient-0.16.0.redhat-00008.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "98d7d29199dd01d91093e49b109ed7cb1341d7f6"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12916225",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2OOYGAVVAAG",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.5.4:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/prometheus/client_java",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "simpleclient_common",
+      "purl": "pkg:maven/io.prometheus/simpleclient_common@0.16.0.redhat-00008?type=jar",
+      "type": "library",
+      "group": "io.prometheus",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fef0f5d24854fe0a02cd6d36bf48d97a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e0082e1f10104d2e8bf35a4ba9c7fab0f4caf49a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1d8340db9309cf93bfd12fd7540a96799228eae074057a04511f20767fcfff08"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.prometheus/simpleclient_common@0.16.0.redhat-00008?type=jar",
+      "version": "0.16.0.redhat-00008",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "51dec6cef4f589cca814f01311bc68c48f36967a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/prometheus/client_java.git#0.16.0.redhat-00008"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/simpleclient_common-0.16.0.redhat-00008.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/simpleclient_common-0.16.0.redhat-00008.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e0082e1f10104d2e8bf35a4ba9c7fab0f4caf49a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12916254",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2OOYGAVVAAG",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.5.4:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/prometheus/client_java",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "slf4j-api",
+      "purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36.redhat-00006?type=jar",
+      "type": "library",
+      "group": "org.slf4j",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "96780a43780c7268766ef6c3cf4dc5fb"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "cd74b2274c8e3146e2556430457f03aedc7ee2b6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "abaca57d174773370259c895b3eb7a594a088ced26ea4b34d4e349e6bdca1d61"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36.redhat-00006?type=jar",
+      "version": "1.7.36.redhat-00006",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f546d43ad1473d507b8f33053cf9a54abda42c77",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/slf4j.git#1.7.36.redhat-00006"
+          },
+          {
+            "uid": "e9ee55cca93c2bf26f14482a9bdf961c750d2a56",
+            "url": "https://github.com/qos-ch/slf4j#v_1.7.36"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/slf4j-api-1.7.36.redhat-00006.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/slf4j-api-1.7.36.redhat-00006.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "cd74b2274c8e3146e2556430457f03aedc7ee2b6"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12150223",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7ENB5XMSDYA2",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.5.4-golang:1.0.6",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/qos-ch/slf4j",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sqlite-libs",
+      "purl": "pkg:rpm/redhat/sqlite-libs@3.34.1-9.el9_7?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-9.el9_7?arch=x86_64",
+      "version": "3.34.1-9.el9_7",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "090d0a726f7ce2fcbb25be0f7e96b70378250808",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#090d0a726f7ce2fcbb25be0f7e96b70378250808"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3821376",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#090d0a726f7ce2fcbb25be0f7e96b70378250808",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sshd-common",
+      "purl": "pkg:maven/org.apache.sshd/sshd-common@2.12.1.redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.apache.sshd",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2874a4b71bd7ca2c9dee5f5f952120cf"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "27ce043019b9b8638d43137dc585679adf08e762"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5d366b05fabd148ccd87540dd3eacb7fde9c2485bd89cc5f2b5daed4ae8aa7fe"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.sshd/sshd-common@2.12.1.redhat-00002?type=jar",
+      "version": "2.12.1.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "263e8ad06b4119bd77c0f2ab7590f27b56765167",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/mina-sshd.git#2.12.1.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/sshd-common-2.12.1.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/sshd-common-2.12.1.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "27ce043019b9b8638d43137dc585679adf08e762"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12432365",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BAC67Y6YUFIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/mina-sshd.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "systemd-libs",
+      "purl": "pkg:rpm/redhat/systemd-libs@252-55.el9_7.7?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-libs@252-55.el9_7.7?arch=x86_64",
+      "version": "252-55.el9_7.7",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7a54b41392bf0d6d1897d7baa9a83552b9d5cd6d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#7a54b41392bf0d6d1897d7baa9a83552b9d5cd6d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3902740",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#7a54b41392bf0d6d1897d7baa9a83552b9d5cd6d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tar",
+      "purl": "pkg:rpm/redhat/tar@1.34-7.el9?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tar@1.34-7.el9?arch=x86_64&epoch=2",
+      "version": "2:1.34-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d1fc43344a7008a811f51ede55eb29b53a45553e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tar#d1fc43344a7008a811f51ede55eb29b53a45553e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3229093",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tar#d1fc43344a7008a811f51ede55eb29b53a45553e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "terminal-api",
+      "purl": "pkg:maven/org.aesh/terminal-api@2.6.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.aesh",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fe8cdcc397b20a0e65df9dfa7ab71ed2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c2a69338315b20eb68a1d56a96faa5c55090eae9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0580e486cc441e29adb21e597c1f2120ba2664105e2b6a6b32e9900bf93127cd"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.aesh/terminal-api@2.6.0.redhat-00001?type=jar",
+      "version": "2.6.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.apache.org/licenses/LICENSE-2.0",
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe8fb39a4dcf5d9a0d00c8afa1202f6b8c4b09f0",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/aeshell/aesh-readline.git#2.6.0.redhat-00001"
+          },
+          {
+            "uid": "d89da56200c476df7e7a6d9cd2edc036ef251399",
+            "url": "https://github.com/aeshell/aesh-readline#2.6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/readline-2.6.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/readline-2.6.0.redhat-00001.jar:org.aesh:terminal-api"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12914516",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2NCQULNVAAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/aeshell/aesh-readline",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tzdata",
+      "purl": "pkg:rpm/redhat/tzdata@2025b-2.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata@2025b-2.el9?arch=noarch",
+      "version": "2025b-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "98ef567e656a781e87b66609d1bb1d6da553d12d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#98ef567e656a781e87b66609d1bb1d6da553d12d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3789195",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#98ef567e656a781e87b66609d1bb1d6da553d12d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tzdata-java",
+      "purl": "pkg:rpm/redhat/tzdata-java@2025b-2.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata-java@2025b-2.el9?arch=noarch",
+      "version": "2025b-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "98ef567e656a781e87b66609d1bb1d6da553d12d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#98ef567e656a781e87b66609d1bb1d6da553d12d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3789195",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#98ef567e656a781e87b66609d1bb1d6da553d12d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "unzip",
+      "purl": "pkg:rpm/redhat/unzip@6.0-59.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/unzip@6.0-59.el9?arch=x86_64",
+      "version": "6.0-59.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4ae2cd013e67e5b2ce54ea0cc79b16e652f1223a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/unzip#4ae2cd013e67e5b2ce54ea0cc79b16e652f1223a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3689766",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/unzip#4ae2cd013e67e5b2ce54ea0cc79b16e652f1223a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vim-minimal",
+      "purl": "pkg:rpm/redhat/vim-minimal@8.2.2637-23.el9_7?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/vim-minimal@8.2.2637-23.el9_7?arch=x86_64&epoch=2",
+      "version": "2:8.2.2637-23.el9_7",
+      "licenses": [
+        {
+          "license": {
+            "name": "Vim and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7e98f6e9ae9ba912ddba3c0c12037fd8660d1848",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/vim#7e98f6e9ae9ba912ddba3c0c12037fd8660d1848"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3844189",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/vim#7e98f6e9ae9ba912ddba3c0c12037fd8660d1848",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-common",
+      "purl": "pkg:maven/org.wildfly.common/wildfly-common@1.7.0.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "org.wildfly.common",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c62dc6e82c0ae461653301a4537d6709"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c636a5e7a438be8aef34a5c413879ff0a1775bc1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2a9dcdbac5641ea1270a46d12001da7d901dbfea11680bcedc1ec2a8e967f3bd"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.7.0.Final-redhat-00003?type=jar",
+      "version": "1.7.0.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://repository.jboss.org/licenses/apache-2.0.txt",
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "18b12a8c82c4b1732a7d839b45d9f497b4686364",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly/wildfly-common.git#1.7.0.Final-redhat-00003"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-common-1.7.0.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-common-1.7.0.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c636a5e7a438be8aef34a5c413879ff0a1775bc1"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12039522",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A633354X2DYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.3.9:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly/wildfly-common.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-asn1",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-asn1@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "96369aecdf04dc59f7e5309cb4e5288b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "460156081c3192dd532fc07cb1eba058bb195d05"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a858d05badf45631e11a89aa7c76196d8d03c2274f546258f8b7f23ad4a29ed8"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-asn1@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-asn1-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-asn1-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "460156081c3192dd532fc07cb1eba058bb195d05"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618370",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-auth",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-auth@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c685aae9caf845212c5f996baf3e1d8c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f55436cc90c95718ce2cd24f6e745ef41a6ad113"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "094179c0ecc646fad23450591fab5c44960d5f48ab3ff1d6967d27953add84b3"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f55436cc90c95718ce2cd24f6e745ef41a6ad113"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618319",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-auth-server",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "52f12bc9704c0923d073372763ae6f28"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bb262ae99e55d345d34a698b3bbade1b4431607c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "81abac6c99a1fca2ca01447f586131061c758b955078030f66ca60fc8231d59d"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-server-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-server-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bb262ae99e55d345d34a698b3bbade1b4431607c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618241",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-auth-server-http",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-http@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "41f6404d97944b33a5ba99154c1d1613"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "75bab52581df4c45f5495fc3ec80a0853bf4616c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1c89999c737a69ac362051b2f479465d688fa0426223508737d6e99724212717"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-http@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-server-http-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-server-http-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "75bab52581df4c45f5495fc3ec80a0853bf4616c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618272",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-auth-server-sasl",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-sasl@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a4314c30daa3a0f1b8b144bbbbb54261"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b5534ab52256e81a018068c004ae914217db4a83"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "859e527ea906a929d94d193c7a91a56deb49540f25608e96bd7107cf64e70c26"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-sasl@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-server-sasl-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-server-sasl-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b5534ab52256e81a018068c004ae914217db4a83"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618269",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-auth-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c6e51179f09e5faa829d981f0a36ba11"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "04a08640149cab3018aa1518211a043b3366a7e3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7d2d9d99fbfceb42f6fcb7d9477ab2a8cc78f92b67da1c16eb580c2d587eea87"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "04a08640149cab3018aa1518211a043b3366a7e3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618353",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-base",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-base@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7c6e94cddef9f99e54eba8b755c0d0e4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c169c31e8969450a626609c3db7b64a427513b69"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "81872ede4ef02e1451093fd722ff58a3f14e14c13f55d1dacaeb2a5a024062ff"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-base@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-base-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-base-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c169c31e8969450a626609c3db7b64a427513b69"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618247",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-client",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-client@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5dbd26fda83578f5f9a31dee3c7e4017"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6b14bd65ae9351e56f923350d91f998eee1abdff"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "03f589ec85adf8c072b9e1751497d8db86cc21908afcb567e37b05d8e08cd6e0"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-client@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-client-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-client-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6b14bd65ae9351e56f923350d91f998eee1abdff"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618342",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-credential",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-credential@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "45e2646a21bbb6b86ad09f3ff23ed880"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c42df2b02b80a66da8199effef861b40083e484b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "095cd3b91196d6b46b176a51926386ea8931b452e458815811adcfe4d78594f5"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-credential@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-credential-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-credential-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c42df2b02b80a66da8199effef861b40083e484b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618303",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-credential-source-impl",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-credential-source-impl@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "08185b55de0a855651af87d514da49b2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3a915baf765ada14d1a8893e756adb6019335ab4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e12ec075ac4794cff9243fb152b092d41529bad0fd2364435ee18beb4dba1a20"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-credential-source-impl@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-credential-source-impl-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-credential-source-impl-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3a915baf765ada14d1a8893e756adb6019335ab4"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618307",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-credential-store",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-credential-store@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3b2e03d6fd2f275bfa20bae4574e8178"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4de7a708428fff5c9def1ece1ace1e2cb504c077"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "982d3cf62d3f752015f38fa870610c8c29dd74d2220fc69e6a1dd638e624470f"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-credential-store@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-credential-store-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-credential-store-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4de7a708428fff5c9def1ece1ace1e2cb504c077"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618372",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-encryption",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-encryption@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b7cc643183225ecc838a8df68df4f97d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a658367c435f956a18aff516a331a2959209d772"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8a46cb43361fda428e084cb2c1071c5fbdfefb490d65fbe506440fe80b64b756"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-encryption@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-encryption-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-encryption-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a658367c435f956a18aff516a331a2959209d772"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618234",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ca2c27d967580e6c671c0a4ba11dc9f6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bee48ec4084759995ece7d0646240d123d70949f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5170d71e3142d88a9a90614cfb9788223e03fc5611a4c109ae4b96caba576942"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bee48ec4084759995ece7d0646240d123d70949f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618323",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http-basic",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http-basic@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5cf2962c0f4cb9b2e31daeeb23f529e3"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2b42b478eca79537402bc1e8620dad1e88683936"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "711015920b9d2a1b40b60df193526e66e691bc97dedd2bf61cff769cceac4878"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-basic@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-basic-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-basic-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "2b42b478eca79537402bc1e8620dad1e88683936"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618202",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http-bearer",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http-bearer@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "0097ed106a830a54603d15f9ef90aa6a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "70159b3ee7825840a040feb36872d9923b11ca49"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "91c1b789a2b31aebb24bab3cb888a09587695b3c65724a2a38169871d318349c"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-bearer@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-bearer-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-bearer-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "70159b3ee7825840a040feb36872d9923b11ca49"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618332",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http-cert",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http-cert@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f92978d644569ae85fa3541b8c070776"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "28738814c89177cfd18a9163f0d298b82e4da22d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "793de567005c93ff9155e81d2d3d70929e424a30791ee2422d670331cb88079a"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-cert@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-cert-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-cert-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "28738814c89177cfd18a9163f0d298b82e4da22d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618258",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http-digest",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http-digest@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "113b2a9aa0bf5ee51e944124fd4d6e07"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "da9355061a9c01b3b620b45f15cc9e744659f449"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f3393297314c3234111f3a859da5a4474c1579d01fb7b20d328a9aa89fee50c3"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-digest@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-digest-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-digest-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "da9355061a9c01b3b620b45f15cc9e744659f449"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618320",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http-spnego",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http-spnego@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "228306ab78b2595415c2a12f81f1bfea"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0b4916479a9c50f7b644f51d8b57f22a5a981915"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "45287683428163aeadd7cfa139f97ee24e52a7ac5fdb444eafefcbe5e400954c"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-spnego@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-spnego-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-spnego-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0b4916479a9c50f7b644f51d8b57f22a5a981915"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618193",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "cfade8fc269b979139fcb7e927b91c31"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "816baa1f07629b2d3be4839b88a603f115e84a6b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2fe2eb4796a8ce1fef3cc656c91789e36a015387d2e6fd4f733c8877ec4235e8"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "816baa1f07629b2d3be4839b88a603f115e84a6b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618349",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-json-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-json-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "069d99715e6d212d2358c27bc3b03a12"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8972acab24228787f17c3d8caad13f203d654caf"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "67a448bfb9e9a24367cbf62eb822949685f0ce717925a6af0a58c427f55c3528"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-json-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-json-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-json-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8972acab24228787f17c3d8caad13f203d654caf"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618294",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-keystore",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-keystore@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "759bd0bcd0446ed5a6810612620289cf"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c765f370fe4d35afbfe5be796c50df4a7e87a9d3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4f58f66cf6376b3d703f013c864df7f939e1e70621ea4428d03aee5ec8625c8c"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-keystore@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-keystore-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-keystore-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c765f370fe4d35afbfe5be796c50df4a7e87a9d3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618219",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-mechanism",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "58af58f597bd5b39a14f6403bc10a540"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2c0731ed348c7c190628eac2a7a96f60d5b6ef6f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "da75eeef835dd043d293c6f89fcca7ec751bff2a5e0fbe8d042d96676284bdff"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "2c0731ed348c7c190628eac2a7a96f60d5b6ef6f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618375",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-mechanism-digest",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-digest@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e82e4f72943f6acd2c15d4aa8e70f080"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0e9a9cb881d5f9d46dc7acee15c9fe6850405d76"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "96b5ee288c68aec73499edc45c139e66170011ac43c217b718d0d2c53e5457fb"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-digest@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-digest-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-digest-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0e9a9cb881d5f9d46dc7acee15c9fe6850405d76"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618364",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-mechanism-gssapi",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-gssapi@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "850a147b69cd6efb434a604f4369d51a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c4633cd18bef70cbffa4e7f7a0a424f2dfc74aa5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e2c3d6bf3d61ed69b844ff5bb25857c0de9eca371e9d197838dc1dbf8386d41c"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-gssapi@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-gssapi-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-gssapi-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c4633cd18bef70cbffa4e7f7a0a424f2dfc74aa5"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618292",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-mechanism-http",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-http@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "19dd1d55adbc35504baa2844a1de8365"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "762554fa69ce52ec638ceadec66f38aff1fd9541"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1b4a6519abdc8f53f744e7481fe688d6b0d1915cd923734aaa115c7ec49617d6"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-http@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-http-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-http-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "762554fa69ce52ec638ceadec66f38aff1fd9541"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618180",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-mechanism-oauth2",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-oauth2@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9e67c0ae7cff4dc9281314ba85680330"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ec2ee86d249895338410a8285a574318982e91af"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "badfd30da511429734070fb84314a08264595d9b6f7e80ad0d2ee47cff5cf8e3"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-oauth2@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-oauth2-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-oauth2-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ec2ee86d249895338410a8285a574318982e91af"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618190",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-mechanism-scram",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-scram@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fb2d9c6dbb480b1a5f729e9695909979"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "aab196f4d2fcfc2f827242ced9377b4d217aaa79"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5d6ae2bd7f0dff50e0d2a1684a96404d58e6bf3d5a45b111e6c6340b89c6bcdf"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-scram@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-scram-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-scram-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "aab196f4d2fcfc2f827242ced9377b4d217aaa79"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618311",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-password-impl",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-password-impl@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f2f45aa277c8481a245d2cc3408beb20"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "59d601b527bd3134e444bd10b418c98d306e3f02"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "057130d737085286958b3c5661384061e4685a45e7c4b7160ce48b8245ea6be2"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-password-impl@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-password-impl-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-password-impl-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "59d601b527bd3134e444bd10b418c98d306e3f02"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618366",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-permission",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-permission@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "70c07bcff12a9ce2d26f4f284a9b4e0b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f18a2310c2054b0e179067a41bf7040da1a22a1f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bc650be1614c6005b1dd08d90fe570d0d56852a57b5a922cdd64f2a074cf2100"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-permission@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-permission-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-permission-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f18a2310c2054b0e179067a41bf7040da1a22a1f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618249",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-provider-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-provider-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f7cddaac5aa2f4e8050cddfa7d3230c3"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9946f45b86a15d9600a6d0784e4fe773b1750eb3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f36891fe8a297e5ed2d14d8aca91b567dfb5e32b375d1deb166ac5fd254eaf61"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-provider-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-provider-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-provider-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9946f45b86a15d9600a6d0784e4fe773b1750eb3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618244",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-realm",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-realm@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "debe0e7572ee20bc753a15a692dcc2ad"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a9fb5c8545e448832e41eb0f175af096491a9185"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bb5af01d91c959bdf70dd003c8a2afd162f785e088b97d7d8b73433b95cd44fa"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-realm@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-realm-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-realm-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a9fb5c8545e448832e41eb0f175af096491a9185"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618215",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-realm-ldap",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-realm-ldap@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "72f75d732b48a9773b45f22f6609766c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "38ccfc49e796008d34019863aed2f73036ffdb22"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "21e607c2cde3aa6f32321811037d0a1b35acc34bebce8f3cb46d2c48d94b94ca"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-realm-ldap@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-realm-ldap-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-realm-ldap-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "38ccfc49e796008d34019863aed2f73036ffdb22"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618340",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-realm-token",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-realm-token@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5500fbe4595b933ee4d2363f493a9779"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "120f1c05dd8578440ee0c0a4273d5b8a9de02cfa"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "84a0eec5e5b7ccc4c39dc3233a4180675aa67c9926718f70f0ea566a57a674dd"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-realm-token@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-realm-token-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-realm-token-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "120f1c05dd8578440ee0c0a4273d5b8a9de02cfa"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618324",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "129e85140ea6e19eb8520555dfecc69a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d7ee5c694dd651e9b669420684582eed8619a3e7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fb209eb3abc67e58414b5b34b093ee819adeff5b8d6d8d0842e46ad947f6c06d"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d7ee5c694dd651e9b669420684582eed8619a3e7"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618344",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-digest",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-digest@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "650c2e2f74eeb6374fb8a4dc7624f981"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8ab7488868a1f74cb37085e82d64a8ccce3bf2a7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "724109cc240468ee202b6df6c315e7f3348aff48e19af15b71c825cd7cdfbefb"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-digest@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-digest-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-digest-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8ab7488868a1f74cb37085e82d64a8ccce3bf2a7"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618228",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-external",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-external@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d1941f9517c34bbfd91dea867ad06c6a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "109dedc0135514454e137c08a84f56bf4d1c8eee"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e8e44d7673731d14c8eb2cd4356b373f0eb23a85aaaff8140e1ac30641ad643b"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-external@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-external-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-external-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "109dedc0135514454e137c08a84f56bf4d1c8eee"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618198",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-gs2",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gs2@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "192f09436e0e6c384bdd34899354de56"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b0906db9cc5d029f9dca8fe93efad2623d14b94d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3f0534121fd708c8d6c8d91b2ef55f1a3b824b53b2b559495b2df11e6f11992a"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gs2@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-gs2-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-gs2-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b0906db9cc5d029f9dca8fe93efad2623d14b94d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618367",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-gssapi",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gssapi@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "db99a6bc75959418b4b362859806bb90"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7a5b4287ded4d7896fa24fd13ffce55f9b6d12dc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ab846ddbda2bdb5271acfabec42f3c56831e686394156eba039e7b0771cb5271"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gssapi@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-gssapi-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-gssapi-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "7a5b4287ded4d7896fa24fd13ffce55f9b6d12dc"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618276",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-localuser",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-localuser@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d40e2b7922f5f848f72843eecaaf2013"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "783f2a9ce3ae94b7ea4314ddfecef6da0e9a03fc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d41d9f3cbdfab0d83aed5fc6d99e025750d8d1cc6e50386a81ff8374952e91be"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-localuser@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-localuser-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-localuser-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "783f2a9ce3ae94b7ea4314ddfecef6da0e9a03fc"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618274",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-oauth2",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-oauth2@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "aebb194e4c7c00d37795517230ce6e87"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f1446be8d12c24b0eaf20b5ddb1e45976a1ad5a8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "302b4fe033f68c4fd4110b9d02a25266961ec88a6c3201bc0d8a29b29a955e9f"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-oauth2@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-oauth2-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-oauth2-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f1446be8d12c24b0eaf20b5ddb1e45976a1ad5a8"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618226",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-plain",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-plain@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "36df3169cb785fdea343eafe006729d1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f1a706d28c5ac41fc260066cb6f8ed19f812acb5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "86efa43d82a13e653a8d3000c7a0a7a24b0c654951f7c129d474edb944ae5061"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-plain@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-plain-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-plain-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f1a706d28c5ac41fc260066cb6f8ed19f812acb5"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618369",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-scram",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-scram@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a9acde591e81e0d72d7ddc38f91120c7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9ee449c9a64edbd2230f3aa0f3684d555389b15d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d307b83ea3d244ffd263ed24b854cae91431d5c4500907416e314591e0e2c724"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-scram@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-scram-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-scram-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9ee449c9a64edbd2230f3aa0f3684d555389b15d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618388",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-security-manager-action",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-security-manager-action@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fe5e3c1d9d88c8c84fe8ebbc4ce49bcc"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "30fe49791b2830e448cc4ef318cfc092e409d7fa"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b6cf001f282d6ffa6b9c6ddc987576a1201b94e5065d84efbea977d8058fb7dc"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-security-manager-action@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-security-manager-action-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-security-manager-action-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "30fe49791b2830e448cc4ef318cfc092e409d7fa"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618300",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-ssh-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-ssh-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "96e8673522f7d20abd3d41abfda42c08"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "434ceff3f904bccf1109e13527dacfd818cf818b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "63b60586599c0e3c828f744ce33912e88572fdfb4f0dd488dbbebe43b2996cbc"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-ssh-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-ssh-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-ssh-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "434ceff3f904bccf1109e13527dacfd818cf818b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618216",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-ssl",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-ssl@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ab7ba1e213d5957600db9d9df64ef6aa"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "dad49d1480e0e838598bdeaaaf8de39b091e04b4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b8cd93a623267c6dfae6a57cee2ce52aa109d189956fcb4e172e6cfd8ece33b4"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-ssl@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-ssl-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-ssl-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "dad49d1480e0e838598bdeaaaf8de39b091e04b4"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618248",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4623d3ecf9af4fe869f1b2b3e12cc280"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6016370030f27397fa6b1ecff79490079467eb6a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "14c392a161b3283758c9b776cbeea9cd6d00e08bf5f1250436d5d81c231d58d2"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6016370030f27397fa6b1ecff79490079467eb6a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618385",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-x500",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-x500@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a782576e8383c9c92c0629964327d97f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1bb36faa79e271b38d852468ac270e1b81867bf0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "27a9b6b97e63689a940eb02c4019f1ad5c62b25f0e4a5cbf1ed4a69e8361f2d5"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "1bb36faa79e271b38d852468ac270e1b81867bf0"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618204",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-x500-cert",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "31f34a159c5e77c2e80153e42afd974d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b22faf3e75e57f29f813287fde112f167cd3800a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d7186f5d4408a2b4ce8efc3df2c8b04c6030f469f23d80feb78615a0b06bf6dc"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-cert-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-cert-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b22faf3e75e57f29f813287fde112f167cd3800a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618310",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-x500-cert-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f3be416613f34734d69abec321005e2e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "859b41574ca0df4e48ee513332b2581ebc5b1b0d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5f4dc0e2f7b668bdf9f35b7c66c3b5ae8f564186ff983e15fcaa568de97025f3"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-cert-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-cert-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "859b41574ca0df4e48ee513332b2581ebc5b1b0d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618302",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-x500-principal",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-principal@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "447e6f1a530fdbc8f3ab0988f0bd8175"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "03681bd9be88efb63f621b2dfdf7a074756402a0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5746ea27d0f993abeaed51dd6fd2cdfdc4bd96f65c9fb0a400e8c08ac6c0f9a4"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-principal@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-principal-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-principal-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "03681bd9be88efb63f621b2dfdf7a074756402a0"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618236",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "xstream",
+      "purl": "pkg:maven/com.thoughtworks.xstream/xstream@1.4.21.redhat-00001?type=jar",
+      "type": "library",
+      "group": "com.thoughtworks.xstream",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "15a50df0644d5bcac35b0b7d0898f27a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0d8133682adaafa6e4ca73ac64cc6de19fb20064"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0b292f89725c6c65f0e53c551e9b9185c866220e6ce714a7c4ee09cec15ec5a4"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.thoughtworks.xstream/xstream@1.4.21.redhat-00001?type=jar",
+      "version": "1.4.21.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4f6d982c46261b8bc43abec294da2a018d25dcc3",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/x-stream/xstream.git#1.4.21.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/xstream-1.4.21.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/xstream-1.4.21.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0d8133682adaafa6e4ca73ac64cc6de19fb20064"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13161382",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BDYFFO2AWNQAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.6.3:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/x-stream/xstream.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "xz-libs",
+      "purl": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "version": "5.2.5-8.el9_0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+            "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2032531",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "zip",
+      "purl": "pkg:rpm/redhat/zip@3.0-35.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zip@3.0-35.el9?arch=x86_64",
+      "version": "3.0-35.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5985b742a23b7e3afe5d922f3f63713a892beec3",
+            "url": "git://pkgs.devel.redhat.com/rpms/zip#5985b742a23b7e3afe5d922f3f63713a892beec3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2377364",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zip#5985b742a23b7e3afe5d922f3f63713a892beec3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "zlib",
+      "purl": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "version": "1.2.11-40.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Boost"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+            "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2495976",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:oci/datagrid-8@sha256%3A6a28608358b7af404b1f6699cad8ff338a8cc763214ade7d4ce6b8aab6125ecd?arch=amd64&os=linux&tag=1.5-8.1764765711",
+      "dependsOn": [
+        "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12.redhat-00005?type=jar",
+        "pkg:maven/org.latencyutils/LatencyUtils@2.0.3.redhat-00005?type=jar",
+        "pkg:maven/org.aesh/aesh@2.8.4.redhat-00001?type=jar",
+        "pkg:maven/io.agroal/agroal-api@2.4.0.redhat-00001?type=jar",
+        "pkg:maven/io.agroal/agroal-pool@2.4.0.redhat-00001?type=jar",
+        "pkg:rpm/redhat/alsa-lib@1.2.14-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64",
+        "pkg:maven/org.antlr/antlr-runtime@3.5.3.redhat-00001?type=jar",
+        "pkg:rpm/redhat/audit-libs@3.1.5-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/avahi-libs@0.8-23.el9?arch=x86_64",
+        "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/bsdtar@3.5.3-6.el9_6?arch=x86_64",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+        "pkg:maven/com.github.ben-manes.caffeine/caffeine@3.1.8.redhat-00002?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.17.1.redhat-00001?type=jar",
+        "pkg:maven/org.apache.commons/commons-compress@1.27.1.redhat-00001?type=jar",
+        "pkg:maven/commons-io/commons-io@2.18.0.redhat-00001?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.18.0.redhat-00002?type=jar",
+        "pkg:maven/org.apache.commons/commons-math3@3.6.1.redhat-00003?type=jar",
+        "pkg:rpm/redhat/copy-jdk-configs@4.0-3.el9?arch=noarch",
+        "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64",
+        "pkg:rpm/redhat/crypto-policies@20250905-1.git377cc42.el9_7?arch=noarch",
+        "pkg:rpm/redhat/crypto-policies-scripts@20250905-1.git377cc42.el9_7?arch=noarch",
+        "pkg:rpm/redhat/cups-libs@2.3.3op2-34.el9_7?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/curl-minimal@7.76.1-34.el9?arch=x86_64",
+        "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-22.el9?arch=x86_64",
+        "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+        "pkg:rpm/redhat/dnf-data@4.14.0-31.el9?arch=noarch",
+        "pkg:rpm/redhat/elfutils-libelf@0.193-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/expat@2.5.0-5.el9_7.1?arch=x86_64",
+        "pkg:rpm/redhat/file@5.39-16.el9?arch=x86_64",
+        "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+        "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/findutils@4.8.0-7.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+        "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/glib2@2.68.4-18.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/glibc@2.34-231.el9_7.2?arch=x86_64",
+        "pkg:rpm/redhat/glibc-common@2.34-231.el9_7.2?arch=x86_64",
+        "pkg:rpm/redhat/glibc-minimal-langpack@2.34-231.el9_7.2?arch=x86_64",
+        "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/gnutls@3.8.3-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+        "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+        "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+        "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+        "pkg:maven/org.hibernate.common/hibernate-commons-annotations@6.0.6.Final-redhat-00001?type=jar",
+        "pkg:maven/org.hibernate.search/hibernate-search-backend-lucene@7.1.2.Final-redhat-00002?type=jar",
+        "pkg:maven/org.hibernate.search/hibernate-search-engine@7.1.2.Final-redhat-00002?type=jar",
+        "pkg:maven/org.hibernate.search/hibernate-search-mapper-pojo-base@7.1.2.Final-redhat-00002?type=jar",
+        "pkg:maven/org.hibernate.search/hibernate-search-util-common@7.1.2.Final-redhat-00002?type=jar",
+        "pkg:maven/org.hibernate.search/hibernate-search-v5migrationhelper-engine@7.1.2.Final-redhat-00002?type=jar",
+        "pkg:maven/com.carrotsearch/hppc@0.9.1.redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-anchored-keys@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-api@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-cachestore-jdbc@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-cachestore-jdbc-common@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-cachestore-remote@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-cachestore-rocksdb@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-cachestore-sql@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-cli-client@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-client-hotrod@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-client-rest@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-clustered-counter@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-commons@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-commons-graalvm@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-core@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-jboss-marshalling@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-multimap@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-objectfilter@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-query@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-query-core@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-query-dsl@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-remote-query-client@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-remote-query-server@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-scripting@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-core@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-hotrod@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-insights@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-memcached@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-resp@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-rest@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-router@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?package-id=c7ba178dee624963",
+        "pkg:maven/org.infinispan/infinispan-tasks@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-tasks-api@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-tools@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:rpm/redhat/iproute@6.14.0-2.el9?arch=x86_64",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.16.2.redhat-00001?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.16.2.redhat-00001?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.16.2.redhat-00001?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.16.2.redhat-00001?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.16.2.redhat-00001?type=jar",
+        "pkg:maven/org.glassfish/jakarta.json@2.0.1.redhat-00001?type=jar",
+        "pkg:maven/jakarta.transaction/jakarta.transaction-api@2.0.1.redhat-00004?type=jar",
+        "pkg:maven/io.smallrye/jandex@3.3.0.redhat-00001?type=jar",
+        "pkg:maven/org.fusesource.jansi/jansi@2.4.0.redhat-00003?type=jar",
+        "pkg:rpm/redhat/java-21-openjdk-headless@21.0.9.0.10-1.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/javapackages-filesystem@6.4.0-1.el9?arch=noarch",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.6.1.Final-redhat-00001?type=jar",
+        "pkg:maven/org.jboss.marshalling/jboss-marshalling@2.2.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.jboss.marshalling/jboss-marshalling-river@2.2.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.jboss.threads/jboss-threads@3.6.1.Final-redhat-00001?type=jar",
+        "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32.redhat-00003?type=jar",
+        "pkg:maven/org.jctools/jctools-core@4.0.1?type=jar",
+        "pkg:maven/org.jctools/jctools-core@4.0.5.redhat-00001?type=jar",
+        "pkg:maven/org.jgroups/jgroups@5.3.16.Final-redhat-00001?type=jar",
+        "pkg:maven/org.openjdk.jmh/jmh-core@1.37.0.redhat-00001?type=jar",
+        "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4.redhat-00002?type=jar",
+        "pkg:maven/jrt-fs/jrt-fs@21.0.9?type=jar",
+        "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+        "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+        "pkg:maven/org.jspecify/jspecify@1.0.0.redhat-00001?type=jar",
+        "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/krb5-libs@1.21.1-8.el9_6?arch=x86_64",
+        "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+        "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+        "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+        "pkg:maven/io.lettuce/lettuce-core@6.5.4.RELEASE-redhat-00001?type=jar",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/libarchive@3.5.3-6.el9_6?arch=x86_64",
+        "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libblkid@2.37.4-21.el9?arch=x86_64",
+        "pkg:rpm/redhat/libbpf@1.5.0-2.el9?arch=x86_64&epoch=2",
+        "pkg:rpm/redhat/libcap@2.48-10.el9?arch=x86_64",
+        "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libcom_err@1.46.5-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/libcurl-minimal@7.76.1-34.el9?arch=x86_64",
+        "pkg:rpm/redhat/libdnf@0.69.0-16.el9?arch=x86_64",
+        "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/libgcc@11.5.0-11.el9?arch=x86_64",
+        "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/libmount@2.37.4-21.el9?arch=x86_64",
+        "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/librepo@1.14.5-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+        "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsemanage@3.6-5.el9_6?arch=x86_64",
+        "pkg:rpm/redhat/libsepol@3.6-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-11.el9?arch=x86_64",
+        "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/libtirpc@1.3.3-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/libtool-ltdl@2.4.6-46.el9?arch=x86_64",
+        "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+        "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64",
+        "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libxml2@2.9.13-14.el9_7?arch=x86_64",
+        "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64",
+        "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?classifier=linux-x86_64&type=jar",
+        "pkg:rpm/redhat/lksctp-tools@1.0.19-3.el9_4?arch=x86_64",
+        "pkg:maven/org.apache.logging.log4j/log4j-api@2.23.1.redhat-00002?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-core@2.23.1.redhat-00002?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-jul@2.23.1.redhat-00002?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-slf4j-impl@2.23.1.redhat-00002?type=jar",
+        "pkg:rpm/redhat/lsof@4.94.0-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/lua@5.4.4-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/lua-posix@35.0-8.el9?arch=x86_64",
+        "pkg:maven/org.apache.lucene/lucene-analysis-common@9.9.2.redhat-00001?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-core@9.9.2.redhat-00002?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-facet@9.9.2.redhat-00002?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-highlighter@9.9.2.redhat-00001?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-join@9.9.2.redhat-00002?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-queries@9.9.2.redhat-00002?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-queryparser@9.9.2.redhat-00002?type=jar",
+        "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64",
+        "pkg:maven/io.micrometer/micrometer-commons@1.12.13.redhat-00001?type=jar",
+        "pkg:maven/io.micrometer/micrometer-core@1.12.13.redhat-00001?type=jar",
+        "pkg:maven/io.micrometer/micrometer-observation@1.12.13.redhat-00001?type=jar",
+        "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.12.13.redhat-00001?type=jar",
+        "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/ncurses-base@6.2-12.20210508.el9?arch=noarch",
+        "pkg:rpm/redhat/ncurses-libs@6.2-12.20210508.el9?arch=x86_64",
+        "pkg:rpm/redhat/nettle@3.10.1-1.el9?arch=x86_64",
+        "pkg:maven/io.netty/netty-buffer@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-codec-dns@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-codec-http@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-codec-http2@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-common@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-handler@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-resolver@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-resolver-dns@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?package-id=0eb6ce733297e359",
+        "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/nspr@4.36.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/nss@3.112.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/nss-softokn@3.112.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/nss-softokn-freebl@3.112.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/nss-sysinit@3.112.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/nss-tools@3.112.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/nss-util@3.112.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/openldap@2.6.8-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/openssl@3.5.1-4.el9_7?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/openssl-fips-provider@3.0.7-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/openssl-libs@3.5.1-4.el9_7?arch=x86_64&epoch=1",
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-api-events@1.32.0.alpha-redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-context@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-exporter-common@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp-common@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-exporter-sender-jdk@1.32.0.alpha-redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.32.0.redhat-00001?type=jar",
+        "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+        "pkg:maven/org.infinispan.protostream/protostream@5.0.14.Final-redhat-00002?type=jar",
+        "pkg:maven/org.infinispan.protostream/protostream-types@5.0.14.Final-redhat-00002?type=jar",
+        "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/python3@3.9.23-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/python3-libs@3.9.23-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/python3-pip-wheel@21.3.1-1.el9?arch=noarch",
+        "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-15.el9?arch=noarch",
+        "pkg:maven/org.reactivestreams/reactive-streams@1.0.4.redhat-00004?type=jar",
+        "pkg:maven/io.projectreactor/reactor-core@3.6.6.redhat-00001?type=jar",
+        "pkg:maven/org.aesh/readline@2.6.0.redhat-00001?type=jar",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/redhat-release@9.7-0.7.el9?arch=x86_64",
+        "pkg:rpm/redhat/rootfiles@8.1-35.el9?arch=noarch",
+        "pkg:rpm/redhat/rpm@4.16.1.3-39.el9?arch=x86_64",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-39.el9?arch=x86_64",
+        "pkg:rpm/redhat/rsync@3.2.5-3.el9?arch=x86_64",
+        "pkg:maven/com.redhat.insights/runtimes-java-api@2.0.4.redhat-00003?type=jar",
+        "pkg:maven/com.redhat.insights/runtimes-java-core-runtime@2.0.4.redhat-00003?type=jar",
+        "pkg:maven/io.reactivex.rxjava3/rxjava@3.1.10.redhat-00001?type=jar",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+        "pkg:rpm/redhat/shadow-utils@4.9-15.el9?arch=x86_64&epoch=2",
+        "pkg:maven/io.prometheus/simpleclient@0.16.0.redhat-00008?type=jar",
+        "pkg:maven/io.prometheus/simpleclient_common@0.16.0.redhat-00008?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36.redhat-00006?type=jar",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-9.el9_7?arch=x86_64",
+        "pkg:maven/org.apache.sshd/sshd-common@2.12.1.redhat-00002?type=jar",
+        "pkg:rpm/redhat/systemd-libs@252-55.el9_7.7?arch=x86_64",
+        "pkg:rpm/redhat/tar@1.34-7.el9?arch=x86_64&epoch=2",
+        "pkg:maven/org.aesh/terminal-api@2.6.0.redhat-00001?type=jar",
+        "pkg:rpm/redhat/tzdata@2025b-2.el9?arch=noarch",
+        "pkg:rpm/redhat/tzdata-java@2025b-2.el9?arch=noarch",
+        "pkg:rpm/redhat/unzip@6.0-59.el9?arch=x86_64",
+        "pkg:rpm/redhat/vim-minimal@8.2.2637-23.el9_7?arch=x86_64&epoch=2",
+        "pkg:maven/org.wildfly.common/wildfly-common@1.7.0.Final-redhat-00003?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-asn1@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-auth@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-http@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-sasl@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-auth-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-base@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-client@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-credential@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-credential-source-impl@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-credential-store@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-encryption@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http-basic@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http-bearer@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http-cert@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http-digest@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http-spnego@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-json-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-keystore@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-digest@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-gssapi@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-http@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-oauth2@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-scram@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-password-impl@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-permission@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-provider-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-realm@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-realm-ldap@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-realm-token@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-digest@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-external@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gs2@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gssapi@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-localuser@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-oauth2@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-plain@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-scram@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-security-manager-action@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-ssh-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-ssl@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-x500@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-x500-principal@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/com.thoughtworks.xstream/xstream@1.4.21.redhat-00001?type=jar",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+        "pkg:rpm/redhat/zip@3.0-35.el9?arch=x86_64",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12.redhat-00005?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3.redhat-00005?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.aesh/aesh@2.8.4.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.agroal/agroal-api@2.4.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.agroal/agroal-pool@2.4.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/alsa-lib@1.2.14-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.antlr/antlr-runtime@3.5.3.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/audit-libs@3.1.5-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/avahi-libs@0.8-23.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bsdtar@3.5.3-6.el9_6?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ca-certificates@2025.2.80_v9.0.305-91.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.github.ben-manes.caffeine/caffeine@3.1.8.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/commons-codec/commons-codec@1.17.1.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-compress@1.27.1.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/commons-io/commons-io@2.18.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-lang3@3.18.0.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-math3@3.6.1.redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/copy-jdk-configs@4.0-3.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies@20250905-1.git377cc42.el9_7?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies-scripts@20250905-1.git377cc42.el9_7?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cups-libs@2.3.3op2-34.el9_7?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/curl-minimal@7.76.1-34.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-22.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-data@4.14.0-31.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libelf@0.193-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/expat@2.5.0-5.el9_7.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/file@5.39-16.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/findutils@4.8.0-7.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib2@2.68.4-18.el9_7?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc@2.34-231.el9_7.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-common@2.34-231.el9_7.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-231.el9_7.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnutls@3.8.3-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@6.0.6.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.search/hibernate-search-backend-lucene@7.1.2.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.search/hibernate-search-engine@7.1.2.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.search/hibernate-search-mapper-pojo-base@7.1.2.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.search/hibernate-search-util-common@7.1.2.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.search/hibernate-search-v5migrationhelper-engine@7.1.2.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.carrotsearch/hppc@0.9.1.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-anchored-keys@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-api@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-cachestore-jdbc@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-cachestore-jdbc-common@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-cachestore-remote@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-cachestore-rocksdb@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-cachestore-sql@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-cli-client@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-client-hotrod@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-client-rest@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-clustered-counter@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-commons@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-commons-graalvm@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-core@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-jboss-marshalling@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-multimap@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-objectfilter@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-query@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-query-core@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-query-dsl@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-remote-query-client@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-remote-query-server@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-scripting@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-core@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-hotrod@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-insights@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-memcached@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-resp@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-rest@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-router@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?package-id=c7ba178dee624963",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-tasks@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-tasks-api@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-tools@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/iproute@6.14.0-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.16.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.16.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.16.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.16.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.16.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.glassfish/jakarta.json@2.0.1.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@2.0.1.redhat-00004?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.smallrye/jandex@3.3.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.fusesource.jansi/jansi@2.4.0.redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.9.0.10-1.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/javapackages-filesystem@6.4.0-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jboss.logging/jboss-logging@3.6.1.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jboss.marshalling/jboss-marshalling@2.2.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jboss.marshalling/jboss-marshalling-river@2.2.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jboss.threads/jboss-threads@3.6.1.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32.redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jctools/jctools-core@4.0.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jctools/jctools-core@4.0.5.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jgroups/jgroups@5.3.16.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.openjdk.jmh/jmh-core@1.37.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/jrt-fs/jrt-fs@21.0.9?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jspecify/jspecify@1.0.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/krb5-libs@1.21.1-8.el9_6?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.lettuce/lettuce-core@6.5.4.RELEASE-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libarchive@3.5.3-6.el9_6?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libblkid@2.37.4-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libbpf@1.5.0-2.el9?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap@2.48-10.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcom_err@1.46.5-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-34.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf@0.69.0-16.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcc@11.5.0-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmount@2.37.4-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librepo@1.14.5-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsemanage@3.6-5.el9_6?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsepol@3.6-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtirpc@1.3.3-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtool-ltdl@2.4.6-46.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxml2@2.9.13-14.el9_7?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?classifier=linux-x86_64&type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lksctp-tools@1.0.19-3.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.23.1.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-core@2.23.1.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-jul@2.23.1.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-slf4j-impl@2.23.1.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lsof@4.94.0-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua@5.4.4-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-posix@35.0-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-analysis-common@9.9.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-core@9.9.2.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-facet@9.9.2.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-highlighter@9.9.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-join@9.9.2.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-queries@9.9.2.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-queryparser@9.9.2.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.micrometer/micrometer-commons@1.12.13.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.micrometer/micrometer-core@1.12.13.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.micrometer/micrometer-observation@1.12.13.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.12.13.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-base@6.2-12.20210508.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-libs@6.2-12.20210508.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nettle@3.10.1-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-buffer@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-codec@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-codec-dns@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-codec-http@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-codec-http2@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-common@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-handler@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-resolver@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-transport@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?package-id=0eb6ce733297e359",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nspr@4.36.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss@3.112.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-softokn@3.112.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-softokn-freebl@3.112.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-sysinit@3.112.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-tools@3.112.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-util@3.112.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openldap@2.6.8-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl@3.5.1-4.el9_7?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-libs@3.5.1-4.el9_7?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-api@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-api-events@1.32.0.alpha-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-context@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-common@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp-common@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-sender-jdk@1.32.0.alpha-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan.protostream/protostream@5.0.14.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan.protostream/protostream-types@5.0.14.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3@3.9.23-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libs@3.9.23-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pip-wheel@21.3.1-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-15.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.4.redhat-00004?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.projectreactor/reactor-core@3.6.6.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.aesh/readline@2.6.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/redhat-release@9.7-0.7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rootfiles@8.1-35.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm@4.16.1.3-39.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-39.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rsync@3.2.5-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.redhat.insights/runtimes-java-api@2.0.4.redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.redhat.insights/runtimes-java-core-runtime@2.0.4.redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.reactivex.rxjava3/rxjava@3.1.10.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/shadow-utils@4.9-15.el9?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.prometheus/simpleclient@0.16.0.redhat-00008?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.prometheus/simpleclient_common@0.16.0.redhat-00008?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36.redhat-00006?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-9.el9_7?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.sshd/sshd-common@2.12.1.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-libs@252-55.el9_7.7?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tar@1.34-7.el9?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.aesh/terminal-api@2.6.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata@2025b-2.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata-java@2025b-2.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/unzip@6.0-59.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/vim-minimal@8.2.2637-23.el9_7?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.common/wildfly-common@1.7.0.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-asn1@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-http@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-sasl@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-base@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-client@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-credential@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-credential-source-impl@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-credential-store@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-encryption@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-basic@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-bearer@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-cert@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-digest@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-spnego@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-json-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-keystore@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-digest@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-gssapi@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-http@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-oauth2@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-scram@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-password-impl@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-permission@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-provider-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-realm@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-realm-ldap@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-realm-token@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-digest@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-external@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gs2@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gssapi@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-localuser@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-oauth2@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-plain@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-scram@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-security-manager-action@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-ssh-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-ssl@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-principal@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.thoughtworks.xstream/xstream@1.4.21.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zip@3.0-35.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:b59f4bea-2fa4-40ca-a278-cbadf4702df3"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/datagrid-datagrid-8/latest/image-index-2025-12-04-2BE8E55FCB8946B.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/datagrid-datagrid-8/latest/image-index-2025-12-04-2BE8E55FCB8946B.json
@@ -1,0 +1,192 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [
+        {
+          "name": "SBOMer",
+          "version": "f1c3bca6",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+                "acknowledgement": "declared"
+              }
+            }
+          ],
+          "provider": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          },
+          "externalReferences": [
+            {
+              "url": "https://github.com/project-ncl/sbomer",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "datagrid/datagrid-8",
+      "purl": "pkg:oci/datagrid-datagrid-8@sha256%3A1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1764765711",
+      "type": "container",
+      "description": "Image index manifest of pkg:oci/datagrid-datagrid-8@sha256%3A1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95"
+    },
+    "timestamp": "2025-12-04T06:52:42Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156818"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "datagrid/datagrid-8",
+      "purl": "pkg:oci/datagrid-datagrid-8@sha256%3A1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1764765711",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95"
+        }
+      ],
+      "bom-ref": "datagrid-8-rhel9-container_image-index",
+      "version": "sha256:1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-datagrid-8@sha256%3A1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-datagrid-8@sha256%3A1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1764765711"
+          }
+        ]
+      },
+      "pedigree": {
+        "variants": [
+          {
+            "name": "datagrid/datagrid-8",
+            "purl": "pkg:oci/datagrid-8@sha256%3A6a28608358b7af404b1f6699cad8ff338a8cc763214ade7d4ce6b8aab6125ecd?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1764765711",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "6a28608358b7af404b1f6699cad8ff338a8cc763214ade7d4ce6b8aab6125ecd"
+              }
+            ],
+            "bom-ref": "datagrid-8-rhel9-container_amd64",
+            "version": "sha256:6a28608358b7af404b1f6699cad8ff338a8cc763214ade7d4ce6b8aab6125ecd",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          },
+          {
+            "name": "datagrid/datagrid-8",
+            "purl": "pkg:oci/datagrid-8@sha256%3Ab6ccaf5c964246e3637f8b7323052763d45e985f53ad0d41d8ee99b7f278041c?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1764765711",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "b6ccaf5c964246e3637f8b7323052763d45e985f53ad0d41d8ee99b7f278041c"
+              }
+            ],
+            "bom-ref": "datagrid-8-rhel9-container_arm64",
+            "version": "sha256:b6ccaf5c964246e3637f8b7323052763d45e985f53ad0d41d8ee99b7f278041c",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          },
+          {
+            "name": "datagrid/datagrid-8",
+            "purl": "pkg:oci/datagrid-8@sha256%3A7127a3c4e37196df7578117fa8bd169e9eda48c2aa88734825cd10b4bc368830?arch=ppc64le&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1764765711",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "7127a3c4e37196df7578117fa8bd169e9eda48c2aa88734825cd10b4bc368830"
+              }
+            ],
+            "bom-ref": "datagrid-8-rhel9-container_ppc64le",
+            "version": "sha256:7127a3c4e37196df7578117fa8bd169e9eda48c2aa88734825cd10b4bc368830",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          },
+          {
+            "name": "datagrid/datagrid-8",
+            "purl": "pkg:oci/datagrid-8@sha256%3Ab16cc2b62260ca923bc6d9ee2448341dd205f08f37c86c73a6bacb06c7dc8f9e?arch=s390x&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1764765711",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "b16cc2b62260ca923bc6d9ee2448341dd205f08f37c86c73a6bacb06c7dc8f9e"
+              }
+            ],
+            "bom-ref": "datagrid-8-rhel9-container_s390x",
+            "version": "sha256:b16cc2b62260ca923bc6d9ee2448341dd205f08f37c86c73a6bacb06c7dc8f9e",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "datagrid-8-rhel9-container"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "datagrid/datagrid-8"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "8.1764765711"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "1.5"
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:47570d0f-42c3-3cbc-81d7-1b2ca77bbe3f"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/datagrid-datagrid-8/latest/product-2025-12-08-6483D4F2E4B1469.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/datagrid-datagrid-8/latest/product-2025-12-08-6483D4F2E4B1469.json
@@ -1,0 +1,146 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [
+        {
+          "name": "SBOMer",
+          "version": "f1c3bca6",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+                "acknowledgement": "declared"
+              }
+            }
+          ],
+          "provider": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          },
+          "externalReferences": [
+            {
+              "url": "https://github.com/project-ncl/sbomer",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "RHEL-9 based Middleware Containers",
+      "type": "framework",
+      "bom-ref": "RHEL-9-OSE-Middleware",
+      "version": "RHEL-9-OSE-Middleware",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:rhosemc:1.0::el9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-12-08T16:31:12Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "156818"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "datagrid/datagrid-8",
+      "purl": "pkg:oci/datagrid-8-rhel9@sha256%3A1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95"
+        }
+      ],
+      "bom-ref": "pkg:oci/datagrid-8-rhel9@sha256%3A1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95",
+      "version": "sha256:1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-8-rhel9@sha256%3A1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1764765711"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-8-rhel9@sha256%3A1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "datagrid/datagrid-8-prod-operator-bundle",
+      "purl": "pkg:oci/datagrid-8-prod-operator-bundle@sha256%3A16b4763e497fbe5c3798fd3a5fb7cd02614d33ddeff1603aee8aba6eccf4cea0",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "16b4763e497fbe5c3798fd3a5fb7cd02614d33ddeff1603aee8aba6eccf4cea0"
+        }
+      ],
+      "bom-ref": "pkg:oci/datagrid-8-prod-operator-bundle@sha256%3A16b4763e497fbe5c3798fd3a5fb7cd02614d33ddeff1603aee8aba6eccf4cea0",
+      "version": "sha256:16b4763e497fbe5c3798fd3a5fb7cd02614d33ddeff1603aee8aba6eccf4cea0",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-8-prod-operator-bundle@sha256%3A16b4763e497fbe5c3798fd3a5fb7cd02614d33ddeff1603aee8aba6eccf4cea0?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-prod-operator-bundle&tag=8.5.13-1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-8-prod-operator-bundle@sha256%3A16b4763e497fbe5c3798fd3a5fb7cd02614d33ddeff1603aee8aba6eccf4cea0?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-prod-operator-bundle&tag=8.5.13"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "RHEL-9-OSE-Middleware",
+      "provides": [
+        "pkg:oci/datagrid-8-rhel9@sha256%3A1d5525d2d575dcc9d90da57afeb5fb310edc28d97d7ba55290db6bd152a34a95",
+        "pkg:oci/datagrid-8-prod-operator-bundle@sha256%3A16b4763e497fbe5c3798fd3a5fb7cd02614d33ddeff1603aee8aba6eccf4cea0"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:e91920d3-8bc7-3ea4-8ff0-4c2669fd8de0"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/datagrid-datagrid-8/older/binary-2025-10-06-85E079C4EC034F1.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/datagrid-datagrid-8/older/binary-2025-10-06-85E079C4EC034F1.json
@@ -1,0 +1,27088 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "syft",
+          "type": "application",
+          "author": "anchore",
+          "version": "1.27.1"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "datagrid/datagrid-8",
+      "purl": "pkg:oci/datagrid-8@sha256%3A207b8132820f3e42442379f4ae61fc5f946cfae8c5c71818bbcf969ad7f91747?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1758135428",
+      "type": "container"
+    },
+    "timestamp": "2025-10-06T09:52:53Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "154600"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "datagrid/datagrid-8",
+      "purl": "pkg:oci/datagrid-8@sha256%3A207b8132820f3e42442379f4ae61fc5f946cfae8c5c71818bbcf969ad7f91747?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1758135428",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "207b8132820f3e42442379f4ae61fc5f946cfae8c5c71818bbcf969ad7f91747"
+        }
+      ],
+      "bom-ref": "pkg:oci/datagrid-8@sha256%3A207b8132820f3e42442379f4ae61fc5f946cfae8c5c71818bbcf969ad7f91747?arch=amd64&os=linux&tag=1.5-8.1758135428",
+      "version": "sha256:207b8132820f3e42442379f4ae61fc5f946cfae8c5c71818bbcf969ad7f91747",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-8@sha256%3A207b8132820f3e42442379f4ae61fc5f946cfae8c5c71818bbcf969ad7f91747?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1758135428"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-8@sha256%3A207b8132820f3e42442379f4ae61fc5f946cfae8c5c71818bbcf969ad7f91747?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5"
+          }
+        ]
+      },
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "56908efbd0acb84bbcbe0ac1a10ce922cff451d6",
+            "url": "https://pkgs.devel.redhat.com/git/containers/datagrid-8#56908efbd0acb84bbcbe0ac1a10ce922cff451d6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:architecture",
+          "value": "x86_64"
+        },
+        {
+          "name": "sbomer:image:labels:build-date",
+          "value": "2025-09-17T18:58:08"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "datagrid-8-rhel9-container"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.dev-mode",
+          "value": "DEBUG:true"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.dev-mode.port",
+          "value": "DEBUG_PORT:8787"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.license_terms",
+          "value": "https://www.redhat.com/agreements"
+        },
+        {
+          "name": "sbomer:image:labels:description",
+          "value": "Data Grid Server"
+        },
+        {
+          "name": "sbomer:image:labels:distribution-scope",
+          "value": "public"
+        },
+        {
+          "name": "sbomer:image:labels:io.buildah.version",
+          "value": "1.33.12"
+        },
+        {
+          "name": "sbomer:image:labels:io.cekit.version",
+          "value": "4.9.1"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.description",
+          "value": "Provides a scalable in-memory distributed database designed for fast access to large volumes of data."
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.display-name",
+          "value": "Data Grid 8.5"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.expose-services",
+          "value": "8080:http"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.s2i.scripts-url",
+          "value": "image:///usr/local/s2i"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.tags",
+          "value": "datagrid,java,jboss,xpaas"
+        },
+        {
+          "name": "sbomer:image:labels:maintainer",
+          "value": "remerson@redhat.com"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "datagrid/datagrid-8"
+        },
+        {
+          "name": "sbomer:image:labels:org.jboss.product",
+          "value": "datagrid"
+        },
+        {
+          "name": "sbomer:image:labels:org.jboss.product.datagrid.version",
+          "value": "8.5.5.GA"
+        },
+        {
+          "name": "sbomer:image:labels:org.jboss.product.openjdk.version",
+          "value": "21"
+        },
+        {
+          "name": "sbomer:image:labels:org.jboss.product.version",
+          "value": "8.5.5.GA"
+        },
+        {
+          "name": "sbomer:image:labels:org.opencontainers.image.documentation",
+          "value": "https://rh-openjdk.github.io/redhat-openjdk-containers/"
+        },
+        {
+          "name": "sbomer:image:labels:org.opencontainers.image.revision",
+          "value": "ubi9"
+        },
+        {
+          "name": "sbomer:image:labels:org.opencontainers.image.source",
+          "value": "https://github.com/rh-openjdk/redhat-openjdk-containers"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "8.1758135428"
+        },
+        {
+          "name": "sbomer:image:labels:summary",
+          "value": "Data Grid Server"
+        },
+        {
+          "name": "sbomer:image:labels:url",
+          "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/datagrid/datagrid-8/images/1.5-8.1758135428"
+        },
+        {
+          "name": "sbomer:image:labels:usage",
+          "value": "https://rh-openjdk.github.io/redhat-openjdk-containers/"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-ref",
+          "value": "56908efbd0acb84bbcbe0ac1a10ce922cff451d6"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:vendor",
+          "value": "Red Hat"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "1.5"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3844504",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "https://pkgs.devel.redhat.com/git/containers/datagrid-8#56908efbd0acb84bbcbe0ac1a10ce922cff451d6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "HdrHistogram",
+      "purl": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12.redhat-00005?type=jar",
+      "type": "library",
+      "group": "org.hdrhistogram",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c1caad7e00a8929ef9b621ff4a5fe97a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9babda04341092537cf08f258257ddb48eb10da2"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c981533d9c9ef603c8c5cc54e057845092fda91af8ec66ca1a06f778b857aaea"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12.redhat-00005?type=jar",
+      "version": "2.1.12.redhat-00005",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://creativecommons.org/publicdomain/zero/1.0/, https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "43fe40b92029f9bc8dc0c60892cd5b479e8819aa",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/HdrHistogram/HdrHistogram.git#2.1.12.redhat-00005"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/HdrHistogram-2.1.12.redhat-00005.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/HdrHistogram-2.1.12.redhat-00005.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9babda04341092537cf08f258257ddb48eb10da2"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12177243",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7HNRJQRKDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.3.9:1.0.6",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/HdrHistogram/HdrHistogram.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "LatencyUtils",
+      "purl": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3.redhat-00005?type=jar",
+      "type": "library",
+      "group": "org.latencyutils",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "74e6eef8656cc19496e61079b4d925b6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f1a15122edfee057a584cc867e2d1a82bd23eee3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "44693a35ca6d209a1a68c98f51556103e5b840e1d0f8288b86915d6b279ecfde"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3.redhat-00005?type=jar",
+      "version": "2.0.3.redhat-00005",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "name": "Public Domain, per Creative Commons CC0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a42a6a870eb135ff05b4caad90bd24c0f206540a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/LatencyUtils/LatencyUtils.git#2.0.3.redhat-00005"
+          },
+          {
+            "uid": "fa856f73028cd6f05d6f99477c13b248cfadc7f7",
+            "url": "https://github.com/LatencyUtils/LatencyUtils.git#LatencyUtils-2.0.3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/LatencyUtils-2.0.3.redhat-00005.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/LatencyUtils-2.0.3.redhat-00005.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f1a15122edfee057a584cc867e2d1a82bd23eee3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12177249",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7HNTNUC2DYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.3.9:1.0.6",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/LatencyUtils/LatencyUtils.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "aesh",
+      "purl": "pkg:maven/org.aesh/aesh@2.8.4.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.aesh",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "485bf701533babff79296e6fec37a4f0"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "616b3f8b80974394fe8fd734f61b8b0ee252d3fd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b7c14df584564f890a30b3d249c643a2052cd76b0c09ec81f91ef45626b85230"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.aesh/aesh@2.8.4.redhat-00001?type=jar",
+      "version": "2.8.4.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.apache.org/licenses/LICENSE-2.0",
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4a37197bf263b70de5173f531ae78056f965df4e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/aesh.git#2.8.4.redhat-00001"
+          },
+          {
+            "uid": "e0f2d1921e9d6d29c249f0028c4f10bd88a9dd20",
+            "url": "https://github.com/aeshell/aesh.git#e0f2d1921e9d6d29c249f0028c4f10bd88a9dd20"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/aesh-2.8.4.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/aesh-2.8.4.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "616b3f8b80974394fe8fd734f61b8b0ee252d3fd"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13873899",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BHIZVYWHBSIAG",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.3.9:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/aeshell/aesh.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "agroal-api",
+      "purl": "pkg:maven/io.agroal/agroal-api@2.4.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "io.agroal",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "47d6e8b75a5abcb73864ece30fb59163"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e57683d0cf8f7133697b33cd0bcc804be13a033e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3596e67341530b7f685ecc477ce3b73cd26978a8990ccd7d2e673f521a0506c3"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.agroal/agroal-api@2.4.0.redhat-00001?type=jar",
+      "version": "2.4.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "98f6b243e1fdf4ae3841a038ca641c30723a476e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/agroal/agroal.git#2.4.0.redhat-00001"
+          },
+          {
+            "uid": "a54f9e6f2edbff64450b0372d2f0247f823f7559",
+            "url": "https://github.com/agroal/agroal.git#2.4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/agroal-api-2.4.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/agroal-api-2.4.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e57683d0cf8f7133697b33cd0bcc804be13a033e"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12622356",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BBNBQIYM3EYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.3",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/agroal/agroal.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "agroal-pool",
+      "purl": "pkg:maven/io.agroal/agroal-pool@2.4.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "io.agroal",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d8d4e675337531dcb74f2aa163d70190"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4b7a58c10a043260bbf4222d1bd3044f63ce3f6c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "905dddb64716e78ec8d8e09e402a879b9596b0a1a6da45499913fc3eea4c52e6"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.agroal/agroal-pool@2.4.0.redhat-00001?type=jar",
+      "version": "2.4.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "98f6b243e1fdf4ae3841a038ca641c30723a476e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/agroal/agroal.git#2.4.0.redhat-00001"
+          },
+          {
+            "uid": "a54f9e6f2edbff64450b0372d2f0247f823f7559",
+            "url": "https://github.com/agroal/agroal.git#2.4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/agroal-pool-2.4.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/agroal-pool-2.4.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4b7a58c10a043260bbf4222d1bd3044f63ce3f6c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12622348",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BBNBQIYM3EYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.3",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/agroal/agroal.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "alsa-lib",
+      "purl": "pkg:rpm/redhat/alsa-lib@1.2.13-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/alsa-lib@1.2.13-2.el9?arch=x86_64",
+      "version": "1.2.13-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b77156fc3f9d5a364a8656d48b1bbf56277bdb6d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/alsa-lib#b77156fc3f9d5a364a8656d48b1bbf56277bdb6d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3442962",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/alsa-lib#b77156fc3f9d5a364a8656d48b1bbf56277bdb6d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "alternatives",
+      "purl": "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64",
+      "version": "1.24-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "083be09fc542a85ddbf9263d0616613ef5f23348",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#083be09fc542a85ddbf9263d0616613ef5f23348"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3269575",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#083be09fc542a85ddbf9263d0616613ef5f23348",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "antlr-runtime",
+      "purl": "pkg:maven/org.antlr/antlr-runtime@3.5.3.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.antlr",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d80f5b15a4627e916da9e1cfdd5ac3ba"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "89ed934e7299232021180827ba43fec5f02a7908"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fc60a333d05e1ec9b7edc1a5a903fc2e3149c942682ee0de48ee100d08b3bc8b"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.antlr/antlr-runtime@3.5.3.redhat-00001?type=jar",
+      "version": "3.5.3.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b51577f54b7934af40d3c3fe9999ee428afc1013",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/antlr/antlr3.git#3.5.3.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-objectfilter-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-objectfilter-15.0.19.Final-redhat-00001.jar:org.antlr:antlr-runtime"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/10584631",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/AZTFVRLIVUIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.6",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/antlr/antlr3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "audit-libs",
+      "purl": "pkg:rpm/redhat/audit-libs@3.1.5-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/audit-libs@3.1.5-4.el9?arch=x86_64",
+      "version": "3.1.5-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "996c7a2a8241a682bb055edd46c0bab4c8923fa5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#996c7a2a8241a682bb055edd46c0bab4c8923fa5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3505200",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#996c7a2a8241a682bb055edd46c0bab4c8923fa5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "avahi-libs",
+      "purl": "pkg:rpm/redhat/avahi-libs@0.8-22.el9_6.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/avahi-libs@0.8-22.el9_6.1?arch=x86_64",
+      "version": "0.8-22.el9_6.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "907961f1d33ea5acbb2f017814cdaad3e4caa272",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/avahi#907961f1d33ea5acbb2f017814cdaad3e4caa272"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3740920",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/avahi#907961f1d33ea5acbb2f017814cdaad3e4caa272",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "basesystem",
+      "purl": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "version": "11-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+            "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688850",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bash",
+      "purl": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "version": "5.1.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80326284a249f523c3e2d14e0eed2dbaece63c4e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2910143",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bsdtar",
+      "purl": "pkg:rpm/redhat/bsdtar@3.5.3-6.el9_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bsdtar@3.5.3-6.el9_6?arch=x86_64",
+      "version": "3.5.3-6.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "476a518562a29e2fa60704cd358f8afffb8492c4",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#476a518562a29e2fa60704cd358f8afffb8492c4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3803996",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#476a518562a29e2fa60704cd358f8afffb8492c4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bzip2-libs",
+      "purl": "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64",
+      "version": "1.0.8-10.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc546512bf0d59d11d367828d43b5988da3a5d92",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#fc546512bf0d59d11d367828d43b5988da3a5d92"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3469717",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#fc546512bf0d59d11d367828d43b5988da3a5d92",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ca-certificates",
+      "purl": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch",
+      "version": "2024.2.69_v8.0.303-91.4.el9_4",
+      "licenses": [
+        {
+          "expression": "MIT AND GPL-2.0-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d46488391f737a6a74113abca1e34835a70c8054",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#d46488391f737a6a74113abca1e34835a70c8054"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3233446",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#d46488391f737a6a74113abca1e34835a70c8054",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "caffeine",
+      "purl": "pkg:maven/com.github.ben-manes.caffeine/caffeine@3.1.8.redhat-00002?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fbd6ee5eccdc6885d8f526081cf5f30e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6fb7fa88c93a73f03e19ac3a48bf4d75562b7f14"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1e04f06f8d86b417ddf64312eb0bdd56e4942ba0a8e8fb3db958f1de7f0281b3"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.github.ben-manes.caffeine/caffeine@3.1.8.redhat-00002?type=jar",
+      "version": "3.1.8.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b5314d952a017252ae7e189b2112e8d0334f89b7",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/ben-manes/caffeine.git#3.1.8.redhat-00002"
+          },
+          {
+            "uid": "b0723da5976ebb52069f6b0cccfcf44186c3fdf3",
+            "url": "https://github.com/ben-manes/caffeine.git#v3.1.8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/caffeine-3.1.8.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/caffeine-3.1.8.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6fb7fa88c93a73f03e19ac3a48bf4d75562b7f14"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12150903",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7ENB5XM2DYAG",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j11-mvn3.9.2-gradle8.3-gcc-cpp-make:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/ben-manes/caffeine.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "commons-codec",
+      "purl": "pkg:maven/commons-codec/commons-codec@1.17.1.redhat-00001?type=jar",
+      "type": "library",
+      "group": "commons-codec",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2f5bff2bf6696d283e2869b0419ca451"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "26fff2e5416d83e7689903a31fa597193ed6d7c1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e8660def29c6ecc7561af978e105c3e402f8103350905ede0feec5011eb530b8"
+        }
+      ],
+      "bom-ref": "pkg:maven/commons-codec/commons-codec@1.17.1.redhat-00001?type=jar",
+      "version": "1.17.1.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0a70440e5a16b2a4713612ad36587d4327bb71dc",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/commons-codec.git#1.17.1.redhat-00001"
+          },
+          {
+            "uid": "965109705c5236b05011e1c45f47d991abfa521e",
+            "url": "https://github.com/apache/commons-codec#rel/commons-codec-1.17.1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/commons-codec-1.17.1.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/commons-codec-1.17.1.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "26fff2e5416d83e7689903a31fa597193ed6d7c1"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12915991",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2OHPU2VVAAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-oraclejdk8u192-mvn3.6.3-gcc-cpp-make:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/commons-codec",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "commons-compress",
+      "purl": "pkg:maven/org.apache.commons/commons-compress@1.27.1.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.apache.commons",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6a6a96076dd429f80856b5534a6a30d9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2cdf05602d7e9d907acb79a0951ec77535d69d66"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "eef292ee5dc65e8a05ce9ad9dc002d9cc20eb36929cafad08250893f661621bb"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.commons/commons-compress@1.27.1.redhat-00001?type=jar",
+      "version": "1.27.1.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8fd71117d111b4b168cb3e000b88a17612291f7a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/commons-compress.git#1.27.1.redhat-00001"
+          },
+          {
+            "uid": "8de4d85b09a5d60e03191c0d362797de253a3516",
+            "url": "https://github.com/apache/commons-compress.git#rel/commons-compress-1.27.1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/commons-compress-1.27.1.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/commons-compress-1.27.1.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "2cdf05602d7e9d907acb79a0951ec77535d69d66"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13055369",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BDKHVMG7GPYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/commons-compress.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "commons-io",
+      "purl": "pkg:maven/commons-io/commons-io@2.18.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "commons-io",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "98a8b92492fe0f745e3fbbea48c93aff"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1873c333376bce01dcc4fe00c8fdbb711de4aaae"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "70bd51e855f554df686eb20cdafdf812e215512dfdfeb376eb6ac861703df6ab"
+        }
+      ],
+      "bom-ref": "pkg:maven/commons-io/commons-io@2.18.0.redhat-00001?type=jar",
+      "version": "2.18.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "81bb90257f43e935b64638b2b61eb5aeeff11275",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/commons-io.git#2.18.0.redhat-00001"
+          },
+          {
+            "uid": "be0b1eaea246aba841510807484a6ddd6ee5fcdb",
+            "url": "https://github.com/apache/commons-io.git#rel/commons-io-2.18.0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/commons-io-2.18.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/commons-io-2.18.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "1873c333376bce01dcc4fe00c8fdbb711de4aaae"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13374352",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFJW6IBGMKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/commons-io.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "commons-lang3",
+      "purl": "pkg:maven/org.apache.commons/commons-lang3@3.18.0.redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.apache.commons",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1099218a260a3ee077785dc02577828a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "84dbe9df515799981a4881ee3a2a4a32e748c746"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0053c9d466df0b5bcb5ba7bf50a3755162f5ecbd61900196d1d17089c812f030"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.commons/commons-lang3@3.18.0.redhat-00002?type=jar",
+      "version": "3.18.0.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a11dead9f7309c377f5041b4c588a0a39e2f852a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/commons-lang.git#3.18.0.redhat-00002"
+          },
+          {
+            "uid": "5b59487808d0b86a94ad7a1ebd4c200e09b7be09",
+            "url": "https://github.com/apache/commons-lang.git#rel/commons-lang-3.18.0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/commons-lang3-3.18.0.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/commons-lang3-3.18.0.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "84dbe9df515799981a4881ee3a2a4a32e748c746"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14115530",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BIX2VBOPQSAAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/commons-lang.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "commons-math3",
+      "purl": "pkg:maven/org.apache.commons/commons-math3@3.6.1.redhat-00003?type=jar",
+      "type": "library",
+      "group": "org.apache.commons",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "93bcdd177c15c3397e9a0e1369e45032"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6c1e8b7dac8f2bd0169c7b011e8883a878c35060"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "208f2434634de0369bce68566eabfa7a49c37a0ded650a670b5f0da36f9e9ce9"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.commons/commons-math3@3.6.1.redhat-00003?type=jar",
+      "version": "3.6.1.redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ed37bf058a929f7d0440c79ba664c16e6127be53",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/commons-math.git#3.6.1.redhat-00003"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/commons-math3-3.6.1.redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/commons-math3-3.6.1.redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6c1e8b7dac8f2bd0169c7b011e8883a878c35060"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11190034",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A3OKQROB2MYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.0-gradle5.6.2:1.0.8",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/commons-math.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "copy-jdk-configs",
+      "purl": "pkg:rpm/redhat/copy-jdk-configs@4.0-3.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/copy-jdk-configs@4.0-3.el9?arch=noarch",
+      "version": "4.0-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "90e4cb8b7a3ba3d7ba7e88871bc8a6a3d9608b57",
+            "url": "git://pkgs.devel.redhat.com/rpms/copy-jdk-configs#90e4cb8b7a3ba3d7ba7e88871bc8a6a3d9608b57"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688937",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/copy-jdk-configs#90e4cb8b7a3ba3d7ba7e88871bc8a6a3d9608b57",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "coreutils-single",
+      "purl": "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64",
+      "version": "8.32-39.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8435cd1c7488661c55ad9df39743c3c53feeb582",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#8435cd1c7488661c55ad9df39743c3c53feeb582"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3429810",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#8435cd1c7488661c55ad9df39743c3c53feeb582",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies",
+      "purl": "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch",
+      "version": "20250128-1.git5269e22.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc34047780034d3b89fb85dd79da0ad471af7b90",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#fc34047780034d3b89fb85dd79da0ad471af7b90"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3485414",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#fc34047780034d3b89fb85dd79da0ad471af7b90",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies-scripts",
+      "purl": "pkg:rpm/redhat/crypto-policies-scripts@20250128-1.git5269e22.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies-scripts@20250128-1.git5269e22.el9?arch=noarch",
+      "version": "20250128-1.git5269e22.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc34047780034d3b89fb85dd79da0ad471af7b90",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#fc34047780034d3b89fb85dd79da0ad471af7b90"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3485414",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#fc34047780034d3b89fb85dd79da0ad471af7b90",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cups-libs",
+      "purl": "pkg:rpm/redhat/cups-libs@2.3.3op2-33.el9_6.1?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cups-libs@2.3.3op2-33.el9_6.1?arch=x86_64&epoch=1",
+      "version": "1:2.3.3op2-33.el9_6.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 and zlib"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0c2c547a1c7d8684ffddd0bf59cf971522e43c6d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/cups#0c2c547a1c7d8684ffddd0bf59cf971522e43c6d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3830390",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/cups#0c2c547a1c7d8684ffddd0bf59cf971522e43c6d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "curl-minimal",
+      "purl": "pkg:rpm/redhat/curl-minimal@7.76.1-31.el9_6.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/curl-minimal@7.76.1-31.el9_6.1?arch=x86_64",
+      "version": "7.76.1-31.el9_6.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a2733637295493c735a219942d4763b019dbda31",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#a2733637295493c735a219942d4763b019dbda31"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3598144",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#a2733637295493c735a219942d4763b019dbda31",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-lib",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-libs",
+      "purl": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "version": "1:1.12.20-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2546522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#70554edaf0f3f2fe7632fa045dd6abe5440ba228",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dejavu-sans-fonts",
+      "purl": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "version": "2.37-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bitstream Vera and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1479ec5203df4c3e577d1992b22c6976c142afa9",
+            "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688969",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dnf-data",
+      "purl": "pkg:rpm/redhat/dnf-data@4.14.0-25.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf-data@4.14.0-25.el9?arch=noarch",
+      "version": "4.14.0-25.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "48402e5143b69ed69ff77ee229d53746fae8bef6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#48402e5143b69ed69ff77ee229d53746fae8bef6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498531",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#48402e5143b69ed69ff77ee229d53746fae8bef6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libelf",
+      "purl": "pkg:rpm/redhat/elfutils-libelf@0.192-6.el9_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libelf@0.192-6.el9_6?arch=x86_64",
+      "version": "0.192-6.el9_6",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-or-later OR LGPL-3.0-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "96218003db25c2582983f44b71baa585046a2954",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#96218003db25c2582983f44b71baa585046a2954"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3558239",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#96218003db25c2582983f44b71baa585046a2954",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "expat",
+      "purl": "pkg:rpm/redhat/expat@2.5.0-5.el9_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/expat@2.5.0-5.el9_6?arch=x86_64",
+      "version": "2.5.0-5.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3dc8bb2fd09db2e4f99d66dbfc9a5ab4bc8978f5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#3dc8bb2fd09db2e4f99d66dbfc9a5ab4bc8978f5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3582655",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#3dc8bb2fd09db2e4f99d66dbfc9a5ab4bc8978f5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "file",
+      "purl": "pkg:rpm/redhat/file@5.39-16.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/file@5.39-16.el9?arch=x86_64",
+      "version": "5.39-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2800051",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "file-libs",
+      "purl": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "version": "5.39-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2800051",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "filesystem",
+      "purl": "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64",
+      "version": "3.16-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a5b75452255bee32dd79cb51dea804d566ac9e30",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/filesystem#a5b75452255bee32dd79cb51dea804d566ac9e30"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134118",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/filesystem#a5b75452255bee32dd79cb51dea804d566ac9e30",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "findutils",
+      "purl": "pkg:rpm/redhat/findutils@4.8.0-7.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/findutils@4.8.0-7.el9?arch=x86_64&epoch=1",
+      "version": "1:4.8.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "575073254d61c01e14ae09af199e2e4b035191b3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#575073254d61c01e14ae09af199e2e4b035191b3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3154025",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#575073254d61c01e14ae09af199e2e4b035191b3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fonts-filesystem",
+      "purl": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "version": "1:2.0.5-7.el9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ac288ee82aa9655c3784dd2f59cedb3562638129",
+            "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1732053",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gawk",
+      "purl": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "version": "5.1.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv2+ and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3830530bfc524ab9b89fafe76d58a388675ecc11",
+            "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1891122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdbm-libs",
+      "purl": "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&epoch=1",
+      "version": "1:1.23-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1a66bb7ed77701afec99503ce9602021bc24092b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdbm#1a66bb7ed77701afec99503ce9602021bc24092b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2995292",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdbm#1a66bb7ed77701afec99503ce9602021bc24092b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glib2",
+      "purl": "pkg:rpm/redhat/glib2@2.68.4-16.el9_6.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glib2@2.68.4-16.el9_6.2?arch=x86_64",
+      "version": "2.68.4-16.el9_6.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4805cb0ad56e379cc32432955ffecea8b0dc71d9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#4805cb0ad56e379cc32432955ffecea8b0dc71d9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3741084",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#4805cb0ad56e379cc32432955ffecea8b0dc71d9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc",
+      "purl": "pkg:rpm/redhat/glibc@2.34-168.el9_6.23?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc@2.34-168.el9_6.23?arch=x86_64",
+      "version": "2.34-168.el9_6.23",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5667e6d831a802e645f5d2878adf6391ca0e640a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#5667e6d831a802e645f5d2878adf6391ca0e640a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3773508",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#5667e6d831a802e645f5d2878adf6391ca0e640a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-common",
+      "purl": "pkg:rpm/redhat/glibc-common@2.34-168.el9_6.23?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-common@2.34-168.el9_6.23?arch=x86_64",
+      "version": "2.34-168.el9_6.23",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5667e6d831a802e645f5d2878adf6391ca0e640a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#5667e6d831a802e645f5d2878adf6391ca0e640a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3773508",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#5667e6d831a802e645f5d2878adf6391ca0e640a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "purl": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-168.el9_6.23?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-168.el9_6.23?arch=x86_64",
+      "version": "2.34-168.el9_6.23",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5667e6d831a802e645f5d2878adf6391ca0e640a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#5667e6d831a802e645f5d2878adf6391ca0e640a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3773508",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#5667e6d831a802e645f5d2878adf6391ca0e640a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gmp",
+      "purl": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "version": "1:6.2.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+            "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2625518",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gnupg2",
+      "purl": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "version": "2.3.3-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2481337",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gnutls",
+      "purl": "pkg:rpm/redhat/gnutls@3.8.3-6.el9_6.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnutls@3.8.3-6.el9_6.2?arch=x86_64",
+      "version": "3.8.3-6.el9_6.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3fb25ee514c5a74c2477daea18a6938e655d5ab0",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#3fb25ee514c5a74c2477daea18a6938e655d5ab0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3804842",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#3fb25ee514c5a74c2477daea18a6938e655d5ab0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gobject-introspection",
+      "purl": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "version": "1.68.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5fa3808a6c90b0da8da9a85fad983244c13640ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2248264",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "version": "5a6340b3-6229229e",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "version": "fd431d51-4ae0493b",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "gpgme",
+      "purl": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "version": "1.15.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+            "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892040",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "grep",
+      "purl": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "version": "3.6-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7779e81140d7afaf33d2a97f4afdd682457f9697",
+            "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689607",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gzip",
+      "purl": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+      "version": "1.12-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "11df222a2dc5ce7dc943b1bce364d46ea97a535b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gzip#11df222a2dc5ce7dc943b1bce364d46ea97a535b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1982016",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gzip#11df222a2dc5ce7dc943b1bce364d46ea97a535b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hibernate-commons-annotations",
+      "purl": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@6.0.6.Final-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "49f9b7386c252e2d54169d3e507b3faf"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0b3608f5e7d9b30452833ae018d0f9946a5c62d3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "701d20a23a0f7d69f4ed480600442e21721419103fed55d8fe64758648a21383"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@6.0.6.Final-redhat-00001?type=jar",
+      "version": "6.0.6.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b6d38c8141c81799d9aae66802b32a71f6e3af42",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/hibernate/hibernate-commons-annotations.git#6.0.6.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hibernate-commons-annotations-6.0.6.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hibernate-commons-annotations-6.0.6.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0b3608f5e7d9b30452833ae018d0f9946a5c62d3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/9883909",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/AXIV7DVFWSYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.14-9-mvn3.8.4-gradle7.3.3:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/hibernate/hibernate-commons-annotations.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hibernate-search-backend-lucene",
+      "purl": "pkg:maven/org.hibernate.search/hibernate-search-backend-lucene@7.1.2.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.hibernate.search",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "70480e16d85200fc275b4ed223ea85c5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "dc2e03f2d42aaeb5d599bdfe5ab5f53a5b222a3e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c9baf07ad707038330061cc16ca669074736d4c1da889d0ec31fc12358bde9fc"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hibernate.search/hibernate-search-backend-lucene@7.1.2.Final-redhat-00002?type=jar",
+      "version": "7.1.2.Final-redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.opensource.org/licenses/LGPL-2.1",
+            "name": "GNU Lesser General Public License v2.1 or later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cb28def79b97bb1abc5c656959bcde657159dca5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/hibernate/hibernate-search.git#7.1.2.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hibernate-search-backend-lucene-7.1.2.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hibernate-search-backend-lucene-7.1.2.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "dc2e03f2d42aaeb5d599bdfe5ab5f53a5b222a3e"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387875",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNQPNQSUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/hibernate/hibernate-search.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hibernate-search-engine",
+      "purl": "pkg:maven/org.hibernate.search/hibernate-search-engine@7.1.2.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.hibernate.search",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1a83248562c6ffb645b3686bb9176ecc"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "53ffdb99e7aa3278627b051f2d50def61c576700"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "923c74a4ae2ca78ca018e93331ca584188a4336308bd39e539bec90c69aafa51"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hibernate.search/hibernate-search-engine@7.1.2.Final-redhat-00002?type=jar",
+      "version": "7.1.2.Final-redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.opensource.org/licenses/LGPL-2.1",
+            "name": "GNU Lesser General Public License v2.1 or later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cb28def79b97bb1abc5c656959bcde657159dca5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/hibernate/hibernate-search.git#7.1.2.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hibernate-search-engine-7.1.2.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hibernate-search-engine-7.1.2.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "53ffdb99e7aa3278627b051f2d50def61c576700"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387837",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNQPNQSUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/hibernate/hibernate-search.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hibernate-search-mapper-pojo-base",
+      "purl": "pkg:maven/org.hibernate.search/hibernate-search-mapper-pojo-base@7.1.2.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.hibernate.search",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ae0931de3be9696338f0b5cc93d792a8"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1cfea5f6af627804883ba8619320f62430b92087"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c1e6e4c10e988c37fbfecafcb157b8b24a90594c66819abed6efc9582a8c9969"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hibernate.search/hibernate-search-mapper-pojo-base@7.1.2.Final-redhat-00002?type=jar",
+      "version": "7.1.2.Final-redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.opensource.org/licenses/LGPL-2.1",
+            "name": "GNU Lesser General Public License v2.1 or later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cb28def79b97bb1abc5c656959bcde657159dca5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/hibernate/hibernate-search.git#7.1.2.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hibernate-search-mapper-pojo-base-7.1.2.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hibernate-search-mapper-pojo-base-7.1.2.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "1cfea5f6af627804883ba8619320f62430b92087"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387841",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNQPNQSUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/hibernate/hibernate-search.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hibernate-search-util-common",
+      "purl": "pkg:maven/org.hibernate.search/hibernate-search-util-common@7.1.2.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.hibernate.search",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "42b072cd94cae4d35c2636875791c838"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "22343bb88245197e8d60c41f8eb67a29d95630da"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "98b65530036e13db8bf4d3277c783d0171a5ddd3c3a825dc2788044e1c861143"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hibernate.search/hibernate-search-util-common@7.1.2.Final-redhat-00002?type=jar",
+      "version": "7.1.2.Final-redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.opensource.org/licenses/LGPL-2.1",
+            "name": "GNU Lesser General Public License v2.1 or later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cb28def79b97bb1abc5c656959bcde657159dca5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/hibernate/hibernate-search.git#7.1.2.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hibernate-search-util-common-7.1.2.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hibernate-search-util-common-7.1.2.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "22343bb88245197e8d60c41f8eb67a29d95630da"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387858",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNQPNQSUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/hibernate/hibernate-search.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hibernate-search-v5migrationhelper-engine",
+      "purl": "pkg:maven/org.hibernate.search/hibernate-search-v5migrationhelper-engine@7.1.2.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.hibernate.search",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "490a14aeb5fefba0bad4b591150975ab"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8575e0a0c0d04004c4ffa5b03d4d2b35b86306a6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5d2dedd844c7e6d3c181c64646ca8a43083e6c36c8f4b4e6ee971175e9753879"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.hibernate.search/hibernate-search-v5migrationhelper-engine@7.1.2.Final-redhat-00002?type=jar",
+      "version": "7.1.2.Final-redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.opensource.org/licenses/LGPL-2.1",
+            "name": "GNU Lesser General Public License v2.1 or later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cb28def79b97bb1abc5c656959bcde657159dca5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/hibernate/hibernate-search.git#7.1.2.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hibernate-search-v5migrationhelper-engine-7.1.2.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hibernate-search-v5migrationhelper-engine-7.1.2.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8575e0a0c0d04004c4ffa5b03d4d2b35b86306a6"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387810",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNQPNQSUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/hibernate/hibernate-search.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hppc",
+      "purl": "pkg:maven/com.carrotsearch/hppc@0.9.1.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "000dd28c342dcbab651a132492a9eadd"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "aa699c05e5d94209416810bc417aeca3a31b74f9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "79ff752e2f14e309c13e9a43a161d8c207239759cabcfbaf44b8ec000c2ff2dd"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.carrotsearch/hppc@0.9.1.redhat-00001?type=jar",
+      "version": "0.9.1.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "93d10b39214a4a1774715ef1fcfb6b131d0178b3",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/carrotsearch/hppc.git#0.9.1.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/hppc-0.9.1.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/hppc-0.9.1.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "aa699c05e5d94209416810bc417aeca3a31b74f9"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12528357",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BAU5V4AJSMQAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.14-9-mvn3.8.4-gradle7.3.3:1.0.2",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/carrotsearch/hppc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-anchored-keys",
+      "purl": "pkg:maven/org.infinispan/infinispan-anchored-keys@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "53e4c1dfad1940d4aef7f66c69a68bb4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e14a003ba9725024702bb51558d142e05ab5842b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b839114b0305ed4a3b6728e0b4fc2679bcda912f3f0f2243b6c98ce1a5257335"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-anchored-keys@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-anchored-keys-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-anchored-keys-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e14a003ba9725024702bb51558d142e05ab5842b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277601",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-api",
+      "purl": "pkg:maven/org.infinispan/infinispan-api@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c825a3e6c2add8aad9f064119c60c5c7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9a268376e4fb58d5d09fec9c161609359653eff2"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6a479959e3417078fb058b14a7a0097f17e9c7ebf9f66d7179d2018894227cea"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-api@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-api-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-api-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9a268376e4fb58d5d09fec9c161609359653eff2"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277570",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-cachestore-jdbc",
+      "purl": "pkg:maven/org.infinispan/infinispan-cachestore-jdbc@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "51d889a5731e89a2329781b031c513c0"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "73c186c2cfea456f25df4d07afa12860184471b2"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "229293acd52813697290e9ea4860a85d0eb9a797f51a6fba60a0ef4dc44f1823"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-cachestore-jdbc@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-jdbc-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-jdbc-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "73c186c2cfea456f25df4d07afa12860184471b2"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277452",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-cachestore-jdbc-common",
+      "purl": "pkg:maven/org.infinispan/infinispan-cachestore-jdbc-common@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "567356d7b099fb19f5af86f9d582041a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "648fe83e77366dfb57c60ff1e3ad99a4e6182d73"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "70b63e4c6f393ff1f9ef90fc7f17fd3090b3f9751f7f64fdf7e9cac16be835fb"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-cachestore-jdbc-common@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-jdbc-common-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-jdbc-common-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "648fe83e77366dfb57c60ff1e3ad99a4e6182d73"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277672",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-cachestore-remote",
+      "purl": "pkg:maven/org.infinispan/infinispan-cachestore-remote@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "390b75850c286c3828747cb540cdd402"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "139eb8a05fc5441fa00d769675e7311edb6cb219"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "12ddab14ed26cb15190d13c38e672edae4a96abbfb35675a325b288c8f744305"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-cachestore-remote@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-remote-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-remote-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "139eb8a05fc5441fa00d769675e7311edb6cb219"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277810",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-cachestore-rocksdb",
+      "purl": "pkg:maven/org.infinispan/infinispan-cachestore-rocksdb@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "80e1e844d2edace8d0c3759e250a061b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f255ace6c46f4fefdfe9f8fe81df7bae527d4c21"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8276623759f96a7b48b7179518a2541453c7e1047c8557c3faf436b5577ced4f"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-cachestore-rocksdb@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-rocksdb-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-rocksdb-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f255ace6c46f4fefdfe9f8fe81df7bae527d4c21"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277825",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-cachestore-sql",
+      "purl": "pkg:maven/org.infinispan/infinispan-cachestore-sql@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a170fd723dde097780cf77a91a1f287e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "46a2110e69b3d053a5b8e5353ffa051ab2da17d5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f392e4f0b9fd184c5fb40406402f846ddeb8cd6c222e4a4e960c3cb3e9d456f2"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-cachestore-sql@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-sql-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-cachestore-sql-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "46a2110e69b3d053a5b8e5353ffa051ab2da17d5"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277508",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-cli-client",
+      "purl": "pkg:maven/org.infinispan/infinispan-cli-client@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2c569818ed58106b36f6d476613db805"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "76e5d2a13573ae3673d4a5a00e9cc00dfb2c6378"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "65ddeb92e3c9ab3e79aafaa218f8c942f0ab38a71fa088caee2a6f3258b87cec"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-cli-client@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-cli-client-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-cli-client-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "76e5d2a13573ae3673d4a5a00e9cc00dfb2c6378"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277615",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-client-hotrod",
+      "purl": "pkg:maven/org.infinispan/infinispan-client-hotrod@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "abfc6d86a82ea1cd9d2bd01e46f132d5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bd1d7f9187f7f121e73fc68b8eecfc726af16b94"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "883a8624747ce9bca52ac3a2fabcab6e37e03b38b3dc2b006ef0ba532f1997d7"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-client-hotrod@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-client-hotrod-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-client-hotrod-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bd1d7f9187f7f121e73fc68b8eecfc726af16b94"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277799",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-client-rest",
+      "purl": "pkg:maven/org.infinispan/infinispan-client-rest@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9ff10f4f87fa4e747dc9a987653389bc"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "fb615ef234077cd298b5e42b1faf0a1a3e1ef810"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "625b9d15a00f400d64ac155a19830e4983f0fd5b2f9dcbb478a3a0e617e3da90"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-client-rest@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-client-rest-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-client-rest-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "fb615ef234077cd298b5e42b1faf0a1a3e1ef810"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277793",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-clustered-counter",
+      "purl": "pkg:maven/org.infinispan/infinispan-clustered-counter@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "55433d90b17adbec079929a9eba59ccd"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "652620ced40d314c48648423d0cb6ab8c68e0980"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0343af90c16c37123decea8ca70c39ae98fd15c95730d6ff76b80446b2692910"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-clustered-counter@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-clustered-counter-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-clustered-counter-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "652620ced40d314c48648423d0cb6ab8c68e0980"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277817",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-commons",
+      "purl": "pkg:maven/org.infinispan/infinispan-commons@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1df243c398fa4b33c0ea2edd7e0a3cb9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5f6e5feb0a612fbd36728845c3446bd4ad4309ee"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "84a7f7f0e5e7a5bc7772a5c4db0f4f8c705aa296488c15e2dd6690cd4502748f"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-commons@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-commons-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-commons-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5f6e5feb0a612fbd36728845c3446bd4ad4309ee"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277750",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-commons-graalvm",
+      "purl": "pkg:maven/org.infinispan/infinispan-commons-graalvm@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "eea5b4fc23e7b1e31271ece4617ce70e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "255e8e40b85696ca73bb1ac54a749f9144a1f87f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2883a20744877096e4d1e6a152f8a0b1505bc57d29521fdfe31806f7416cc2f8"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-commons-graalvm@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-commons-graalvm-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-commons-graalvm-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "255e8e40b85696ca73bb1ac54a749f9144a1f87f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277754",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-core",
+      "purl": "pkg:maven/org.infinispan/infinispan-core@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "58206d09879e0a3428a2322a18da8bf7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f188352b05b4e2a1eb7c88eea5d6151a505ff32f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "9de4d95a04890d3369c0b583edd4dca69715c400ee3c88398f07d73dab48be6e"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-core@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-core-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-core-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f188352b05b4e2a1eb7c88eea5d6151a505ff32f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277552",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-jboss-marshalling",
+      "purl": "pkg:maven/org.infinispan/infinispan-jboss-marshalling@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "69725b65d2719bcaf2c399388e1c6a42"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a5c6b69d421f977345c13221d74f99a9c37e1026"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4bbe43e5cfd1c7a6d0f0d11873db65e4cd8d8fe697ecd7fd3b8edf0191ffcca4"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-jboss-marshalling@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-jboss-marshalling-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-jboss-marshalling-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a5c6b69d421f977345c13221d74f99a9c37e1026"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277720",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-multimap",
+      "purl": "pkg:maven/org.infinispan/infinispan-multimap@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "005d72dc6ff851e80723c525a92d8d92"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ee541c3846d52c5aeee9aaf60e7cd41a094e9e3b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "83afa5e6842d07dc5853f1ec206dda4c940ef7aeb8aedf573b45cd09d27635fe"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-multimap@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-multimap-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-multimap-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ee541c3846d52c5aeee9aaf60e7cd41a094e9e3b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277563",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-objectfilter",
+      "purl": "pkg:maven/org.infinispan/infinispan-objectfilter@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "80321dfbba06604e2cc7d5a1b65af6ee"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a5d2268b2ba82a0f81ddf60d5a88bdca0969c58b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ecbe19ada05b24012bf2970f7b626c65b46ab3794f7a0eea764c3910700fa170"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-objectfilter@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-objectfilter-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-objectfilter-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a5d2268b2ba82a0f81ddf60d5a88bdca0969c58b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277822",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-query",
+      "purl": "pkg:maven/org.infinispan/infinispan-query@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e64b4ce2f0f73017fbe4d1532a2bb669"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "48cf4b3bb7eb4d29a7a43359de7cff08014424f7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "aeda9999cee0d0691fb72aa80f7744788dae0ef7814f01ca567bc71cb086e723"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-query@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-query-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-query-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "48cf4b3bb7eb4d29a7a43359de7cff08014424f7"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277621",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-query-core",
+      "purl": "pkg:maven/org.infinispan/infinispan-query-core@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6bdecf9627ebfd7ad4bd7aa715fd9af0"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5121236ee86bd2e97e89c6f1662ffebb2cf1c726"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "839d7060bffbef793979a461460dae397b848beeb76ebda5049088352773c328"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-query-core@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-query-core-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-query-core-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5121236ee86bd2e97e89c6f1662ffebb2cf1c726"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277712",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-query-dsl",
+      "purl": "pkg:maven/org.infinispan/infinispan-query-dsl@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7fdd8d81781f147f2b5a51c57ea5048a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1506d3661637ddfb7a0caaf4ec5a739e64147577"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4384fa60294a627734849bdeba50dfb0b737cbde4ffb82615d9ec3d4a036e39e"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-query-dsl@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-query-dsl-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-query-dsl-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "1506d3661637ddfb7a0caaf4ec5a739e64147577"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277638",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-remote-query-client",
+      "purl": "pkg:maven/org.infinispan/infinispan-remote-query-client@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7df8528aa1a42af4a821614aeed0c80a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c69f7e88966f925c1ff1f6469ae0969758d3f480"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2818c7109902cc0a5406f2ccf7e9393883c8b141050c319faf4d15715636b3c9"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-remote-query-client@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-remote-query-client-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-remote-query-client-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c69f7e88966f925c1ff1f6469ae0969758d3f480"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277572",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-remote-query-server",
+      "purl": "pkg:maven/org.infinispan/infinispan-remote-query-server@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "44b6fdc3cbc4dd8e4379ccdefd308163"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0011892a87e79f6a47e77caa0f570867d6ac2fce"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "241f340e46c3c35d7e3d0c9d91791b4a0e44688b3d8489ce4cefbb2be01e305d"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-remote-query-server@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-remote-query-server-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-remote-query-server-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0011892a87e79f6a47e77caa0f570867d6ac2fce"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277726",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-scripting",
+      "purl": "pkg:maven/org.infinispan/infinispan-scripting@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "83c42af96244e1a3e10b78243e628b12"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b465036a4270d4d8c93a37bd89df48657e379aa3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2c94308746c75026bff6e20b7737f0e35e6119f8849e9a126ecb9be5eab590b5"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-scripting@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-scripting-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-scripting-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b465036a4270d4d8c93a37bd89df48657e379aa3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277667",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-core",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-core@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ebfff9aa9eea101acaa6fd4937d52a66"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f2c35dbb068fd2b26fdd5305cd93a6f94f6c3654"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4682d5a29ccc60544fe81429d0e4e646be637a086d54409a17d211be80dd7fb9"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-core@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-core-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-core-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f2c35dbb068fd2b26fdd5305cd93a6f94f6c3654"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277557",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-hotrod",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-hotrod@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "cc1c0bf0c506f87069b75f07b087af17"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "602161be23ef73a4715f38f6fa2c23261c7a2c2e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4a2c502feb0396f770aa6485e96cd2899c5b7f4034920f8eb9e42fd19991ac12"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-hotrod@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-hotrod-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-hotrod-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "602161be23ef73a4715f38f6fa2c23261c7a2c2e"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277539",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-insights",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-insights@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b3c2cdaa0e171e3d131d229e8ab3bc55"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "87c7d683e3d17894cc957648f9f18f9636dce016"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c94e9968ffe2b0f22ca89f9fa56cde4a782f55e30528466f608911ec8014deba"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-insights@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-insights-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-insights-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "87c7d683e3d17894cc957648f9f18f9636dce016"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277498",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-memcached",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-memcached@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2b6de11ee8d3a28b293405894a0d6ca5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b43ef7d49af30f2754426c9460e2176b200e9567"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5a435f54fe1dbc4e20dd3cd5ee401b382df7deca7ee80ec9db48a145359aa94c"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-memcached@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-memcached-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-memcached-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b43ef7d49af30f2754426c9460e2176b200e9567"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277782",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-resp",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-resp@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "84f0b9d459413c8d4817218c8bc26698"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "925157066b72273ca4dab72b59bff2bff8923b30"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "800ff86489413eaa3c521454a12176c0f82b5497b9109470fb27370110276f83"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-resp@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-resp-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-resp-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "925157066b72273ca4dab72b59bff2bff8923b30"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277618",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-rest",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-rest@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6e78b2604d15723d852baeedc099ca5b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b2e87e7bdc6e615a0dc312edfca2c9dd14cd604d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7e2cddf84521dc3a71a3ca229a5a4e4a0fac8a9726fe09af5fab0e541989c98d"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-rest@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-rest-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-rest-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b2e87e7bdc6e615a0dc312edfca2c9dd14cd604d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277488",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-router",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-router@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "12482f189ec249f4e6e9f6fd0cc41590"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "615c6189c6895f312c1a87d370153a8063f5a851"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "62cc5ee9bd963c631a4c68b667ce25df341d31a86633ae0bbc45db2f282b52d9"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-router@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-router-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-router-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "615c6189c6895f312c1a87d370153a8063f5a851"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277519",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-runtime",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ab9a52f4210a249dd5c2233a1881aada"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6935cdbf4c3d7e5898937a5ee710d77ceb0c66e9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8a81e688d9736617cf9bdcbea1be1cafda0fbf04839d9743a8c0070a55e9ba09"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/boot/infinispan-server-runtime-15.0.19.Final-redhat-00001-loader.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/boot/infinispan-server-runtime-15.0.19.Final-redhat-00001-loader.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6401bb733782d0ab1af1fd60eb229615de46e72d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277553",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-server-runtime",
+      "purl": "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ab9a52f4210a249dd5c2233a1881aada"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6935cdbf4c3d7e5898937a5ee710d77ceb0c66e9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8a81e688d9736617cf9bdcbea1be1cafda0fbf04839d9743a8c0070a55e9ba09"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?package-id=c7ba178dee624963",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-server-runtime-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-server-runtime-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6935cdbf4c3d7e5898937a5ee710d77ceb0c66e9"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277553",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-tasks",
+      "purl": "pkg:maven/org.infinispan/infinispan-tasks@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6c5c25d103ce5251b53bd4006e8c073d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6d0f44508fbc6e5fa62eb3d2570baef47ceb6949"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ed44223a7c56a236f5f4092331e28bb78c497a9815c7d327f60345144b387728"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-tasks@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-tasks-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-tasks-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6d0f44508fbc6e5fa62eb3d2570baef47ceb6949"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277476",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-tasks-api",
+      "purl": "pkg:maven/org.infinispan/infinispan-tasks-api@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5ea9d9ce129d27e78c0a49c771d388d3"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ec0dbd08ac0f40e6b4cb94609a74fa5c5f865f9a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "91022893691c3962594db42daa8f723fa2b4967d44f96e9d097855f437f57bec"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-tasks-api@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-tasks-api-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-tasks-api-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ec0dbd08ac0f40e6b4cb94609a74fa5c5f865f9a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277567",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "infinispan-tools",
+      "purl": "pkg:maven/org.infinispan/infinispan-tools@15.0.19.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.infinispan",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "299990a70c302de2c32baa01f9ea7116"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "04f243baa64ed2d13f3dfa539ee7bc249c01a6ab"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c6564c352b2fe968db1160e7fc2bb39d3fe961a09085ff45d1623747205a3af1"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan/infinispan-tools@15.0.19.Final-redhat-00001?type=jar",
+      "version": "15.0.19.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "57ef36131101abd1844e22ee3d5a5ec0203b8b95",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/infinispan/infinispan.git#15.0.19.Final-redhat-00001"
+          },
+          {
+            "uid": "c3972650b7dce3893be199b096e1a818a42d148d",
+            "url": "https://github.com/infinispan/infinispan.git#c3972650b7dce3893be199b096e1a818a42d148d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/infinispan-tools-15.0.19.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/infinispan-tools-15.0.19.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "04f243baa64ed2d13f3dfa539ee7bc249c01a6ab"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277535",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-mandrel-23.1.2.0-mvn3.9.4:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/infinispan/infinispan.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "iproute",
+      "purl": "pkg:rpm/redhat/iproute@6.11.0-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/iproute@6.11.0-1.el9?arch=x86_64",
+      "version": "6.11.0-1.el9",
+      "licenses": [
+        {
+          "expression": "GPL-2.0-or-later AND NIST-PD"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b48b93cae6a05b22324b4da3680df8d15877ea00",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/iproute#b48b93cae6a05b22324b4da3680df8d15877ea00"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3470001",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/iproute#b48b93cae6a05b22324b4da3680df8d15877ea00",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jackson-annotations",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.16.2.redhat-00001?type=jar",
+      "type": "library",
+      "group": "com.fasterxml.jackson.core",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "27a42e46ae645fee05ddac950c45a5a5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8e2228d7b3749929372cc15831e17297ad867bee"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d5c21bee1725602457513dbea38a80fa1f70c5be4ad021c3020b639181faa22f"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.16.2.redhat-00001?type=jar",
+      "version": "2.16.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07d9737f2ac52781e85fe8f87665bdfc6e2e8bb2",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/FasterXML/jackson-annotations.git#2.16.2.redhat-00001"
+          },
+          {
+            "uid": "6a2d806e4aec3e481ac8e78532c31fb4cbf29ad7",
+            "url": "https://github.com/FasterXML/jackson-annotations.git#jackson-annotations-2.16.2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jackson-annotations-2.16.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jackson-annotations-2.16.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8e2228d7b3749929372cc15831e17297ad867bee"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12193632",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7IWFY5UCDYAW",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "jackson-core",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.16.2.redhat-00001?type=jar",
+      "type": "library",
+      "group": "com.fasterxml.jackson.core",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6805a7b54e86c4fb33ade33c7f91e32c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d4c277d701922aba2d8c4623dda1c0b372f7369f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "dca47d81aea8d6cf49d51ad401ca4b3dce370795405ae05e0dda577a6e829865"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.16.2.redhat-00001?type=jar",
+      "version": "2.16.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1db06f09b6d66ea3d644c9f8d94fbdf5e723b6b8",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/FasterXML/jackson-core.git#2.16.2.redhat-00001"
+          },
+          {
+            "uid": "4162dfc503bd97e6824b1d5baa6de7895d3b3367",
+            "url": "https://github.com/FasterXML/jackson-core.git#jackson-core-2.16.2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jackson-core-2.16.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jackson-core-2.16.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d4c277d701922aba2d8c4623dda1c0b372f7369f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12193635",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7IWFY5UCDYAC",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/FasterXML/jackson-core.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jackson-databind",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.16.2.redhat-00001?type=jar",
+      "type": "library",
+      "group": "com.fasterxml.jackson.core",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2342e0d9e400adc6e1d5a2d563db4915"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e7f0c14801bb0185fe03b0e96e2a8a6a085ec1b2"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "01c4fbfc79ce01a6bb3de18cd4365afd89fe0eb9f882ddcd760bef568507bb9a"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.16.2.redhat-00001?type=jar",
+      "version": "2.16.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5aa42b80313de58bda0c417f3f239d25df5ef21f",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/FasterXML/jackson-databind.git#2.16.2.redhat-00001"
+          },
+          {
+            "uid": "a04a0a1852acf9ab5a80d10631026d9814436114",
+            "url": "https://github.com/FasterXML/jackson-databind#jackson-databind-2.16.2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jackson-databind-2.16.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jackson-databind-2.16.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e7f0c14801bb0185fe03b0e96e2a8a6a085ec1b2"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12193640",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7IWFY5UCDYAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/FasterXML/jackson-databind",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jackson-datatype-jdk8",
+      "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.16.2.redhat-00001?type=jar",
+      "type": "library",
+      "group": "com.fasterxml.jackson.datatype",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4def7c9df2ac61a9a202f8ce7069b8f7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e8999d4b9525fdd42dd9a333ba0a080a621968b4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "33840a5ecbc71b03a13d1abc898cd94cabb6ea821a02e8aacdc1b04ee26cbea8"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.16.2.redhat-00001?type=jar",
+      "version": "2.16.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f627019d10505cad34366c2838c651ad74cf4402",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/FasterXML/jackson-modules-java8.git#2.16.2.redhat-00001"
+          },
+          {
+            "uid": "7b02de1312210ac0cbc84ecb2b9be95fe2363ee1",
+            "url": "https://github.com/FasterXML/jackson-modules-java8.git#jackson-modules-java8-2.16.2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jackson-datatype-jdk8-2.16.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jackson-datatype-jdk8-2.16.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e8999d4b9525fdd42dd9a333ba0a080a621968b4"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12193706",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7IWFY5UCDYA4",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/FasterXML/jackson-modules-java8.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jackson-datatype-jsr310",
+      "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.16.2.redhat-00001?type=jar",
+      "type": "library",
+      "group": "com.fasterxml.jackson.datatype",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "426f076655d0b227f3308cc45444b0ad"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c53a960de8eba8d8f22a797f4a3a17610ce6f054"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8022d3e299120aa025ae6fa7ad1970d9cb707cfb722f1270c2e4c66f09d8ec1a"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.16.2.redhat-00001?type=jar",
+      "version": "2.16.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f627019d10505cad34366c2838c651ad74cf4402",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/FasterXML/jackson-modules-java8.git#2.16.2.redhat-00001"
+          },
+          {
+            "uid": "7b02de1312210ac0cbc84ecb2b9be95fe2363ee1",
+            "url": "https://github.com/FasterXML/jackson-modules-java8.git#jackson-modules-java8-2.16.2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jackson-datatype-jsr310-2.16.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jackson-datatype-jsr310-2.16.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c53a960de8eba8d8f22a797f4a3a17610ce6f054"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12193700",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7IWFY5UCDYA4",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/FasterXML/jackson-modules-java8.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jakarta.json",
+      "purl": "pkg:maven/org.glassfish/jakarta.json@2.0.1.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.glassfish",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "eb5182fa4e28a355cb7025a4496e09c1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "38bab560ff71c9e95c3d0e96ba95f81aca4ab9a4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a993fae280a191c7b47b49f862ffd587cf827f67e1ffea09a15b18c6e2bcc76e"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.glassfish/jakarta.json@2.0.1.redhat-00001?type=jar",
+      "version": "2.0.1.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://projects.eclipse.org/license/epl-2.0, https://projects.eclipse.org/license/secondary-gpl-2.0-cp"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a7225d9c6adac65abd71ff0dc03d85b98d52660d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jakartaee/jsonp-api.git#2.0.1.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jakarta.json-2.0.1.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jakarta.json-2.0.1.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "38bab560ff71c9e95c3d0e96ba95f81aca4ab9a4"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11555991",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A4RXCEYTNVIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mx-mvn3.6.0:1.1.2",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "jakarta.transaction-api",
+      "purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@2.0.1.redhat-00004?type=jar",
+      "type": "library",
+      "group": "jakarta.transaction",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e7e50a5c1b223a660b8b09151524dca4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bbaeb416b3b3690e450cfbc29956c2cd0cb14213"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "648ac5de6cf10b58c0aa1357d7e312c4fc5cceea5d62ded7fc9f587573cd9cbb"
+        }
+      ],
+      "bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@2.0.1.redhat-00004?type=jar",
+      "version": "2.0.1.redhat-00004",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d942df8b8a62d3ba0312ec74645a1255d47cb888",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/eclipse-ee4j/jta-api.git#2.0.1.redhat-00004"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jakarta.transaction-api-2.0.1.redhat-00004.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jakarta.transaction-api-2.0.1.redhat-00004.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bbaeb416b3b3690e450cfbc29956c2cd0cb14213"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11187040",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A3OFCG7JKMYBI",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.6.3:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/eclipse-ee4j/jta-api.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jandex",
+      "purl": "pkg:maven/io.smallrye/jandex@3.3.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "io.smallrye",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2057b4a3915c2c9253ff5ce191bfdf11"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9c54762010a098d04486f4755c6ae83e726ce261"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "49dcd14a72f873b8221bfb4f0cf030ea45915cb1b375928959c7aff1cca5eb82"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.smallrye/jandex@3.3.0.redhat-00001?type=jar",
+      "version": "3.3.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1949d05b7d0d775e86ec6207640f261e8a5ac9aa",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jandex.git#3.3.0.redhat-00001"
+          },
+          {
+            "uid": "6e33aa2cc1fac966d0b59e4caaaf3382e0d9e359",
+            "url": "https://github.com/wildfly/jandex.git#3.3.0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jandex-3.3.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jandex-3.3.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9c54762010a098d04486f4755c6ae83e726ce261"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13880051",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BHJSJIKGJSIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17.0.2-8-mx-mvn3.6.3:1.0.2",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly/jandex.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jansi",
+      "purl": "pkg:maven/org.fusesource.jansi/jansi@2.4.0.redhat-00003?type=jar",
+      "type": "library",
+      "group": "org.fusesource.jansi",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "26fecb24841f7a7a6549208eac257e33"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5f9b7d1cfd2db5bfa22defba8cd06c8f68fa3af3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bf7137baf3bfb1e9461b95e5bb8c0e0f8f77d8cfc181ff275ffdb3dd43406e98"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.fusesource.jansi/jansi@2.4.0.redhat-00003?type=jar",
+      "version": "2.4.0.redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f57067c429f217e4c46c368253808a7b54786d88",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jansi.git#2.4.0.redhat-00003"
+          },
+          {
+            "uid": "165d4e0617362fe9d05f626d2b4b290cbaa65c63",
+            "url": "https://github.com/fusesource/jansi.git#jansi-2.4.0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jansi-2.4.0.redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jansi-2.4.0.redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5f9b7d1cfd2db5bfa22defba8cd06c8f68fa3af3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12914508",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2NCQULNVAAC",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.6",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/fusesource/jansi.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "java-21-openjdk-headless",
+      "purl": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.8.0.9-1.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.8.0.9-1.el9?arch=x86_64&epoch=1",
+      "version": "1:21.0.8.0.9-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6c9588372e4482aa42534e4a4637b5fd06b3eca4",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#6c9588372e4482aa42534e4a4637b5fd06b3eca4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3741429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#6c9588372e4482aa42534e4a4637b5fd06b3eca4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "javapackages-filesystem",
+      "purl": "pkg:rpm/redhat/javapackages-filesystem@6.4.0-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/javapackages-filesystem@6.4.0-1.el9?arch=noarch",
+      "version": "6.4.0-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "41385fffa364031f88363ac251bffe64df0243cd",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/javapackages-tools#41385fffa364031f88363ac251bffe64df0243cd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3452090",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/javapackages-tools#41385fffa364031f88363ac251bffe64df0243cd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jboss-logging",
+      "purl": "pkg:maven/org.jboss.logging/jboss-logging@3.6.1.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.jboss.logging",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "03d0985b7d7de558ab1adfc9e2066b4b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "94a50c9ff838417d1eda9db040d0e45e7997724c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "84fdeb83918eab86e6ef623efcd94470f47d1c73a9f8b13e70ed42b2e9ad6107"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.6.1.Final-redhat-00001?type=jar",
+      "version": "3.6.1.Final-redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://repository.jboss.org/licenses/apache-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3be6af5bc6cb005633d59bd86b407cc068e932f0",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jboss-logging/jboss-logging.git#3.6.1.Final-redhat-00001"
+          },
+          {
+            "uid": "086ff9fdd86892ea67ef748fea69a99f3a6bc57d",
+            "url": "https://github.com/jboss-logging/jboss-logging.git#086ff9fdd86892ea67ef748fea69a99f3a6bc57d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jboss-logging-3.6.1.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jboss-logging-3.6.1.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "94a50c9ff838417d1eda9db040d0e45e7997724c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13493016",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF3XU65QKVYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/jboss-logging/jboss-logging.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jboss-marshalling",
+      "purl": "pkg:maven/org.jboss.marshalling/jboss-marshalling@2.2.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.jboss.marshalling",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "dec1475b91d1eda42d7ca629a0ed6778"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b317093216eff6a016c7ba04d9df406a4ba8088d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5c1b40d20ee820cfc6974fb423926a0c98bb9d23b1af84d96e21cfff005abcbd"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jboss.marshalling/jboss-marshalling@2.2.2.Final-redhat-00001?type=jar",
+      "version": "2.2.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9f659bf7f5b5addf218338b2c5a7710a71e93547",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jboss-remoting/jboss-marshalling.git#2.2.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jboss-marshalling-2.2.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jboss-marshalling-2.2.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b317093216eff6a016c7ba04d9df406a4ba8088d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13504331",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5SEZTPKVYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.6.3-gradle7.2:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/jboss-remoting/jboss-marshalling.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jboss-marshalling-river",
+      "purl": "pkg:maven/org.jboss.marshalling/jboss-marshalling-river@2.2.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.jboss.marshalling",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9572df79d6bef317767704c0520d8b52"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b7dce2740881d5233198795003fc892b216caf9e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4d49f81655a9b2ab75ee27780b3ce6e22603a7fb6f8ab4d134daaf9eb14a4c9e"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jboss.marshalling/jboss-marshalling-river@2.2.2.Final-redhat-00001?type=jar",
+      "version": "2.2.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9f659bf7f5b5addf218338b2c5a7710a71e93547",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jboss-remoting/jboss-marshalling.git#2.2.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jboss-marshalling-river-2.2.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jboss-marshalling-river-2.2.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b7dce2740881d5233198795003fc892b216caf9e"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13504322",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5SEZTPKVYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.6.3-gradle7.2:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/jboss-remoting/jboss-marshalling.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jboss-threads",
+      "purl": "pkg:maven/org.jboss.threads/jboss-threads@3.6.1.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.jboss.threads",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "db73d984ca74bf77086482ecbf0829a3"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "08ffac37882606f5d28b991dfd807a5fa09c7e3a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4ed78159cbb176f5f5c65e3799469e4d1d55a4165e7de8bbc34f273c81831c4a"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.6.1.Final-redhat-00001?type=jar",
+      "version": "3.6.1.Final-redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6b988a6b56ddaecf174a5a87d858c3c4555fe339",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jbossas/jboss-threads.git#3.6.1.Final-redhat-00001"
+          },
+          {
+            "uid": "1e97bb4b9e8d5b9ea1963994428202b89cb3f49d",
+            "url": "https://github.com/jbossas/jboss-threads.git#3.6.1.Final"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jboss-threads-3.6.1.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jboss-threads-3.6.1.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "08ffac37882606f5d28b991dfd807a5fa09c7e3a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12432402",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BAC74JRX4FIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.2-13-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/jbossas/jboss-threads.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jcl-over-slf4j",
+      "purl": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32.redhat-00003?type=jar",
+      "type": "library",
+      "group": "org.slf4j",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ab84582a9a7e33505e7751f9735bc199"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8183f7d48345087e1dd3bf4ec947633e5489beee"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4dc5701b31d13eb1c6871fc9fbdc17d3ae45d00f79e139100d430e8db4491a4e"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32.redhat-00003?type=jar",
+      "version": "1.7.32.redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "236b1dcaa8f6126a85b2a76bc7eecaf14ca4b37e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/slf4j.git#1.7.32.redhat-00003"
+          },
+          {
+            "uid": "0d8774854f4ebb0807bcb69867c13f1e991fcde5",
+            "url": "https://github.com/qos-ch/slf4j#v_1.7.32"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jcl-over-slf4j-1.7.32.redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jcl-over-slf4j-1.7.32.redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8183f7d48345087e1dd3bf4ec947633e5489beee"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11961873",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6S3WUGZ2DYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/qos-ch/slf4j",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jctools-core",
+      "purl": "pkg:maven/org.jctools/jctools-core@4.0.1?type=jar",
+      "type": "library",
+      "group": "org.jctools",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2d892c2868d73b9f06166da8f8ee0c57"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e12d5984d45aee3976249400dae1bbcafcf5ff0a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b0bac296a02d65b509e6979360796be1cab97727a1d7bb15d069557d3f62ac2f"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jctools/jctools-core@4.0.1?type=jar",
+      "version": "4.0.1",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.txt",
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-trace-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-trace-1.32.0.redhat-00001.jar:org.jctools:jctools-core"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/9899288",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        }
+      ]
+    },
+    {
+      "name": "jctools-core",
+      "purl": "pkg:maven/org.jctools/jctools-core@4.0.5.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.jctools",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b1be5d5d1139c878b92894eb06ea84df"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a9a79bbd4227cfa897325341ad7ed099a91a068c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3cc2f0d9fbde68cc0540fe73ddc2f70fbb6b8bce505eca90429e8fb6f72692d5"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jctools/jctools-core@4.0.5.redhat-00001?type=jar",
+      "version": "4.0.5.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5a5f0fd1b32399597677c63e87b731dbefa7008b",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/JCTools/JCTools.git#4.0.5.redhat-00001"
+          },
+          {
+            "uid": "a17b56f09cc9ec7d773707578c89f3ca9c11f968",
+            "url": "https://github.com/JCTools/JCTools.git#v4.0.5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-common-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-common-4.1.121.Final-redhat-00003.jar:org.jctools:jctools-core"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12915867",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2OGRGINVAAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/JCTools/JCTools.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jgroups",
+      "purl": "pkg:maven/org.jgroups/jgroups@5.3.16.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.jgroups",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "752c1afd8e6e53ccf777d7e55c6cbaad"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "db07655e0f3d8b201853569785d36692c7fa8976"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1e2ff937dd3cd7a8ad4c5fd8681e49f58763cccbc5a58e110a5e57d8791d3da4"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jgroups/jgroups@5.3.16.Final-redhat-00001?type=jar",
+      "version": "5.3.16.Final-redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4d55f4475e58ef886c87f474a068cd457c2d2366",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/JGroups.git#5.3.16.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jgroups-5.3.16.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jgroups-5.3.16.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "db07655e0f3d8b201853569785d36692c7fa8976"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13873713",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BHIXKX7MZSIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.6.3:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/belaban/JGroups.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jmh-core",
+      "purl": "pkg:maven/org.openjdk.jmh/jmh-core@1.37.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.openjdk.jmh",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1b35c598339845bff90ccf623a836ea2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "99168e5edecf956855d73f1c7bd4e82a19e692bb"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "78b1e52a4316dafb0c5fcb96195808544d9cd3bcc07e53e3f0b22dd324c4bd7b"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.openjdk.jmh/jmh-core@1.37.0.redhat-00001?type=jar",
+      "version": "1.37.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5dcc17974b37a5ae70eed8aa17d9a934c4cc011a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/openjdk/codetools/jmh.git#1.37.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jmh-core-1.37.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jmh-core-1.37.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "99168e5edecf956855d73f1c7bd4e82a19e692bb"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12427354",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BACIJWSW4FIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "jopt-simple",
+      "purl": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4.redhat-00002?type=jar",
+      "type": "library",
+      "group": "net.sf.jopt-simple",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "674f8454633dfe0e94540bb3a012fc84"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "fddd9adc22c99b76a4783c52c9be72651ccbdabf"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bc82c10b1ca3892d0aea1b456d764e26e34c7ea0efa84988d59335d59d3c34f2"
+        }
+      ],
+      "bom-ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4.redhat-00002?type=jar",
+      "version": "5.0.4.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.opensource.org/licenses/mit-license.php"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cde43141d1ce63eebc3342cdc70bb7ba333082fa",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jopt-simple/jopt-simple.git#5.0.4.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jopt-simple-5.0.4.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jopt-simple-5.0.4.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "fddd9adc22c99b76a4783c52c9be72651ccbdabf"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/756791",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/12372",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.3.9:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/jopt-simple/jopt-simple.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jrt-fs",
+      "purl": "pkg:maven/jrt-fs/jrt-fs@21.0.8?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/jrt-fs/jrt-fs@21.0.8?type=jar",
+      "version": "21.0.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/jvm/java-21-openjdk-21.0.8.0.9-1.el9.x86_64/lib/jrt-fs.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/lib/jvm/java-21-openjdk-21.0.8.0.9-1.el9.x86_64/lib/jrt-fs.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "cbc77df813d6027b3ea886124ae62a72b73d771f"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "json-c",
+      "purl": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "version": "0.14-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "391500fb2a46f72180ba1353136c1b3327d71c55",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1728857",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "json-glib",
+      "purl": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "version": "1.6.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d5548792bb86a77330957962541a936d9c391896",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1707185",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jspecify",
+      "purl": "pkg:maven/org.jspecify/jspecify@1.0.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1ff6383495b2f8bde95f9d88458e694e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5a6871bfc86a0081a43fb23926e480f1f62f1de7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d8a7744f6b81521b73d37c4f1ac16fc1041a6cea07dcbbb468fd68e96f036e8a"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.jspecify/jspecify@1.0.0.redhat-00001?type=jar",
+      "version": "1.0.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6202bed29a3526385e179ec85cd15d198bd12f48",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/jspecify/jspecify.git#1.0.0.redhat-00001"
+          },
+          {
+            "uid": "b2a10e14bb81c1b7cb6e488c112fe55cb2218d7d",
+            "url": "https://github.com/jspecify/jspecify#v1.0.0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/jspecify-1.0.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/jspecify-1.0.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5a6871bfc86a0081a43fb23926e480f1f62f1de7"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13268528",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BEKOPSUU5BAAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21-mvn3.8.6-gradle8.9:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/jspecify/jspecify",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "keyutils-libs",
+      "purl": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "version": "1.6.3-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+            "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2212253",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "krb5-libs",
+      "purl": "pkg:rpm/redhat/krb5-libs@1.21.1-8.el9_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/krb5-libs@1.21.1-8.el9_6?arch=x86_64",
+      "version": "1.21.1-8.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "08d251b9d687093e68ae8b88583777d062df7a77",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#08d251b9d687093e68ae8b88583777d062df7a77"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3632943",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#08d251b9d687093e68ae8b88583777d062df7a77",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-font-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "langpacks-en",
+      "purl": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lettuce-core",
+      "purl": "pkg:maven/io.lettuce/lettuce-core@6.5.4.RELEASE-redhat-00001?type=jar",
+      "type": "library",
+      "group": "io.lettuce",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6c5b68f4fa85722a44221e4a3dd3ad15"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ee8f2ed9d766cb004d116237e53d32efe54c3e44"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "863a9e8e74c6f3b57fc69f7cd106c10ffbbefd506107aba5bb1caa54fc52225d"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.lettuce/lettuce-core@6.5.4.RELEASE-redhat-00001?type=jar",
+      "version": "6.5.4.RELEASE-redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8ff18f83cf74bba23b945728b6816a3a6ae1791b",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/lettuce-io/lettuce-core.git#6.5.4.RELEASE-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lettuce-core-6.5.4.RELEASE-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lettuce-core-6.5.4.RELEASE-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ee8f2ed9d766cb004d116237e53d32efe54c3e44"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13488927",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF3BNQJQ2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/lettuce-io/lettuce-core.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libacl",
+      "purl": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "version": "2.3.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2709815",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libarchive",
+      "purl": "pkg:rpm/redhat/libarchive@3.5.3-6.el9_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libarchive@3.5.3-6.el9_6?arch=x86_64",
+      "version": "3.5.3-6.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "476a518562a29e2fa60704cd358f8afffb8492c4",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#476a518562a29e2fa60704cd358f8afffb8492c4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3803996",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libarchive#476a518562a29e2fa60704cd358f8afffb8492c4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libassuan",
+      "purl": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "version": "2.5.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5b185f851a42718727fee9efcf42ba525a59a8bb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689887",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libattr",
+      "purl": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "version": "2.5.1-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+            "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688838",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libblkid",
+      "purl": "pkg:rpm/redhat/libblkid@2.37.4-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libblkid@2.37.4-21.el9?arch=x86_64",
+      "version": "2.37.4-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471212",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libbpf",
+      "purl": "pkg:rpm/redhat/libbpf@1.5.0-1.el9?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libbpf@1.5.0-1.el9?arch=x86_64&epoch=2",
+      "version": "2:1.5.0-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 or BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8370b4dbea8aa55c17265f934664e6c78cdf7c73",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libbpf#8370b4dbea8aa55c17265f934664e6c78cdf7c73"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3486772",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libbpf#8370b4dbea8aa55c17265f934664e6c78cdf7c73",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcap",
+      "purl": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+      "version": "2.48-9.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "579dc340bc85f77708d4c04f72f9cc7c2ad16e27",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap#579dc340bc85f77708d4c04f72f9cc7c2ad16e27"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2590508",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap#579dc340bc85f77708d4c04f72f9cc7c2ad16e27",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcap-ng",
+      "purl": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "version": "0.8.2-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1888632",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcom_err",
+      "purl": "pkg:rpm/redhat/libcom_err@1.46.5-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcom_err@1.46.5-7.el9?arch=x86_64",
+      "version": "1.46.5-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "771c8949276084b3922510ff1540635f077cea19",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#771c8949276084b3922510ff1540635f077cea19"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3481423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#771c8949276084b3922510ff1540635f077cea19",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcurl-minimal",
+      "purl": "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9_6.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9_6.1?arch=x86_64",
+      "version": "7.76.1-31.el9_6.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a2733637295493c735a219942d4763b019dbda31",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#a2733637295493c735a219942d4763b019dbda31"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3598144",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#a2733637295493c735a219942d4763b019dbda31",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libdnf",
+      "purl": "pkg:rpm/redhat/libdnf@0.69.0-13.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf@0.69.0-13.el9?arch=x86_64",
+      "version": "0.69.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7139d16e2670e605c9d1d94aa3a50ceed0119afd",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#7139d16e2670e605c9d1d94aa3a50ceed0119afd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3497458",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#7139d16e2670e605c9d1d94aa3a50ceed0119afd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libevent",
+      "purl": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "version": "2.1.12-8.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3235991",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libffi",
+      "purl": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "version": "3.4.2-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6f484e5230669fffb71870ce41c386e01ab4e47d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467679",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcc",
+      "purl": "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64",
+      "version": "11.5.0-5.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94f8d08fea6e2026c7aa2ba346696bed8a1555f6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#94f8d08fea6e2026c7aa2ba346696bed8a1555f6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3501765",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#94f8d08fea6e2026c7aa2ba346696bed8a1555f6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcrypt",
+      "purl": "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64",
+      "version": "1.10.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6cd6cde2ff10db934bd6b9be9ecdfe75edebb67a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#6cd6cde2ff10db934bd6b9be9ecdfe75edebb67a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3202712",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#6cd6cde2ff10db934bd6b9be9ecdfe75edebb67a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgpg-error",
+      "purl": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "version": "1.42-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "55660568a38dad2e4a858df692830af766ad6532",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1818836",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libidn2",
+      "purl": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "version": "2.3.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or LGPLv3+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c781354177446e1bb6a5b48d2113feaed50cc860",
+            "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libksba",
+      "purl": "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64",
+      "version": "1.5.1-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(LGPLv3+ or GPLv2+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ced1b2ff933b56b33f08882bb4e5ddba997afaa6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libksba#ced1b2ff933b56b33f08882bb4e5ddba997afaa6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3198143",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libksba#ced1b2ff933b56b33f08882bb4e5ddba997afaa6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmnl",
+      "purl": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+      "version": "1.0.4-16.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e4e253af7af3650798d04664f7b96965ed5365ad",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libmnl#e4e253af7af3650798d04664f7b96965ed5365ad"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3049134",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libmnl#e4e253af7af3650798d04664f7b96965ed5365ad",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmodulemd",
+      "purl": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "version": "2.13.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d48969327abbcbfad2ab893639cfb7d22362223d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1695462",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmount",
+      "purl": "pkg:rpm/redhat/libmount@2.37.4-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmount@2.37.4-21.el9?arch=x86_64",
+      "version": "2.37.4-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471212",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnghttp2",
+      "purl": "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64",
+      "version": "1.43.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79861abb0ea729bcf418eabaf5027b18ba623bf9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#79861abb0ea729bcf418eabaf5027b18ba623bf9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2996602",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#79861abb0ea729bcf418eabaf5027b18ba623bf9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpeas",
+      "purl": "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64",
+      "version": "1.30.0-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "14f3f166e32b0592b8a0289de0e7050df985f9a0",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpeas#14f3f166e32b0592b8a0289de0e7050df985f9a0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690090",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpeas#14f3f166e32b0592b8a0289de0e7050df985f9a0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "librepo",
+      "purl": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+      "version": "1.14.5-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "458f8b732e9d31cbe09323c87f796924ac30461c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797210",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libreport-filesystem",
+      "purl": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "version": "2.15.2-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4690267165817ccc06cb342d8ef955ae10b54c75",
+            "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1852394",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "librhsm",
+      "purl": "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64",
+      "version": "0.0.3-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bf2220747d150d79be10852ee5e990f99d7f2a77",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#bf2220747d150d79be10852ee5e990f99d7f2a77"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2996611",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#bf2220747d150d79be10852ee5e990f99d7f2a77",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libselinux",
+      "purl": "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64",
+      "version": "3.6-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "46550b75ecf34b63df099f9f009381df9227ce88",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#46550b75ecf34b63df099f9f009381df9227ce88"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3485081",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#46550b75ecf34b63df099f9f009381df9227ce88",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsemanage",
+      "purl": "pkg:rpm/redhat/libsemanage@3.6-5.el9_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsemanage@3.6-5.el9_6?arch=x86_64",
+      "version": "3.6-5.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ef095b2e9bc119969f848f04b96582d8b85fe5b4",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#ef095b2e9bc119969f848f04b96582d8b85fe5b4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3533947",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#ef095b2e9bc119969f848f04b96582d8b85fe5b4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsepol",
+      "purl": "pkg:rpm/redhat/libsepol@3.6-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsepol@3.6-2.el9?arch=x86_64",
+      "version": "3.6-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "15d6b46b4301c394ab5ab8119d85c499ee730f20",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#15d6b46b4301c394ab5ab8119d85c499ee730f20"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3463707",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#15d6b46b4301c394ab5ab8119d85c499ee730f20",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsigsegv",
+      "purl": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "version": "2.13-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b3dee05a0458f11a68b0f9a878aa676670814326",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690130",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsmartcols",
+      "purl": "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64",
+      "version": "2.37.4-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471212",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsolv",
+      "purl": "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64",
+      "version": "0.7.24-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "334959330f40393346bb399506b5c5081231109d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsolv#334959330f40393346bb399506b5c5081231109d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2995003",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsolv#334959330f40393346bb399506b5c5081231109d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libstdc++",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-5.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-5.el9_5?arch=x86_64",
+      "version": "11.5.0-5.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94f8d08fea6e2026c7aa2ba346696bed8a1555f6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#94f8d08fea6e2026c7aa2ba346696bed8a1555f6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3501765",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#94f8d08fea6e2026c7aa2ba346696bed8a1555f6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtasn1",
+      "purl": "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64",
+      "version": "4.16.0-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "243192561fe59a99450308901f0ff2be9a39489b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtasn1#243192561fe59a99450308901f0ff2be9a39489b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3513775",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtasn1#243192561fe59a99450308901f0ff2be9a39489b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtirpc",
+      "purl": "pkg:rpm/redhat/libtirpc@1.3.3-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtirpc@1.3.3-9.el9?arch=x86_64",
+      "version": "1.3.3-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "SISSL and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "51b799b231540bcf17278cd04c8537a450015e45",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#51b799b231540bcf17278cd04c8537a450015e45"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3198130",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#51b799b231540bcf17278cd04c8537a450015e45",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtool-ltdl",
+      "purl": "pkg:rpm/redhat/libtool-ltdl@2.4.6-46.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtool-ltdl@2.4.6-46.el9?arch=x86_64",
+      "version": "2.4.6-46.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7e2c1061c8fc1a80327da6afee4a76e61313a632",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtool#7e2c1061c8fc1a80327da6afee4a76e61313a632"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3103845",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtool#7e2c1061c8fc1a80327da6afee4a76e61313a632",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libunistring",
+      "purl": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "version": "0.9.10-15.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690195",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libusbx",
+      "purl": "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64",
+      "version": "1.0.26-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e369f619a0e615f4b86409c454308b316c0a78b7",
+            "url": "git://pkgs.devel.redhat.com/rpms/libusbx#e369f619a0e615f4b86409c454308b316c0a78b7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1986004",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libusbx#e369f619a0e615f4b86409c454308b316c0a78b7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libuuid",
+      "purl": "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64",
+      "version": "2.37.4-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3471212",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#7343ce4730e6e11382b8d1f2d510fee8ca13cc57",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libverto",
+      "purl": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "version": "0.3.2-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690209",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxcrypt",
+      "purl": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "version": "4.4.18-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and BSD and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5ae2c88752320b1d81d70ae38259ce56b1c692de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690260",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxml2",
+      "purl": "pkg:rpm/redhat/libxml2@2.9.13-12.el9_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxml2@2.9.13-12.el9_6?arch=x86_64",
+      "version": "2.9.13-12.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "56e5f738b38c68ee30e9dc175a8bee3905d36ae1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#56e5f738b38c68ee30e9dc175a8bee3905d36ae1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3788394",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#56e5f738b38c68ee30e9dc175a8bee3905d36ae1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libyaml",
+      "purl": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "version": "0.2.5-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70e1549fe5e56c95f1e23967e02c657d7af570ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690356",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libzstd",
+      "purl": "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64",
+      "version": "1.5.5-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "65ac97bcf256b0440e458769fae5d197fd761c18",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/zstd#65ac97bcf256b0440e458769fae5d197fd761c18"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3397534",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/zstd#65ac97bcf256b0440e458769fae5d197fd761c18",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "linux-x86_64",
+      "purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?classifier=linux-x86_64&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1873e21ebdb1c4d0cc86bd37286cba73"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a77641ba2c0f5503907982b988f05ed8e621ae2e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "024817cc0bafa0f319adce67a610eac1bdfb3f080abc0bd25755e25b248b3f23"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?classifier=linux-x86_64&type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-transport-native-epoll-linux-x86_64-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-transport-native-epoll-linux-x86_64-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a77641ba2c0f5503907982b988f05ed8e621ae2e"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213523",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lksctp-tools",
+      "purl": "pkg:rpm/redhat/lksctp-tools@1.0.19-3.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lksctp-tools@1.0.19-3.el9_4?arch=x86_64",
+      "version": "1.0.19-3.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2 and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5f86a83e1f7b663385b325c8e8b04d682ef8305e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/lksctp-tools#5f86a83e1f7b663385b325c8e8b04d682ef8305e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2952358",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/lksctp-tools#5f86a83e1f7b663385b325c8e8b04d682ef8305e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log4j-api",
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.23.1.redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.apache.logging.log4j",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "87e858f83f309f9b3ba93d90cef9d641"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "535ec57e0b5256ca7129e7907da5ae0d2ffec43d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ac20f30acd881cffc7e1c519d0dceb18fcfe123842d8b81030c1ffec47c46be2"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.23.1.redhat-00002?type=jar",
+      "version": "2.23.1.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "\"Apache-2.0\";link=\"https://www.apache.org/licenses/LICENSE-2.0.txt\""
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "17e0635b3452b00ecbea3de5c598ddf9e1032b25",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/logging-log4j2.git#2.23.1.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/log4j-api-2.23.1.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/log4j-api-2.23.1.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "535ec57e0b5256ca7129e7907da5ae0d2ffec43d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12924522",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC3HOPOWG2QAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.3:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/logging-log4j2.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log4j-core",
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.23.1.redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.apache.logging.log4j",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a9d35bd01faacd02714f29bdd9c3199e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "57f6d82821d7744f132d035c7dd03a5b4f991884"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5e24419060329207282989cd07d03f81fae8ecdfac5e97c20746d39d9cb74965"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-core@2.23.1.redhat-00002?type=jar",
+      "version": "2.23.1.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "\"Apache-2.0\";link=\"https://www.apache.org/licenses/LICENSE-2.0.txt\""
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "17e0635b3452b00ecbea3de5c598ddf9e1032b25",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/logging-log4j2.git#2.23.1.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/log4j-core-2.23.1.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/log4j-core-2.23.1.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "57f6d82821d7744f132d035c7dd03a5b4f991884"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12924538",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC3HOPOWG2QAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.3:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/logging-log4j2.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log4j-jul",
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-jul@2.23.1.redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.apache.logging.log4j",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fc146233710aba4ef3c4f5a65f2c9935"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4bbff75479f990c03856afc9433b24ec9c4a99ba"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "27dcce885a46a6d6784e2eb189b4c3cdb140146cad6348fc4527316728c12d4c"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-jul@2.23.1.redhat-00002?type=jar",
+      "version": "2.23.1.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "\"Apache-2.0\";link=\"https://www.apache.org/licenses/LICENSE-2.0.txt\""
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "17e0635b3452b00ecbea3de5c598ddf9e1032b25",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/logging-log4j2.git#2.23.1.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/log4j-jul-2.23.1.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/log4j-jul-2.23.1.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4bbff75479f990c03856afc9433b24ec9c4a99ba"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12924430",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC3HOPOWG2QAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.3:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/logging-log4j2.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "log4j-slf4j-impl",
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-slf4j-impl@2.23.1.redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.apache.logging.log4j",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "14f11829a8da5be1eaac8e3b72f6ac08"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "94774073cf8f3ad1c9077bc23adba9898834b418"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "213f139d8d3a708e8ba991d89e30c97d3fe1f8d4bf81301c6d3a7130085934f7"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-slf4j-impl@2.23.1.redhat-00002?type=jar",
+      "version": "2.23.1.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "name": "\"Apache-2.0\";link=\"https://www.apache.org/licenses/LICENSE-2.0.txt\""
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "17e0635b3452b00ecbea3de5c598ddf9e1032b25",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/logging-log4j2.git#2.23.1.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/log4j-slf4j-impl-2.23.1.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/log4j-slf4j-impl-2.23.1.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "94774073cf8f3ad1c9077bc23adba9898834b418"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12924448",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC3HOPOWG2QAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.9.3:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/logging-log4j2.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lsof",
+      "purl": "pkg:rpm/redhat/lsof@4.94.0-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lsof@4.94.0-3.el9?arch=x86_64",
+      "version": "4.94.0-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Sendmail and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d0869d4345af34a0bce8cc84050591ab617c71d6",
+            "url": "git://pkgs.devel.redhat.com/rpms/lsof#d0869d4345af34a0bce8cc84050591ab617c71d6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690479",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lsof#d0869d4345af34a0bce8cc84050591ab617c71d6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua",
+      "purl": "pkg:rpm/redhat/lua@5.4.4-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua@5.4.4-4.el9?arch=x86_64",
+      "version": "5.4.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d795270f6d1372b9636433ed1fb08b2439eed16",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467503",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua-libs",
+      "purl": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "version": "5.4.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d795270f6d1372b9636433ed1fb08b2439eed16",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467503",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua-posix",
+      "purl": "pkg:rpm/redhat/lua-posix@35.0-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua-posix@35.0-8.el9?arch=x86_64",
+      "version": "35.0-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b59d69c683695ed563b24353ca10c2fad1324c2d",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua-posix#b59d69c683695ed563b24353ca10c2fad1324c2d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1903570",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua-posix#b59d69c683695ed563b24353ca10c2fad1324c2d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-analysis-common",
+      "purl": "pkg:maven/org.apache.lucene/lucene-analysis-common@9.9.2.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3f15962f7df0425bd9feacaf273c7e26"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bc2ac3574503f75e72ee648ce242c4ea2a8747bf"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bd79f5325c0462086d31b492608a6cae8ecaa87b473b7ec9f2014a6321b6cb17"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-analysis-common@9.9.2.redhat-00001?type=jar",
+      "version": "9.9.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4d3d1b1a24b8f176709132426956a7b92c7c2675",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-analysis-common-9.9.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-analysis-common-9.9.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bc2ac3574503f75e72ee648ce242c4ea2a8747bf"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12533364",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BAZS6XU3TEYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-core",
+      "purl": "pkg:maven/org.apache.lucene/lucene-core@9.9.2.redhat-00002?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3748dbfbafca95cab6bf70fe80415757"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "43f6d6e0c1b8273cffe3b80418434e316cbb54b0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7182f5ce417d0510352caa06d90cdb8687b60ba0358b4cadde76413f3616bde8"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-core@9.9.2.redhat-00002?type=jar",
+      "version": "9.9.2.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fdf0bb102254f6589265e6ce8968a137fc18709e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-core-9.9.2.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-core-9.9.2.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "43f6d6e0c1b8273cffe3b80418434e316cbb54b0"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13502776",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5KYYHC2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-facet",
+      "purl": "pkg:maven/org.apache.lucene/lucene-facet@9.9.2.redhat-00002?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7fa3e701879d196d75ea1968343e32d8"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "33b163f42aeb809ffd6969c1b46b4612e28fb51b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c0692ec878ec2525a88ba37e7f11a74f541fe1cc6146119f59ebfcf0c3e5f036"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-facet@9.9.2.redhat-00002?type=jar",
+      "version": "9.9.2.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fdf0bb102254f6589265e6ce8968a137fc18709e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-facet-9.9.2.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-facet-9.9.2.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "33b163f42aeb809ffd6969c1b46b4612e28fb51b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13502692",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5KYYHC2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-highlighter",
+      "purl": "pkg:maven/org.apache.lucene/lucene-highlighter@9.9.2.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "675f677407d1b192a92d3dc9d3104cb1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3452e289096135cb4215166d4d43d02bed53419c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6beec6476108ced023d3ff25df8bfaa933fba5a2d62f3cacb03c3d35ab166bd8"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-highlighter@9.9.2.redhat-00001?type=jar",
+      "version": "9.9.2.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4d3d1b1a24b8f176709132426956a7b92c7c2675",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-highlighter-9.9.2.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-highlighter-9.9.2.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3452e289096135cb4215166d4d43d02bed53419c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12533423",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BAZS6XU3TEYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-join",
+      "purl": "pkg:maven/org.apache.lucene/lucene-join@9.9.2.redhat-00002?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b5f2de2fada558edfca15e553e41abbd"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "726bda128dd0bb832dce0d59893cca5b2ef1ea47"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0fc014310ca57df29de9de983b10ebc6eed23b25a13b944896d1a249fba7058d"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-join@9.9.2.redhat-00002?type=jar",
+      "version": "9.9.2.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fdf0bb102254f6589265e6ce8968a137fc18709e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-join-9.9.2.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-join-9.9.2.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "726bda128dd0bb832dce0d59893cca5b2ef1ea47"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13502697",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5KYYHC2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-queries",
+      "purl": "pkg:maven/org.apache.lucene/lucene-queries@9.9.2.redhat-00002?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8e67dbfb583dd501f7e3e6dd2e4ef0c9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "23f07f72903d6a04709c3314311a182b867a5c7b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2b7421ce3bf562d561393548ee7010e7967d1a3f80fe1b388b9e88c88e21e6a5"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-queries@9.9.2.redhat-00002?type=jar",
+      "version": "9.9.2.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fdf0bb102254f6589265e6ce8968a137fc18709e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-queries-9.9.2.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-queries-9.9.2.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "23f07f72903d6a04709c3314311a182b867a5c7b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13502749",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5KYYHC2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lucene-queryparser",
+      "purl": "pkg:maven/org.apache.lucene/lucene-queryparser@9.9.2.redhat-00002?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "22789e8ecb6a32a0a5787c4fd4990a70"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "82260a94df2702eac7f85c565d02ed3b6d05d976"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b47b987de42892eb437e23ad13a60351161e1cb04e7529788d4c702b400883e3"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.lucene/lucene-queryparser@9.9.2.redhat-00002?type=jar",
+      "version": "9.9.2.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "ICU"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fdf0bb102254f6589265e6ce8968a137fc18709e",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/lucene.git#9.9.2.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/lucene-queryparser-9.9.2.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/lucene-queryparser-9.9.2.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "82260a94df2702eac7f85c565d02ed3b6d05d976"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13502703",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BF5KYYHC2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.4-gettext-jss:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/lucene.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lz4-libs",
+      "purl": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "version": "1.9.3-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690509",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "microdnf",
+      "purl": "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64",
+      "version": "3.9.1-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cc6603992b29365e456f8747a8d17c17b8dc45a4",
+            "url": "git://pkgs.devel.redhat.com/rpms/microdnf#cc6603992b29365e456f8747a8d17c17b8dc45a4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2324298",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/microdnf#cc6603992b29365e456f8747a8d17c17b8dc45a4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "micrometer-commons",
+      "purl": "pkg:maven/io.micrometer/micrometer-commons@1.12.13.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "676eb18381b7a88734edcdc2f371ac9d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6d62652a0510d24e09294a9ff9188e6bd7a35178"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "992fc34743feb471d6dcc6fca4304fea08d35b8c706a7130ea416d50dd604bc4"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.micrometer/micrometer-commons@1.12.13.redhat-00001?type=jar",
+      "version": "1.12.13.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cceb355b800195d01ed93bbc3f5d56bf4b8d43f5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/micrometer-metrics/micrometer.git#1.12.13.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/micrometer-commons-1.12.13.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/micrometer-commons-1.12.13.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6d62652a0510d24e09294a9ff9188e6bd7a35178"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387666",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNP2EUIMKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j11-mvn3.9.2-gradle8.3-gcc-cpp-make:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/micrometer-metrics/micrometer.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "micrometer-core",
+      "purl": "pkg:maven/io.micrometer/micrometer-core@1.12.13.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7072d2946ebb878a63f1ad4d6343fe83"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3ac5a2fbbc934bb8b88c7125e21c673f7d73fff4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f84e87477c46ef299ed86c8cb2670f76b6355d78ecfe8de0ea0b8507fc268764"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.micrometer/micrometer-core@1.12.13.redhat-00001?type=jar",
+      "version": "1.12.13.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cceb355b800195d01ed93bbc3f5d56bf4b8d43f5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/micrometer-metrics/micrometer.git#1.12.13.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/micrometer-core-1.12.13.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/micrometer-core-1.12.13.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3ac5a2fbbc934bb8b88c7125e21c673f7d73fff4"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387708",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNP2EUIMKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j11-mvn3.9.2-gradle8.3-gcc-cpp-make:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/micrometer-metrics/micrometer.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "micrometer-observation",
+      "purl": "pkg:maven/io.micrometer/micrometer-observation@1.12.13.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9d6e579f34cc07df1e82a6bc6f9d486d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "dc96515c3be42592a1affe51f6fbb12c289e59d9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "360ae16c3b2dcfcb6af5c9225cce7d5b1d30f65d79df6fdfd5840c9ba426c9e3"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.micrometer/micrometer-observation@1.12.13.redhat-00001?type=jar",
+      "version": "1.12.13.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cceb355b800195d01ed93bbc3f5d56bf4b8d43f5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/micrometer-metrics/micrometer.git#1.12.13.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/micrometer-observation-1.12.13.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/micrometer-observation-1.12.13.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "dc96515c3be42592a1affe51f6fbb12c289e59d9"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387644",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNP2EUIMKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j11-mvn3.9.2-gradle8.3-gcc-cpp-make:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/micrometer-metrics/micrometer.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "micrometer-registry-prometheus",
+      "purl": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.12.13.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "afa9e6c072cdd57e67e6acac5edbeaae"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "01e8afc73fee8eab8b069346f15415473fb322f4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ef08b6521a4305e7be92a1284ed5cc396717731dfa8f7b026e3f94d60bd9fda2"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.12.13.redhat-00001?type=jar",
+      "version": "1.12.13.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cceb355b800195d01ed93bbc3f5d56bf4b8d43f5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/micrometer-metrics/micrometer.git#1.12.13.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/micrometer-registry-prometheus-1.12.13.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/micrometer-registry-prometheus-1.12.13.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "01e8afc73fee8eab8b069346f15415473fb322f4"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387709",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNP2EUIMKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j11-mvn3.9.2-gradle8.3-gcc-cpp-make:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/micrometer-metrics/micrometer.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "mpfr",
+      "purl": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "version": "4.1.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "207ac3816285664c0c73fa4894dbdead53d1ca40",
+            "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690656",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ncurses-base",
+      "purl": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_6.2?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_6.2?arch=noarch",
+      "version": "6.2-10.20210508.el9_6.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a279980d3dc4f334e6fc4177f1c29fd2de47420c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#a279980d3dc4f334e6fc4177f1c29fd2de47420c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3738666",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#a279980d3dc4f334e6fc4177f1c29fd2de47420c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ncurses-libs",
+      "purl": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_6.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_6.2?arch=x86_64",
+      "version": "6.2-10.20210508.el9_6.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a279980d3dc4f334e6fc4177f1c29fd2de47420c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#a279980d3dc4f334e6fc4177f1c29fd2de47420c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3738666",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ncurses#a279980d3dc4f334e6fc4177f1c29fd2de47420c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nettle",
+      "purl": "pkg:rpm/redhat/nettle@3.10.1-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nettle@3.10.1-1.el9?arch=x86_64",
+      "version": "3.10.1-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5100403b46842ba5c03a944f6792a20fc763f6da",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#5100403b46842ba5c03a944f6792a20fc763f6da"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3510365",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#5100403b46842ba5c03a944f6792a20fc763f6da",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-buffer",
+      "purl": "pkg:maven/io.netty/netty-buffer@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a3ee3ed80856434488c6bfd887fc3199"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6c74eb2c6ff72797676cb4cfc12a21cf13f76196"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3c4cf0915a2248fba20f835a0a9e5203660eda5476b6a38d22c676fc50e267fe"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-buffer-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-buffer-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6c74eb2c6ff72797676cb4cfc12a21cf13f76196"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213625",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-codec",
+      "purl": "pkg:maven/io.netty/netty-codec@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "37c0c4d9c5f7ec732b7a1a082034d7fd"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2ca92bfb5d2470ec0a10f73024fee659b536ea3a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "813a455304335b76e1301e486154b795d320a75015141b01fce93effb672ebbd"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-codec@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-codec-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-codec-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "2ca92bfb5d2470ec0a10f73024fee659b536ea3a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213536",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-codec-dns",
+      "purl": "pkg:maven/io.netty/netty-codec-dns@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "04644e520c848c87d49ba82b4db5823b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0bce2bc72df4a29c8074afbdbe727fb80d3421d3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e6a45206760e94df8db41aa4672a99f30db4ef7ba90779df15eebbef634f2dc7"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-codec-dns@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-codec-dns-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-codec-dns-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0bce2bc72df4a29c8074afbdbe727fb80d3421d3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213498",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-codec-http",
+      "purl": "pkg:maven/io.netty/netty-codec-http@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2b46462fc555670956015b6709d19a3b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d224bc5f21d4c5b8ebfba32dc78981da47d179ca"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ed7368ec39e5dc59240265fbd8c3e3966be8c2f0652163d43a00f0f2b3df89ca"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-codec-http@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-codec-http-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-codec-http-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d224bc5f21d4c5b8ebfba32dc78981da47d179ca"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213522",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-codec-http2",
+      "purl": "pkg:maven/io.netty/netty-codec-http2@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d3d62afb86e37d417eb88b4138cce15f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "60b12338cfcd9c12f1e53a192ad812e3891d3d0d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ed99f05810f7e547a8a62a3aeb14b2fc98233fcf418e4dbe14f233f512c76ad7"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-codec-http2@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-codec-http2-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-codec-http2-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "60b12338cfcd9c12f1e53a192ad812e3891d3d0d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213574",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-common",
+      "purl": "pkg:maven/io.netty/netty-common@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7e459306d2633e4ad954414201046bc6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7ae9e3c1c232b5cb4c74bf9f9371052124de4995"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5b5d52a6297c98129c26c982ac3d1e34ad70c06bdc7a7a08705686b05b05e5a5"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-common@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-common-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-common-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "7ae9e3c1c232b5cb4c74bf9f9371052124de4995"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213657",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-handler",
+      "purl": "pkg:maven/io.netty/netty-handler@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8beb68a2b6672adec37f89ade370aa99"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a8c783a0cbfb4fb886f3ecb0431e4cb79971f0e8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "728c319fe094b5f864c1a9eacb5f731614b98e939dfb9a0b5445c82ad9396d97"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-handler@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-handler-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-handler-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a8c783a0cbfb4fb886f3ecb0431e4cb79971f0e8"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213662",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-resolver",
+      "purl": "pkg:maven/io.netty/netty-resolver@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "df3e5b746c9eed9160e7f0a4b748db73"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f660750dee3de43e3dbb423c701043e77b5d0bdc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1a47865145e1462c322df1bbff7c2502785eb8c39023e57fdc384ec467763f1f"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-resolver-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-resolver-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f660750dee3de43e3dbb423c701043e77b5d0bdc"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213592",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-resolver-dns",
+      "purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "12be67c9e9bd84312a84bb47aa8acb58"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "07a7ba61d3772e51bf758d160ba8b12912b7442a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "de7d9b706e50e6e51114854d2304e4a37f428687ae67cc4ca0f54374cb085831"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-resolver-dns-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-resolver-dns-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "07a7ba61d3772e51bf758d160ba8b12912b7442a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213529",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-transport",
+      "purl": "pkg:maven/io.netty/netty-transport@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6ddf22a2f5e0f402032dad0e56621521"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "dfea097c493faaf173d0f332583ac02e71590304"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2790c30762328bcc9840871d0762efecc6554d1f9fb9195e717c2e9a352a17f0"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-transport@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-transport-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-transport-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "dfea097c493faaf173d0f332583ac02e71590304"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213565",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-transport-classes-epoll",
+      "purl": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9659a2895b1c9091d078c7a2340e9f0c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d741dc4588ce5ad4f043e87e52bf9e70decf2796"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "05811c9f9eede1524a33f31cc1ba1276c71129314af83755f12087de4cf39905"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-transport-classes-epoll-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-transport-classes-epoll-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d741dc4588ce5ad4f043e87e52bf9e70decf2796"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213627",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-transport-native-epoll",
+      "purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d61bd0771b8378844ebde13a5b7a8eac"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "28a3b9deb3db1aa6ab35a1b101afd7f7d419c9fd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e6ca3015299f1d255b76b3a05a590b2aab3745bd889804f39e993b5dd6a81567"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-transport-native-epoll-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-transport-native-epoll-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "28a3b9deb3db1aa6ab35a1b101afd7f7d419c9fd"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213587",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-transport-native-epoll",
+      "purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d61bd0771b8378844ebde13a5b7a8eac"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "28a3b9deb3db1aa6ab35a1b101afd7f7d419c9fd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e6ca3015299f1d255b76b3a05a590b2aab3745bd889804f39e993b5dd6a81567"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?package-id=0eb6ce733297e359",
+      "version": "4.1.121.Final-redhat-00003",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-transport-native-epoll-linux-x86_64-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-transport-native-epoll-linux-x86_64-4.1.121.Final-redhat-00003.jar:io.netty:netty-transport-native-epoll"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213587",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "netty-transport-native-unix-common",
+      "purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.121.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "io.netty",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "bf57526c157ee1074f7ccd5f2df575a7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bc340f2f382216d39fc206662bd63ed398139b21"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6144169cfb3719a1eb65821647eac90e4178112a115bf4a5d92f7c5fa72098cb"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.121.Final-redhat-00003?type=jar",
+      "version": "4.1.121.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "name": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e08d510cf162afe96fec62255eaf9e14cdaac997",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/netty/netty.git#4.1.121.Final-redhat-00003"
+          },
+          {
+            "uid": "43c44a77b78010ba0fe926cd00e4acff94287dce",
+            "url": "https://github.com/netty/netty.git#4.1.121.Final-rh"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/netty-transport-native-unix-common-4.1.121.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/netty-transport-native-unix-common-4.1.121.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bc340f2f382216d39fc206662bd63ed398139b21"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14213675",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJIEU2ZSL2IAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-sbt1.5.5-gcc-cpp-make:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/netty/netty.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "npth",
+      "purl": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "version": "1.6-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+            "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690792",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nspr",
+      "purl": "pkg:rpm/redhat/nspr@4.36.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nspr@4.36.0-4.el9_4?arch=x86_64",
+      "version": "4.36.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss",
+      "purl": "pkg:rpm/redhat/nss@3.112.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss@3.112.0-4.el9_4?arch=x86_64",
+      "version": "3.112.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-softokn",
+      "purl": "pkg:rpm/redhat/nss-softokn@3.112.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-softokn@3.112.0-4.el9_4?arch=x86_64",
+      "version": "3.112.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-softokn-freebl",
+      "purl": "pkg:rpm/redhat/nss-softokn-freebl@3.112.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-softokn-freebl@3.112.0-4.el9_4?arch=x86_64",
+      "version": "3.112.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-sysinit",
+      "purl": "pkg:rpm/redhat/nss-sysinit@3.112.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-sysinit@3.112.0-4.el9_4?arch=x86_64",
+      "version": "3.112.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-tools",
+      "purl": "pkg:rpm/redhat/nss-tools@3.112.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-tools@3.112.0-4.el9_4?arch=x86_64",
+      "version": "3.112.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-util",
+      "purl": "pkg:rpm/redhat/nss-util@3.112.0-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-util@3.112.0-4.el9_4?arch=x86_64",
+      "version": "3.112.0-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3793429",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#8e8df8b196b2e018327ce4bd7d96ba6bfed40f89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openldap",
+      "purl": "pkg:rpm/redhat/openldap@2.6.8-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openldap@2.6.8-4.el9?arch=x86_64",
+      "version": "2.6.8-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "OLDAP-2.8"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9025f0ac208ee130e00cd0a4df276ce3be00cc31",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#9025f0ac208ee130e00cd0a4df276ce3be00cc31"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3505959",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#9025f0ac208ee130e00cd0a4df276ce3be00cc31",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl",
+      "purl": "pkg:rpm/redhat/openssl@3.2.2-6.el9_5.1?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl@3.2.2-6.el9_5.1?arch=x86_64&epoch=1",
+      "version": "1:3.2.2-6.el9_5.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2c6e91ce81908f921a235e85391ba3676a6825a7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#2c6e91ce81908f921a235e85391ba3676a6825a7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3487083",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#2c6e91ce81908f921a235e85391ba3676a6825a7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-fips-provider",
+      "purl": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-6.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-6.el9_5?arch=x86_64",
+      "version": "3.0.7-6.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3378feb4c39482e9191806ec051c29f3e56ffda7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#3378feb4c39482e9191806ec051c29f3e56ffda7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3289267",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#3378feb4c39482e9191806ec051c29f3e56ffda7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-fips-provider-so",
+      "purl": "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-6.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-6.el9_5?arch=x86_64",
+      "version": "3.0.7-6.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3378feb4c39482e9191806ec051c29f3e56ffda7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#3378feb4c39482e9191806ec051c29f3e56ffda7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3289267",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#3378feb4c39482e9191806ec051c29f3e56ffda7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-libs",
+      "purl": "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&epoch=1",
+      "version": "1:3.2.2-6.el9_5.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2c6e91ce81908f921a235e85391ba3676a6825a7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#2c6e91ce81908f921a235e85391ba3676a6825a7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3487083",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#2c6e91ce81908f921a235e85391ba3676a6825a7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-api",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-api@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ec551ed4304bdc08248ff0014272446c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "217c88e8100f57669d0f3036a7fa9e804bce7ad0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4b2026442f89dfca07ce0ca84f0541b21f9efd190c749741cf6c883c50049e09"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-api@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-api-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-api-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "217c88e8100f57669d0f3036a7fa9e804bce7ad0"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897119",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-api-events",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-api-events@1.32.0.alpha-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b89aa9e43a063d1a49689f49754db1a7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ad7ed14186dbd2d3f54c3aa4436cd7e7323f4ebf"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f3a94473035b71317a95eb521c07fdd8f2715bc845c3bba69a4dfce61606ded9"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-api-events@1.32.0.alpha-redhat-00001?type=jar",
+      "version": "1.32.0.alpha-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-api-events-1.32.0.alpha-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-api-events-1.32.0.alpha-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ad7ed14186dbd2d3f54c3aa4436cd7e7323f4ebf"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897053",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-context",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-context@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "24e76e2756671979d163f136cc1314d1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c1d65ea72838a9c316051e3fc0b77ec00621af3b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d7f4dba88db21a6892d788a86683072b681f82e1f7f75babfe873a9f3ec88f06"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-context@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-context-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-context-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c1d65ea72838a9c316051e3fc0b77ec00621af3b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897044",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-exporter-common",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-exporter-common@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "662c1e332a93c3f10920cd010f15f2af"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e8dd933ea522db6980fa9b10272e3068e6601399"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "406cc33f84f3889948be9438f33a1add4ba5b811f98efe7b04b4ef377d8b8de4"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-common@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-common-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-common-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e8dd933ea522db6980fa9b10272e3068e6601399"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897085",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-exporter-otlp",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1ba37c5425a2581191f47ac0c85cd301"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f2297156863e931e8850ab85a8c0e6f0ffb48035"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ed6e0b4bcb7f99179b43e310ed96003c6ecc496da9c26ca690b57ac9982c019b"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-otlp-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-otlp-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f2297156863e931e8850ab85a8c0e6f0ffb48035"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897079",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-exporter-otlp-common",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp-common@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "095872d37b85c8da8b6022d2ad494767"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "eb9b8e71e3465e6b039ae5c11bf506a81d21f8da"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "19dbbac172f33d1f482b0d3dcd355c055b6a3679aa00458b039705088acd94cc"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp-common@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-otlp-common-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-otlp-common-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "eb9b8e71e3465e6b039ae5c11bf506a81d21f8da"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897103",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-exporter-sender-jdk",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-exporter-sender-jdk@1.32.0.alpha-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5d4c20077aa399dcddf486ae3eeca078"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5683cc88721f16a0a16349242aef45148d833041"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3a384ada023d160eb64205b447c1d4bd5162730916f00b25378863ba31badb38"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-sender-jdk@1.32.0.alpha-redhat-00001?type=jar",
+      "version": "1.32.0.alpha-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-sender-jdk-1.32.0.alpha-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-exporter-sender-jdk-1.32.0.alpha-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5683cc88721f16a0a16349242aef45148d833041"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897162",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "58d428756c21d9a8323bd61362113e30"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a92a3369fa2040d879317784e3bc57ad693ec40b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e32deef70a831e78800d24a0ce467e1f710ca3155611d76cdd028d42fc298cc5"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a92a3369fa2040d879317784e3bc57ad693ec40b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897093",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk-common",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "bcc0064144dd022905b6b149ba1667e2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5e8a203be43bcd8cc52c0809c2a6a00d67b73377"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fca8e3578766d5b30afc6e78dddc1761922c03ab3e2cb2c2978f6d3896f61665"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-common-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-common-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5e8a203be43bcd8cc52c0809c2a6a00d67b73377"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897086",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk-extension-autoconfigure",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "82114fa0fce937e5e96d06bfc4f036b9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ac9a1bd070ad1cc264d9e429bb7070020dae5168"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "14254c1da7065e08a626f7846e718704a242c18154194eeb4257fed3f09a6c1f"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-extension-autoconfigure-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-extension-autoconfigure-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ac9a1bd070ad1cc264d9e429bb7070020dae5168"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897158",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk-extension-autoconfigure-spi",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "57d161ec62e4a910fdf3b8ecbdca6120"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c1fa08f788e3576ddae8533897e7a68366b5546d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fa787c0203949e8dca613ac5bcd88e8186eabd59d30d88bb4a302bb21f0bdc3f"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-extension-autoconfigure-spi-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-extension-autoconfigure-spi-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c1fa08f788e3576ddae8533897e7a68366b5546d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897125",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk-logs",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6bc0a6924b321dae476234c3097f684f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1b2913fc9295b6ef11d22fdac4c03d0a0100bfa7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e0239e938201a04ab85ebca824a0f66bb5a63ab1f70350427c566f0619ea9c90"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-logs-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-logs-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "1b2913fc9295b6ef11d22fdac4c03d0a0100bfa7"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897147",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk-metrics",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "55bf83bac58ea19bc8fd737c23517fed"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d19285a43369a29cb7cc6c1206ed54e65cad666c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5d270dcead76b47cdd98e9bad15c5fc34b5e7163df0cc972f49483c8fda3fc79"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-metrics-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-metrics-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d19285a43369a29cb7cc6c1206ed54e65cad666c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897106",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "opentelemetry-sdk-trace",
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.32.0.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "321deec9610688249804ca947bc61418"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e208fba515941eb3f90241dea76ae79dd77e33fe"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "227120f953c075702c8601afaf798b38d6eb2035671db5eb4176b5bd2327b6b9"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.32.0.redhat-00001?type=jar",
+      "version": "1.32.0.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "25b844c22e9acc2b01d391eb8d520a428c85198a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/open-telemetry/opentelemetry-java.git#1.32.0.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-trace-1.32.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/opentelemetry-sdk-trace-1.32.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e208fba515941eb3f90241dea76ae79dd77e33fe"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/11897047",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A6MHBNZ2SDYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j17-mvn3.8.6-gradle8.0.2-gettext-jss:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/open-telemetry/opentelemetry-java.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "p11-kit",
+      "purl": "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64",
+      "version": "0.25.3-3.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3af459e136c2ab22bad5a3577540eae19c51e96c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#3af459e136c2ab22bad5a3577540eae19c51e96c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3361662",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#3af459e136c2ab22bad5a3577540eae19c51e96c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "p11-kit-trust",
+      "purl": "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64",
+      "version": "0.25.3-3.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3af459e136c2ab22bad5a3577540eae19c51e96c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#3af459e136c2ab22bad5a3577540eae19c51e96c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3361662",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#3af459e136c2ab22bad5a3577540eae19c51e96c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre",
+      "purl": "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64",
+      "version": "8.44-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d94c9b77e3a4ea15a6f946ef3c050bc09f6742a0",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre#d94c9b77e3a4ea15a6f946ef3c050bc09f6742a0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3009164",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre#d94c9b77e3a4ea15a6f946ef3c050bc09f6742a0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre2",
+      "purl": "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64",
+      "version": "10.40-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e9e4f078efd0299ed2dbda1c777a7c65f658",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#0715e9e4f078efd0299ed2dbda1c777a7c65f658"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3200608",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#0715e9e4f078efd0299ed2dbda1c777a7c65f658",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre2-syntax",
+      "purl": "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch",
+      "version": "10.40-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e9e4f078efd0299ed2dbda1c777a7c65f658",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#0715e9e4f078efd0299ed2dbda1c777a7c65f658"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3200608",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#0715e9e4f078efd0299ed2dbda1c777a7c65f658",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "popt",
+      "purl": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "version": "1.18-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+            "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691597",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "procps-ng",
+      "purl": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+      "version": "3.3.17-14.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "277f9aaff8edd7603ea88dfe5e42cbb2d229a76f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/procps-ng#277f9aaff8edd7603ea88dfe5e42cbb2d229a76f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2865070",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/procps-ng#277f9aaff8edd7603ea88dfe5e42cbb2d229a76f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "protostream",
+      "purl": "pkg:maven/org.infinispan.protostream/protostream@5.0.14.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.infinispan.protostream",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7e2feb510b5fbe1b4ed4b234bc829958"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "fefe468705bf1c2ff180169fac3e18350d4ae740"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5087f67250376e1199e512efdc562c30a9ac6b0b5c0955684beeba516ed71339"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan.protostream/protostream@5.0.14.Final-redhat-00002?type=jar",
+      "version": "5.0.14.Final-redhat-00002",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "04ff1c343f4cefc1e81e2af45ebd6dcc2d487818",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/protostream.git#5.0.14.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/protostream-5.0.14.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/protostream-5.0.14.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "fefe468705bf1c2ff180169fac3e18350d4ae740"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277114",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.2-13-mx7.4.1-mvn3.9.6-protobuf:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "protostream-types",
+      "purl": "pkg:maven/org.infinispan.protostream/protostream-types@5.0.14.Final-redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.infinispan.protostream",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6fde908b02566e3b10c0d4de092761a4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "549d53949825303f7c73cbd14b70a29c653710d3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f70a37d2b7d5dfbebb90612009adf4b04a5379219d7c01cc66f82a6db4aa79b7"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.infinispan.protostream/protostream-types@5.0.14.Final-redhat-00002?type=jar",
+      "version": "5.0.14.Final-redhat-00002",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "04ff1c343f4cefc1e81e2af45ebd6dcc2d487818",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/protostream.git#5.0.14.Final-redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/protostream-types-5.0.14.Final-redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/protostream-types-5.0.14.Final-redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "549d53949825303f7c73cbd14b70a29c653710d3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14277140",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BJSIHUQAAWYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.2-13-mx7.4.1-mvn3.9.6-protobuf:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "psmisc",
+      "purl": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+      "version": "23.4-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4bb81408b08c44d02985b6af55bbd75260c6b3ed",
+            "url": "git://pkgs.devel.redhat.com/rpms/psmisc#4bb81408b08c44d02985b6af55bbd75260c6b3ed"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691630",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/psmisc#4bb81408b08c44d02985b6af55bbd75260c6b3ed",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3",
+      "purl": "pkg:rpm/redhat/python3@3.9.21-2.el9_6.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3@3.9.21-2.el9_6.2?arch=x86_64",
+      "version": "3.9.21-2.el9_6.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ffda08bd1ea354c4159bc9bb46ed3c359ee381c5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#ffda08bd1ea354c4159bc9bb46ed3c359ee381c5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3810318",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#ffda08bd1ea354c4159bc9bb46ed3c359ee381c5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libs",
+      "purl": "pkg:rpm/redhat/python3-libs@3.9.21-2.el9_6.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libs@3.9.21-2.el9_6.2?arch=x86_64",
+      "version": "3.9.21-2.el9_6.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ffda08bd1ea354c4159bc9bb46ed3c359ee381c5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#ffda08bd1ea354c4159bc9bb46ed3c359ee381c5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3810318",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3.9#ffda08bd1ea354c4159bc9bb46ed3c359ee381c5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-pip-wheel",
+      "purl": "pkg:rpm/redhat/python3-pip-wheel@21.3.1-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pip-wheel@21.3.1-1.el9?arch=noarch",
+      "version": "21.3.1-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "26ebeb19b2a1b18c017935ddb5d83aa7e287dee9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#26ebeb19b2a1b18c017935ddb5d83aa7e287dee9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2974574",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#26ebeb19b2a1b18c017935ddb5d83aa7e287dee9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-setuptools-wheel",
+      "purl": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-13.el9_6.1?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-13.el9_6.1?arch=noarch",
+      "version": "53.0.0-13.el9_6.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and (BSD or ASL 2.0)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fbafcb8421beaf6d55cf22569e0df76409dc0cf1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#fbafcb8421beaf6d55cf22569e0df76409dc0cf1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3708992",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#fbafcb8421beaf6d55cf22569e0df76409dc0cf1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "reactive-streams",
+      "purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.4.redhat-00004?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9381c32c1d4745f9035c2cf9d0a83ff7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b1381212d6a040fd785014972e327af5dad39c7d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "75ab47d00be4dfc81fca99675de881abf76db1034ef926bd4c162dafa7a3fd8a"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.4.redhat-00004?type=jar",
+      "version": "1.0.4.redhat-00004",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b7a6b624adf4dc03a8c3d4d0acc771209d4f8f5",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/reactive-streams/reactive-streams-jvm.git#1.0.4.redhat-00004"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/reactive-streams-1.0.4.redhat-00004.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/reactive-streams-1.0.4.redhat-00004.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b1381212d6a040fd785014972e327af5dad39c7d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347260",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGQDLWKMKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.6.0-gradle5.6.2:1.0.9",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/reactive-streams/reactive-streams-jvm.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "reactor-core",
+      "purl": "pkg:maven/io.projectreactor/reactor-core@3.6.6.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "95d34c69cd5c5322b03a26f9e43d733c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e2ca11478777b6a48327f84182bf4aa77f86b7ca"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "cccf053c2a9c883c7c02b747c41f7183dc565ec7697ee0a0e97c92b412f2ec4a"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.projectreactor/reactor-core@3.6.6.redhat-00001?type=jar",
+      "version": "3.6.6.redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e0d7284c9dc6fa17905c1564df7af3dc3a3e63ed",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/reactor/reactor-core.git#3.6.6.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/reactor-core-3.6.6.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/reactor-core-3.6.6.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e2ca11478777b6a48327f84182bf4aa77f86b7ca"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13396154",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFPLEZYESTQAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j8-oraclejdk9-j11-j17-j21-mvn3.8.6-gradle8.5:1.0.1",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/reactor/reactor-core.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "readline",
+      "purl": "pkg:maven/org.aesh/readline@2.6.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.aesh",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e01ea83d38f320a2938b3f50eebe3309"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4ff63a5a560347142f3dca1a2ea9e0fd825b47d8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6a53971e15ba50aa59e46f3301090a256c405889921b17c241510afda30c9b14"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.aesh/readline@2.6.0.redhat-00001?type=jar",
+      "version": "2.6.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.apache.org/licenses/LICENSE-2.0",
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe8fb39a4dcf5d9a0d00c8afa1202f6b8c4b09f0",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/aeshell/aesh-readline.git#2.6.0.redhat-00001"
+          },
+          {
+            "uid": "d89da56200c476df7e7a6d9cd2edc036ef251399",
+            "url": "https://github.com/aeshell/aesh-readline#2.6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/readline-2.6.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/readline-2.6.0.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4ff63a5a560347142f3dca1a2ea9e0fd825b47d8"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12914520",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2NCQULNVAAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/aeshell/aesh-readline",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "readline",
+      "purl": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "version": "8.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be386f45be1322adf2bd79dd94c9904c4efa3d22",
+            "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691921",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "redhat-release",
+      "purl": "pkg:rpm/redhat/redhat-release@9.6-0.1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/redhat-release@9.6-0.1.el9?arch=x86_64",
+      "version": "9.6-0.1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1ab570fc4cf762aadbee8f2037f2eb76de4cefe1",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#1ab570fc4cf762aadbee8f2037f2eb76de4cefe1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3559997",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#1ab570fc4cf762aadbee8f2037f2eb76de4cefe1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rootfiles",
+      "purl": "pkg:rpm/redhat/rootfiles@8.1-34.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rootfiles@8.1-34.el9?arch=noarch",
+      "version": "8.1-34.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff231a14de30cf202aa97606b89fc4372d8f2220",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rootfiles#ff231a14de30cf202aa97606b89fc4372d8f2220"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3505679",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rootfiles#ff231a14de30cf202aa97606b89fc4372d8f2220",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:rpm/redhat/rpm@4.16.1.3-37.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm@4.16.1.3-37.el9?arch=x86_64",
+      "version": "4.16.1.3-37.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9caa0d20bb293b977b3a0c2bee6fdce9a6de055a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#9caa0d20bb293b977b3a0c2bee6fdce9a6de055a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3465558",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#9caa0d20bb293b977b3a0c2bee6fdce9a6de055a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm-libs",
+      "purl": "pkg:rpm/redhat/rpm-libs@4.16.1.3-37.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-37.el9?arch=x86_64",
+      "version": "4.16.1.3-37.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9caa0d20bb293b977b3a0c2bee6fdce9a6de055a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#9caa0d20bb293b977b3a0c2bee6fdce9a6de055a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3465558",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#9caa0d20bb293b977b3a0c2bee6fdce9a6de055a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rsync",
+      "purl": "pkg:rpm/redhat/rsync@3.2.5-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rsync@3.2.5-3.el9?arch=x86_64",
+      "version": "3.2.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7b368221c0e4ef50115cba7ccbbf5c00395151bf",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rsync#7b368221c0e4ef50115cba7ccbbf5c00395151bf"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3495179",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rsync#7b368221c0e4ef50115cba7ccbbf5c00395151bf",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtimes-java-api",
+      "purl": "pkg:maven/com.redhat.insights/runtimes-java-api@2.0.4.redhat-00003?type=jar",
+      "type": "library",
+      "group": "com.redhat.insights",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4a46b6b8023fe43fb67aac4682d70b09"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d2484f042607f75b3f2e20739c86ca4012fe652d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "92cc5f46095f2b6c55bb54bc7ea9292aa69ee4199b1947f3c3ed4db26e496a28"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.redhat.insights/runtimes-java-api@2.0.4.redhat-00003?type=jar",
+      "version": "2.0.4.redhat-00003",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "92747c701c13608adca5e6eb61e606ef1741d591",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/RedHatInsights/insights-ingress-java.git#2.0.4.redhat-00003"
+          },
+          {
+            "uid": "a5bd420016a21d545887b114c8a092d24f65e5cf",
+            "url": "https://github.com/RedHatInsights/insights-java-client.git#2.0.4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/runtimes-java-api-2.0.4.redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/runtimes-java-api-2.0.4.redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d2484f042607f75b3f2e20739c86ca4012fe652d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14082362",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BIRQ6NFD5OIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.6.3-golang1.24-gcc-make:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/RedHatInsights/insights-java-client.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "runtimes-java-core-runtime",
+      "purl": "pkg:maven/com.redhat.insights/runtimes-java-core-runtime@2.0.4.redhat-00003?type=jar",
+      "type": "library",
+      "group": "com.redhat.insights",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7e23e6d55e7732671d8b35d1224ee328"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "810406a363fc3baf0b01b8d3384fd8cb6099571f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "89b09e7d66503ffae5503369ac6ec555998187bce1ff5c6dd6b7f9431a213117"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.redhat.insights/runtimes-java-core-runtime@2.0.4.redhat-00003?type=jar",
+      "version": "2.0.4.redhat-00003",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "92747c701c13608adca5e6eb61e606ef1741d591",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/RedHatInsights/insights-ingress-java.git#2.0.4.redhat-00003"
+          },
+          {
+            "uid": "a5bd420016a21d545887b114c8a092d24f65e5cf",
+            "url": "https://github.com/RedHatInsights/insights-java-client.git#2.0.4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/runtimes-java-core-runtime-2.0.4.redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/runtimes-java-core-runtime-2.0.4.redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "810406a363fc3baf0b01b8d3384fd8cb6099571f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/14082353",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BIRQ6NFD5OIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.6.3-golang1.24-gcc-make:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/RedHatInsights/insights-java-client.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rxjava",
+      "purl": "pkg:maven/io.reactivex.rxjava3/rxjava@3.1.10.redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6e8e73ae153f7f6329fb95f12ce67987"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ac90da1798d2b98c7b98e8a5d4eb7a8075206210"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "78e0f778927cada89eedc51a7cc9282420b98b139dc3c736e47d4bdd7d6908cb"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.reactivex.rxjava3/rxjava@3.1.10.redhat-00001?type=jar",
+      "version": "3.1.10.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "045b1123ed7327c870e7667e3e1b059b5d5ad2b9",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/ReactiveX/RxJava.git#3.1.10.redhat-00001"
+          },
+          {
+            "uid": "ede5cfcb41a6a1c8f955d77d80883d5d08e843d9",
+            "url": "https://github.com/ReactiveX/RxJava.git#ede5cfcb41a6a1c8f955d77d80883d5d08e843d9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/rxjava-3.1.10.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/rxjava-3.1.10.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ac90da1798d2b98c7b98e8a5d4eb7a8075206210"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13387911",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFNRQZJP4KYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3-gradle7.1.1:1.0.6",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/ReactiveX/RxJava.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sed",
+      "purl": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "version": "4.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dad14ff8a62e967c0afb23d1d237a927d847e86e",
+            "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1692031",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "setup",
+      "purl": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "version": "2.13.7-10.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2892761",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "shadow-utils",
+      "purl": "pkg:rpm/redhat/shadow-utils@4.9-12.el9?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/shadow-utils@4.9-12.el9?arch=x86_64&epoch=2",
+      "version": "2:4.9-12.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e8b686171bcdf97bc14b0cce11c0586875326510",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#e8b686171bcdf97bc14b0cce11c0586875326510"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3376943",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#e8b686171bcdf97bc14b0cce11c0586875326510",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "simpleclient",
+      "purl": "pkg:maven/io.prometheus/simpleclient@0.16.0.redhat-00008?type=jar",
+      "type": "library",
+      "group": "io.prometheus",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7428be73e58996a7719f6bb97dfb6723"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "98d7d29199dd01d91093e49b109ed7cb1341d7f6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "16f467422ae4a4ba7b93391403afff75470bc2c4340bd00f2b4e3731ca10ccac"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.prometheus/simpleclient@0.16.0.redhat-00008?type=jar",
+      "version": "0.16.0.redhat-00008",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "51dec6cef4f589cca814f01311bc68c48f36967a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/prometheus/client_java.git#0.16.0.redhat-00008"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/simpleclient-0.16.0.redhat-00008.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/simpleclient-0.16.0.redhat-00008.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "98d7d29199dd01d91093e49b109ed7cb1341d7f6"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12916225",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2OOYGAVVAAG",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.5.4:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/prometheus/client_java",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "simpleclient_common",
+      "purl": "pkg:maven/io.prometheus/simpleclient_common@0.16.0.redhat-00008?type=jar",
+      "type": "library",
+      "group": "io.prometheus",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fef0f5d24854fe0a02cd6d36bf48d97a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e0082e1f10104d2e8bf35a4ba9c7fab0f4caf49a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1d8340db9309cf93bfd12fd7540a96799228eae074057a04511f20767fcfff08"
+        }
+      ],
+      "bom-ref": "pkg:maven/io.prometheus/simpleclient_common@0.16.0.redhat-00008?type=jar",
+      "version": "0.16.0.redhat-00008",
+      "licenses": [
+        {
+          "license": {
+            "name": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "51dec6cef4f589cca814f01311bc68c48f36967a",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/prometheus/client_java.git#0.16.0.redhat-00008"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/simpleclient_common-0.16.0.redhat-00008.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/simpleclient_common-0.16.0.redhat-00008.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e0082e1f10104d2e8bf35a4ba9c7fab0f4caf49a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12916254",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2OOYGAVVAAG",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.5.4:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/prometheus/client_java",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "slf4j-api",
+      "purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36.redhat-00006?type=jar",
+      "type": "library",
+      "group": "org.slf4j",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "96780a43780c7268766ef6c3cf4dc5fb"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "cd74b2274c8e3146e2556430457f03aedc7ee2b6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "abaca57d174773370259c895b3eb7a594a088ced26ea4b34d4e349e6bdca1d61"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36.redhat-00006?type=jar",
+      "version": "1.7.36.redhat-00006",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f546d43ad1473d507b8f33053cf9a54abda42c77",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/slf4j.git#1.7.36.redhat-00006"
+          },
+          {
+            "uid": "e9ee55cca93c2bf26f14482a9bdf961c750d2a56",
+            "url": "https://github.com/qos-ch/slf4j#v_1.7.36"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/slf4j-api-1.7.36.redhat-00006.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/slf4j-api-1.7.36.redhat-00006.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "cd74b2274c8e3146e2556430457f03aedc7ee2b6"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12150223",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A7ENB5XMSDYA2",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.5.4-golang:1.0.6",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/qos-ch/slf4j",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sqlite-libs",
+      "purl": "pkg:rpm/redhat/sqlite-libs@3.34.1-8.el9_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-8.el9_6?arch=x86_64",
+      "version": "3.34.1-8.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a2adb3533c888ea9126b2e18b060f979dc6d2fbb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#a2adb3533c888ea9126b2e18b060f979dc6d2fbb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3758308",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#a2adb3533c888ea9126b2e18b060f979dc6d2fbb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sshd-common",
+      "purl": "pkg:maven/org.apache.sshd/sshd-common@2.12.1.redhat-00002?type=jar",
+      "type": "library",
+      "group": "org.apache.sshd",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2874a4b71bd7ca2c9dee5f5f952120cf"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "27ce043019b9b8638d43137dc585679adf08e762"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5d366b05fabd148ccd87540dd3eacb7fde9c2485bd89cc5f2b5daed4ae8aa7fe"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.apache.sshd/sshd-common@2.12.1.redhat-00002?type=jar",
+      "version": "2.12.1.redhat-00002",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "263e8ad06b4119bd77c0f2ab7590f27b56765167",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/apache/mina-sshd.git#2.12.1.redhat-00002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/sshd-common-2.12.1.redhat-00002.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/sshd-common-2.12.1.redhat-00002.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "27ce043019b9b8638d43137dc585679adf08e762"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12432365",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BAC67Y6YUFIAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.3:1.0.7",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/apache/mina-sshd.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "systemd-libs",
+      "purl": "pkg:rpm/redhat/systemd-libs@252-51.el9_6.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-libs@252-51.el9_6.2?arch=x86_64",
+      "version": "252-51.el9_6.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "100227cc1e4057d30f9de27ee2a3dd6d0b30a334",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#100227cc1e4057d30f9de27ee2a3dd6d0b30a334"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3797441",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#100227cc1e4057d30f9de27ee2a3dd6d0b30a334",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tar",
+      "purl": "pkg:rpm/redhat/tar@1.34-7.el9?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tar@1.34-7.el9?arch=x86_64&epoch=2",
+      "version": "2:1.34-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d1fc43344a7008a811f51ede55eb29b53a45553e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tar#d1fc43344a7008a811f51ede55eb29b53a45553e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3229093",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tar#d1fc43344a7008a811f51ede55eb29b53a45553e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "terminal-api",
+      "purl": "pkg:maven/org.aesh/terminal-api@2.6.0.redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.aesh",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fe8cdcc397b20a0e65df9dfa7ab71ed2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c2a69338315b20eb68a1d56a96faa5c55090eae9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0580e486cc441e29adb21e597c1f2120ba2664105e2b6a6b32e9900bf93127cd"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.aesh/terminal-api@2.6.0.redhat-00001?type=jar",
+      "version": "2.6.0.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://www.apache.org/licenses/LICENSE-2.0",
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe8fb39a4dcf5d9a0d00c8afa1202f6b8c4b09f0",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/aeshell/aesh-readline.git#2.6.0.redhat-00001"
+          },
+          {
+            "uid": "d89da56200c476df7e7a6d9cd2edc036ef251399",
+            "url": "https://github.com/aeshell/aesh-readline#2.6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/readline-2.6.0.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/readline-2.6.0.redhat-00001.jar:org.aesh:terminal-api"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12914516",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BC2NCQULNVAAE",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/aeshell/aesh-readline",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tzdata",
+      "purl": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "version": "2025b-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff671e79a03e80cf1c432e92fa02aff95d597a97",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3572007",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tzdata-java",
+      "purl": "pkg:rpm/redhat/tzdata-java@2025b-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata-java@2025b-1.el9?arch=noarch",
+      "version": "2025b-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff671e79a03e80cf1c432e92fa02aff95d597a97",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3572007",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "unzip",
+      "purl": "pkg:rpm/redhat/unzip@6.0-58.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/unzip@6.0-58.el9_5?arch=x86_64",
+      "version": "6.0-58.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8804116fd00d9e7cc929cbe628c06d27cf7d7000",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/unzip#8804116fd00d9e7cc929cbe628c06d27cf7d7000"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3492020",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/unzip#8804116fd00d9e7cc929cbe628c06d27cf7d7000",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vim-minimal",
+      "purl": "pkg:rpm/redhat/vim-minimal@8.2.2637-22.el9_6?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/vim-minimal@8.2.2637-22.el9_6?arch=x86_64&epoch=2",
+      "version": "2:8.2.2637-22.el9_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "Vim and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "99204e95ee526797c94e17edd4de1effeff6d55c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/vim#99204e95ee526797c94e17edd4de1effeff6d55c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3530051",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/vim#99204e95ee526797c94e17edd4de1effeff6d55c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-common",
+      "purl": "pkg:maven/org.wildfly.common/wildfly-common@1.7.0.Final-redhat-00003?type=jar",
+      "type": "library",
+      "group": "org.wildfly.common",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c62dc6e82c0ae461653301a4537d6709"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c636a5e7a438be8aef34a5c413879ff0a1775bc1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2a9dcdbac5641ea1270a46d12001da7d901dbfea11680bcedc1ec2a8e967f3bd"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.7.0.Final-redhat-00003?type=jar",
+      "version": "1.7.0.Final-redhat-00003",
+      "licenses": [
+        {
+          "license": {
+            "url": "http://repository.jboss.org/licenses/apache-2.0.txt",
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "18b12a8c82c4b1732a7d839b45d9f497b4686364",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly/wildfly-common.git#1.7.0.Final-redhat-00003"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-common-1.7.0.Final-redhat-00003.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-common-1.7.0.Final-redhat-00003.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c636a5e7a438be8aef34a5c413879ff0a1775bc1"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/12039522",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/A633354X2DYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.3.9:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly/wildfly-common.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-asn1",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-asn1@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "96369aecdf04dc59f7e5309cb4e5288b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "460156081c3192dd532fc07cb1eba058bb195d05"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a858d05badf45631e11a89aa7c76196d8d03c2274f546258f8b7f23ad4a29ed8"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-asn1@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-asn1-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-asn1-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "460156081c3192dd532fc07cb1eba058bb195d05"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618370",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-auth",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-auth@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c685aae9caf845212c5f996baf3e1d8c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f55436cc90c95718ce2cd24f6e745ef41a6ad113"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "094179c0ecc646fad23450591fab5c44960d5f48ab3ff1d6967d27953add84b3"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f55436cc90c95718ce2cd24f6e745ef41a6ad113"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618319",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-auth-server",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "52f12bc9704c0923d073372763ae6f28"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bb262ae99e55d345d34a698b3bbade1b4431607c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "81abac6c99a1fca2ca01447f586131061c758b955078030f66ca60fc8231d59d"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-server-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-server-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bb262ae99e55d345d34a698b3bbade1b4431607c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618241",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-auth-server-http",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-http@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "41f6404d97944b33a5ba99154c1d1613"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "75bab52581df4c45f5495fc3ec80a0853bf4616c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1c89999c737a69ac362051b2f479465d688fa0426223508737d6e99724212717"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-http@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-server-http-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-server-http-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "75bab52581df4c45f5495fc3ec80a0853bf4616c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618272",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-auth-server-sasl",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-sasl@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a4314c30daa3a0f1b8b144bbbbb54261"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b5534ab52256e81a018068c004ae914217db4a83"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "859e527ea906a929d94d193c7a91a56deb49540f25608e96bd7107cf64e70c26"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-sasl@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-server-sasl-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-server-sasl-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b5534ab52256e81a018068c004ae914217db4a83"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618269",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-auth-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c6e51179f09e5faa829d981f0a36ba11"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "04a08640149cab3018aa1518211a043b3366a7e3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7d2d9d99fbfceb42f6fcb7d9477ab2a8cc78f92b67da1c16eb580c2d587eea87"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-auth-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "04a08640149cab3018aa1518211a043b3366a7e3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618353",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-base",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-base@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7c6e94cddef9f99e54eba8b755c0d0e4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c169c31e8969450a626609c3db7b64a427513b69"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "81872ede4ef02e1451093fd722ff58a3f14e14c13f55d1dacaeb2a5a024062ff"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-base@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-base-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-base-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c169c31e8969450a626609c3db7b64a427513b69"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618247",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-client",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-client@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5dbd26fda83578f5f9a31dee3c7e4017"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6b14bd65ae9351e56f923350d91f998eee1abdff"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "03f589ec85adf8c072b9e1751497d8db86cc21908afcb567e37b05d8e08cd6e0"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-client@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-client-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-client-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6b14bd65ae9351e56f923350d91f998eee1abdff"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618342",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-credential",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-credential@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "45e2646a21bbb6b86ad09f3ff23ed880"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c42df2b02b80a66da8199effef861b40083e484b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "095cd3b91196d6b46b176a51926386ea8931b452e458815811adcfe4d78594f5"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-credential@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-credential-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-credential-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c42df2b02b80a66da8199effef861b40083e484b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618303",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-credential-source-impl",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-credential-source-impl@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "08185b55de0a855651af87d514da49b2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3a915baf765ada14d1a8893e756adb6019335ab4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e12ec075ac4794cff9243fb152b092d41529bad0fd2364435ee18beb4dba1a20"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-credential-source-impl@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-credential-source-impl-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-credential-source-impl-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3a915baf765ada14d1a8893e756adb6019335ab4"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618307",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-credential-store",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-credential-store@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3b2e03d6fd2f275bfa20bae4574e8178"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4de7a708428fff5c9def1ece1ace1e2cb504c077"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "982d3cf62d3f752015f38fa870610c8c29dd74d2220fc69e6a1dd638e624470f"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-credential-store@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-credential-store-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-credential-store-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4de7a708428fff5c9def1ece1ace1e2cb504c077"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618372",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-encryption",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-encryption@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b7cc643183225ecc838a8df68df4f97d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a658367c435f956a18aff516a331a2959209d772"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8a46cb43361fda428e084cb2c1071c5fbdfefb490d65fbe506440fe80b64b756"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-encryption@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-encryption-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-encryption-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a658367c435f956a18aff516a331a2959209d772"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618234",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ca2c27d967580e6c671c0a4ba11dc9f6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bee48ec4084759995ece7d0646240d123d70949f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5170d71e3142d88a9a90614cfb9788223e03fc5611a4c109ae4b96caba576942"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bee48ec4084759995ece7d0646240d123d70949f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618323",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http-basic",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http-basic@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5cf2962c0f4cb9b2e31daeeb23f529e3"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2b42b478eca79537402bc1e8620dad1e88683936"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "711015920b9d2a1b40b60df193526e66e691bc97dedd2bf61cff769cceac4878"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-basic@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-basic-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-basic-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "2b42b478eca79537402bc1e8620dad1e88683936"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618202",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http-bearer",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http-bearer@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "0097ed106a830a54603d15f9ef90aa6a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "70159b3ee7825840a040feb36872d9923b11ca49"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "91c1b789a2b31aebb24bab3cb888a09587695b3c65724a2a38169871d318349c"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-bearer@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-bearer-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-bearer-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "70159b3ee7825840a040feb36872d9923b11ca49"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618332",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http-cert",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http-cert@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f92978d644569ae85fa3541b8c070776"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "28738814c89177cfd18a9163f0d298b82e4da22d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "793de567005c93ff9155e81d2d3d70929e424a30791ee2422d670331cb88079a"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-cert@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-cert-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-cert-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "28738814c89177cfd18a9163f0d298b82e4da22d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618258",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http-digest",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http-digest@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "113b2a9aa0bf5ee51e944124fd4d6e07"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "da9355061a9c01b3b620b45f15cc9e744659f449"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f3393297314c3234111f3a859da5a4474c1579d01fb7b20d328a9aa89fee50c3"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-digest@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-digest-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-digest-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "da9355061a9c01b3b620b45f15cc9e744659f449"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618320",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http-spnego",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http-spnego@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "228306ab78b2595415c2a12f81f1bfea"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0b4916479a9c50f7b644f51d8b57f22a5a981915"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "45287683428163aeadd7cfa139f97ee24e52a7ac5fdb444eafefcbe5e400954c"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-spnego@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-spnego-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-spnego-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0b4916479a9c50f7b644f51d8b57f22a5a981915"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618193",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-http-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-http-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "cfade8fc269b979139fcb7e927b91c31"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "816baa1f07629b2d3be4839b88a603f115e84a6b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2fe2eb4796a8ce1fef3cc656c91789e36a015387d2e6fd4f733c8877ec4235e8"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-http-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "816baa1f07629b2d3be4839b88a603f115e84a6b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618349",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-json-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-json-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "069d99715e6d212d2358c27bc3b03a12"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8972acab24228787f17c3d8caad13f203d654caf"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "67a448bfb9e9a24367cbf62eb822949685f0ce717925a6af0a58c427f55c3528"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-json-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-json-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-json-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8972acab24228787f17c3d8caad13f203d654caf"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618294",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-keystore",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-keystore@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "759bd0bcd0446ed5a6810612620289cf"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c765f370fe4d35afbfe5be796c50df4a7e87a9d3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4f58f66cf6376b3d703f013c864df7f939e1e70621ea4428d03aee5ec8625c8c"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-keystore@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-keystore-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-keystore-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c765f370fe4d35afbfe5be796c50df4a7e87a9d3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618219",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-mechanism",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "58af58f597bd5b39a14f6403bc10a540"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2c0731ed348c7c190628eac2a7a96f60d5b6ef6f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "da75eeef835dd043d293c6f89fcca7ec751bff2a5e0fbe8d042d96676284bdff"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "2c0731ed348c7c190628eac2a7a96f60d5b6ef6f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618375",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-mechanism-digest",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-digest@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e82e4f72943f6acd2c15d4aa8e70f080"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0e9a9cb881d5f9d46dc7acee15c9fe6850405d76"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "96b5ee288c68aec73499edc45c139e66170011ac43c217b718d0d2c53e5457fb"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-digest@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-digest-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-digest-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0e9a9cb881d5f9d46dc7acee15c9fe6850405d76"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618364",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-mechanism-gssapi",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-gssapi@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "850a147b69cd6efb434a604f4369d51a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c4633cd18bef70cbffa4e7f7a0a424f2dfc74aa5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e2c3d6bf3d61ed69b844ff5bb25857c0de9eca371e9d197838dc1dbf8386d41c"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-gssapi@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-gssapi-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-gssapi-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c4633cd18bef70cbffa4e7f7a0a424f2dfc74aa5"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618292",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-mechanism-http",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-http@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "19dd1d55adbc35504baa2844a1de8365"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "762554fa69ce52ec638ceadec66f38aff1fd9541"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1b4a6519abdc8f53f744e7481fe688d6b0d1915cd923734aaa115c7ec49617d6"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-http@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-http-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-http-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "762554fa69ce52ec638ceadec66f38aff1fd9541"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618180",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-mechanism-oauth2",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-oauth2@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9e67c0ae7cff4dc9281314ba85680330"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ec2ee86d249895338410a8285a574318982e91af"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "badfd30da511429734070fb84314a08264595d9b6f7e80ad0d2ee47cff5cf8e3"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-oauth2@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-oauth2-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-oauth2-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "ec2ee86d249895338410a8285a574318982e91af"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618190",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-mechanism-scram",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-scram@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fb2d9c6dbb480b1a5f729e9695909979"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "aab196f4d2fcfc2f827242ced9377b4d217aaa79"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5d6ae2bd7f0dff50e0d2a1684a96404d58e6bf3d5a45b111e6c6340b89c6bcdf"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-scram@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-scram-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-mechanism-scram-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "aab196f4d2fcfc2f827242ced9377b4d217aaa79"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618311",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-password-impl",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-password-impl@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f2f45aa277c8481a245d2cc3408beb20"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "59d601b527bd3134e444bd10b418c98d306e3f02"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "057130d737085286958b3c5661384061e4685a45e7c4b7160ce48b8245ea6be2"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-password-impl@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-password-impl-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-password-impl-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "59d601b527bd3134e444bd10b418c98d306e3f02"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618366",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-permission",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-permission@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "70c07bcff12a9ce2d26f4f284a9b4e0b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f18a2310c2054b0e179067a41bf7040da1a22a1f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bc650be1614c6005b1dd08d90fe570d0d56852a57b5a922cdd64f2a074cf2100"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-permission@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-permission-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-permission-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f18a2310c2054b0e179067a41bf7040da1a22a1f"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618249",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-provider-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-provider-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f7cddaac5aa2f4e8050cddfa7d3230c3"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9946f45b86a15d9600a6d0784e4fe773b1750eb3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f36891fe8a297e5ed2d14d8aca91b567dfb5e32b375d1deb166ac5fd254eaf61"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-provider-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-provider-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-provider-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9946f45b86a15d9600a6d0784e4fe773b1750eb3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618244",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-realm",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-realm@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "debe0e7572ee20bc753a15a692dcc2ad"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a9fb5c8545e448832e41eb0f175af096491a9185"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bb5af01d91c959bdf70dd003c8a2afd162f785e088b97d7d8b73433b95cd44fa"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-realm@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-realm-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-realm-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "a9fb5c8545e448832e41eb0f175af096491a9185"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618215",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-realm-ldap",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-realm-ldap@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "72f75d732b48a9773b45f22f6609766c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "38ccfc49e796008d34019863aed2f73036ffdb22"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "21e607c2cde3aa6f32321811037d0a1b35acc34bebce8f3cb46d2c48d94b94ca"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-realm-ldap@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-realm-ldap-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-realm-ldap-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "38ccfc49e796008d34019863aed2f73036ffdb22"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618340",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-realm-token",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-realm-token@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5500fbe4595b933ee4d2363f493a9779"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "120f1c05dd8578440ee0c0a4273d5b8a9de02cfa"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "84a0eec5e5b7ccc4c39dc3233a4180675aa67c9926718f70f0ea566a57a674dd"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-realm-token@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-realm-token-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-realm-token-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "120f1c05dd8578440ee0c0a4273d5b8a9de02cfa"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618324",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "129e85140ea6e19eb8520555dfecc69a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d7ee5c694dd651e9b669420684582eed8619a3e7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fb209eb3abc67e58414b5b34b093ee819adeff5b8d6d8d0842e46ad947f6c06d"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d7ee5c694dd651e9b669420684582eed8619a3e7"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618344",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-digest",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-digest@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "650c2e2f74eeb6374fb8a4dc7624f981"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8ab7488868a1f74cb37085e82d64a8ccce3bf2a7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "724109cc240468ee202b6df6c315e7f3348aff48e19af15b71c825cd7cdfbefb"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-digest@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-digest-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-digest-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8ab7488868a1f74cb37085e82d64a8ccce3bf2a7"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618228",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-external",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-external@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d1941f9517c34bbfd91dea867ad06c6a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "109dedc0135514454e137c08a84f56bf4d1c8eee"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e8e44d7673731d14c8eb2cd4356b373f0eb23a85aaaff8140e1ac30641ad643b"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-external@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-external-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-external-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "109dedc0135514454e137c08a84f56bf4d1c8eee"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618198",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-gs2",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gs2@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "192f09436e0e6c384bdd34899354de56"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b0906db9cc5d029f9dca8fe93efad2623d14b94d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3f0534121fd708c8d6c8d91b2ef55f1a3b824b53b2b559495b2df11e6f11992a"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gs2@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-gs2-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-gs2-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b0906db9cc5d029f9dca8fe93efad2623d14b94d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618367",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-gssapi",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gssapi@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "db99a6bc75959418b4b362859806bb90"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7a5b4287ded4d7896fa24fd13ffce55f9b6d12dc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ab846ddbda2bdb5271acfabec42f3c56831e686394156eba039e7b0771cb5271"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gssapi@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-gssapi-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-gssapi-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "7a5b4287ded4d7896fa24fd13ffce55f9b6d12dc"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618276",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-localuser",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-localuser@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d40e2b7922f5f848f72843eecaaf2013"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "783f2a9ce3ae94b7ea4314ddfecef6da0e9a03fc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d41d9f3cbdfab0d83aed5fc6d99e025750d8d1cc6e50386a81ff8374952e91be"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-localuser@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-localuser-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-localuser-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "783f2a9ce3ae94b7ea4314ddfecef6da0e9a03fc"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618274",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-oauth2",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-oauth2@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "aebb194e4c7c00d37795517230ce6e87"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f1446be8d12c24b0eaf20b5ddb1e45976a1ad5a8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "302b4fe033f68c4fd4110b9d02a25266961ec88a6c3201bc0d8a29b29a955e9f"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-oauth2@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-oauth2-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-oauth2-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f1446be8d12c24b0eaf20b5ddb1e45976a1ad5a8"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618226",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-plain",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-plain@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "36df3169cb785fdea343eafe006729d1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f1a706d28c5ac41fc260066cb6f8ed19f812acb5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "86efa43d82a13e653a8d3000c7a0a7a24b0c654951f7c129d474edb944ae5061"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-plain@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-plain-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-plain-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f1a706d28c5ac41fc260066cb6f8ed19f812acb5"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618369",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-sasl-scram",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-scram@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a9acde591e81e0d72d7ddc38f91120c7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9ee449c9a64edbd2230f3aa0f3684d555389b15d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d307b83ea3d244ffd263ed24b854cae91431d5c4500907416e314591e0e2c724"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-scram@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-scram-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-sasl-scram-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9ee449c9a64edbd2230f3aa0f3684d555389b15d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618388",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-security-manager-action",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-security-manager-action@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fe5e3c1d9d88c8c84fe8ebbc4ce49bcc"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "30fe49791b2830e448cc4ef318cfc092e409d7fa"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b6cf001f282d6ffa6b9c6ddc987576a1201b94e5065d84efbea977d8058fb7dc"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-security-manager-action@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-security-manager-action-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-security-manager-action-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "30fe49791b2830e448cc4ef318cfc092e409d7fa"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618300",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-ssh-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-ssh-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "96e8673522f7d20abd3d41abfda42c08"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "434ceff3f904bccf1109e13527dacfd818cf818b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "63b60586599c0e3c828f744ce33912e88572fdfb4f0dd488dbbebe43b2996cbc"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-ssh-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-ssh-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-ssh-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "434ceff3f904bccf1109e13527dacfd818cf818b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618216",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-ssl",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-ssl@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ab7ba1e213d5957600db9d9df64ef6aa"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "dad49d1480e0e838598bdeaaaf8de39b091e04b4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b8cd93a623267c6dfae6a57cee2ce52aa109d189956fcb4e172e6cfd8ece33b4"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-ssl@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-ssl-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-ssl-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "dad49d1480e0e838598bdeaaaf8de39b091e04b4"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618248",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4623d3ecf9af4fe869f1b2b3e12cc280"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6016370030f27397fa6b1ecff79490079467eb6a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "14c392a161b3283758c9b776cbeea9cd6d00e08bf5f1250436d5d81c231d58d2"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6016370030f27397fa6b1ecff79490079467eb6a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618385",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-x500",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-x500@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a782576e8383c9c92c0629964327d97f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1bb36faa79e271b38d852468ac270e1b81867bf0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "27a9b6b97e63689a940eb02c4019f1ad5c62b25f0e4a5cbf1ed4a69e8361f2d5"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "1bb36faa79e271b38d852468ac270e1b81867bf0"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618204",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-x500-cert",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "31f34a159c5e77c2e80153e42afd974d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b22faf3e75e57f29f813287fde112f167cd3800a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d7186f5d4408a2b4ce8efc3df2c8b04c6030f469f23d80feb78615a0b06bf6dc"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-cert-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-cert-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "b22faf3e75e57f29f813287fde112f167cd3800a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618310",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-x500-cert-util",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert-util@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f3be416613f34734d69abec321005e2e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "859b41574ca0df4e48ee513332b2581ebc5b1b0d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5f4dc0e2f7b668bdf9f35b7c66c3b5ae8f564186ff983e15fcaa568de97025f3"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert-util@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-cert-util-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-cert-util-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "859b41574ca0df4e48ee513332b2581ebc5b1b0d"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618302",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "wildfly-elytron-x500-principal",
+      "purl": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-principal@2.6.2.Final-redhat-00001?type=jar",
+      "type": "library",
+      "group": "org.wildfly.security",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "447e6f1a530fdbc8f3ab0988f0bd8175"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "03681bd9be88efb63f621b2dfdf7a074756402a0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5746ea27d0f993abeaed51dd6fd2cdfdc4bd96f65c9fb0a400e8c08ac6c0f9a4"
+        }
+      ],
+      "bom-ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-principal@2.6.2.Final-redhat-00001?type=jar",
+      "version": "2.6.2.Final-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8231703b2adaa7b8d9e57fcd78b66190b6c42d0d",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/wildfly-security/wildfly-elytron.git#2.6.2.Final-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-principal-2.6.2.Final-redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/wildfly-elytron-x500-principal-2.6.2.Final-redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "03681bd9be88efb63f621b2dfdf7a074756402a0"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13618236",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BGKCNRPL2VYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11.0.9-11-mvn3.6.3:1.0.4",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/wildfly-security/wildfly-elytron.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "xstream",
+      "purl": "pkg:maven/com.thoughtworks.xstream/xstream@1.4.21.redhat-00001?type=jar",
+      "type": "library",
+      "group": "com.thoughtworks.xstream",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "15a50df0644d5bcac35b0b7d0898f27a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0d8133682adaafa6e4ca73ac64cc6de19fb20064"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0b292f89725c6c65f0e53c551e9b9185c866220e6ce714a7c4ee09cec15ec5a4"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.thoughtworks.xstream/xstream@1.4.21.redhat-00001?type=jar",
+      "version": "1.4.21.redhat-00001",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4f6d982c46261b8bc43abec294da2a018d25dcc3",
+            "url": "https://gitlab.cee.redhat.com/pnc-workspace/x-stream/xstream.git#1.4.21.redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/opt/infinispan/lib/xstream-1.4.21.redhat-00001.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/opt/infinispan/lib/xstream-1.4.21.redhat-00001.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0d8133682adaafa6e4ca73ac64cc6de19fb20064"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13161382",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BDYFFO2AWNQAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-7-j11-mvn3.6.3:1.0.5",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        },
+        {
+          "url": "https://github.com/x-stream/xstream.git",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "xz-libs",
+      "purl": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "version": "5.2.5-8.el9_0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+            "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2032531",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "zip",
+      "purl": "pkg:rpm/redhat/zip@3.0-35.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zip@3.0-35.el9?arch=x86_64",
+      "version": "3.0-35.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5985b742a23b7e3afe5d922f3f63713a892beec3",
+            "url": "git://pkgs.devel.redhat.com/rpms/zip#5985b742a23b7e3afe5d922f3f63713a892beec3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2377364",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zip#5985b742a23b7e3afe5d922f3f63713a892beec3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "zlib",
+      "purl": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "version": "1.2.11-40.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Boost"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+            "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2495976",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:oci/datagrid-8@sha256%3A207b8132820f3e42442379f4ae61fc5f946cfae8c5c71818bbcf969ad7f91747?arch=amd64&os=linux&tag=1.5-8.1758135428",
+      "dependsOn": [
+        "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12.redhat-00005?type=jar",
+        "pkg:maven/org.latencyutils/LatencyUtils@2.0.3.redhat-00005?type=jar",
+        "pkg:maven/org.aesh/aesh@2.8.4.redhat-00001?type=jar",
+        "pkg:maven/io.agroal/agroal-api@2.4.0.redhat-00001?type=jar",
+        "pkg:maven/io.agroal/agroal-pool@2.4.0.redhat-00001?type=jar",
+        "pkg:rpm/redhat/alsa-lib@1.2.13-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64",
+        "pkg:maven/org.antlr/antlr-runtime@3.5.3.redhat-00001?type=jar",
+        "pkg:rpm/redhat/audit-libs@3.1.5-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/avahi-libs@0.8-22.el9_6.1?arch=x86_64",
+        "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/bsdtar@3.5.3-6.el9_6?arch=x86_64",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch",
+        "pkg:maven/com.github.ben-manes.caffeine/caffeine@3.1.8.redhat-00002?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.17.1.redhat-00001?type=jar",
+        "pkg:maven/org.apache.commons/commons-compress@1.27.1.redhat-00001?type=jar",
+        "pkg:maven/commons-io/commons-io@2.18.0.redhat-00001?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.18.0.redhat-00002?type=jar",
+        "pkg:maven/org.apache.commons/commons-math3@3.6.1.redhat-00003?type=jar",
+        "pkg:rpm/redhat/copy-jdk-configs@4.0-3.el9?arch=noarch",
+        "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64",
+        "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch",
+        "pkg:rpm/redhat/crypto-policies-scripts@20250128-1.git5269e22.el9?arch=noarch",
+        "pkg:rpm/redhat/cups-libs@2.3.3op2-33.el9_6.1?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/curl-minimal@7.76.1-31.el9_6.1?arch=x86_64",
+        "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+        "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+        "pkg:rpm/redhat/dnf-data@4.14.0-25.el9?arch=noarch",
+        "pkg:rpm/redhat/elfutils-libelf@0.192-6.el9_6?arch=x86_64",
+        "pkg:rpm/redhat/expat@2.5.0-5.el9_6?arch=x86_64",
+        "pkg:rpm/redhat/file@5.39-16.el9?arch=x86_64",
+        "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+        "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/findutils@4.8.0-7.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+        "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/glib2@2.68.4-16.el9_6.2?arch=x86_64",
+        "pkg:rpm/redhat/glibc@2.34-168.el9_6.23?arch=x86_64",
+        "pkg:rpm/redhat/glibc-common@2.34-168.el9_6.23?arch=x86_64",
+        "pkg:rpm/redhat/glibc-minimal-langpack@2.34-168.el9_6.23?arch=x86_64",
+        "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/gnutls@3.8.3-6.el9_6.2?arch=x86_64",
+        "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+        "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+        "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+        "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+        "pkg:maven/org.hibernate.common/hibernate-commons-annotations@6.0.6.Final-redhat-00001?type=jar",
+        "pkg:maven/org.hibernate.search/hibernate-search-backend-lucene@7.1.2.Final-redhat-00002?type=jar",
+        "pkg:maven/org.hibernate.search/hibernate-search-engine@7.1.2.Final-redhat-00002?type=jar",
+        "pkg:maven/org.hibernate.search/hibernate-search-mapper-pojo-base@7.1.2.Final-redhat-00002?type=jar",
+        "pkg:maven/org.hibernate.search/hibernate-search-util-common@7.1.2.Final-redhat-00002?type=jar",
+        "pkg:maven/org.hibernate.search/hibernate-search-v5migrationhelper-engine@7.1.2.Final-redhat-00002?type=jar",
+        "pkg:maven/com.carrotsearch/hppc@0.9.1.redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-anchored-keys@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-api@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-cachestore-jdbc@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-cachestore-jdbc-common@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-cachestore-remote@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-cachestore-rocksdb@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-cachestore-sql@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-cli-client@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-client-hotrod@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-client-rest@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-clustered-counter@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-commons@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-commons-graalvm@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-core@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-jboss-marshalling@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-multimap@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-objectfilter@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-query@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-query-core@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-query-dsl@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-remote-query-client@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-remote-query-server@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-scripting@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-core@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-hotrod@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-insights@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-memcached@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-resp@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-rest@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-router@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?package-id=c7ba178dee624963",
+        "pkg:maven/org.infinispan/infinispan-tasks@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-tasks-api@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:maven/org.infinispan/infinispan-tools@15.0.19.Final-redhat-00001?type=jar",
+        "pkg:rpm/redhat/iproute@6.11.0-1.el9?arch=x86_64",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.16.2.redhat-00001?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.16.2.redhat-00001?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.16.2.redhat-00001?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.16.2.redhat-00001?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.16.2.redhat-00001?type=jar",
+        "pkg:maven/org.glassfish/jakarta.json@2.0.1.redhat-00001?type=jar",
+        "pkg:maven/jakarta.transaction/jakarta.transaction-api@2.0.1.redhat-00004?type=jar",
+        "pkg:maven/io.smallrye/jandex@3.3.0.redhat-00001?type=jar",
+        "pkg:maven/org.fusesource.jansi/jansi@2.4.0.redhat-00003?type=jar",
+        "pkg:rpm/redhat/java-21-openjdk-headless@21.0.8.0.9-1.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/javapackages-filesystem@6.4.0-1.el9?arch=noarch",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.6.1.Final-redhat-00001?type=jar",
+        "pkg:maven/org.jboss.marshalling/jboss-marshalling@2.2.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.jboss.marshalling/jboss-marshalling-river@2.2.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.jboss.threads/jboss-threads@3.6.1.Final-redhat-00001?type=jar",
+        "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32.redhat-00003?type=jar",
+        "pkg:maven/org.jctools/jctools-core@4.0.1?type=jar",
+        "pkg:maven/org.jctools/jctools-core@4.0.5.redhat-00001?type=jar",
+        "pkg:maven/org.jgroups/jgroups@5.3.16.Final-redhat-00001?type=jar",
+        "pkg:maven/org.openjdk.jmh/jmh-core@1.37.0.redhat-00001?type=jar",
+        "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4.redhat-00002?type=jar",
+        "pkg:maven/jrt-fs/jrt-fs@21.0.8?type=jar",
+        "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+        "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+        "pkg:maven/org.jspecify/jspecify@1.0.0.redhat-00001?type=jar",
+        "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/krb5-libs@1.21.1-8.el9_6?arch=x86_64",
+        "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+        "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+        "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+        "pkg:maven/io.lettuce/lettuce-core@6.5.4.RELEASE-redhat-00001?type=jar",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/libarchive@3.5.3-6.el9_6?arch=x86_64",
+        "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libblkid@2.37.4-21.el9?arch=x86_64",
+        "pkg:rpm/redhat/libbpf@1.5.0-1.el9?arch=x86_64&epoch=2",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+        "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libcom_err@1.46.5-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9_6.1?arch=x86_64",
+        "pkg:rpm/redhat/libdnf@0.69.0-13.el9?arch=x86_64",
+        "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/libmount@2.37.4-21.el9?arch=x86_64",
+        "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+        "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsemanage@3.6-5.el9_6?arch=x86_64",
+        "pkg:rpm/redhat/libsepol@3.6-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-5.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/libtirpc@1.3.3-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/libtool-ltdl@2.4.6-46.el9?arch=x86_64",
+        "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+        "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64",
+        "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libxml2@2.9.13-12.el9_6?arch=x86_64",
+        "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64",
+        "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?classifier=linux-x86_64&type=jar",
+        "pkg:rpm/redhat/lksctp-tools@1.0.19-3.el9_4?arch=x86_64",
+        "pkg:maven/org.apache.logging.log4j/log4j-api@2.23.1.redhat-00002?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-core@2.23.1.redhat-00002?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-jul@2.23.1.redhat-00002?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-slf4j-impl@2.23.1.redhat-00002?type=jar",
+        "pkg:rpm/redhat/lsof@4.94.0-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/lua@5.4.4-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/lua-posix@35.0-8.el9?arch=x86_64",
+        "pkg:maven/org.apache.lucene/lucene-analysis-common@9.9.2.redhat-00001?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-core@9.9.2.redhat-00002?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-facet@9.9.2.redhat-00002?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-highlighter@9.9.2.redhat-00001?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-join@9.9.2.redhat-00002?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-queries@9.9.2.redhat-00002?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-queryparser@9.9.2.redhat-00002?type=jar",
+        "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64",
+        "pkg:maven/io.micrometer/micrometer-commons@1.12.13.redhat-00001?type=jar",
+        "pkg:maven/io.micrometer/micrometer-core@1.12.13.redhat-00001?type=jar",
+        "pkg:maven/io.micrometer/micrometer-observation@1.12.13.redhat-00001?type=jar",
+        "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.12.13.redhat-00001?type=jar",
+        "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_6.2?arch=noarch",
+        "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_6.2?arch=x86_64",
+        "pkg:rpm/redhat/nettle@3.10.1-1.el9?arch=x86_64",
+        "pkg:maven/io.netty/netty-buffer@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-codec-dns@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-codec-http@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-codec-http2@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-common@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-handler@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-resolver@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-resolver-dns@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?package-id=0eb6ce733297e359",
+        "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.121.Final-redhat-00003?type=jar",
+        "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/nspr@4.36.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/nss@3.112.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/nss-softokn@3.112.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/nss-softokn-freebl@3.112.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/nss-sysinit@3.112.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/nss-tools@3.112.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/nss-util@3.112.0-4.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/openldap@2.6.8-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/openssl@3.2.2-6.el9_5.1?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/openssl-fips-provider@3.0.7-6.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-6.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&epoch=1",
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-api-events@1.32.0.alpha-redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-context@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-exporter-common@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp-common@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-exporter-sender-jdk@1.32.0.alpha-redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.32.0.redhat-00001?type=jar",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.32.0.redhat-00001?type=jar",
+        "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+        "pkg:maven/org.infinispan.protostream/protostream@5.0.14.Final-redhat-00002?type=jar",
+        "pkg:maven/org.infinispan.protostream/protostream-types@5.0.14.Final-redhat-00002?type=jar",
+        "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/python3@3.9.21-2.el9_6.2?arch=x86_64",
+        "pkg:rpm/redhat/python3-libs@3.9.21-2.el9_6.2?arch=x86_64",
+        "pkg:rpm/redhat/python3-pip-wheel@21.3.1-1.el9?arch=noarch",
+        "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-13.el9_6.1?arch=noarch",
+        "pkg:maven/org.reactivestreams/reactive-streams@1.0.4.redhat-00004?type=jar",
+        "pkg:maven/io.projectreactor/reactor-core@3.6.6.redhat-00001?type=jar",
+        "pkg:maven/org.aesh/readline@2.6.0.redhat-00001?type=jar",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/redhat-release@9.6-0.1.el9?arch=x86_64",
+        "pkg:rpm/redhat/rootfiles@8.1-34.el9?arch=noarch",
+        "pkg:rpm/redhat/rpm@4.16.1.3-37.el9?arch=x86_64",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-37.el9?arch=x86_64",
+        "pkg:rpm/redhat/rsync@3.2.5-3.el9?arch=x86_64",
+        "pkg:maven/com.redhat.insights/runtimes-java-api@2.0.4.redhat-00003?type=jar",
+        "pkg:maven/com.redhat.insights/runtimes-java-core-runtime@2.0.4.redhat-00003?type=jar",
+        "pkg:maven/io.reactivex.rxjava3/rxjava@3.1.10.redhat-00001?type=jar",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+        "pkg:rpm/redhat/shadow-utils@4.9-12.el9?arch=x86_64&epoch=2",
+        "pkg:maven/io.prometheus/simpleclient@0.16.0.redhat-00008?type=jar",
+        "pkg:maven/io.prometheus/simpleclient_common@0.16.0.redhat-00008?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36.redhat-00006?type=jar",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-8.el9_6?arch=x86_64",
+        "pkg:maven/org.apache.sshd/sshd-common@2.12.1.redhat-00002?type=jar",
+        "pkg:rpm/redhat/systemd-libs@252-51.el9_6.2?arch=x86_64",
+        "pkg:rpm/redhat/tar@1.34-7.el9?arch=x86_64&epoch=2",
+        "pkg:maven/org.aesh/terminal-api@2.6.0.redhat-00001?type=jar",
+        "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+        "pkg:rpm/redhat/tzdata-java@2025b-1.el9?arch=noarch",
+        "pkg:rpm/redhat/unzip@6.0-58.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/vim-minimal@8.2.2637-22.el9_6?arch=x86_64&epoch=2",
+        "pkg:maven/org.wildfly.common/wildfly-common@1.7.0.Final-redhat-00003?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-asn1@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-auth@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-http@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-sasl@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-auth-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-base@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-client@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-credential@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-credential-source-impl@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-credential-store@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-encryption@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http-basic@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http-bearer@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http-cert@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http-digest@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http-spnego@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-http-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-json-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-keystore@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-digest@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-gssapi@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-http@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-oauth2@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-scram@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-password-impl@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-permission@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-provider-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-realm@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-realm-ldap@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-realm-token@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-digest@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-external@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gs2@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gssapi@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-localuser@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-oauth2@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-plain@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-scram@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-security-manager-action@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-ssh-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-ssl@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-x500@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert-util@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/org.wildfly.security/wildfly-elytron-x500-principal@2.6.2.Final-redhat-00001?type=jar",
+        "pkg:maven/com.thoughtworks.xstream/xstream@1.4.21.redhat-00001?type=jar",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+        "pkg:rpm/redhat/zip@3.0-35.el9?arch=x86_64",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12.redhat-00005?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3.redhat-00005?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.aesh/aesh@2.8.4.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.agroal/agroal-api@2.4.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.agroal/agroal-pool@2.4.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/alsa-lib@1.2.13-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/alternatives@1.24-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.antlr/antlr-runtime@3.5.3.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/audit-libs@3.1.5-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/avahi-libs@0.8-22.el9_6.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bsdtar@3.5.3-6.el9_6?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.github.ben-manes.caffeine/caffeine@3.1.8.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/commons-codec/commons-codec@1.17.1.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-compress@1.27.1.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/commons-io/commons-io@2.18.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-lang3@3.18.0.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-math3@3.6.1.redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/copy-jdk-configs@4.0-3.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/coreutils-single@8.32-39.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies@20250128-1.git5269e22.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies-scripts@20250128-1.git5269e22.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cups-libs@2.3.3op2-33.el9_6.1?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/curl-minimal@7.76.1-31.el9_6.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-libs@1.12.20-8.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-data@4.14.0-25.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libelf@0.192-6.el9_6?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/expat@2.5.0-5.el9_6?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/file@5.39-16.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/findutils@4.8.0-7.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib2@2.68.4-16.el9_6.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc@2.34-168.el9_6.23?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-common@2.34-168.el9_6.23?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-168.el9_6.23?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnutls@3.8.3-6.el9_6.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@6.0.6.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.search/hibernate-search-backend-lucene@7.1.2.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.search/hibernate-search-engine@7.1.2.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.search/hibernate-search-mapper-pojo-base@7.1.2.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.search/hibernate-search-util-common@7.1.2.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.search/hibernate-search-v5migrationhelper-engine@7.1.2.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.carrotsearch/hppc@0.9.1.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-anchored-keys@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-api@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-cachestore-jdbc@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-cachestore-jdbc-common@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-cachestore-remote@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-cachestore-rocksdb@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-cachestore-sql@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-cli-client@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-client-hotrod@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-client-rest@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-clustered-counter@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-commons@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-commons-graalvm@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-core@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-jboss-marshalling@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-multimap@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-objectfilter@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-query@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-query-core@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-query-dsl@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-remote-query-client@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-remote-query-server@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-scripting@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-core@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-hotrod@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-insights@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-memcached@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-resp@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-rest@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-router@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-server-runtime@15.0.19.Final-redhat-00001?package-id=c7ba178dee624963",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-tasks@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-tasks-api@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan/infinispan-tools@15.0.19.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/iproute@6.11.0-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.16.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.16.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.16.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.16.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.16.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.glassfish/jakarta.json@2.0.1.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@2.0.1.redhat-00004?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.smallrye/jandex@3.3.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.fusesource.jansi/jansi@2.4.0.redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.8.0.9-1.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/javapackages-filesystem@6.4.0-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jboss.logging/jboss-logging@3.6.1.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jboss.marshalling/jboss-marshalling@2.2.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jboss.marshalling/jboss-marshalling-river@2.2.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jboss.threads/jboss-threads@3.6.1.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32.redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jctools/jctools-core@4.0.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jctools/jctools-core@4.0.5.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jgroups/jgroups@5.3.16.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.openjdk.jmh/jmh-core@1.37.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/jrt-fs/jrt-fs@21.0.8?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jspecify/jspecify@1.0.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/krb5-libs@1.21.1-8.el9_6?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.lettuce/lettuce-core@6.5.4.RELEASE-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libarchive@3.5.3-6.el9_6?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libblkid@2.37.4-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libbpf@1.5.0-1.el9?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcom_err@1.46.5-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9_6.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf@0.69.0-13.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmnl@1.0.4-16.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmount@2.37.4-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libselinux@3.6-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsemanage@3.6-5.el9_6?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsepol@3.6-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsmartcols@2.37.4-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-5.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtasn1@4.16.0-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtirpc@1.3.3-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtool-ltdl@2.4.6-46.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuuid@2.37.4-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxml2@2.9.13-12.el9_6?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libzstd@1.5.5-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?classifier=linux-x86_64&type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lksctp-tools@1.0.19-3.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.23.1.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-core@2.23.1.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-jul@2.23.1.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-slf4j-impl@2.23.1.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lsof@4.94.0-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua@5.4.4-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-posix@35.0-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-analysis-common@9.9.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-core@9.9.2.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-facet@9.9.2.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-highlighter@9.9.2.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-join@9.9.2.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-queries@9.9.2.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.lucene/lucene-queryparser@9.9.2.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.micrometer/micrometer-commons@1.12.13.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.micrometer/micrometer-core@1.12.13.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.micrometer/micrometer-observation@1.12.13.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.12.13.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9_6.2?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9_6.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nettle@3.10.1-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-buffer@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-codec@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-codec-dns@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-codec-http@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-codec-http2@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-common@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-handler@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-resolver@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-transport@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.121.Final-redhat-00003?package-id=0eb6ce733297e359",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.121.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nspr@4.36.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss@3.112.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-softokn@3.112.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-softokn-freebl@3.112.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-sysinit@3.112.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-tools@3.112.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-util@3.112.0-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openldap@2.6.8-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl@3.2.2-6.el9_5.1?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-6.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-6.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-api@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-api-events@1.32.0.alpha-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-context@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-common@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp-common@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-sender-jdk@1.32.0.alpha-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.32.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/procps-ng@3.3.17-14.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan.protostream/protostream@5.0.14.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.infinispan.protostream/protostream-types@5.0.14.Final-redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/psmisc@23.4-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3@3.9.21-2.el9_6.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libs@3.9.21-2.el9_6.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pip-wheel@21.3.1-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-13.el9_6.1?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.4.redhat-00004?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.projectreactor/reactor-core@3.6.6.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.aesh/readline@2.6.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/redhat-release@9.6-0.1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rootfiles@8.1-34.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm@4.16.1.3-37.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-37.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rsync@3.2.5-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.redhat.insights/runtimes-java-api@2.0.4.redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.redhat.insights/runtimes-java-core-runtime@2.0.4.redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.reactivex.rxjava3/rxjava@3.1.10.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/shadow-utils@4.9-12.el9?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.prometheus/simpleclient@0.16.0.redhat-00008?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.prometheus/simpleclient_common@0.16.0.redhat-00008?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36.redhat-00006?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-8.el9_6?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.sshd/sshd-common@2.12.1.redhat-00002?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-libs@252-51.el9_6.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tar@1.34-7.el9?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.aesh/terminal-api@2.6.0.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata-java@2025b-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/unzip@6.0-58.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/vim-minimal@8.2.2637-22.el9_6?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.common/wildfly-common@1.7.0.Final-redhat-00003?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-asn1@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-http@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-server-sasl@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-auth-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-base@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-client@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-credential@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-credential-source-impl@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-credential-store@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-encryption@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-basic@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-bearer@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-cert@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-digest@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-spnego@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-http-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-json-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-keystore@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-digest@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-gssapi@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-http@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-oauth2@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-mechanism-scram@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-password-impl@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-permission@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-provider-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-realm@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-realm-ldap@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-realm-token@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-digest@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-external@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gs2@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-gssapi@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-localuser@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-oauth2@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-plain@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-sasl-scram@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-security-manager-action@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-ssh-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-ssl@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-cert-util@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.wildfly.security/wildfly-elytron-x500-principal@2.6.2.Final-redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.thoughtworks.xstream/xstream@1.4.21.redhat-00001?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zip@3.0-35.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:b3045197-2d09-42e1-8c82-bbf39ecd9393"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/datagrid-datagrid-8/older/image-index-2025-10-06-BD74B271CC444BA.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/datagrid-datagrid-8/older/image-index-2025-10-06-BD74B271CC444BA.json
@@ -1,0 +1,173 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "SBOMer",
+          "type": "application",
+          "author": "Red Hat",
+          "version": "17652b6e"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "datagrid/datagrid-8",
+      "purl": "pkg:oci/datagrid-datagrid-8@sha256%3A6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1758135428",
+      "type": "container",
+      "description": "Image index manifest of pkg:oci/datagrid-datagrid-8@sha256%3A6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358"
+    },
+    "timestamp": "2025-10-06T09:55:01Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "154600"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "datagrid/datagrid-8",
+      "purl": "pkg:oci/datagrid-datagrid-8@sha256%3A6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1758135428",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358"
+        }
+      ],
+      "bom-ref": "datagrid-8-rhel9-container_image-index",
+      "version": "sha256:6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-datagrid-8@sha256%3A6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-datagrid-8@sha256%3A6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1758135428"
+          }
+        ]
+      },
+      "pedigree": {
+        "variants": [
+          {
+            "name": "datagrid/datagrid-8",
+            "purl": "pkg:oci/datagrid-8@sha256%3A207b8132820f3e42442379f4ae61fc5f946cfae8c5c71818bbcf969ad7f91747?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1758135428",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "207b8132820f3e42442379f4ae61fc5f946cfae8c5c71818bbcf969ad7f91747"
+              }
+            ],
+            "bom-ref": "datagrid-8-rhel9-container_amd64",
+            "version": "sha256:207b8132820f3e42442379f4ae61fc5f946cfae8c5c71818bbcf969ad7f91747",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          },
+          {
+            "name": "datagrid/datagrid-8",
+            "purl": "pkg:oci/datagrid-8@sha256%3A4b0a13c756ade3a50c72b6e4bed3be18bfe674a21259b987c6afe65b30d5ac18?arch=arm64&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1758135428",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "4b0a13c756ade3a50c72b6e4bed3be18bfe674a21259b987c6afe65b30d5ac18"
+              }
+            ],
+            "bom-ref": "datagrid-8-rhel9-container_arm64",
+            "version": "sha256:4b0a13c756ade3a50c72b6e4bed3be18bfe674a21259b987c6afe65b30d5ac18",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          },
+          {
+            "name": "datagrid/datagrid-8",
+            "purl": "pkg:oci/datagrid-8@sha256%3Ada7c74f704dcff7efe717102dd5baf4f6ea35f3406c4f5d2c23cab55f5d2856e?arch=ppc64le&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1758135428",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "da7c74f704dcff7efe717102dd5baf4f6ea35f3406c4f5d2c23cab55f5d2856e"
+              }
+            ],
+            "bom-ref": "datagrid-8-rhel9-container_ppc64le",
+            "version": "sha256:da7c74f704dcff7efe717102dd5baf4f6ea35f3406c4f5d2c23cab55f5d2856e",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          },
+          {
+            "name": "datagrid/datagrid-8",
+            "purl": "pkg:oci/datagrid-8@sha256%3A394564317f2378619d38e23cd43d251bfb83db560c6c342ff0c8c209e9397523?arch=s390x&os=linux&repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1758135428",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "394564317f2378619d38e23cd43d251bfb83db560c6c342ff0c8c209e9397523"
+              }
+            ],
+            "bom-ref": "datagrid-8-rhel9-container_s390x",
+            "version": "sha256:394564317f2378619d38e23cd43d251bfb83db560c6c342ff0c8c209e9397523",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "datagrid-8-rhel9-container"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "datagrid/datagrid-8"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "8.1758135428"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "1.5"
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:9bf6cd0b-7279-3803-963a-474eb7ad0609"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/datagrid-datagrid-8/older/product-2025-10-07-D792D72A114A47A.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/container/datagrid-datagrid-8/older/product-2025-10-07-D792D72A114A47A.json
@@ -1,0 +1,127 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "SBOMer",
+          "type": "application",
+          "author": "Red Hat",
+          "version": "17652b6e"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "RHEL-9 based Middleware Containers",
+      "type": "framework",
+      "bom-ref": "RHEL-9-OSE-Middleware",
+      "version": "RHEL-9-OSE-Middleware",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:rhosemc:1.0::el9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-10-07T12:56:42Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "154600"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "datagrid/datagrid-8",
+      "purl": "pkg:oci/datagrid-8-rhel9@sha256%3A6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358"
+        }
+      ],
+      "bom-ref": "pkg:oci/datagrid-8-rhel9@sha256%3A6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358",
+      "version": "sha256:6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-8-rhel9@sha256%3A6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5-8.1758135428"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-8-rhel9@sha256%3A6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-rhel9&tag=1.5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "datagrid/datagrid-8-prod-operator-bundle",
+      "purl": "pkg:oci/datagrid-8-prod-operator-bundle@sha256%3A555817165278c0a860d891e83349368e9c55bd79ce31bbf723fef2a529aa6d40",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "555817165278c0a860d891e83349368e9c55bd79ce31bbf723fef2a529aa6d40"
+        }
+      ],
+      "bom-ref": "pkg:oci/datagrid-8-prod-operator-bundle@sha256%3A555817165278c0a860d891e83349368e9c55bd79ce31bbf723fef2a529aa6d40",
+      "version": "sha256:555817165278c0a860d891e83349368e9c55bd79ce31bbf723fef2a529aa6d40",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-8-prod-operator-bundle@sha256%3A555817165278c0a860d891e83349368e9c55bd79ce31bbf723fef2a529aa6d40?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-prod-operator-bundle&tag=8.5.12-1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/datagrid-8-prod-operator-bundle@sha256%3A555817165278c0a860d891e83349368e9c55bd79ce31bbf723fef2a529aa6d40?repository_url=registry.access.redhat.com%2Fdatagrid%2Fdatagrid-8-prod-operator-bundle&tag=8.5.12"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "RHEL-9-OSE-Middleware",
+      "provides": [
+        "pkg:oci/datagrid-8-rhel9@sha256%3A6b78aaf15558c0522d22ba3003244203e6d39e6fe737c3075e30de8763218358",
+        "pkg:oci/datagrid-8-prod-operator-bundle@sha256%3A555817165278c0a860d891e83349368e9c55bd79ce31bbf723fef2a529aa6d40"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:2ef4b4c7-12ae-3a04-8f0b-f9c951ff1773"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/libsoup3/latest/product-2025-12-11-E2251709C91242E.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/libsoup3/latest/product-2025-12-11-E2251709C91242E.json
@@ -1,0 +1,173 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [
+        {
+          "name": "SBOMer",
+          "version": "f1c3bca6",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+                "acknowledgement": "declared"
+              }
+            }
+          ],
+          "provider": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          },
+          "externalReferences": [
+            {
+              "url": "https://github.com/project-ncl/sbomer",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "Red Hat Enterprise Linux 10",
+      "type": "operating-system",
+      "bom-ref": "RHEL-10.1.Z",
+      "version": "RHEL-10.1.Z",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/o:redhat:enterprise_linux:10.1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-12-11T17:48:16Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "157131"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8d71921acbf5cc8ed014b07e14452ad6d93bcbb49e790cd8810c8dfa8671e6e3"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-s390x-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-s390x-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "RHEL-10.1.Z",
+      "provides": [
+        "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:941dc0dd-5322-35f6-a41f-c627f60b3dbf"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/libsoup3/latest/rpm-2025-12-10-5609FCE0067D4F6.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/libsoup3/latest/rpm-2025-12-10-5609FCE0067D4F6.json
@@ -1,0 +1,1428 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "rpm-manifest-generator",
+          "type": "application",
+          "version": "0.0.1",
+          "manufacturer": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          }
+        }
+      ]
+    },
+    "licenses": [
+      {
+        "expression": "LGPL-2.0-or-later"
+      }
+    ],
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8d71921acbf5cc8ed014b07e14452ad6d93bcbb49e790cd8810c8dfa8671e6e3"
+        }
+      ],
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-s390x-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-s390x-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "a54f110f69a08f076a282604056cae04"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "f6c9119dabbdab4a1f5c71d6e18ac22671a485044a0bf6647b36473b385c3c67"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. It was originally part of a SOAP (Simple Object Access Protocol) implementation called Soup, but the SOAP and non-SOAP parts have now been split into separate packages. libsoup uses the Glib main loop and is designed to work well with GTK applications. This enables GNOME applications to access HTTP servers on the network in a completely asynchronous fashion, very similar to the Gtk+ programming model (a synchronous operation mode is also supported for those who want it), but the SOAP parts were removed long ago."
+    },
+    "timestamp": "2025-12-10T08:21:12Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "157131"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8d71921acbf5cc8ed014b07e14452ad6d93bcbb49e790cd8810c8dfa8671e6e3"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-s390x-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-s390x-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "pedigree": {
+        "ancestors": [
+          {
+            "name": "libsoup",
+            "purl": "pkg:generic/libsoup@3.6.5?download_url=https://pkgs.devel.redhat.com/repo/rpms/libsoup3/libsoup-3.6.5.tar.xz/sha512/cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03/libsoup-3.6.5.tar.xz&checksum=SHA-512:cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03",
+            "type": "library",
+            "hashes": [
+              {
+                "alg": "SHA-512",
+                "content": "cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03"
+              }
+            ],
+            "bom-ref": "pkg:generic/libsoup@3.6.5?download_url=https://pkgs.devel.redhat.com/repo/rpms/libsoup3/libsoup-3.6.5.tar.xz/sha512/cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03/libsoup-3.6.5.tar.xz&checksum=SHA-512:cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03",
+            "version": "3.6.5",
+            "evidence": {
+              "identity": [
+                {
+                  "field": "purl",
+                  "concludedValue": "pkg:generic/libsoup@3.6.5?download_url=https://pkgs.devel.redhat.com/repo/rpms/libsoup3/libsoup-3.6.5.tar.xz/sha512/cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03/libsoup-3.6.5.tar.xz&checksum=SHA-512:cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03"
+                }
+              ]
+            },
+            "pedigree": {
+              "ancestors": [
+                {
+                  "name": "libsoup",
+                  "purl": "pkg:generic/libsoup@3.6.5?download_url=https://download.gnome.org/sources/libsoup/3.6/libsoup-3.6.5.tar.xz&checksum=SHA-256:6891765aac3e949017945c3eaebd8cc8216df772456dc9f460976fbdb7ada234",
+                  "type": "library",
+                  "hashes": [
+                    {
+                      "alg": "SHA-256",
+                      "content": "6891765aac3e949017945c3eaebd8cc8216df772456dc9f460976fbdb7ada234"
+                    }
+                  ],
+                  "bom-ref": "pkg:generic/libsoup@3.6.5?download_url=https://download.gnome.org/sources/libsoup/3.6/libsoup-3.6.5.tar.xz&checksum=SHA-256:6891765aac3e949017945c3eaebd8cc8216df772456dc9f460976fbdb7ada234",
+                  "version": "3.6.5",
+                  "evidence": {
+                    "identity": [
+                      {
+                        "field": "purl",
+                        "concludedValue": "pkg:generic/libsoup@3.6.5?download_url=https://download.gnome.org/sources/libsoup/3.6/libsoup-3.6.5.tar.xz&checksum=SHA-256:6891765aac3e949017945c3eaebd8cc8216df772456dc9f460976fbdb7ada234"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "a54f110f69a08f076a282604056cae04"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "f6c9119dabbdab4a1f5c71d6e18ac22671a485044a0bf6647b36473b385c3c67"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. It was originally part of a SOAP (Simple Object Access Protocol) implementation called Soup, but the SOAP and non-SOAP parts have now been split into separate packages. libsoup uses the Glib main loop and is designed to work well with GTK applications. This enables GNOME applications to access HTTP servers on the network in a completely asynchronous fashion, very similar to the Gtk+ programming model (a synchronous operation mode is also supported for those who want it), but the SOAP parts were removed long ago.",
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3908830",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        }
+      ]
+    },
+    {
+      "name": "libsoup3-debuginfo",
+      "purl": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-debug-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ef738ded8d7ef6f08a1a257ce36c8c151a5a826da3f8f11520ede05a7e9b3f5c"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=aarch64",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-debug-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-debug-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-debug-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-debug-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "41c6423138db1887207cd91345b6a529"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "9fcc271ca0a47efac42489140ba22409b33b4173dd7b9c855a9971ec0d10999e"
+        }
+      ],
+      "description": "This package provides debug information for package libsoup3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3-devel",
+      "purl": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "72645a77cad0c244a4c114c6a335c5ddd6c9efdd5501eddb52e2a9ceee914268"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=aarch64",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "8414b952a76a98f931f328897667ed4f"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "712bd26e8319deb4177eccd7067e31ec1113b4021992b36026b42c8e7e12eb71"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. This package allows you to develop applications that use the libsoup library."
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ca21ceee356f031f5926b74170d2e12f6782ecf109269693095cccbb09ee52bf"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=aarch64",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "6458d2bc2c0b289b56a37dfd7c4fe3d0"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b7199afe984f043595c3b3e63b380aef25a3db37b354e14ca2d9b5d23c3b33df"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. It was originally part of a SOAP (Simple Object Access Protocol) implementation called Soup, but the SOAP and non-SOAP parts have now been split into separate packages. libsoup uses the Glib main loop and is designed to work well with GTK applications. This enables GNOME applications to access HTTP servers on the network in a completely asynchronous fashion, very similar to the Gtk+ programming model (a synchronous operation mode is also supported for those who want it), but the SOAP parts were removed long ago."
+    },
+    {
+      "name": "libsoup3-debugsource",
+      "purl": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cd466eab01ae97e34e03154e72a27e663c82dbb8e1247185c26045951d7cde2f"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=aarch64",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "f626a0393f7a3939d39b30a4990b0664"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "0702194f41b8618cabea4920a6324cfde6a3bfbc459a00bab730206fb3e18955"
+        }
+      ],
+      "description": "This package provides debug sources for package libsoup3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3-doc",
+      "purl": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a2f26972683f9d38e4ac6ede1f086e43c40ed4e026f2d973053145cd4caf2d54"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=rhel-10-for-s390x-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=rhel-10-for-x86_64-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=rhel-10-for-ppc64le-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=rhel-10-for-ppc64le-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=rhel-10-for-x86_64-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=rhel-10-for-s390x-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=rhel-10-for-aarch64-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch&repository_id=rhel-10-for-aarch64-appstream-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "17433a3bc53e81625c8e459066ef78f3"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "181683d746f013c8b7f6b159b68dceb731b37df4fb287020dc2d3c0c1c8432fb"
+        }
+      ],
+      "description": "This package contains developer documentation for libsoup3."
+    },
+    {
+      "name": "libsoup3-debuginfo",
+      "purl": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-debug-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5261171423e2714ce51fe3e4b6899aa2cddf7be41f6c2189210dcd9fc096a2ff"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=ppc64le",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-debug-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-debug-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-debug-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-debug-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "d6991ca2fd3ffb4542f518181fcbe085"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "82034d933c2f970e3423e7daf02f4553ff15eb1ea7bc9c1ce40834e67b8f75d5"
+        }
+      ],
+      "description": "This package provides debug information for package libsoup3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3-devel",
+      "purl": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "58efb3788d7959a0b6451642bf6ab26e809fa0451b520ce1b62a69bac4a4bb0b"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=ppc64le",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "18ab5f44568b6c7c6264825f8d776b3c"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "6dfc289e1142a0626cd6932c647ff09364db8784a49107bf49934503ea2ac0f4"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. This package allows you to develop applications that use the libsoup library."
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d88f630e3be5b7307dc0907c254c51c1b0c61f3562e0164358ce0be7a47af681"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=ppc64le",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "8eb989888b6bed7f8c255668c495576d"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "a2d6a2e982e7e2b5fa47e93175b4ba1a20d5383ec0fd0e75b59e63507e24b29d"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. It was originally part of a SOAP (Simple Object Access Protocol) implementation called Soup, but the SOAP and non-SOAP parts have now been split into separate packages. libsoup uses the Glib main loop and is designed to work well with GTK applications. This enables GNOME applications to access HTTP servers on the network in a completely asynchronous fashion, very similar to the Gtk+ programming model (a synchronous operation mode is also supported for those who want it), but the SOAP parts were removed long ago."
+    },
+    {
+      "name": "libsoup3-debugsource",
+      "purl": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "03d83f34e527cece8bfb6e53f6c594d961e0161d96cd08e3cd4c435ee9dee968"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=ppc64le",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "59b93906e1efcc122bcf53712c059fd0"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "256eeafbe3fb387b9543f0322d22a6ca38827d93b6522291bba143dae63f7219"
+        }
+      ],
+      "description": "This package provides debug sources for package libsoup3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3-debuginfo",
+      "purl": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-debug-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f1396d685f015c73572c865595081146455c07f3b1dea540af9fd7886c1d00b2"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=x86_64",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-debug-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-debug-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-debug-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-debug-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "65d508dc841e5a39d8373034268a64dd"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "8ed4f7bf0fd7bf635edf9d048b2400467724d6da6da149260d677403c6dacb93"
+        }
+      ],
+      "description": "This package provides debug information for package libsoup3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3-debugsource",
+      "purl": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a2f6e1ea54c6c7ab8e54e38cde8d03aa681800713c6c7f62743c7c4b191b580f"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=x86_64",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "43f691fefab469358c6d55244b2bc6b5"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "c5c652915c273d9c29f5fed4ec30db1434d271ea51f25f859717574b5f647d0d"
+        }
+      ],
+      "description": "This package provides debug sources for package libsoup3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b0a6da014a8f13659f29a3769d886410d9736c841dffd3f55dccc8dd92fb8205"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=x86_64",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "f307588527ea9b43575749fff1a293ae"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "33df74b4617088f04befe92e30d823293430b2e6a52603364befa3dff8dab4db"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. It was originally part of a SOAP (Simple Object Access Protocol) implementation called Soup, but the SOAP and non-SOAP parts have now been split into separate packages. libsoup uses the Glib main loop and is designed to work well with GTK applications. This enables GNOME applications to access HTTP servers on the network in a completely asynchronous fashion, very similar to the Gtk+ programming model (a synchronous operation mode is also supported for those who want it), but the SOAP parts were removed long ago."
+    },
+    {
+      "name": "libsoup3-devel",
+      "purl": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "087ab4a7a5f17feb4376b6739e76e0083c198a4bfceaafbd19747586f475276b"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=x86_64",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "7c1c8c7e25a9de6dff8c2997c68ca098"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "817d6abf0f70b5d3eddd3bd965c0bc9e925bd654b58c5d7da79b50f3892cdfd2"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. This package allows you to develop applications that use the libsoup library."
+    },
+    {
+      "name": "libsoup3-debuginfo",
+      "purl": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-debug-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "370c13868c0628e0c54f7bf033dd911594ba12e77bc4d35879f63f99ee677782"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=s390x",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-debug-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=s390x&repository_id=rhel-10-for-s390x-appstream-debug-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-debug-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=s390x&repository_id=rhel-10-for-s390x-appstream-debug-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "3424a6f0fac629598bf42a2bf6d14ca3"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b55463ae6ed192bf7c13ed69c6604f1008e36a289471dad1eb8a7201019145da"
+        }
+      ],
+      "description": "This package provides debug information for package libsoup3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3-debugsource",
+      "purl": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1789d3598eeaa8b4312faa5dbd5b5a1bd7f797e155fecc880a52de15a87b28ef"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=s390x",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=s390x&repository_id=rhel-10-for-s390x-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=s390x&repository_id=rhel-10-for-s390x-appstream-source-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "60c517dc0cd5041055fe5c7c10a2584b"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "e7f3d663173103ac65ae231538c02c99d231a728a41112e934d0f965a44499eb"
+        }
+      ],
+      "description": "This package provides debug sources for package libsoup3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2fdda7893974e2cbee10cae0a6198d2b44c0beb35fa9ca67a614216f0fd37b75"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=s390x",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=s390x&repository_id=rhel-10-for-s390x-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=s390x&repository_id=rhel-10-for-s390x-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "c9e04964b98f9be1d2a0d4dc85ec1866"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "1bb92c4776efe71e0ba601858849b10eb823613830dca99b4c1836d18ee53889"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. It was originally part of a SOAP (Simple Object Access Protocol) implementation called Soup, but the SOAP and non-SOAP parts have now been split into separate packages. libsoup uses the Glib main loop and is designed to work well with GTK applications. This enables GNOME applications to access HTTP servers on the network in a completely asynchronous fashion, very similar to the Gtk+ programming model (a synchronous operation mode is also supported for those who want it), but the SOAP parts were removed long ago."
+    },
+    {
+      "name": "libsoup3-devel",
+      "purl": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3bee6d8c51fb817d6ca2fc68b7e39d4c7729367356c007a3921bbc522927a939"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=s390x",
+      "version": "3.6.5-3.el10_1.7",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=s390x&repository_id=rhel-10-for-s390x-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=s390x&repository_id=rhel-10-for-s390x-appstream-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "e021249efdbacf548e6037b0f215778d"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "2cb2cc0f7ace35f78d8e4fce18a1ab332e2c5d6741be57447ed5509e5b7e10e4"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. This package allows you to develop applications that use the libsoup library."
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/libsoup3@3.6.5-3.el10_1.7",
+      "type": "library",
+      "bom-ref": "pkg:rpm/libsoup3@3.6.5-3.el10_1.7?package-id=76ea5d86849069e9",
+      "version": "3.6.5-3.el10_1.7",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "elf-binary-package-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/libsoup-3.0.so.0.7.4"
+        }
+      ]
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-gzbbow1q/extracted_rpms/libsoup3-3.6.5-3.el10_1.7.aarch64/usr/lib64/libsoup-3.0.so.0.7.4",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "4f0fc91b5c82ab9e24a5878149d73ec89f33baa6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c6179d971e9beac44e647b4797ba11332075b347ab0069513045345f9c4554a5"
+        }
+      ],
+      "bom-ref": "033e8adc23c5a072"
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/libsoup3@3.6.5-3.el10_1.7",
+      "type": "library",
+      "bom-ref": "pkg:rpm/libsoup3@3.6.5-3.el10_1.7?package-id=8e46e270439a7fe0",
+      "version": "3.6.5-3.el10_1.7",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "elf-binary-package-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/libsoup-3.0.so.0.7.4"
+        }
+      ]
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/libsoup3@3.6.5-3.el10_1.7",
+      "type": "library",
+      "bom-ref": "pkg:rpm/libsoup3@3.6.5-3.el10_1.7?package-id=972899fbaa384fb0",
+      "version": "3.6.5-3.el10_1.7",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "elf-binary-package-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/libsoup-3.0.so.0.7.4"
+        }
+      ]
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/libsoup3@3.6.5-3.el10_1.7",
+      "type": "library",
+      "bom-ref": "pkg:rpm/libsoup3@3.6.5-3.el10_1.7?package-id=707e0e6cedf7adaf",
+      "version": "3.6.5-3.el10_1.7",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "elf-binary-package-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/libsoup-3.0.so.0.7.4"
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=src",
+      "provides": [
+        "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=aarch64",
+        "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=aarch64",
+        "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=aarch64",
+        "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=aarch64",
+        "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.7?arch=noarch",
+        "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=ppc64le",
+        "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=ppc64le",
+        "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=ppc64le",
+        "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=ppc64le",
+        "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=x86_64",
+        "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=x86_64",
+        "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=x86_64",
+        "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=x86_64",
+        "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.7?arch=s390x",
+        "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.7?arch=s390x",
+        "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=s390x",
+        "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.7?arch=s390x"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=aarch64",
+      "provides": [
+        "033e8adc23c5a072",
+        "pkg:rpm/libsoup3@3.6.5-3.el10_1.7?package-id=76ea5d86849069e9"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=ppc64le",
+      "provides": [
+        "033e8adc23c5a072",
+        "pkg:rpm/libsoup3@3.6.5-3.el10_1.7?package-id=8e46e270439a7fe0"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=x86_64",
+      "provides": [
+        "033e8adc23c5a072",
+        "pkg:rpm/libsoup3@3.6.5-3.el10_1.7?package-id=972899fbaa384fb0"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.7?arch=s390x",
+      "provides": [
+        "pkg:rpm/libsoup3@3.6.5-3.el10_1.7?package-id=707e0e6cedf7adaf",
+        "033e8adc23c5a072"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:c4a180f4-87d3-4baf-ad68-c143da8cfd68"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/libsoup3/older/product-2025-11-11-CD32282B963F42C.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/libsoup3/older/product-2025-11-11-CD32282B963F42C.json
@@ -1,0 +1,173 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [
+        {
+          "name": "SBOMer",
+          "version": "a128392a",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+                "acknowledgement": "declared"
+              }
+            }
+          ],
+          "provider": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          },
+          "externalReferences": [
+            {
+              "url": "https://github.com/project-ncl/sbomer",
+              "type": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "Red Hat Enterprise Linux 10",
+      "type": "operating-system",
+      "bom-ref": "RHEL-10.1.Z",
+      "version": "RHEL-10.1.Z",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/o:redhat:enterprise_linux:10.1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-11-11T19:55:06Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "155545"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b32fb06c03452a17993867677192da4d5c1c1606f21d695752178d06c42ca4b1"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-s390x-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-s390x-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "RHEL-10.1.Z",
+      "provides": [
+        "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:f19501e3-8954-3cf7-8b60-a373dd1e044c"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/libsoup3/older/rpm-2025-10-27-B38A3A44DA644A4.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-3278/rpm/libsoup3/older/rpm-2025-10-27-B38A3A44DA644A4.json
@@ -1,0 +1,1428 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "rpm-manifest-generator",
+          "type": "application",
+          "version": "0.0.1",
+          "manufacturer": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          }
+        }
+      ]
+    },
+    "licenses": [
+      {
+        "expression": "LGPL-2.0-or-later"
+      }
+    ],
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b32fb06c03452a17993867677192da4d5c1c1606f21d695752178d06c42ca4b1"
+        }
+      ],
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-s390x-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-s390x-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "d304543a9c708bf70f4ceb2d4938afc7"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "86365e4d4faffb0b7106b9f6ff3b78e3d499885bd60f6e739823f8a7e1ce8750"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. It was originally part of a SOAP (Simple Object Access Protocol) implementation called Soup, but the SOAP and non-SOAP parts have now been split into separate packages. libsoup uses the Glib main loop and is designed to work well with GTK applications. This enables GNOME applications to access HTTP servers on the network in a completely asynchronous fashion, very similar to the Gtk+ programming model (a synchronous operation mode is also supported for those who want it), but the SOAP parts were removed long ago."
+    },
+    "timestamp": "2025-10-27T09:41:35Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "155545"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b32fb06c03452a17993867677192da4d5c1c1606f21d695752178d06c42ca4b1"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-s390x-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-s390x-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "pedigree": {
+        "ancestors": [
+          {
+            "name": "libsoup",
+            "purl": "pkg:generic/libsoup@3.6.5?download_url=https://pkgs.devel.redhat.com/repo/rpms/libsoup3/libsoup-3.6.5.tar.xz/sha512/cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03/libsoup-3.6.5.tar.xz&checksum=SHA-512:cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03",
+            "type": "library",
+            "hashes": [
+              {
+                "alg": "SHA-512",
+                "content": "cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03"
+              }
+            ],
+            "bom-ref": "pkg:generic/libsoup@3.6.5?download_url=https://pkgs.devel.redhat.com/repo/rpms/libsoup3/libsoup-3.6.5.tar.xz/sha512/cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03/libsoup-3.6.5.tar.xz&checksum=SHA-512:cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03",
+            "version": "3.6.5",
+            "evidence": {
+              "identity": [
+                {
+                  "field": "purl",
+                  "concludedValue": "pkg:generic/libsoup@3.6.5?download_url=https://pkgs.devel.redhat.com/repo/rpms/libsoup3/libsoup-3.6.5.tar.xz/sha512/cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03/libsoup-3.6.5.tar.xz&checksum=SHA-512:cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03"
+                }
+              ]
+            },
+            "pedigree": {
+              "ancestors": [
+                {
+                  "name": "libsoup",
+                  "purl": "pkg:generic/libsoup@3.6.5?download_url=https://download.gnome.org/sources/libsoup/3.6/libsoup-3.6.5.tar.xz&checksum=SHA-256:6891765aac3e949017945c3eaebd8cc8216df772456dc9f460976fbdb7ada234",
+                  "type": "library",
+                  "hashes": [
+                    {
+                      "alg": "SHA-256",
+                      "content": "6891765aac3e949017945c3eaebd8cc8216df772456dc9f460976fbdb7ada234"
+                    }
+                  ],
+                  "bom-ref": "pkg:generic/libsoup@3.6.5?download_url=https://download.gnome.org/sources/libsoup/3.6/libsoup-3.6.5.tar.xz&checksum=SHA-256:6891765aac3e949017945c3eaebd8cc8216df772456dc9f460976fbdb7ada234",
+                  "version": "3.6.5",
+                  "evidence": {
+                    "identity": [
+                      {
+                        "field": "purl",
+                        "concludedValue": "pkg:generic/libsoup@3.6.5?download_url=https://download.gnome.org/sources/libsoup/3.6/libsoup-3.6.5.tar.xz&checksum=SHA-256:6891765aac3e949017945c3eaebd8cc8216df772456dc9f460976fbdb7ada234"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "d304543a9c708bf70f4ceb2d4938afc7"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "86365e4d4faffb0b7106b9f6ff3b78e3d499885bd60f6e739823f8a7e1ce8750"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. It was originally part of a SOAP (Simple Object Access Protocol) implementation called Soup, but the SOAP and non-SOAP parts have now been split into separate packages. libsoup uses the Glib main loop and is designed to work well with GTK applications. This enables GNOME applications to access HTTP servers on the network in a completely asynchronous fashion, very similar to the Gtk+ programming model (a synchronous operation mode is also supported for those who want it), but the SOAP parts were removed long ago.",
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3875948",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        }
+      ]
+    },
+    {
+      "name": "libsoup3-debuginfo",
+      "purl": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-debug-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "aeaf67baae44f6dfb183a2788ab03250ccde6669c733b74810b7eb75a3257d1d"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=aarch64",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-debug-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-debug-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-debug-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-debug-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "791bd01a47d6bbf46520a8c2c8c5ce71"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "1ddb975755a07c138b22241cd581f885ebb9bb16dd46c3dbe25837f9fc9e547d"
+        }
+      ],
+      "description": "This package provides debug information for package libsoup3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3-devel",
+      "purl": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8884a68651a111f71885f1b920b8e403f1bedfc5e7b48d345a70d8a0bfda90e7"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=aarch64",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "3369d853568891569b6d1c941a1bd5aa"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "a83ebffc136d8a8d85cad25ae52710b30e9b6aa89fb3a9043a353cf2b9db337f"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. This package allows you to develop applications that use the libsoup library."
+    },
+    {
+      "name": "libsoup3-debugsource",
+      "purl": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b756d60d229449f31d53fc1c05ce6bc92478081ef21ee49234a5eb6124e8d326"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=aarch64",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-source-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "1b11ffb241fbce1d096e9b4f1be3bc6a"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "61f8fe4fb020e6fc7259e3ec847825896befa38d20bfbb799fa2378655538f03"
+        }
+      ],
+      "description": "This package provides debug sources for package libsoup3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "91e3d51ea70e880830b4bee89fd606869125e66e57a401a8e7635343de815876"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=aarch64",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=aarch64&repository_id=rhel-10-for-aarch64-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=aarch64&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "f7ed65883da953c676199c354f3d81f6"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "3316e8e46b9f700f77f0a86c66875ece07abe45117ac077d62c5306e61eff67b"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. It was originally part of a SOAP (Simple Object Access Protocol) implementation called Soup, but the SOAP and non-SOAP parts have now been split into separate packages. libsoup uses the Glib main loop and is designed to work well with GTK applications. This enables GNOME applications to access HTTP servers on the network in a completely asynchronous fashion, very similar to the Gtk+ programming model (a synchronous operation mode is also supported for those who want it), but the SOAP parts were removed long ago."
+    },
+    {
+      "name": "libsoup3-doc",
+      "purl": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "246221a99cbc150e8afd6c6f37fabcb47158dde84450589bcd01d428c7e14dbe"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=rhel-10-for-aarch64-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=rhel-10-for-x86_64-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=rhel-10-for-s390x-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=rhel-10-for-ppc64le-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=rhel-10-for-x86_64-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=rhel-10-for-ppc64le-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=rhel-10-for-aarch64-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=codeready-builder-for-rhel-10-aarch64-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch&repository_id=rhel-10-for-s390x-appstream-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "62d5131f27185c0d2c75646e82951a2b"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "c344d59b307befab97f64d644b523a29978be3b50d50f6139716047d7bdfe343"
+        }
+      ],
+      "description": "This package contains developer documentation for libsoup3."
+    },
+    {
+      "name": "libsoup3-debuginfo",
+      "purl": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-debug-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "284a8597482a6162864f8ff70b712601085210d6cd99ba43c2b3a987c59aa32f"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=ppc64le",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-debug-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-debug-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-debug-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-debug-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "33d670f46d9f19e10f4342f7e28e9528"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "71ff48c743ba76775283db26d410c9edb8a181cac8df5c465c6a2757760c1a15"
+        }
+      ],
+      "description": "This package provides debug information for package libsoup3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bb8d7a3a1161c03baac003e6eb2e0dc145d85edfaefa63dafb7828842b1c5b91"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=ppc64le",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "5a3ac022366aae2114f97bc03a2a514f"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "304fe4d3bfd8b56bdcc2bbd3eb6dede372b4759e1494f6a47b3a7cc51dd77eff"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. It was originally part of a SOAP (Simple Object Access Protocol) implementation called Soup, but the SOAP and non-SOAP parts have now been split into separate packages. libsoup uses the Glib main loop and is designed to work well with GTK applications. This enables GNOME applications to access HTTP servers on the network in a completely asynchronous fashion, very similar to the Gtk+ programming model (a synchronous operation mode is also supported for those who want it), but the SOAP parts were removed long ago."
+    },
+    {
+      "name": "libsoup3-debugsource",
+      "purl": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f1dacd5d9cfeb23e528ba4b7b18c572a33af3e644edfec349ddcfbecfa121b6c"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=ppc64le",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-source-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "69666f7534c9276b4ed07b83c832ba5a"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "e214be1811bfbce380c027d28e2df2103386104625f2540675f6eb35c2312c0f"
+        }
+      ],
+      "description": "This package provides debug sources for package libsoup3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3-devel",
+      "purl": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4ed34c2738d8f3570be839853b9742a50ef47ed0c78a3668187c2468997c5e0e"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=ppc64le",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=codeready-builder-for-rhel-10-ppc64le-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=ppc64le&repository_id=rhel-10-for-ppc64le-appstream-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "94fd34a9f049f8d18ebcd89b7020f678"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "e0f973e887a40db1186c39148d19fa2ce77751ec54cf37e4dbe3b29fb14feb7f"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. This package allows you to develop applications that use the libsoup library."
+    },
+    {
+      "name": "libsoup3-debuginfo",
+      "purl": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-debug-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2abdc398df665cd36232fc202b6d652e348a86a2e0745e80f58423c84e746299"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=x86_64",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-debug-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-debug-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-debug-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-debug-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "fe2f82b993c47b74c7d64df2d699504a"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "0f712659389876febf3df825ce2afd1becd26b2fe4064b2aec46fda3a0f5876d"
+        }
+      ],
+      "description": "This package provides debug information for package libsoup3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b8ee002b24520c10879872bbc0352f3bb3ecda6f20ab1908a3979b57531f6813"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=x86_64",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "ee4178d04763842b7028b4d46370afbb"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "ef6043c7e0b8e17727751cb44ef24838614657385d490b84364a5bd0a328af6c"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. It was originally part of a SOAP (Simple Object Access Protocol) implementation called Soup, but the SOAP and non-SOAP parts have now been split into separate packages. libsoup uses the Glib main loop and is designed to work well with GTK applications. This enables GNOME applications to access HTTP servers on the network in a completely asynchronous fashion, very similar to the Gtk+ programming model (a synchronous operation mode is also supported for those who want it), but the SOAP parts were removed long ago."
+    },
+    {
+      "name": "libsoup3-devel",
+      "purl": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1326cc79c72af45a5f11e34337d571b0973e74fe38c666b88d73441073ef9489"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=x86_64",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "7c4017838b0ba87628936ee5eb0bb483"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "33dc6ad7b1806ad6068a4abbb4f482d84ed6a29c01bca4e358bc06a6eca61766"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. This package allows you to develop applications that use the libsoup library."
+    },
+    {
+      "name": "libsoup3-debugsource",
+      "purl": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "00d047d6f2ca49e31487ee0443856da7af8b48e00e9d1db981c63bc81d26b11e"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=x86_64",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=x86_64&repository_id=rhel-10-for-x86_64-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=x86_64&repository_id=codeready-builder-for-rhel-10-x86_64-source-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "82c2f8cd1cbf1fa3491388d17b595577"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "fb05067627fbc6c168e8827029f201e48b3401648b56646b1b004a3c6e572929"
+        }
+      ],
+      "description": "This package provides debug sources for package libsoup3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3-debuginfo",
+      "purl": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-debug-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0a275a5ac12e8d7022c4a86f187f652bcee1a6f2a0c2b4ca8da01ec142de0bf6"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=s390x",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-debug-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-debug-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=s390x&repository_id=rhel-10-for-s390x-appstream-debug-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=s390x&repository_id=rhel-10-for-s390x-appstream-debug-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "0aa919077211f34929c69ae8695a61f5"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "f52af19b0f2d7a03cb49903c2700afad4b68d5a76b2ade17fec5805de221d7c5"
+        }
+      ],
+      "description": "This package provides debug information for package libsoup3. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c10852d877fc7b53c8247eaafc0ed8512206c796d2a6e6b413d43c8300372804"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=s390x",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=s390x&repository_id=rhel-10-for-s390x-appstream-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=s390x&repository_id=rhel-10-for-s390x-appstream-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "2d7565ae2645361acadb5389bf5a8da7"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "c92195145367c126b26c3a5c683b0d9317eebaffa5768a832dd4452c08d5943e"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. It was originally part of a SOAP (Simple Object Access Protocol) implementation called Soup, but the SOAP and non-SOAP parts have now been split into separate packages. libsoup uses the Glib main loop and is designed to work well with GTK applications. This enables GNOME applications to access HTTP servers on the network in a completely asynchronous fashion, very similar to the Gtk+ programming model (a synchronous operation mode is also supported for those who want it), but the SOAP parts were removed long ago."
+    },
+    {
+      "name": "libsoup3-debugsource",
+      "purl": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ce85f75f6e77fd031a11f2c99100a28f2a5fc72479e743d9d1d1a14b9394f293"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=s390x",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=s390x&repository_id=rhel-10-for-s390x-appstream-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-source-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=s390x&repository_id=rhel-10-for-s390x-appstream-source-rpms__10"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "545091cb86414f0a12121d1e3fd0ea64"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "54273128970b77513cea9bddd02c3ff2d3d7a1c275515ef30a41358aedbd1b78"
+        }
+      ],
+      "description": "This package provides debug sources for package libsoup3. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "libsoup3-devel",
+      "purl": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10_DOT_1",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c8967a58c781f47dea91defe49ede016bc1da10faa7c90f0cfcabca914e4fd6c"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=s390x",
+      "version": "3.6.5-3.el10_1.6",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=s390x&repository_id=rhel-10-for-s390x-appstream-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=s390x&repository_id=codeready-builder-for-rhel-10-s390x-rpms__10_DOT_1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=s390x&repository_id=rhel-10-for-s390x-appstream-rpms__10_DOT_1"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "LGPL-2.0-or-later"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "407a6c109d76fa1391c3ed2f44c39b55"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "e17beaae40540cb3daf1a1a656cab9e41a362928306364a79908d910599ae3e4"
+        }
+      ],
+      "description": "Libsoup is an HTTP library implementation in C. This package allows you to develop applications that use the libsoup library."
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/libsoup3@3.6.5-3.el10_1.6",
+      "type": "library",
+      "bom-ref": "pkg:rpm/libsoup3@3.6.5-3.el10_1.6?package-id=1b7d81f94e78429a",
+      "version": "3.6.5-3.el10_1.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "elf-binary-package-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/libsoup-3.0.so.0.7.4"
+        }
+      ]
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-2vcdmyg5/extracted_rpms/libsoup3-3.6.5-3.el10_1.6.aarch64/usr/lib64/libsoup-3.0.so.0.7.4",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "37c7885626a233330e08d4736f45a1ed715352aa"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e19b4277b3e1d6cc95da5bda860dac4eb094abeb14aaa09478f1a06fdd9962d0"
+        }
+      ],
+      "bom-ref": "033e8adc23c5a072"
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/libsoup3@3.6.5-3.el10_1.6",
+      "type": "library",
+      "bom-ref": "pkg:rpm/libsoup3@3.6.5-3.el10_1.6?package-id=44a74c66697f3763",
+      "version": "3.6.5-3.el10_1.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "elf-binary-package-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/libsoup-3.0.so.0.7.4"
+        }
+      ]
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/libsoup3@3.6.5-3.el10_1.6",
+      "type": "library",
+      "bom-ref": "pkg:rpm/libsoup3@3.6.5-3.el10_1.6?package-id=3ad276b441e8f3eb",
+      "version": "3.6.5-3.el10_1.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "elf-binary-package-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/libsoup-3.0.so.0.7.4"
+        }
+      ]
+    },
+    {
+      "name": "libsoup3",
+      "purl": "pkg:rpm/libsoup3@3.6.5-3.el10_1.6",
+      "type": "library",
+      "bom-ref": "pkg:rpm/libsoup3@3.6.5-3.el10_1.6?package-id=57d58c74a0998c88",
+      "version": "3.6.5-3.el10_1.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "elf-binary-package-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/libsoup-3.0.so.0.7.4"
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=src",
+      "provides": [
+        "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=aarch64",
+        "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=aarch64",
+        "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=aarch64",
+        "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=aarch64",
+        "pkg:rpm/redhat/libsoup3-doc@3.6.5-3.el10_1.6?arch=noarch",
+        "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=ppc64le",
+        "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=ppc64le",
+        "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=ppc64le",
+        "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=ppc64le",
+        "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=x86_64",
+        "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=x86_64",
+        "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=x86_64",
+        "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=x86_64",
+        "pkg:rpm/redhat/libsoup3-debuginfo@3.6.5-3.el10_1.6?arch=s390x",
+        "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=s390x",
+        "pkg:rpm/redhat/libsoup3-debugsource@3.6.5-3.el10_1.6?arch=s390x",
+        "pkg:rpm/redhat/libsoup3-devel@3.6.5-3.el10_1.6?arch=s390x"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=aarch64",
+      "provides": [
+        "pkg:rpm/libsoup3@3.6.5-3.el10_1.6?package-id=1b7d81f94e78429a",
+        "033e8adc23c5a072"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=ppc64le",
+      "provides": [
+        "033e8adc23c5a072",
+        "pkg:rpm/libsoup3@3.6.5-3.el10_1.6?package-id=44a74c66697f3763"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=x86_64",
+      "provides": [
+        "033e8adc23c5a072",
+        "pkg:rpm/libsoup3@3.6.5-3.el10_1.6?package-id=3ad276b441e8f3eb"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsoup3@3.6.5-3.el10_1.6?arch=s390x",
+      "provides": [
+        "pkg:rpm/libsoup3@3.6.5-3.el10_1.6?package-id=57d58c74a0998c88",
+        "033e8adc23c5a072"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:290dd718-2cbd-40a8-b39c-24e6ef2d13a9"
+}

--- a/modules/analysis/src/endpoints/tests/latest_filters.rs
+++ b/modules/analysis/src/endpoints/tests/latest_filters.rs
@@ -641,6 +641,10 @@ fn sort(json: &mut Value) {
     Req { what: What::Q("name~openssl-synthetic"), ancestors: Some(10), ..Req::default() },
     4
 )]
+#[case( // name partial search
+    Req { what: What::Q("name~libsoup3-devel"), ancestors: Some(10), ..Req::default() },
+    8
+)]
 #[case( // purl partial search
     Req { what: What::Q("purl~openssl-synthetic-test"), ancestors: Some(10), ..Req::default() },
     4
@@ -671,8 +675,34 @@ async fn resolve_rh_variant_latest_filter_tc_3278(
                 "product-2025-11-25-D05BF995974542F.json",
             ][..],
         ),
+        "container/datagrid-datagrid-8/latest/".join(
+            &[
+                "binary-2025-12-04-62F0D268C8094C2.json",
+                "image-index-2025-12-04-2BE8E55FCB8946B.json",
+                "product-2025-12-08-6483D4F2E4B1469.json",
+            ][..],
+        ),
+        "container/datagrid-datagrid-8/older/".join(
+            &[
+                "binary-2025-10-06-85E079C4EC034F1.json",
+                "image-index-2025-10-06-BD74B271CC444BA.json",
+                "product-2025-10-07-D792D72A114A47A.json",
+            ][..],
+        ),
         "middleware/quarkus-3.20/latest/".join(&["product-2025-12-01-EDA6638AD2F4451.json"][..]),
         "middleware/quarkus-3.20/older/".join(&["product-2025-10-14-28954C62C811417.json"][..]),
+        "rpm/libsoup3/latest/".join(
+            &[
+                "product-2025-12-11-E2251709C91242E.json",
+                "rpm-2025-12-10-5609FCE0067D4F6.json",
+            ][..],
+        ),
+        "rpm/libsoup3/older/".join(
+            &[
+                "product-2025-11-11-CD32282B963F42C.json",
+                "rpm-2025-10-27-B38A3A44DA644A4.json",
+            ][..],
+        ),
         "rpm/webkit2gtk3/latest/".join(
             &[
                 "product-2025-12-08-A9F140D67EB2408.json",


### PR DESCRIPTION
## Summary by Sourcery

Expand latest filter coverage for TC-3278 with additional RPM and container scenarios and corresponding test data.

Tests:
- Add a new latest filter test case for libsoup3-devel name query under TC-3278.

Chores:
- Add CycloneDX fixture data for datagrid-datagrid-8 container images and libsoup3 RPMs to support TC-3278 latest filter tests.