### PR TITLE
chore: prepeare release 0.4.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8280,7 +8280,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-auth"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8314,7 +8314,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-common"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8364,7 +8364,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-cvss"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "serde",
  "test-log",
@@ -8374,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-db"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8391,7 +8391,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-entity"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8417,7 +8417,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-infrastructure"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "actix-cors",
  "actix-tls",
@@ -8453,7 +8453,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-migration"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "sea-orm-migration",
@@ -8470,7 +8470,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-analysis"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8521,7 +8521,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-fundamental"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8598,7 +8598,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-graphql"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8621,7 +8621,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-importer"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8679,7 +8679,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ingestor"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8733,7 +8733,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-storage"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8765,7 +8765,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ui"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "actix-web",
  "actix-web-static-files",
@@ -8787,7 +8787,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-user"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8809,14 +8809,14 @@ dependencies = [
 
 [[package]]
 name = "trustify-query"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "utoipa",
 ]
 
 [[package]]
 name = "trustify-query-derive"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-server"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8866,7 +8866,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-test-context"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8909,7 +8909,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-trustd"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -9936,7 +9936,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.8"
+version = "0.4.9"
 edition = "2024"
 publish = false
 license = "Apache-2.0"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache License, Version 2.0
     identifier: Apache-2.0
-  version: 0.4.8
+  version: 0.4.9
 paths:
   /.well-known/trustify:
     get:


### PR DESCRIPTION
## Summary by Sourcery

Prepare the project for the 0.4.9 release by updating version metadata.

Build:
- Bump workspace crate version from 0.4.8 to 0.4.9 in Cargo.toml.

Documentation:
- Update OpenAPI specification version to 0.4.9 to match the new release.