### PR TITLE
fix: sbom groups list endpoint - groups param should be query param not path param

### DIFF
--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -150,6 +150,7 @@ pub async fn get_license_export(
 }
 
 #[derive(Clone, Debug, Default, serde::Deserialize, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 struct GroupFilterQuery {
     /// Filter by group IDs. Only SBOMs assigned to any of the provided groups will be returned.
     /// Can be specified multiple times. Malformed IDs are silently ignored.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2417,11 +2417,11 @@ paths:
           format: int64
           minimum: 0
       - name: group
-        in: path
+        in: query
         description: |-
           Filter by group IDs. Only SBOMs assigned to any of the provided groups will be returned.
           Can be specified multiple times. Malformed IDs are silently ignored.
-        required: true
+        required: false
         schema:
           type: array
           items:


### PR DESCRIPTION
fixes: https://github.com/guacsec/trustify/issues/2262

## Summary by Sourcery

Bug Fixes:
- Correct the SBOM groups list API contract so the group filter is passed as a query parameter rather than a path parameter.