### PR TITLE
Minor cleanups to the CVSS changes

### DIFF
--- a/modules/analysis/src/endpoints/tests/latest_filters.rs
+++ b/modules/analysis/src/endpoints/tests/latest_filters.rs
@@ -1,11 +1,11 @@
 use super::req::*;
-use crate::test::{Join, caller};
+use crate::test::caller;
 use jsonpath_rust::JsonPath;
 use rstest::*;
 use serde_json::{Value, json};
 use std::cmp;
 use test_context::test_context;
-use trustify_test_context::{TrustifyContext, subset::ContainsSubset};
+use trustify_test_context::{Join, TrustifyContext, subset::ContainsSubset};
 
 #[test_context(TrustifyContext)]
 #[rstest]

--- a/modules/analysis/src/endpoints/tests/rh_variant.rs
+++ b/modules/analysis/src/endpoints/tests/rh_variant.rs
@@ -1,10 +1,10 @@
 use super::req::*;
-use crate::test::{Join, caller};
+use crate::test::caller;
 use rstest::rstest;
 use serde_json::{Value, json};
 use test_context::test_context;
 use test_log::test;
-use trustify_test_context::{TrustifyContext, subset::ContainsSubset};
+use trustify_test_context::{Join, TrustifyContext, subset::ContainsSubset};
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]

--- a/modules/analysis/src/test/data.rs
+++ b/modules/analysis/src/test/data.rs
@@ -1,4 +1,4 @@
-use crate::test::Join;
+use trustify_test_context::Join;
 
 pub const BASE: &str = "cyclonedx/rh/latest_filters/TC-3278/";
 

--- a/modules/analysis/src/test/mod.rs
+++ b/modules/analysis/src/test/mod.rs
@@ -6,7 +6,6 @@ use crate::{
     model::{BaseSummary, Node as GraphNode},
     service::AnalysisService,
 };
