### PR TITLE
feat: migrate API consumers to read from advisory_vulnerability_score table

### DIFF
--- a/cvss/src/cvss3/score.rs
+++ b/cvss/src/cvss3/score.rs
@@ -74,3 +74,21 @@ impl FromIterator<Cvss3Base> for Score {
         }
     }
 }
+
+impl FromIterator<f64> for Score {
+    fn from_iter<I: IntoIterator<Item = f64>>(iter: I) -> Self {
+        let mut count: usize = 0;
+        let mut sum = 0.0;
+        for v in iter {
+            sum += v;
+            count += 1;
+        }
+        if count > 0 {
+            // Round to 1 decimal place (CVSS scores are displayed with 1 decimal precision)
+            let avg = sum / (count as f64);
+            Self::new((avg * 10.0).round() / 10.0)
+        } else {
+            Self::default()
+        }
+    }
+}

--- a/entity/src/advisory_vulnerability_score.rs
+++ b/entity/src/advisory_vulnerability_score.rs
@@ -74,6 +74,26 @@ pub enum ScoreType {
     V4_0,
 }
 
+impl ScoreType {
+    /// Returns true if this is a CVSS v3.x score type (V3_0 or V3_1).
+    ///
+    /// NOTE: This helper exists for backward compatibility during the migration
+    /// from legacy cvss3 table. It will be removed once all consumers support
+    /// all CVSS versions.
+    #[inline]
+    pub fn is_cvss3(self) -> bool {
+        matches!(self, Self::V3_0 | Self::V3_1)
+    }
+}
+
+impl Model {
+    /// Returns true if this score is a CVSS v3.x score (V3_0 or V3_1).
+    #[inline]
+    pub fn is_cvss3(&self) -> bool {
+        self.r#type.is_cvss3()
+    }
+}
+
 // severity
 
 #[derive(

--- a/entity/src/vulnerability.rs
+++ b/entity/src/vulnerability.rs
@@ -1,5 +1,5 @@
 use crate::{
-    advisory, advisory_vulnerability,
+    advisory, advisory_vulnerability, advisory_vulnerability_score,
     cvss3::{self, Severity},
     vulnerability_description,
 };
@@ -40,6 +40,9 @@ pub enum Relation {
     #[sea_orm(has_many = "super::cvss3::Entity")]
     Cvss3,
 
+    #[sea_orm(has_many = "super::advisory_vulnerability_score::Entity")]
+    AdvisoryVulnerabilityScore,
+
     #[sea_orm(has_many = "super::purl_status::Entity")]
     PurlStatuses,
 }
@@ -73,6 +76,12 @@ impl Related<advisory_vulnerability::Entity> for Entity {
 impl Related<cvss3::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::Cvss3.def()
+    }
+}
+
+impl Related<advisory_vulnerability_score::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::AdvisoryVulnerabilityScore.def()
     }
 }
 

--- a/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
+++ b/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
@@ -3,9 +3,10 @@ use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, LoaderTrait, QueryFilte
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use trustify_common::memo::Memo;
-use trustify_cvss::cvss3::Cvss3Base;
 use trustify_cvss::cvss3::severity::Severity;
