### PR TITLE
feat: add xz to the xtask container

### DIFF
--- a/.github/scripts/Containerfile.xtask
+++ b/.github/scripts/Containerfile.xtask
@@ -20,7 +20,7 @@ LABEL \
     org.opencontainers.image.description="Trustify - xtask binary" \
     org.opencontainers.image.source="https://github.com/guacsec/trustify"
 
-RUN dnf install --nodocs -y zlib openssl krb5-libs libzstd lz4-libs libxml2 unzip
+RUN dnf install --nodocs -y zlib openssl krb5-libs libzstd lz4-libs libxml2 unzip xz
 
 COPY --from=builder /unpack/xtask /usr/local/bin
 


### PR DESCRIPTION
When generating dumps using that container, having xz can create smaller dumps.

## Summary by Sourcery

New Features:
- Include xz in the xtask container image to allow creating compressed dumps with smaller size.