### PR TITLE
Backport #2202 to release/0.4.z

### DIFF
--- a/modules/fundamental/src/purl/endpoints/mod.rs
+++ b/modules/fundamental/src/purl/endpoints/mod.rs
@@ -31,7 +31,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         .app_data(web::Data::new(purl_service))
         .service(base::get_base_purl)
         .service(base::all_base_purls)
-        .service(recommend)
+        .service(recommend) // Must be before `get` to avoid {key} matching "recommend"
         .service(all)
         .service(get);
 }

--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -26,7 +26,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         .app_data(web::Data::new(service))
         .app_data(web::Data::new(db))
         .service(all)
-        .service(analyze)
+        .service(analyze) // Must be before `get` to avoid {id} matching "analyze"
         .service(get);
 }
 


### PR DESCRIPTION
Backport of https://github.com/guacsec/trustify/pull/2202 to 0.4.z branch
Manual backport after cherry-pick failed https://github.com/guacsec/trustify/pull/2202#issuecomment-3748699229