-use trustify_entity::{advisory, advisory_vulnerability, cvss3, vulnerability};
+use trustify_entity::{
+    advisory, advisory_vulnerability, advisory_vulnerability_score, vulnerability,
+};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -119,19 +120,22 @@ impl AdvisoryVulnerabilitySummary {
         vulnerabilities: &[vulnerability::Model],
         tx: &C,
     ) -> Result<Vec<Self>, Error> {
-        let mut cvss3s = vulnerabilities
+        let mut all_scores = vulnerabilities
             .load_many(
-                cvss3::Entity::find().filter(cvss3::Column::AdvisoryId.eq(advisory.id)),
+                advisory_vulnerability_score::Entity::find()
+                    .filter(advisory_vulnerability_score::Column::AdvisoryId.eq(advisory.id)),
                 tx,
             )
             .await?;
 
         let mut summaries = Vec::new();
 
-        for (vuln, mut cvss3) in vulnerabilities.iter().zip(cvss3s.drain(..)) {
-            let cvss3_scores = cvss3
+        for (vuln, mut scores) in vulnerabilities.iter().zip(all_scores.drain(..)) {
+            // Filter to V3.x scores and format as vector strings
+            let cvss3_scores: Vec<String> = scores
                 .drain(..)
-                .map(|e| Cvss3Base::from(e).to_string())
+                .filter(|s| s.is_cvss3())
+                .map(|e| e.vector)
                 .collect();
 
             summaries.push(AdvisoryVulnerabilitySummary {

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -3,13 +3,13 @@ mod vulnerability_advisory;
 pub use vulnerability_advisory::*;
 
 use crate::{Error, vulnerability::model::VulnerabilityHead};
-use sea_orm::{ConnectionTrait, ModelTrait};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, ModelTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
 use tracing::{info_span, instrument};
 use tracing_futures::Instrument;
 use trustify_common::memo::Memo;
 use trustify_cvss::cvss3::severity::Severity;
-use trustify_entity::{advisory_vulnerability, cvss3, vulnerability};
+use trustify_entity::{advisory_vulnerability, advisory_vulnerability_score, vulnerability};
 use trustify_module_ingestor::common::{Deprecation, DeprecationForExt};
 use utoipa::ToSchema;
 
@@ -52,8 +52,8 @@ impl VulnerabilityDetails {
             .instrument(info_span!("find related"))
             .await?;
 
-        let cvss3 = vulnerability
-            .find_related(cvss3::Entity)
+        let scores = advisory_vulnerability_score::Entity::find()
+            .filter(advisory_vulnerability_score::Column::VulnerabilityId.eq(&vulnerability.id))
             .all(tx)
             .instrument(info_span!("find scores"))
             .await?;
@@ -61,7 +61,7 @@ impl VulnerabilityDetails {
         let advisories = VulnerabilityAdvisorySummary::from_entities(
             vulnerability,
             &advisory_vulnerabilities,
-            &cvss3,
+            &scores,
             tx,
         )
         .await?;

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -23,9 +23,9 @@ use trustify_common::{
     memo::Memo,
     purl::Purl,
 };
-use trustify_cvss::cvss3::{Cvss3Base, score::Score, severity::Severity};
+use trustify_cvss::cvss3::{score::Score, severity::Severity};
 use trustify_entity::{
-    advisory, advisory_vulnerability, base_purl, cpe, cvss3, organization,
+    advisory, advisory_vulnerability, advisory_vulnerability_score, base_purl, cpe, organization,
     package_relates_to_package, purl_status, qualified_purl, relationship::Relationship, sbom,
     sbom_node, sbom_package, sbom_package_purl_ref, status, version_range, versioned_purl,
     vulnerability,
@@ -58,16 +58,23 @@ impl VulnerabilityAdvisoryHead {
         advisory_vulnerability: &advisory_vulnerability::Model,
         tx: &C,
     ) -> Result<Self, Error> {
-        let cvss3 = cvss3::Entity::find()
-            .filter(cvss3::Column::AdvisoryId.eq(advisory_vulnerability.advisory_id))
-            .filter(cvss3::Column::VulnerabilityId.eq(&vulnerability.id))
+        let scores = advisory_vulnerability_score::Entity::find()
+            .filter(
+                advisory_vulnerability_score::Column::AdvisoryId
+                    .eq(advisory_vulnerability.advisory_id),
+            )
+            .filter(advisory_vulnerability_score::Column::VulnerabilityId.eq(&vulnerability.id))
             .all(tx)
             .await?;
 
-        let score = if cvss3.is_empty() {
+        // Use stored score values directly (no vector parsing needed)
+        let cvss3_scores: Vec<_> = scores.iter().filter(|s| s.is_cvss3()).collect();
+        let average_score = if cvss3_scores.is_empty() {
             None
         } else {
-            Some(Score::from_iter(cvss3.iter().map(Cvss3Base::from)))
+            Some(Score::from_iter(
+                cvss3_scores.iter().map(|s| s.score as f64),
+            ))
         };
 
         if let Some(advisory) = &advisory_vulnerability
@@ -77,8 +84,8 @@ impl VulnerabilityAdvisoryHead {
         {
             Ok(VulnerabilityAdvisoryHead {
                 head: AdvisoryHead::from_advisory(advisory, Memo::NotProvided, tx).await?,
-                severity: score.map(|score| score.severity()),
-                score: score.map(|score| score.value()),
+                severity: average_score.map(|s| s.severity()),
+                score: average_score.map(|s| s.value()),
             })
         } else {
             Err(Error::Data("Underlying advisory is missing".to_string()))
@@ -86,7 +93,7 @@ impl VulnerabilityAdvisoryHead {
     }
     pub async fn from_entities<C: ConnectionTrait>(
         vuln_advisories: &[advisory::Model],
-        vuln_cvss3s: &[cvss3::Model],
+        vuln_scores: &[advisory_vulnerability_score::Model],
         tx: &C,
     ) -> Result<Vec<Self>, Error> {
         let mut heads = Vec::new();
@@ -94,22 +101,25 @@ impl VulnerabilityAdvisoryHead {
         let organizations = vuln_advisories.load_one(organization::Entity, tx).await?;
 
         for (advisory, issuer) in vuln_advisories.iter().zip(organizations.into_iter()) {
-            // filter all vulnerability cvss3 to those that pertain to only this advisory.
-            let cvss3 = vuln_cvss3s
+            // Filter to V3.x scores for this advisory
+            let cvss3_scores: Vec<_> = vuln_scores
                 .iter()
-                .filter(|e| e.advisory_id == advisory.id)
-                .collect::<Vec<_>>();
+                .filter(|e| e.advisory_id == advisory.id && e.is_cvss3())
+                .collect();
 
-            let score = if cvss3.is_empty() {
+            // Use stored score values directly (no vector parsing needed)
+            let average_score = if cvss3_scores.is_empty() {
                 None
             } else {
-                Some(Score::from_iter(cvss3.into_iter().map(Cvss3Base::from)))
+                Some(Score::from_iter(
+                    cvss3_scores.iter().map(|s| s.score as f64),
+                ))
             };
 
             heads.push(VulnerabilityAdvisoryHead {
                 head: AdvisoryHead::from_advisory(advisory, Memo::Provided(issuer), tx).await?,
-                severity: score.map(|score| score.severity()),
-                score: score.map(|score| score.value()),
+                severity: average_score.map(|s| s.severity()),
+                score: average_score.map(|s| s.value()),
             });
         }
 
@@ -141,14 +151,14 @@ impl VulnerabilityAdvisorySummary {
         fields(
             vulnerability=vulnerability.id,
             advisory_vulnerabilities=advisory_vulnerabilities.len(),
-            vuln_cvss3=vuln_cvss3.len(),
+            vuln_scores=vuln_scores.len(),
         ),
         err(level=tracing::Level::INFO),
     )]
     pub async fn from_entities<C: ConnectionTrait>(
         vulnerability: &vulnerability::Model,
         advisory_vulnerabilities: &[advisory_vulnerability::Model],
-        vuln_cvss3: &[cvss3::Model],
+        vuln_scores: &[advisory_vulnerability_score::Model],
         tx: &C,
     ) -> Result<Vec<Self>, Error> {
         let purl_status_query = purl_status::Entity::find()
@@ -305,10 +315,18 @@ impl VulnerabilityAdvisorySummary {
                 ))
                 .await?;
 
-            let cvss3_scores = vuln_cvss3
+            // Filter to V3.x scores and format as vector strings
+            let cvss3_scores: Vec<String> = vuln_scores
                 .iter()
                 .filter(|e| e.advisory_id == advisory_vulnerability.advisory_id)
-                .map(|e| Cvss3Base::from(e.clone()).to_string())
+                .filter(|s| {
+                    matches!(
+                        s.r#type,
+                        advisory_vulnerability_score::ScoreType::V3_0
+                            | advisory_vulnerability_score::ScoreType::V3_1
+                    )
+                })
+                .map(|e| e.vector.clone())
                 .collect();
 
             let sbom_statuses = vuln_sbom_statuses

--- a/modules/fundamental/src/vulnerability/model/summary.rs
+++ b/modules/fundamental/src/vulnerability/model/summary.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 use trustify_common::memo::Memo;
 use trustify_cvss::cvss3::severity::Severity;
 use trustify_entity::{
-    advisory, advisory_vulnerability, cvss3, vulnerability, vulnerability_description,
+    advisory, advisory_vulnerability, advisory_vulnerability_score, vulnerability,
+    vulnerability_description,
 };
 use trustify_module_ingestor::common::{Deprecation, DeprecationExt};
 use utoipa::ToSchema;
@@ -43,7 +44,9 @@ impl VulnerabilitySummary {
             )
             .await?;
 
-        let vuln_cvss3s = vulnerabilities.load_many(cvss3::Entity, tx).await?;
+        let all_scores = vulnerabilities
+            .load_many(advisory_vulnerability_score::Entity::find(), tx)
+            .await?;
 
         let descriptions = vulnerabilities
             .load_many(
@@ -55,11 +58,11 @@ impl VulnerabilitySummary {
 
         let mut summaries = Vec::new();
 
-        for (((vuln, advisories), vuln_cvss3s), description) in vulnerabilities
+        for (((vuln, advisories), description), vuln_scores) in vulnerabilities
             .iter()
             .zip(advisories.iter())
-            .zip(vuln_cvss3s.iter())
             .zip(descriptions.iter())
+            .zip(all_scores.iter())
         {
             summaries.push(VulnerabilitySummary {
                 head: VulnerabilityHead::from_vulnerability_entity(
@@ -70,7 +73,7 @@ impl VulnerabilitySummary {
                 .await?,
                 average_severity: vuln.base_severity.map(|s| s.into()),
                 average_score: vuln.base_score,
-                advisories: VulnerabilityAdvisoryHead::from_entities(advisories, vuln_cvss3s, tx)
+                advisories: VulnerabilityAdvisoryHead::from_entities(advisories, vuln_scores, tx)
                     .await?,
             });
         }

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -28,7 +28,9 @@ use trustify_common::{
     model::{Paginated, PaginatedResults},
     purl::Purl,
 };
-use trustify_entity::{advisory, cvss3, organization, vulnerability, vulnerability_description};
+use trustify_entity::{
+    advisory, advisory_vulnerability_score, organization, vulnerability, vulnerability_description,
+};
 use trustify_module_ingestor::common::Deprecation;
 
 struct AdvisoryData {
@@ -40,7 +42,7 @@ struct AnalysisData {
     purls_with_vulnerabilities: Vec<QueryResult>,
     warnings: HashMap<String, Vec<String>>,
     descriptions_map: HashMap<String, vulnerability_description::Model>,
-    cvss3_scores: Vec<cvss3::Model>,
+    scores: Vec<advisory_vulnerability_score::Model>,
     advisories_map: HashMap<Uuid, AdvisoryData>,
 }
 
@@ -219,19 +221,23 @@ impl VulnerabilityService {
                 .map(|desc| (desc.vulnerability_id.clone(), desc))
                 .collect();
 
-        // Pre-fetch cvss3 scores
-        let cvss3_scores = if !advisory_ids.is_empty() && !vulnerability_ids.is_empty() {
-            cvss3::Entity::find()
-                .filter(Expr::col(cvss3::Column::AdvisoryId).eq(PgFunc::any(advisory_ids.clone())))
+        // Pre-fetch scores from advisory_vulnerability_score table
+        let scores = if !advisory_ids.is_empty() && !vulnerability_ids.is_empty() {
+            advisory_vulnerability_score::Entity::find()
                 .filter(
-                    Expr::col(cvss3::Column::VulnerabilityId).eq(PgFunc::any(vulnerability_ids)),
+                    Expr::col(advisory_vulnerability_score::Column::AdvisoryId)
+                        .eq(PgFunc::any(advisory_ids.clone())),
+                )
+                .filter(
+                    Expr::col(advisory_vulnerability_score::Column::VulnerabilityId)
+                        .eq(PgFunc::any(vulnerability_ids)),
                 )
                 .all(connection)
                 .await?
         } else {
             vec![]
         };
-        log::debug!("Pre-fetched {} cvss3 scores", cvss3_scores.len());
+        log::debug!("Pre-fetched {} scores", scores.len());
 
         // Pre-fetch advisories
         let advisories = if !advisory_ids.is_empty() {
@@ -266,7 +272,7 @@ impl VulnerabilityService {
             purls_with_vulnerabilities,
             warnings,
             descriptions_map,
-            cvss3_scores,
+            scores,
             advisories_map: advisories,
         })
     }
@@ -284,13 +290,15 @@ impl VulnerabilityService {
             purls_with_vulnerabilities,
             mut warnings,
             descriptions_map,
-            cvss3_scores,
+            scores,
             advisories_map,
         } = data;
 
-        let mut cvss3_map: HashMap<(Uuid, String), Vec<cvss3::Model>> = HashMap::new();
-        for score in cvss3_scores {
-            cvss3_map
+        // Build a map of (advisory_id, vulnerability_id) -> Vec<Model> for score calculation
+        let mut scores_map: HashMap<(Uuid, String), Vec<advisory_vulnerability_score::Model>> =
+            HashMap::new();
+        for score in scores {
+            scores_map
                 .entry((score.advisory_id, score.vulnerability_id.clone()))
                 .or_default()
                 .push(score);
@@ -303,7 +311,7 @@ impl VulnerabilityService {
                 row,
                 connection,
                 &descriptions_map,
-                &cvss3_map,
+                &scores_map,
                 &advisories_map,
             )
             .await?;
@@ -342,18 +350,17 @@ impl VulnerabilityService {
             purls_with_vulnerabilities,
             mut warnings,
             descriptions_map,
-            cvss3_scores,
+            scores,
             advisories_map,
         } = data;
 
-        let mut cvss3_map: HashMap<(Uuid, String), Vec<Score>> = HashMap::new();
-        for score in cvss3_scores {
-            if let Ok(converted_score) = Score::try_from(score.clone()) {
-                cvss3_map
-                    .entry((score.advisory_id, score.vulnerability_id))
-                    .or_default()
-                    .push(converted_score);
-            }
+        let mut scores_map: HashMap<(Uuid, String), Vec<Score>> = HashMap::new();
+        for score in scores {
+            let converted_score = Score::from(score.clone());
+            scores_map
+                .entry((score.advisory_id, score.vulnerability_id))
+                .or_default()
+                .push(converted_score);
         }
 
         let mut result = BTreeMap::new();
@@ -363,7 +370,7 @@ impl VulnerabilityService {
                 row,
                 connection,
                 &descriptions_map,
-                &cvss3_map,
+                &scores_map,
                 &advisories_map,
             )
             .await?;
@@ -498,7 +505,7 @@ GROUP BY
         row: QueryResult,
         connection: &C,
         descriptions_map: &HashMap<String, vulnerability_description::Model>,
-        cvss3_map: &HashMap<(Uuid, String), Vec<cvss3::Model>>,
+        scores_map: &HashMap<(Uuid, String), Vec<advisory_vulnerability_score::Model>>,
         advisories_map: &HashMap<Uuid, AdvisoryData>,
     ) -> Result<(String, AnalysisDetailsV3), Error>
     where
@@ -561,7 +568,8 @@ GROUP BY
                 continue;
             };
 
-            let scores = cvss3_map
+            // Look up scores from pre-fetched map
+            let score_models = scores_map
                 .get(&(*advisory_id, vulnerability.id.clone()))
                 .map(|v| v.as_slice())
                 .unwrap_or(&[]);
@@ -577,7 +585,7 @@ GROUP BY
                     entry.status.clone(),
                     Some(entry.version_range.clone()),
                     None,
-                    scores,
+                    score_models,
                 )?;
                 purl_statuses.push(purl_status);
             }
@@ -598,7 +606,7 @@ GROUP BY
         row: QueryResult,
         connection: &C,
         descriptions_map: &HashMap<String, vulnerability_description::Model>,
-        cvss3_map: &HashMap<(Uuid, String), Vec<Score>>,
+        scores_map: &HashMap<(Uuid, String), Vec<Score>>,
         advisories_map: &HashMap<Uuid, AdvisoryData>,
     ) -> Result<(String, AnalysisDetails), Error>
     where
@@ -653,8 +661,8 @@ GROUP BY
                 continue;
             };
 
-            // Look up scores from pre-fetched cvss3_map
-            let scores: Vec<Score> = cvss3_map
+            // Look up scores from pre-fetched scores_map
+            let scores: Vec<Score> = scores_map
                 .get(&(*advisory_id, vulnerability.id.clone()))
                 .cloned()
                 .unwrap_or_default();


### PR DESCRIPTION
Update VulnerabilityService, PurlStatus, and VulnerabilitySummary to query CVSS scores from the new unified advisory_vulnerability_score table instead of the legacy cvss3 table. This completes the read-side migration for the score consolidation work started in PR #1913.

The ingestion side continues to write to both tables (dual-write) to ensure backwards compatibility. Removal of the dual-write, deprecation of the legacy table, and any appropriate API changes will be addressed in follow-up PRs.

## Summary by Sourcery

Migrate vulnerability- and advisory-related API consumers to read CVSS and related scores from the unified advisory_vulnerability_score table instead of the legacy cvss3 table while preserving existing response shapes and averaging behavior.

New Features:
- Support multiple CVSS schema versions (V2, V3.0, V3.1, V4.0) in the advisory_vulnerability_score-backed Score model and related API representations.

Enhancements:
- Update VulnerabilityService, PurlStatus, SbomDetails, and related summary/detail models to prefetch and compute scores via advisory_vulnerability_score records, including average score/severity aggregation based on stored numeric values.
- Introduce helpers on advisory_vulnerability_score types to identify CVSS v3.x scores and overload Score construction to work directly from advisory_vulnerability_score models and raw f64 score values.
- Adjust tests and advisory ingestion paths to create scores using the new ScoreCreator flow targeting advisory_vulnerability_score, aligning test data with the new storage model.