### PR TITLE
fix(sbom): accept SHA-256 identifiers in packages and related endpoints

### DIFF
--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -26,7 +26,7 @@ use crate::{
 use actix_web::{HttpResponse, Responder, delete, get, http::header, post, web};
 use config::Config;
 use futures_util::TryStreamExt;
-use sea_orm::{TransactionTrait, prelude::Uuid};
+use sea_orm::TransactionTrait;
 use serde_qs::actix::QsQuery;
 use std::str::FromStr;
 use trustify_auth::{
@@ -364,26 +364,33 @@ pub async fn delete(
     tag = "sbom",
     operation_id = "listPackages",
     params(
-        ("id", Path, description = "ID of the SBOM to get packages for"),
+        ("id" = Id, Path, description = "ID of the SBOM to get packages for"),
         Query,
         Paginated,
     ),
     responses(
         (status = 200, description = "Packages", body = PaginatedResults<SbomPackage>),
+        (status = 404, description = "The SBOM could not be found"),
     ),
 )]
 #[get("/v2/sbom/{id}/packages")]
 pub async fn packages(
     fetch: web::Data<SbomService>,
     db: web::Data<Database>,
-    id: web::Path<Uuid>,
+    id: web::Path<String>,
     web::Query(search): web::Query<Query>,
     web::Query(paginated): web::Query<Paginated>,
     _: Require<ReadSbom>,
 ) -> actix_web::Result<impl Responder> {
+    let id = Id::from_str(&id).map_err(Error::IdKey)?;
     let tx = db.begin_read().await?;
+
+    let Some(sbom) = fetch.fetch_sbom_summary(id, &tx).await? else {
+        return Ok(HttpResponse::NotFound().finish());
+    };
+
     let result = fetch
-        .fetch_sbom_packages(id.into_inner(), search, paginated, &tx)
+        .fetch_sbom_packages(sbom.head.id, search, paginated, &tx)
         .await?;
 
     Ok(HttpResponse::Ok().json(result))
@@ -407,31 +414,36 @@ struct RelatedQuery {
     tag = "sbom",
     operation_id = "listRelatedPackages",
     params(
-        ("id", Path, description = "ID of SBOM to search packages in"),
+        ("id" = Id, Path, description = "ID of SBOM to search packages in"),
         RelatedQuery,
         Query,
         Paginated,
     ),
     responses(
         (status = 200, description = "Packages", body = PaginatedResults<SbomPackageRelation>),
+        (status = 404, description = "The SBOM could not be found"),
     ),
 )]
 #[get("/v2/sbom/{id}/related")]
 pub async fn related(
     fetch: web::Data<SbomService>,
     db: web::Data<Database>,
-    id: web::Path<Uuid>,
+    id: web::Path<String>,
     web::Query(search): web::Query<Query>,
     web::Query(paginated): web::Query<Paginated>,
     web::Query(related): web::Query<RelatedQuery>,
     _: Require<ReadSbom>,
 ) -> actix_web::Result<impl Responder> {
-    let id = id.into_inner();
+    let id = Id::from_str(&id).map_err(Error::IdKey)?;
     let tx = db.begin_read().await?;
+
+    let Some(sbom) = fetch.fetch_sbom_summary(id, &tx).await? else {
+        return Ok(HttpResponse::NotFound().finish());
+    };
 
     let result = fetch
         .fetch_related_packages(
-            id,
+            sbom.head.id,
             search,
             paginated,
             related.which,

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1818,3 +1818,114 @@ async fn filter_sboms_by_group(
 
     Ok(())
 }
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn packages_by_hash(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    let result = ctx
+        .ingest_document("zookeeper-3.9.2-cyclonedx.json")
+        .await?;
+    let id = result.id.to_string();
+
+    // Fetch summary to get hashes
+    let req = TestRequest::get()
+        .uri(&format!("/api/v2/sbom/urn:uuid:{id}"))
+        .to_request();
+    let sbom: Value = app.call_and_read_body_json(req).await;
+    let sha256 = sbom["sha256"].as_str().unwrap();
+
+    // Fetch packages by UUID
+    let req = TestRequest::get()
+        .uri(&format!("/api/v2/sbom/urn:uuid:{id}/packages"))
+        .to_request();
+    let by_uuid: Value = app.call_and_read_body_json(req).await;
+
+    // Fetch packages by SHA-256
+    let req = TestRequest::get()
+        .uri(&format!("/api/v2/sbom/{sha256}/packages"))
+        .to_request();
+    let by_hash: Value = app.call_and_read_body_json(req).await;
+
+    // Results should match
+    assert_eq!(by_uuid["total"], by_hash["total"]);
+    assert!(by_uuid["total"].as_u64().unwrap() > 0);
+
+    // Non-existent hash -> 404
+    let req = TestRequest::get()
+        .uri("/api/v2/sbom/sha256:0000000000000000000000000000000000000000000000000000000000000000/packages")
+        .to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+    // Invalid identifier (no prefix) -> 400
+    let req = TestRequest::get()
+        .uri("/api/v2/sbom/not-an-id/packages")
+        .to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::BAD_REQUEST, response.status());
+
+    // Unsupported prefix -> 400
+    let req = TestRequest::get()
+        .uri("/api/v2/sbom/sha123:abcd/packages")
+        .to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::BAD_REQUEST, response.status());
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn related_by_hash(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    let result = ctx
+        .ingest_document("zookeeper-3.9.2-cyclonedx.json")
+        .await?;
+    let id = result.id.to_string();
+
+    // Fetch summary to get hashes
+    let req = TestRequest::get()
+        .uri(&format!("/api/v2/sbom/urn:uuid:{id}"))
+        .to_request();
+    let sbom: Value = app.call_and_read_body_json(req).await;
+    let sha256 = sbom["sha256"].as_str().unwrap();
+
+    // Fetch related by UUID
+    let req = TestRequest::get()
+        .uri(&format!("/api/v2/sbom/urn:uuid:{id}/related"))
+        .to_request();
+    let by_uuid: Value = app.call_and_read_body_json(req).await;
+
+    // Fetch related by SHA-256
+    let req = TestRequest::get()
+        .uri(&format!("/api/v2/sbom/{sha256}/related"))
+        .to_request();
+    let by_hash: Value = app.call_and_read_body_json(req).await;
+
+    // Results should match
+    assert_eq!(by_uuid["total"], by_hash["total"]);
+
+    // Non-existent hash -> 404
+    let req = TestRequest::get()
+        .uri("/api/v2/sbom/sha256:0000000000000000000000000000000000000000000000000000000000000000/related")
+        .to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+    // Invalid identifier (no prefix) -> 400
+    let req = TestRequest::get()
+        .uri("/api/v2/sbom/not-an-id/related")
+        .to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::BAD_REQUEST, response.status());
+
+    // Unsupported prefix -> 400
+    let req = TestRequest::get()
+        .uri("/api/v2/sbom/sha123:abcd/related")
+        .to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::BAD_REQUEST, response.status());
+
+    Ok(())
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2877,8 +2877,7 @@ paths:
         description: ID of the SBOM to get packages for
         required: true
         schema:
-          type: string
-          format: uuid
+          $ref: '#/components/schemas/Id'
       - name: q
         in: query
         description: |
@@ -2982,6 +2981,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_SbomPackage'
+        '404':
+          description: The SBOM could not be found
   /api/v2/sbom/{id}/related:
     get:
       tags:
@@ -2994,8 +2995,7 @@ paths:
         description: ID of SBOM to search packages in
         required: true
         schema:
-          type: string
-          format: uuid
+          $ref: '#/components/schemas/Id'
       - name: reference
         in: query
         description: The Package to use as reference
@@ -3124,6 +3124,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_SbomPackageRelation'
+        '404':
+          description: The SBOM could not be found
   /api/v2/sbom/{key}/download:
     get:
       tags:


### PR DESCRIPTION
The `/packages` and `/related` SBOM endpoints declared their path parameter as `web::Path<Uuid>`, which caused actix-web to reject non-UUID identifiers (e.g. `sha256:...`) before the handler was executed.

All other SBOM endpoints already accept identifiers as `String` and parse them via `Id::from_str()`, allowing both UUIDs and SHA-256 hashes.

Changes:
- Updated `/packages` and `/related` endpoints to use `web::Path<String>`
- Parse identifiers using `Id::from_str()`, matching the pattern used by other SBOM endpoints
- Fixes 404 errors when accessing SBOMs by SHA-256 hash

## Summary by Sourcery

Allow SBOM package and related endpoints to resolve SBOMs by either UUID or SHA-256 identifier and return 404 when the SBOM is not found.

Bug Fixes:
- Fix SBOM /packages and /related endpoints rejecting non-UUID identifiers by supporting SHA-256-based lookups.

Enhancements:
- Align SBOM package and related endpoints with other SBOM APIs by resolving a generic Id and using the canonical SBOM head ID internally.
- Document 404 responses for SBOM package and related listing endpoints in the OpenAPI metadata.

Tests:
- Add integration tests verifying /packages and /related endpoints work with SHA-256 IDs, match UUID-based results, and return 404 for unknown hashes.