-use std::fmt::Display;
 use trustify_entity::relationship::Relationship;
 use trustify_test_context::{
     TrustifyContext,
@@ -114,23 +113,4 @@ where
     log::debug!("Ancestors: {ancestors:#?}");
 
     f(ancestors.as_slice())
-}
-
-pub(crate) trait Join: Sized {
-    /// Turn a base prefix and an iterator of items into an iterator of base + item.
-    fn join(self, other: impl IntoIterator<Item = impl Display>) -> impl Iterator<Item = String>;
-
-    /// Same as [`Self::join`], but accepting iterators of iterators for joining, flattening them.
-    fn chain(
-        self,
-        other: impl IntoIterator<Item = impl IntoIterator<Item = impl Display>>,
-    ) -> impl Iterator<Item = String> {
-        Self::join(self, other.into_iter().flatten())
-    }
-}
-
-impl<D: Display> Join for D {
-    fn join(self, other: impl IntoIterator<Item = impl Display>) -> impl Iterator<Item = String> {
-        other.into_iter().map(move |s| format!("{self}{s}"))
-    }
 }

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -117,6 +117,7 @@ impl Graph {
                 vulnerability::Column::Modified,
                 vulnerability::Column::Withdrawn,
                 vulnerability::Column::Cwes,
+                vulnerability::Column::BaseType,
                 vulnerability::Column::BaseScore,
                 vulnerability::Column::BaseSeverity,
             ]),

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -81,7 +81,6 @@ impl VulnerabilityInformation {
             || self.withdrawn.is_some()
             || self.cwes.is_some()
             || self.base_score.is_some()
-            || self.base_score.is_some()
     }
 }
 

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -362,18 +362,9 @@ fn get_score(cvss: &Value) -> Option<(ScoreType, f64, Severity)> {
         .and_then(Value::as_str)
         .and_then(|s| Severity::from_str(&s.to_lowercase()).ok());
 
-    fn from_cvss_v2(score: f64) -> Option<Severity> {
-        match score {
-            s if (0.0..4.0).contains(&s) => Some(Severity::Low),
-            s if (4.0..7.0).contains(&s) => Some(Severity::Medium),
-            s if (7.0..=10.0).contains(&s) => Some(Severity::High),
-            _ => None,
-        }
-    }
-
     match r#type {
         // CVSS v2.0 does not have a baseSeverity field, so we need to calculate it from the score.
-        ScoreType::V2_0 => Some((r#type, score, from_cvss_v2(score)?)),
+        ScoreType::V2_0 => Some((r#type, score, (score, ScoreType::V2_0).into())),
         _ => Some((r#type, score, severity?)),
     }
 }

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -364,7 +364,13 @@ fn get_score(cvss: &Value) -> Option<(ScoreType, f64, Severity)> {
 
     match r#type {
         // CVSS v2.0 does not have a baseSeverity field, so we need to calculate it from the score.
-        ScoreType::V2_0 => Some((r#type, score, (score, ScoreType::V2_0).into())),
+        ScoreType::V2_0 => {
+            // CVSS v2 scores must be in the valid range [0.0, 10.0]
+            if !(0.0..=10.0).contains(&score) {
+                return None;
+            }
+            Some((r#type, score, (score, ScoreType::V2_0).into()))
+        }
         _ => Some((r#type, score, severity?)),
     }
 }

--- a/modules/ingestor/src/service/advisory/cve/mod.rs
+++ b/modules/ingestor/src/service/advisory/cve/mod.rs
@@ -59,9 +59,9 @@ pub fn extract_scores(cve: &Cve, creator: &mut ScoreCreator) {
         let metric = CvssMetric::from(cve_metric);
 
         let cvss_objects: Vec<Cvss> = vec![
-            metric.cvss_v3_1.map(Cvss::V3_1),
-            metric.cvss_v3_0.map(Cvss::V3_0),
             metric.cvss_v2_0.map(Cvss::V2),
+            metric.cvss_v3_0.map(Cvss::V3_0),
+            metric.cvss_v3_1.map(Cvss::V3_1),
             metric.cvss_v4_0.map(Cvss::V4),
         ]
         .into_iter()

--- a/test-context/src/lib.rs
+++ b/test-context/src/lib.rs
@@ -24,6 +24,7 @@ use serde::Serialize;
 use std::{
     env,
     fmt::Debug,
+    fmt::Display,
     io::{Cursor, Read, Seek, Write},
     path::{Path, PathBuf},
 };
@@ -37,6 +38,7 @@ use trustify_module_ingestor::{
     service::{Cache, Format, IngestorService, dataset::DatasetIngestResult},
 };
 use trustify_module_storage::service::fs::FileSystemBackend;
+use walkdir::DirEntry;
 use zip::write::FileOptions;
 
 pub enum Dataset {
@@ -226,6 +228,32 @@ $$;
         Ok(r)
     }
 
+    pub async fn ingest_parallel_vec(
+        &self,
+        paths: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Result<Vec<IngestResult>, anyhow::Error> {
+        // hold on to paths for the async part
+
+        let paths = Vec::from_iter(paths);
+        let paths: Vec<_> = paths.iter().map(|s| s.as_ref()).collect();
+
+        // ensure we drop 'f' before 'paths'
+
+        let r = {
+            let mut f = vec![];
+
+            for path in paths {
+                f.push(self.ingest_document(path));
+            }
+
+            futures::future::try_join_all(f).await?
+        };
+
+        // return result
+
+        Ok(r)
+    }
+
     /// Create a dataset on the fly and ingest it
     ///
     /// The path can either be a literal path, or a pre-defined constant like [`Dataset`].
@@ -233,28 +261,75 @@ $$;
         &self,
         path: impl AsRef<Path>,
     ) -> Result<DatasetIngestResult, anyhow::Error> {
-        let base = self.absolute_path(path)?;
         let mut data = vec![];
         let mut dataset = zip::write::ZipWriter::new(Cursor::new(&mut data));
-        for entry in walkdir::WalkDir::new(&base) {
-            let entry = entry?;
-            let Ok(path) = entry.path().strip_prefix(&base) else {
-                continue;
-            };
 
+        self.walk_documents(path, |entry, path| {
             if entry.file_type().is_file() {
                 dataset.start_file_from_path(path, FileOptions::<()>::default())?;
                 dataset.write_all(&(std::fs::read(entry.path())?))?;
             } else if entry.file_type().is_dir() {
                 dataset.add_directory_from_path(path, FileOptions::<()>::default())?;
             }
-        }
+
+            Ok(())
+        })?;
+
         dataset.finish()?;
 
         Ok(self
             .db
             .transaction(async |tx| self.ingestor.ingest_dataset(&data, (), 0, tx).await)
             .await?)
+    }
+
+    /// Recursively ingest all documents in a path
+    pub async fn ingest_path(
+        &self,
+        path: impl AsRef<Path>,
+        parallel: bool,
+    ) -> Result<Vec<IngestResult>, anyhow::Error> {
+        let base = self.absolute_path(path)?;
+
+        let mut docs = vec![];
+        self.walk_documents(&base, |entry, path| {
+            if entry.file_type().is_file()
+                && let Some(s) = path.to_str()
+            {
+                let s = base
+                    .join(s)
+                    .to_str()
+                    .expect("must be a valid name")
+                    .to_string();
+                log::info!("Adding: {s}");
+                docs.push(s.to_string());
+            }
+            Ok(())
+        })?;
+
+        if parallel {
+            self.ingest_parallel_vec(docs).await
+        } else {
+            self.ingest_documents(docs).await
+        }
+    }
+
+    fn walk_documents<F>(&self, path: impl AsRef<Path>, mut f: F) -> Result<(), anyhow::Error>
+    where
+        F: FnMut(&DirEntry, &Path) -> Result<(), anyhow::Error>,
+    {
+        let base = self.absolute_path(path)?;
+
+        for entry in walkdir::WalkDir::new(&base) {
+            let entry = entry?;
+            let Ok(path) = entry.path().strip_prefix(&base) else {
+                continue;
+            };
+
+            f(&entry, path)?;
+        }
+
+        Ok(())
     }
 
     pub(crate) fn teardown(&self) {
@@ -380,6 +455,25 @@ pub trait IngestionResult: Sized {
 impl IngestionResult for Vec<IngestResult> {
     fn collect_ids(self) -> impl Iterator<Item = String> {
         self.into_iter().map(|r| r.id)
+    }
+}
+
+pub trait Join: Sized {
+    /// Turn a base prefix and an iterator of items into an iterator of base + item.
+    fn join(self, other: impl IntoIterator<Item = impl Display>) -> impl Iterator<Item = String>;
+
+    /// Same as [`Self::join`], but accepting iterators of iterators for joining, flattening them.
+    fn chain(
+        self,
+        other: impl IntoIterator<Item = impl IntoIterator<Item = impl Display>>,
+    ) -> impl Iterator<Item = String> {
+        Self::join(self, other.into_iter().flatten())
+    }
+}
+
+impl<D: Display> Join for D {
+    fn join(self, other: impl IntoIterator<Item = impl Display>) -> impl Iterator<Item = String> {
+        other.into_iter().map(move |s| format!("{self}{s}"))
     }
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Refine CVSS handling and test utilities while cleaning up minor issues in vulnerability and analysis code.

New Features:
- Add support for ingesting all documents under a path with optional parallel processing in the test context utilities.

Bug Fixes:
- Fix CVSS v2 severity derivation by reusing the shared score-to-severity conversion logic.
- Remove a duplicated base score check in vulnerability information presence detection.

Enhancements:
- Refactor document walking logic into a reusable helper and reuse it across dataset creation and path ingestion in tests.
- Reorder CVSS metric extraction to prefer v2, then v3.0, then v3.1, and finally v4 when building score objects.
- Promote the Join helper trait to the shared test-context crate and update analysis tests to use the shared implementation.
- Include the vulnerability base type column in graph queries to align with the extended vulnerability model.

Tests:
- Adjust analysis tests to consume shared Join utilities and updated test data paths.