### PR TITLE
chore: move csaf-rs to scm-rs organization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "csaf"
 version = "0.5.0"
-source = "git+https://github.com/trustification/csaf-rs?branch=main#63ac9e19d881cbf1808de38b6849635cda19931d"
+source = "git+https://github.com/scm-rs/csaf-rs?branch=main#63ac9e19d881cbf1808de38b6849635cda19931d"
 dependencies = [
  "chrono",
  "cpe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,7 @@ postgresql_commands = { version = "0.20.0", default-features = false, features =
 # required due to https://github.com/KenDJohnson/cpe-rs/pull/15
 #cpe = { git = "https://github.com/ctron/cpe-rs", rev = "c3c05e637f6eff7dd4933c2f56d070ee2ddfb44b" }
 # required due to https://github.com/voteblake/csaf-rs/pull/29
-csaf = { git = "https://github.com/trustification/csaf-rs", branch = "main" }
+csaf = { git = "https://github.com/scm-rs/csaf-rs", branch = "main" }
 # required due to https://github.com/gcmurphy/osv/pull/58
 #osv = { git = "https://github.com/ctron/osv", branch = "feature/drop_deps_1" }
 


### PR DESCRIPTION
We moved the csaf-rs library to the scm-rs organization. Long term, I think it'd be good to migrate to https://github.com/csaf-rs/csaf (https://github.com/guacsec/trustify/issues/2225)

## Summary by Sourcery

Build:
- Update the csaf Git dependency URL in Cargo.toml to reference the scm-rs/csaf-rs repository.