### PR TITLE
feat: reduce psql noise in build/test output

### DIFF
--- a/common/db/src/lib.rs
+++ b/common/db/src/lib.rs
@@ -92,6 +92,7 @@ impl<'a> Database<'a> {
         let db = Self::setup(database).await?;
 
         let mut cmd = PsqlBuilder::new()
+            .quiet() // or .output("/dev/null") to remove set_config noise
             .dbname(&database.name)
             .host(&database.host)
             .port(database.port)


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Enable quiet mode on the psql command used during database setup to minimize extraneous log output in build and test runs.