### PR TITLE
Backport 2156 to release/0.4.z

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "csaf"
 version = "0.5.0"
-source = "git+https://github.com/trustification/csaf-rs?rev=17620a225744b4a18845d4f7bf63354e01109b91#17620a225744b4a18845d4f7bf63354e01109b91"
+source = "git+https://github.com/trustification/csaf-rs?branch=purl-name-encoding-fix#9f4e0d24795a1d01eef1d805ab434c28d6f4df8a"
 dependencies = [
  "chrono",
  "cpe",
@@ -5132,12 +5132,12 @@ dependencies = [
 
 [[package]]
 name = "packageurl"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53362339d1c48910f1b0c35e2ae96e2d32e442c7dc3ac5f622908ec87221f08"
+checksum = "35da99768af1ae8830ccf30d295db0e09c24bcfda5a67515191dd4b773f6d82a"
 dependencies = [
  "percent-encoding",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "csaf"
 version = "0.5.0"
-source = "git+https://github.com/trustification/csaf-rs?branch=purl-name-encoding-fix#9f4e0d24795a1d01eef1d805ab434c28d6f4df8a"
+source = "git+https://github.com/trustification/csaf-rs?branch=main#63ac9e19d881cbf1808de38b6849635cda19931d"
 dependencies = [
  "chrono",
  "cpe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ opentelemetry-otlp = "0.30"
 opentelemetry_sdk = "0.30"
 opentelemetry-instrumentation-actix-web = "0.22.0"
 osv = { version = "0.2.1", default-features = false, features = [] }
-packageurl = "0.3.0"
+packageurl = "0.6"
 parking_lot = "0.12"
 peak_alloc = "0.3.0"
 pem = "3"
@@ -204,7 +204,7 @@ postgresql_commands = { version = "0.20.0", default-features = false, features =
 # required due to https://github.com/KenDJohnson/cpe-rs/pull/15
 #cpe = { git = "https://github.com/ctron/cpe-rs", rev = "c3c05e637f6eff7dd4933c2f56d070ee2ddfb44b" }
 # required due to https://github.com/voteblake/csaf-rs/pull/29
-csaf = { git = "https://github.com/trustification/csaf-rs", rev = "17620a225744b4a18845d4f7bf63354e01109b91" }
+csaf = { git = "https://github.com/trustification/csaf-rs", branch = "purl-name-encoding-fix" }
 # required due to https://github.com/gcmurphy/osv/pull/58
 #osv = { git = "https://github.com/ctron/osv", branch = "feature/drop_deps_1" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ postgresql_commands = { version = "0.20.0", default-features = false, features =
 # required due to https://github.com/KenDJohnson/cpe-rs/pull/15
 #cpe = { git = "https://github.com/ctron/cpe-rs", rev = "c3c05e637f6eff7dd4933c2f56d070ee2ddfb44b" }
 # required due to https://github.com/voteblake/csaf-rs/pull/29
-csaf = { git = "https://github.com/trustification/csaf-rs", branch = "purl-name-encoding-fix" }
+csaf = { git = "https://github.com/trustification/csaf-rs", branch = "main" }
 # required due to https://github.com/gcmurphy/osv/pull/58
 #osv = { git = "https://github.com/ctron/osv", branch = "feature/drop_deps_1" }
 

--- a/common/src/purl.rs
+++ b/common/src/purl.rs
@@ -222,7 +222,7 @@ struct PurlVisitor;
 impl Visitor<'_> for PurlVisitor {
     type Value = Purl;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
         formatter.write_str("a pURL")
     }
 
@@ -235,13 +235,13 @@ impl Visitor<'_> for PurlVisitor {
 }
 
 impl Display for Purl {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut purl = PackageUrl::new(&self.ty, &self.name).map_err(|_| fmt::Error)?;
         if let Some(ns) = &self.namespace {
-            purl.with_namespace(ns);
+            purl.with_namespace(ns).map_err(|_| fmt::Error)?;
         }
         if let Some(version) = &self.version {
-            purl.with_version(version);
+            purl.with_version(version).map_err(|_| fmt::Error)?;
         }
         for (key, value) in &self.qualifiers {
             purl.add_qualifier(key, value).map_err(|_| fmt::Error)?;
@@ -251,7 +251,7 @@ impl Display for Purl {
 }
 
 impl Debug for Purl {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{self}")
     }
 }
@@ -438,6 +438,11 @@ mod tests {
         assert_eq!(
             purl.to_string().as_str(),
             "pkg:npm/%40fastify/this%40that@3.8-%236.el8"
+        );
+        let purl = Purl::from_str("pkg:generic/ibm-granite%2Fgranite-docling-258M@1.0")?;
+        assert_eq!(
+            purl.to_string().as_str(),
+            "pkg:generic/ibm-granite%2Fgranite-docling-258M@1.0"
         );
 
         Ok(())

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -49,7 +49,6 @@ tracing-futures = { workspace = true, features = ["futures-03"] }
 utoipa = { workspace = true, features = ["actix_extras", "uuid", "time"] }
 utoipa-actix-web = { workspace = true }
 uuid = { workspace = true }
-packageurl = { workspace = true }
 semver = { workspace = true }
 regex = { workspace = true }
 lenient_semver = { workspace = true }

--- a/modules/ingestor/src/service/advisory/osv/translate.rs
+++ b/modules/ingestor/src/service/advisory/osv/translate.rs
@@ -27,7 +27,7 @@ fn translate<'a>(ecosystem: &Ecosystem, name: &'a str) -> Option<PackageUrl<'a>>
                 let name = split[1];
                 PackageUrl::new("maven", name)
                     .and_then(|mut purl| {
-                        purl.with_namespace(namespace);
+                        purl.with_namespace(namespace)?;
                         if repo != MAVEN_DEFAULT_REPO {
                             purl.add_qualifier("repository_url", repo.clone())?;
                         }
@@ -59,9 +59,9 @@ fn split_name<'a>(name: &'a str, ty: &'a str, separator: &str) -> Option<Package
             let namespace = split[0..=split.len() - 2].join(separator);
             let name = split[split.len() - 1];
             PackageUrl::new(ty, name)
-                .map(|mut purl| {
-                    purl.with_namespace(namespace);
-                    purl
+                .and_then(|mut purl| {
+                    purl.with_namespace(namespace)?;
+                    Ok(purl)
                 })
                 .ok()
         }


### PR DESCRIPTION
To address https://redhat.atlassian.net/browse/TC-3090

## Summary by Sourcery

Update package URL handling to be compatible with newer dependencies and fix formatting and translation behavior.

Bug Fixes:
- Ensure pURL string formatting correctly propagates errors from setting namespace and version.
- Fix Maven and other ecosystem name translation to handle fallible namespace assignment without panicking.
- Add a regression test for preserving encoded slashes in generic pURLs.

Enhancements:
- Update the packageurl dependency to version 0.6 and align code with its fallible API.
- Point the csaf dependency to the main branch instead of a fixed revision and remove an unused packageurl dependency from the fundamental module.

Build:
- Adjust Cargo.toml dependencies to newer versions and clean up unused workspace dependencies.

Tests:
- Extend pURL tests to cover encoded namespace components and ensure round-trip string stability.