### PR TITLE
feat: query new scores table

### DIFF
--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -16,9 +16,11 @@ use trustify_cvss::cvss3::{
     AttackComplexity, AttackVector, Availability, Confidentiality, Cvss3Base, Integrity,
     PrivilegesRequired, Scope, UserInteraction,
 };
-use trustify_entity::labels::Labels;
+use trustify_entity::{advisory_vulnerability_score, labels::Labels};
 use trustify_module_ingestor::{
-    graph::advisory::AdvisoryInformation, model::IngestResult, service::Format,
+    graph::{advisory::AdvisoryInformation, cvss::ScoreCreator},
+    model::IngestResult,
+    service::Format,
 };
 use trustify_module_storage::service::{StorageBackend, StorageKey};
 use trustify_test_context::{TrustifyContext, call::CallService, document_bytes};
@@ -159,6 +161,19 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let advisory_vuln = advisory2
         .link_to_vulnerability("CVE-123", None, &ctx.db)
         .await?;
+
+    // Use ScoreCreator to write to advisory_vulnerability_score table
+    let mut score_creator = ScoreCreator::new(advisory2.advisory.id);
+    score_creator.add(trustify_module_ingestor::graph::cvss::ScoreInformation {
+        vulnerability_id: "CVE-123".to_string(),
+        r#type: advisory_vulnerability_score::ScoreType::V3_0,
+        vector: "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:N/A:N".to_string(),
+        score: 6.8,
+        severity: advisory_vulnerability_score::Severity::Medium,
+    });
+    score_creator.create(&ctx.db).await?;
+
+    // Also call the legacy method to ensure both tables are populated
     advisory_vuln
         .ingest_cvss3_score(
             Cvss3Base {
@@ -256,6 +271,19 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     let advisory_vuln = advisory
         .link_to_vulnerability("CVE-123", None, &ctx.db)
         .await?;
+
+    // Use ScoreCreator to write to advisory_vulnerability_score table
+    let mut score_creator = ScoreCreator::new(advisory.advisory.id);
+    score_creator.add(trustify_module_ingestor::graph::cvss::ScoreInformation {
+        vulnerability_id: "CVE-123".to_string(),
+        r#type: advisory_vulnerability_score::ScoreType::V3_0,
+        vector: "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:N/A:N".to_string(),
+        score: 6.8,
+        severity: advisory_vulnerability_score::Severity::Medium,
+    });
+    score_creator.create(&ctx.db).await?;
+
+    // Also call the legacy method to ensure both tables are populated
     advisory_vuln
         .ingest_cvss3_score(
             Cvss3Base {

--- a/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
+++ b/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
@@ -1,11 +1,11 @@
 use crate::{Error, vulnerability::model::VulnerabilityHead};
-use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, LoaderTrait, QueryFilter};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use trustify_common::memo::Memo;
-use trustify_cvss::cvss3::Cvss3Base;
 use trustify_cvss::cvss3::severity::Severity;
-use trustify_entity::{advisory, advisory_vulnerability, cvss3, vulnerability};
+use trustify_entity::{advisory, advisory_vulnerability, advisory_vulnerability_score, vulnerability};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -119,19 +119,39 @@ impl AdvisoryVulnerabilitySummary {
         vulnerabilities: &[vulnerability::Model],
         tx: &C,
     ) -> Result<Vec<Self>, Error> {
-        let mut cvss3s = vulnerabilities
-            .load_many(
-                cvss3::Entity::find().filter(cvss3::Column::AdvisoryId.eq(advisory.id)),
-                tx,
-            )
+        // Fetch all scores for this advisory
+        let all_scores = advisory_vulnerability_score::Entity::find()
+            .filter(advisory_vulnerability_score::Column::AdvisoryId.eq(advisory.id))
+            .all(tx)
             .await?;
+
+        // Group scores by vulnerability_id
+        let mut scores_by_vuln: HashMap<String, Vec<advisory_vulnerability_score::Model>> =
+            HashMap::new();
+        for score in all_scores {
+            scores_by_vuln
+                .entry(score.vulnerability_id.clone())
+                .or_default()
+                .push(score);
+        }
 
         let mut summaries = Vec::new();
 
-        for (vuln, mut cvss3) in vulnerabilities.iter().zip(cvss3s.drain(..)) {
-            let cvss3_scores = cvss3
-                .drain(..)
-                .map(|e| Cvss3Base::from(e).to_string())
+        for vuln in vulnerabilities.iter() {
+            // Get scores for this vulnerability
+            let scores = scores_by_vuln.get(&vuln.id).cloned().unwrap_or_default();
+
+            // Filter to V3.x scores and format as vector strings
+            let cvss3_scores: Vec<String> = scores
+                .into_iter()
+                .filter(|s| {
+                    matches!(
+                        s.r#type,
+                        advisory_vulnerability_score::ScoreType::V3_0
+                            | advisory_vulnerability_score::ScoreType::V3_1
+                    )
+                })
+                .map(|e| e.vector)
                 .collect();
 
             summaries.push(AdvisoryVulnerabilitySummary {

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -24,10 +24,10 @@ use trustify_common::{
 };
 use trustify_cvss::cvss3::{Cvss3Base, score::Score, severity::Severity};
 use trustify_entity::{
-    advisory, base_purl, cpe, cvss3, license, organization, product, product_status,
-    product_version, product_version_range, purl_status, qualified_purl, sbom, sbom_package,
-    sbom_package_license, sbom_package_purl_ref, status, version_range, versioned_purl,
-    vulnerability,
+    advisory, advisory_vulnerability_score, base_purl, cpe, license, organization, product,
+    product_status, product_version, product_version_range, purl_status, qualified_purl, sbom,
+    sbom_package, sbom_package_license, sbom_package_purl_ref, status, version_range,
+    versioned_purl, vulnerability,
 };
 use trustify_module_ingestor::common::{Deprecation, DeprecationForExt};
 use utoipa::ToSchema;
@@ -336,8 +336,25 @@ impl PurlStatus {
         cpe: Option<String>,
         tx: &C,
     ) -> Result<Self, Error> {
-        let cvss3 = vuln.find_related(cvss3::Entity).all(tx).await?;
-        let average_score = Score::from_iter(cvss3.iter().map(Cvss3Base::from));
+        let scores = advisory_vulnerability_score::Entity::find()
+            .filter(advisory_vulnerability_score::Column::VulnerabilityId.eq(&vuln.id))
+            .all(tx)
+            .await?;
+
+        // Filter to V3.x scores for average calculation
+        let cvss3_scores: Vec<Cvss3Base> = scores
+            .iter()
+            .filter(|s| {
+                matches!(
+                    s.r#type,
+                    advisory_vulnerability_score::ScoreType::V3_0
+                        | advisory_vulnerability_score::ScoreType::V3_1
+                )
+            })
+            .filter_map(|s| s.vector.parse::<Cvss3Base>().ok())
+            .collect();
+
+        let average_score = Score::from_iter(cvss3_scores);
         let issuer = Memo::Provided(advisory.find_related(organization::Entity).one(tx).await?);
 
         Ok(Self {

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -24,9 +24,9 @@ use tracing::instrument;
 use trustify_common::{db::VersionMatches, memo::Memo};
 use trustify_cvss::cvss3::{Cvss3Base, score::Score, severity::Severity};
 use trustify_entity::{
-    advisory, advisory_vulnerability, base_purl, cpe, cvss3, organization, purl_status,
-    qualified_purl, sbom, sbom_node, sbom_package, sbom_package_purl_ref, status, version_range,
-    versioned_purl, vulnerability,
+    advisory, advisory_vulnerability, advisory_vulnerability_score, base_purl, cpe, organization,
+    purl_status, qualified_purl, sbom, sbom_node, sbom_package, sbom_package_purl_ref, status,
+    version_range, versioned_purl, vulnerability,
 };
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -333,18 +333,25 @@ impl SbomDetails {
                 .collect();
         log::debug!("Pre-fetched {} organizations", organizations_map.len());
 
-        // Pre-fetch cvss3 scores
-        let cvss3_scores = cvss3::Entity::find()
-            .filter(Expr::col(cvss3::Column::AdvisoryId).eq(PgFunc::any(advisory_ids)))
-            .filter(Expr::col(cvss3::Column::VulnerabilityId).eq(PgFunc::any(vulnerability_ids)))
+        // Pre-fetch scores from advisory_vulnerability_score table
+        let scores = advisory_vulnerability_score::Entity::find()
+            .filter(
+                Expr::col(advisory_vulnerability_score::Column::AdvisoryId)
+                    .eq(PgFunc::any(advisory_ids)),
+            )
+            .filter(
+                Expr::col(advisory_vulnerability_score::Column::VulnerabilityId)
+                    .eq(PgFunc::any(vulnerability_ids)),
+            )
             .all(tx)
             .await?;
-        log::debug!("Pre-fetched {} cvss3 scores", cvss3_scores.len());
+        log::debug!("Pre-fetched {} scores", scores.len());
 
-        // Build cvss3 lookup map (needs special handling for Vec aggregation)
-        let mut cvss3_map: BTreeMap<(Uuid, String), Vec<cvss3::Model>> = BTreeMap::new();
-        for score in cvss3_scores {
-            cvss3_map
+        // Build scores lookup map (needs special handling for Vec aggregation)
+        let mut scores_map: BTreeMap<(Uuid, String), Vec<advisory_vulnerability_score::Model>> =
+            BTreeMap::new();
+        for score in scores {
+            scores_map
                 .entry((score.advisory_id, score.vulnerability_id.clone()))
                 .or_default()
                 .push(score);
@@ -424,7 +431,7 @@ impl SbomDetails {
             });
         }
 
-        let advisories = SbomAdvisory::from_models(relevant_advisory_info, &cvss3_map, tx).await?;
+        let advisories = SbomAdvisory::from_models(relevant_advisory_info, &scores_map, tx).await?;
 
         Ok(Some(SbomDetails {
             summary,
@@ -444,7 +451,7 @@ impl SbomAdvisory {
     #[instrument(skip_all, err(level=tracing::Level::INFO))]
     pub async fn from_models<C: ConnectionTrait>(
         statuses: Vec<QueryCatcher>,
-        cvss3_map: &BTreeMap<(Uuid, String), Vec<cvss3::Model>>,
+        scores_map: &BTreeMap<(Uuid, String), Vec<advisory_vulnerability_score::Model>>,
         tx: &C,
     ) -> Result<Vec<Self>, Error> {
         let mut advisories = BTreeMap::new();
@@ -488,8 +495,8 @@ impl SbomAdvisory {
                     each.status.slug.clone(),
                     status_cpe,
                     vec![],
-                    // Look up pre-fetched cvss3 scores from the map
-                    cvss3_map
+                    // Look up pre-fetched scores from the map
+                    scores_map
                         .get(&(each.advisory.id, each.vulnerability.id.clone()))
                         .cloned()
                         .unwrap_or_default(),
@@ -554,7 +561,7 @@ impl SbomStatus {
             advisory_vulnerability,
             vulnerability,
             packages,
-            cvss3
+            score_models
         ),
         err(level=tracing::Level::INFO)
     )]
@@ -564,12 +571,27 @@ impl SbomStatus {
         status: String,
         cpe: Option<OwnedUri>,
         packages: Vec<SbomPackage>,
-        cvss3: Vec<cvss3::Model>,
+        score_models: Vec<advisory_vulnerability_score::Model>,
     ) -> Result<Self, Error> {
-        let average = Score::from_iter(cvss3.iter().map(Cvss3Base::from));
-        let scores = cvss3
+        // Filter to V3.x scores for average calculation
+        let cvss3_scores: Vec<Cvss3Base> = score_models
+            .iter()
+            .filter(|s| {
+                matches!(
+                    s.r#type,
+                    advisory_vulnerability_score::ScoreType::V3_0
+                        | advisory_vulnerability_score::ScoreType::V3_1
+                )
+            })
+            .filter_map(|s| s.vector.parse::<Cvss3Base>().ok())
+            .collect();
+
+        let average = Score::from_iter(cvss3_scores);
+
+        // Convert all scores (all versions) to Score model
+        let scores = score_models
             .into_iter()
-            .filter_map(|cvss3| crate::common::model::Score::try_from(cvss3).ok())
+            .map(crate::common::model::Score::from)
             .collect();
 
         Ok(Self {

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -3,13 +3,13 @@ mod vulnerability_advisory;
 pub use vulnerability_advisory::*;
 
 use crate::{Error, vulnerability::model::VulnerabilityHead};
-use sea_orm::{ConnectionTrait, ModelTrait};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, ModelTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
 use tracing::{info_span, instrument};
 use tracing_futures::Instrument;
 use trustify_common::memo::Memo;
 use trustify_cvss::cvss3::severity::Severity;
-use trustify_entity::{advisory_vulnerability, cvss3, vulnerability};
+use trustify_entity::{advisory_vulnerability, advisory_vulnerability_score, vulnerability};
 use trustify_module_ingestor::common::{Deprecation, DeprecationForExt};
 use utoipa::ToSchema;
 
@@ -52,8 +52,8 @@ impl VulnerabilityDetails {
             .instrument(info_span!("find related"))
             .await?;
 
-        let cvss3 = vulnerability
-            .find_related(cvss3::Entity)
+        let scores = advisory_vulnerability_score::Entity::find()
+            .filter(advisory_vulnerability_score::Column::VulnerabilityId.eq(&vulnerability.id))
             .all(tx)
             .instrument(info_span!("find scores"))
             .await?;
@@ -61,7 +61,7 @@ impl VulnerabilityDetails {
         let advisories = VulnerabilityAdvisorySummary::from_entities(
             vulnerability,
             &advisory_vulnerabilities,
-            &cvss3,
+            &scores,
             tx,
         )
         .await?;

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -25,7 +25,7 @@ use trustify_common::{
 };
 use trustify_cvss::cvss3::{Cvss3Base, score::Score, severity::Severity};
 use trustify_entity::{
-    advisory, advisory_vulnerability, base_purl, cpe, cvss3, organization,
+    advisory, advisory_vulnerability, advisory_vulnerability_score, base_purl, cpe, organization,
     package_relates_to_package, purl_status, qualified_purl, relationship::Relationship, sbom,
     sbom_node, sbom_package, sbom_package_purl_ref, status, version_range, versioned_purl,
     vulnerability,
@@ -58,16 +58,32 @@ impl VulnerabilityAdvisoryHead {
         advisory_vulnerability: &advisory_vulnerability::Model,
         tx: &C,
     ) -> Result<Self, Error> {
-        let cvss3 = cvss3::Entity::find()
-            .filter(cvss3::Column::AdvisoryId.eq(advisory_vulnerability.advisory_id))
-            .filter(cvss3::Column::VulnerabilityId.eq(&vulnerability.id))
+        let scores = advisory_vulnerability_score::Entity::find()
+            .filter(
+                advisory_vulnerability_score::Column::AdvisoryId
+                    .eq(advisory_vulnerability.advisory_id),
+            )
+            .filter(advisory_vulnerability_score::Column::VulnerabilityId.eq(&vulnerability.id))
             .all(tx)
             .await?;
 
-        let score = if cvss3.is_empty() {
+        // Filter to V3.x scores for combined score calculation
+        let cvss3_scores: Vec<Cvss3Base> = scores
+            .iter()
+            .filter(|s| {
+                matches!(
+                    s.r#type,
+                    advisory_vulnerability_score::ScoreType::V3_0
+                        | advisory_vulnerability_score::ScoreType::V3_1
+                )
+            })
+            .filter_map(|s| s.vector.parse::<Cvss3Base>().ok())
+            .collect();
+
+        let score = if cvss3_scores.is_empty() {
             None
         } else {
-            Some(Score::from_iter(cvss3.iter().map(Cvss3Base::from)))
+            Some(Score::from_iter(cvss3_scores))
         };
 
         if let Some(advisory) = &advisory_vulnerability
@@ -86,7 +102,7 @@ impl VulnerabilityAdvisoryHead {
     }
     pub async fn from_entities<C: ConnectionTrait>(
         vuln_advisories: &[advisory::Model],
-        vuln_cvss3s: &[cvss3::Model],
+        vuln_scores: &[advisory_vulnerability_score::Model],
         tx: &C,
     ) -> Result<Vec<Self>, Error> {
         let mut heads = Vec::new();
@@ -94,16 +110,24 @@ impl VulnerabilityAdvisoryHead {
         let organizations = vuln_advisories.load_one(organization::Entity, tx).await?;
 
         for (advisory, issuer) in vuln_advisories.iter().zip(organizations.into_iter()) {
-            // filter all vulnerability cvss3 to those that pertain to only this advisory.
-            let cvss3 = vuln_cvss3s
+            // Filter scores to those that pertain to this advisory and are V3.x
+            let cvss3_scores: Vec<Cvss3Base> = vuln_scores
                 .iter()
                 .filter(|e| e.advisory_id == advisory.id)
-                .collect::<Vec<_>>();
+                .filter(|s| {
+                    matches!(
+                        s.r#type,
+                        advisory_vulnerability_score::ScoreType::V3_0
+                            | advisory_vulnerability_score::ScoreType::V3_1
+                    )
+                })
+                .filter_map(|s| s.vector.parse::<Cvss3Base>().ok())
+                .collect();
 
-            let score = if cvss3.is_empty() {
+            let score = if cvss3_scores.is_empty() {
                 None
             } else {
-                Some(Score::from_iter(cvss3.into_iter().map(Cvss3Base::from)))
+                Some(Score::from_iter(cvss3_scores))
             };
 
             heads.push(VulnerabilityAdvisoryHead {
@@ -141,14 +165,14 @@ impl VulnerabilityAdvisorySummary {
         fields(
             vulnerability=vulnerability.id,
             advisory_vulnerabilities=advisory_vulnerabilities.len(),
-            vuln_cvss3=vuln_cvss3.len(),
+            vuln_scores=vuln_scores.len(),
         ),
         err(level=tracing::Level::INFO),
     )]
     pub async fn from_entities<C: ConnectionTrait>(
         vulnerability: &vulnerability::Model,
         advisory_vulnerabilities: &[advisory_vulnerability::Model],
-        vuln_cvss3: &[cvss3::Model],
+        vuln_scores: &[advisory_vulnerability_score::Model],
         tx: &C,
     ) -> Result<Vec<Self>, Error> {
         let purl_status_query = purl_status::Entity::find()
@@ -305,10 +329,18 @@ impl VulnerabilityAdvisorySummary {
                 ))
                 .await?;
 
-            let cvss3_scores = vuln_cvss3
+            // Filter to V3.x scores and format as vector strings
+            let cvss3_scores: Vec<String> = vuln_scores
                 .iter()
                 .filter(|e| e.advisory_id == advisory_vulnerability.advisory_id)
-                .map(|e| Cvss3Base::from(e.clone()).to_string())
+                .filter(|s| {
+                    matches!(
+                        s.r#type,
+                        advisory_vulnerability_score::ScoreType::V3_0
+                            | advisory_vulnerability_score::ScoreType::V3_1
+                    )
+                })
+                .map(|e| e.vector.clone())
                 .collect();
 
             let sbom_statuses = vuln_sbom_statuses

--- a/modules/fundamental/src/vulnerability/model/summary.rs
+++ b/modules/fundamental/src/vulnerability/model/summary.rs
@@ -3,11 +3,14 @@ use crate::{
     vulnerability::model::{VulnerabilityAdvisoryHead, VulnerabilityHead},
 };
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, LoaderTrait, QueryFilter};
+use sea_query::{Expr, PgFunc};
+use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use trustify_common::memo::Memo;
 use trustify_cvss::cvss3::severity::Severity;
 use trustify_entity::{
-    advisory, advisory_vulnerability, cvss3, vulnerability, vulnerability_description,
+    advisory, advisory_vulnerability, advisory_vulnerability_score, vulnerability,
+    vulnerability_description,
 };
 use trustify_module_ingestor::common::{Deprecation, DeprecationExt};
 use utoipa::ToSchema;
@@ -43,7 +46,29 @@ impl VulnerabilitySummary {
             )
             .await?;
 
-        let vuln_cvss3s = vulnerabilities.load_many(cvss3::Entity, tx).await?;
+        // Fetch all scores for the given vulnerabilities
+        let vulnerability_ids: Vec<String> = vulnerabilities.iter().map(|v| v.id.clone()).collect();
+        let all_scores = if !vulnerability_ids.is_empty() {
+            advisory_vulnerability_score::Entity::find()
+                .filter(
+                    Expr::col(advisory_vulnerability_score::Column::VulnerabilityId)
+                        .eq(PgFunc::any(vulnerability_ids)),
+                )
+                .all(tx)
+                .await?
+        } else {
+            vec![]
+        };
+
+        // Group scores by vulnerability_id
+        let mut scores_by_vuln: HashMap<String, Vec<advisory_vulnerability_score::Model>> =
+            HashMap::new();
+        for score in all_scores {
+            scores_by_vuln
+                .entry(score.vulnerability_id.clone())
+                .or_default()
+                .push(score);
+        }
 
         let descriptions = vulnerabilities
             .load_many(
@@ -55,12 +80,14 @@ impl VulnerabilitySummary {
 
         let mut summaries = Vec::new();
 
-        for (((vuln, advisories), vuln_cvss3s), description) in vulnerabilities
+        for ((vuln, advisories), description) in vulnerabilities
             .iter()
             .zip(advisories.iter())
-            .zip(vuln_cvss3s.iter())
             .zip(descriptions.iter())
         {
+            // Get scores for this vulnerability from the pre-fetched map
+            let vuln_scores = scores_by_vuln.get(&vuln.id).cloned().unwrap_or_default();
+
             summaries.push(VulnerabilitySummary {
                 head: VulnerabilityHead::from_vulnerability_entity(
                     vuln,
@@ -70,7 +97,7 @@ impl VulnerabilitySummary {
                 .await?,
                 average_severity: vuln.base_severity.map(|s| s.into()),
                 average_score: vuln.base_score,
-                advisories: VulnerabilityAdvisoryHead::from_entities(advisories, vuln_cvss3s, tx)
+                advisories: VulnerabilityAdvisoryHead::from_entities(advisories, &vuln_scores, tx)
                     .await?,
             });
         }

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -29,7 +29,9 @@ use trustify_common::{
     purl::Purl,
 };
 use trustify_cvss::cvss3::{Cvss3Base, score::Score as CvssScore};
-use trustify_entity::{advisory, cvss3, organization, vulnerability, vulnerability_description};
+use trustify_entity::{
+    advisory, advisory_vulnerability_score, organization, vulnerability, vulnerability_description,
+};
 use trustify_module_ingestor::common::Deprecation;
 
 struct AdvisoryData {
@@ -41,7 +43,7 @@ struct AnalysisData {
     purls_with_vulnerabilities: Vec<QueryResult>,
     warnings: HashMap<String, Vec<String>>,
     descriptions_map: HashMap<String, vulnerability_description::Model>,
-    cvss3_scores: Vec<cvss3::Model>,
+    scores: Vec<advisory_vulnerability_score::Model>,
     advisories_map: HashMap<Uuid, AdvisoryData>,
 }
 
@@ -214,19 +216,23 @@ impl VulnerabilityService {
                 .map(|desc| (desc.vulnerability_id.clone(), desc))
                 .collect();
 
-        // Pre-fetch cvss3 scores
-        let cvss3_scores = if !advisory_ids.is_empty() && !vulnerability_ids.is_empty() {
-            cvss3::Entity::find()
-                .filter(Expr::col(cvss3::Column::AdvisoryId).eq(PgFunc::any(advisory_ids.clone())))
+        // Pre-fetch scores from advisory_vulnerability_score table
+        let scores = if !advisory_ids.is_empty() && !vulnerability_ids.is_empty() {
+            advisory_vulnerability_score::Entity::find()
                 .filter(
-                    Expr::col(cvss3::Column::VulnerabilityId).eq(PgFunc::any(vulnerability_ids)),
+                    Expr::col(advisory_vulnerability_score::Column::AdvisoryId)
+                        .eq(PgFunc::any(advisory_ids.clone())),
+                )
+                .filter(
+                    Expr::col(advisory_vulnerability_score::Column::VulnerabilityId)
+                        .eq(PgFunc::any(vulnerability_ids)),
                 )
                 .all(connection)
                 .await?
         } else {
             vec![]
         };
-        log::debug!("Pre-fetched {} cvss3 scores", cvss3_scores.len());
+        log::debug!("Pre-fetched {} scores", scores.len());
 
         // Pre-fetch advisories
         let advisories = if !advisory_ids.is_empty() {
@@ -261,7 +267,7 @@ impl VulnerabilityService {
             purls_with_vulnerabilities,
             warnings,
             descriptions_map,
-            cvss3_scores,
+            scores,
             advisories_map: advisories,
         })
     }
@@ -278,17 +284,36 @@ impl VulnerabilityService {
             purls_with_vulnerabilities,
             mut warnings,
             descriptions_map,
-            cvss3_scores,
+            scores,
             advisories_map,
         } = data;
 
+        // Build a map of (advisory_id, vulnerability_id) -> Vec<Cvss3Base> for v3 score calculation
+        // Filter to only V3.0 and V3.1 scores since CvssScore only understands CVSS v3
         let mut cvss3_map: HashMap<(Uuid, String), Vec<Cvss3Base>> = HashMap::new();
-        for score in cvss3_scores {
-            let converted_score = Cvss3Base::from(score.clone());
-            cvss3_map
-                .entry((score.advisory_id, score.vulnerability_id))
-                .or_default()
-                .push(converted_score);
+        for score in scores {
+            // Only include V3.0 and V3.1 for the combined score calculation
+            match score.r#type {
+                advisory_vulnerability_score::ScoreType::V3_0
+                | advisory_vulnerability_score::ScoreType::V3_1 => {}
+                _ => continue, // Skip V2.0 and V4.0 for CvssScore calculation
+            };
+
+            // Parse the vector string to get Cvss3Base
+            if let Ok(cvss3_base) = score.vector.parse::<Cvss3Base>() {
+                cvss3_map
+                    .entry((score.advisory_id, score.vulnerability_id.clone()))
+                    .or_default()
+                    .push(cvss3_base);
+            } else {
+                // Fallback: log warning if vector parsing fails
+                log::warn!(
+                    "Failed to parse CVSS vector '{}' for advisory={}, vuln={}",
+                    score.vector,
+                    score.advisory_id,
+                    score.vulnerability_id
+                );
+            }
         }
 
         let mut result = BTreeMap::new();
@@ -336,18 +361,19 @@ impl VulnerabilityService {
             purls_with_vulnerabilities,
             mut warnings,
             descriptions_map,
-            cvss3_scores,
+            scores,
             advisories_map,
         } = data;
 
-        let mut cvss3_map: HashMap<(Uuid, String), Vec<Score>> = HashMap::new();
-        for score in cvss3_scores {
-            if let Ok(converted_score) = Score::try_from(score.clone()) {
-                cvss3_map
-                    .entry((score.advisory_id, score.vulnerability_id))
-                    .or_default()
-                    .push(converted_score);
-            }
+        // Build a map of (advisory_id, vulnerability_id) -> Vec<Score>
+        // Includes all CVSS versions (V2.0, V3.0, V3.1, V4.0)
+        let mut scores_map: HashMap<(Uuid, String), Vec<Score>> = HashMap::new();
+        for score in scores {
+            let converted_score = Score::from(score.clone());
+            scores_map
+                .entry((score.advisory_id, score.vulnerability_id))
+                .or_default()
+                .push(converted_score);
         }
 
         let mut result = BTreeMap::new();
@@ -357,7 +383,7 @@ impl VulnerabilityService {
                 row,
                 connection,
                 &descriptions_map,
-                &cvss3_map,
+                &scores_map,
                 &advisories_map,
             )
             .await?;
@@ -600,7 +626,7 @@ GROUP BY
         row: QueryResult,
         connection: &C,
         descriptions_map: &HashMap<String, vulnerability_description::Model>,
-        cvss3_map: &HashMap<(Uuid, String), Vec<Score>>,
+        scores_map: &HashMap<(Uuid, String), Vec<Score>>,
         advisories_map: &HashMap<Uuid, AdvisoryData>,
     ) -> Result<(String, AnalysisDetailsV2), Error>
     where
@@ -655,8 +681,8 @@ GROUP BY
                 continue;
             };
 
-            // Look up scores from pre-fetched cvss3_map
-            let scores: Vec<Score> = cvss3_map
+            // Look up scores from pre-fetched scores_map
+            let scores: Vec<Score> = scores_map
                 .get(&(*advisory_id, vulnerability.id.clone()))
                 .cloned()
                 .unwrap_or_default();


### PR DESCRIPTION
## Summary by Sourcery

Switch vulnerability, SBOM, advisory, purl, and details APIs to consume scores from the new advisory_vulnerability_score table instead of the legacy cvss3 table while preserving existing CVSS v3 aggregation behavior.

Enhancements:
- Aggregate and compute combined/average CVSS scores from advisory_vulnerability_score records, filtering to CVSS v3.x for v3-specific calculations and supporting all CVSS versions in generic score lists.
- Introduce a conversion from advisory_vulnerability_score models to the common Score model, normalizing type, severity, and numeric precision.
- Refactor prefetching and lookup of scores across vulnerability, SBOM, advisory, and purl flows to use keyed maps of advisory/vulnerability IDs for efficient reuse.

Tests:
- Extend advisory endpoint tests to populate and validate data written via ScoreCreator into the advisory_vulnerability_score table alongside legacy cvss3 writes.