### PR TITLE
chore: removing rust-toolchain.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ version = "0.4.0-beta.1"
 edition = "2024"
 publish = false
 license = "Apache-2.0"
+rust-version = "1.92.0"
 
 [workspace.dependencies]
 actix = "0.13.3"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 actix-web = { workspace = true }

--- a/common/auth/Cargo.toml
+++ b/common/auth/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 description = "Authentication and authorization functionality"
 
 [dependencies]

--- a/common/db/Cargo.toml
+++ b/common/db/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 trustify-migration = { workspace = true }

--- a/common/infrastructure/Cargo.toml
+++ b/common/infrastructure/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 actix-cors = { workspace = true }

--- a/cvss/Cargo.toml
+++ b/cvss/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [features]
 graphql = ["async-graphql"]

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "migration"

--- a/modules/analysis/Cargo.toml
+++ b/modules/analysis/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 trustify-auth = { workspace = true }

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/modules/graphql/Cargo.toml
+++ b/modules/graphql/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 trustify-entity = { workspace = true, features = ["graphql"] }

--- a/modules/importer/Cargo.toml
+++ b/modules/importer/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 trustify-auth = { workspace = true }

--- a/modules/ingestor/Cargo.toml
+++ b/modules/ingestor/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 trustify-auth = { workspace = true }

--- a/modules/storage/Cargo.toml
+++ b/modules/storage/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 trustify-common = { workspace = true }

--- a/modules/ui/Cargo.toml
+++ b/modules/ui/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 

--- a/modules/user/Cargo.toml
+++ b/modules/user/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 trustify-auth = { workspace = true }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 utoipa = { workspace = true }

--- a/query/query-derive/Cargo.toml
+++ b/query/query-derive/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.91.0"
-components = [ "rustfmt", "clippy" ]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [features]
 graphql = ["trustify-module-graphql"]

--- a/test-context/Cargo.toml
+++ b/test-context/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 trustify-auth = { workspace = true }

--- a/trustd/Cargo.toml
+++ b/trustd/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "trustd"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
## Summary by Sourcery

Remove the Rust toolchain configuration file from the repository.

Build:
- Stop tracking the rust-toolchain.toml file so local toolchain selection is no longer enforced by the repo.

Chores:
- Clean up obsolete Rust tooling configuration by deleting rust-toolchain.toml.