### PR TITLE
fix: metrics matching routes with path params first

### DIFF
--- a/modules/fundamental/src/purl/endpoints/mod.rs
+++ b/modules/fundamental/src/purl/endpoints/mod.rs
@@ -31,7 +31,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         .app_data(web::Data::new(purl_service))
         .service(base::get_base_purl)
         .service(base::all_base_purls)
-        .service(recommend)
+        .service(recommend) // Must be before `get` to avoid {key} matching "recommend"
         .service(all)
         .service(get);
 }

--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -29,7 +29,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         .app_data(web::Data::new(service))
         .app_data(web::Data::new(db))
         .service(all)
-        .service(analyze)
+        .service(analyze) // Must be before `get` to avoid {id} matching "analyze"
         .service(analyze_v3)
         .service(get);
 }


### PR DESCRIPTION
Fix https://github.com/guacsec/trustify/issues/2201

## Summary by Sourcery

Bug Fixes:
- Fix incorrect route/middleware matching by registering parameterized endpoints after more specific PURL and vulnerability routes.