### PR TITLE
fix(migration): add missing FK indexes for query performance

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -48,6 +48,7 @@ mod m0002060_add_sbom_group_field;
 mod m0002070_alter_sbom_group_restrict_parent;
 mod m0002080_add_cargo_version_scheme;
 mod m0002090_vulnerability_id_sort_index;
+mod m0002100_perf_fk_indexes;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -112,6 +113,7 @@ impl MigratorExt for Migrator {
             .normal(m0002070_alter_sbom_group_restrict_parent::Migration)
             .normal(m0002080_add_cargo_version_scheme::Migration)
             .normal(m0002090_vulnerability_id_sort_index::Migration)
+            .normal(m0002100_perf_fk_indexes::Migration)
     }
 }
 

--- a/migration/src/m0002100_perf_fk_indexes.rs
+++ b/migration/src/m0002100_perf_fk_indexes.rs
@@ -1,0 +1,209 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // product_version.sbom_id — used in analysis graph loading:
+        //   LEFT JOIN product_version ON sbom.sbom_id = product_version.sbom_id
+        // Without this index, every SBOM graph load triggers a sequential scan
+        // of the entire product_version table.
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(ProductVersion::Table)
+                    .name(Indexes::ProductVersionSbomIdIdx.to_string())
+                    .col(ProductVersion::SbomId)
+                    .to_owned(),
+            )
+            .await?;
+
+        // product_version.product_id — used in analysis graph loading:
+        //   LEFT JOIN product ON product_version.product_id = product.id
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(ProductVersion::Table)
+                    .name(Indexes::ProductVersionProductIdIdx.to_string())
+                    .col(ProductVersion::ProductId)
+                    .to_owned(),
+            )
+            .await?;
+
+        // package_relates_to_package (sbom_id, relationship) — used in CPE
+        // context filter SQL and SBOM advisory queries:
+        //   WHERE sbom_id = $1 AND relationship = 13
+        // The existing PK (sbom_id, left_node_id, relationship, right_node_id)
+        // has left_node_id between sbom_id and relationship, forcing a scan of
+        // all left_node_id values per SBOM.
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(PackageRelatesToPackage::Table)
+                    .name(Indexes::PackageRelatesToPackageSbomRelIdx.to_string())
+                    .col(PackageRelatesToPackage::SbomId)
+                    .col(PackageRelatesToPackage::Relationship)
+                    .to_owned(),
+            )
+            .await?;
+
+        // purl_status.version_range_id — used in vulnerability analysis:
+        //   INNER JOIN version_range ON purl_status.version_range_id = version_range.id
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(PurlStatus::Table)
+                    .name(Indexes::PurlStatusVersionRangeIdIdx.to_string())
+                    .col(PurlStatus::VersionRangeId)
+                    .to_owned(),
+            )
+            .await?;
+
+        // cpe (vendor, product, version) — used in the generalized CPE lookup
+        // within product_advisory_info_sql():
+        //   WHERE (vendor, product, version) IN (SELECT ...)
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(Cpe::Table)
+                    .name(Indexes::CpeVendorProductVersionIdx.to_string())
+                    .col(Cpe::Vendor)
+                    .col(Cpe::Product)
+                    .col(Cpe::Version)
+                    .to_owned(),
+            )
+            .await?;
+
+        // advisory.issuer_id — used in advisory listing/detail queries:
+        //   LEFT JOIN organization ON advisory.issuer_id = organization.id
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(Advisory::Table)
+                    .name(Indexes::AdvisoryIssuerIdIdx.to_string())
+                    .col(Advisory::IssuerId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(Advisory::Table)
+                    .name(Indexes::AdvisoryIssuerIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(Cpe::Table)
+                    .name(Indexes::CpeVendorProductVersionIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(PurlStatus::Table)
+                    .name(Indexes::PurlStatusVersionRangeIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(PackageRelatesToPackage::Table)
+                    .name(Indexes::PackageRelatesToPackageSbomRelIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(ProductVersion::Table)
+                    .name(Indexes::ProductVersionProductIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(ProductVersion::Table)
+                    .name(Indexes::ProductVersionSbomIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+pub enum Indexes {
+    ProductVersionSbomIdIdx,
+    ProductVersionProductIdIdx,
+    PackageRelatesToPackageSbomRelIdx,
+    PurlStatusVersionRangeIdIdx,
+    CpeVendorProductVersionIdx,
+    AdvisoryIssuerIdIdx,
+}
+
+#[derive(DeriveIden)]
+pub enum ProductVersion {
+    Table,
+    SbomId,
+    ProductId,
+}
+
+#[derive(DeriveIden)]
+pub enum PackageRelatesToPackage {
+    Table,
+    SbomId,
+    Relationship,
+}
+
+#[derive(DeriveIden)]
+pub enum PurlStatus {
+    Table,
+    VersionRangeId,
+}
+
+#[derive(DeriveIden)]
+pub enum Cpe {
+    Table,
+    Vendor,
+    Product,
+    Version,
+}
+
+#[derive(DeriveIden)]
+pub enum Advisory {
+    Table,
+    IssuerId,
+}


### PR DESCRIPTION
## Summary

- Adds 6 missing indexes on foreign key columns that cause sequential scans on cold tables
- Most impactful for the analysis service's SBOM graph loading path (`GET /api/v2/analysis/component/{key}`)
- Follows the same pattern as m0001200 and m0001110

## Problem

Several FK columns lack indexes. When tables are cold (not in PostgreSQL's buffer cache), queries that JOIN on these columns trigger full sequential scans. The analysis service's `get_nodes()` query (`modules/analysis/src/service/load/mod.rs:138`) is the worst offender — it runs for every SBOM graph load and includes:

```sql
LEFT JOIN product_version ON sbom.sbom_id = product_version.sbom_id  -- no index
LEFT JOIN product ON product_version.product_id = product.id          -- no index
```

## Indexes Added

| Index | Column(s) | Query Path |
|-------|-----------|------------|
| `product_version_sbom_id_idx` | `product_version(sbom_id)` | Analysis graph load — every `get_nodes()` call |
| `product_version_product_id_idx` | `product_version(product_id)` | Analysis graph load — product JOIN |
| `package_relates_to_package_sbom_rel_idx` | `(sbom_id, relationship)` | CPE context filter in `product_advisory_info_sql()` |
| `purl_status_version_range_id_idx` | `purl_status(version_range_id)` | Vulnerability analysis JOINs |
| `cpe_vendor_product_version_idx` | `cpe(vendor, product, version)` | Generalized CPE tuple lookup |
| `advisory_issuer_id_idx` | `advisory(issuer_id)` | Advisory listing with organization JOIN |

## Why `package_relates_to_package` needs a separate index

The PK is `(sbom_id, left_node_id, relationship, right_node_id)`. Queries filter `WHERE sbom_id = $1 AND relationship = 13`, but `left_node_id` sits between `sbom_id` and `relationship` in the composite key, so PostgreSQL can only use the leading `sbom_id` column and must scan all `left_node_id` values to find matching relationships.

## Test plan

- [ ] Migration applies cleanly (`cargo run -p trustify-migration -- up`)
- [ ] Migration rolls back cleanly (`cargo run -p trustify-migration -- down`)
- [ ] `EXPLAIN ANALYZE` on the `get_nodes()` query shows Index Scan on `product_version` instead of Seq Scan
- [ ] Existing tests pass (`cargo test --all-features`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Introduce migration m0002100 to add targeted indexes on frequently joined foreign key columns and CPE tuple fields to reduce sequential scans and speed up analysis-related queries.