### PR TITLE
feat: add ability to retrieve scores of authoritative advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8314,6 +8314,7 @@ dependencies = [
  "hide",
  "human-date-parser",
  "humantime",
+ "isx",
  "itertools 0.14.0",
  "lenient_semver",
  "log",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -19,6 +19,7 @@ hex = { workspace = true }
 hide = { workspace = true }
 human-date-parser = { workspace = true }
 humantime = { workspace = true }
+isx = { workspace = true }
 itertools = { workspace = true }
 lenient_semver = { workspace = true }
 log = { workspace = true }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -11,6 +11,7 @@ pub mod memo;
 pub mod model;
 pub mod package;
 pub mod purl;
+pub mod requested_field;
 pub mod reqwest;
 pub mod sbom;
 pub mod serde;

--- a/common/src/requested_field.rs
+++ b/common/src/requested_field.rs
@@ -54,9 +54,9 @@ impl<T: utoipa::__dev::ComposeSchema> utoipa::__dev::ComposeSchema for Requested
     }
 }
 
-impl<T: utoipa::__dev::ComposeSchema> ToSchema for RequestedField<T> {
+impl<T: utoipa::__dev::ComposeSchema + ToSchema> ToSchema for RequestedField<T> {
     fn name() -> Cow<'static, str> {
-        "RequestedField".into()
+        format!("RequestedField_{}", T::name()).into()
     }
 }
 

--- a/common/src/requested_field.rs
+++ b/common/src/requested_field.rs
@@ -1,0 +1,153 @@
+use isx::IsDefault;
+use serde::{Deserialize, Serialize, Serializer};
+use std::borrow::Cow;
+use utoipa::{
+    ToSchema,
+    openapi::{RefOr, Schema},
+};
+
+/// Tri-state wrapper for response fields that are only included on request.
+///
+/// * `NotRequested` — the caller did not ask for this field; it is omitted from the response
+///   (via `skip_serializing_if = "IsDefault::is_default"`).
+/// * `Requested(None)` — the field was requested but no data is available; serialized as `null`.
+/// * `Requested(Some(value))` — the field was requested and data is present; serialized normally.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum RequestedField<T> {
+    #[default]
+    NotRequested,
+    Requested(Option<T>),
+}
+
+impl<T> IsDefault for RequestedField<T> {
+    fn is_default(&self) -> bool {
+        matches!(self, RequestedField::NotRequested)
+    }
+}
+
+impl<T> From<Option<T>> for RequestedField<T> {
+    fn from(option: Option<T>) -> Self {
+        RequestedField::Requested(option)
+    }
+}
+
+impl<T: Serialize> Serialize for RequestedField<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            RequestedField::NotRequested => serializer.serialize_none(),
+            RequestedField::Requested(inner) => inner.serialize(serializer),
+        }
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for RequestedField<T> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(RequestedField::Requested(Option::<T>::deserialize(
+            deserializer,
+        )?))
+    }
+}
+
+impl<T: utoipa::__dev::ComposeSchema> utoipa::__dev::ComposeSchema for RequestedField<T> {
+    fn compose(generics: Vec<RefOr<Schema>>) -> RefOr<Schema> {
+        <Option<T> as utoipa::__dev::ComposeSchema>::compose(generics)
+    }
+}
+
+impl<T: utoipa::__dev::ComposeSchema> ToSchema for RequestedField<T> {
+    fn name() -> Cow<'static, str> {
+        "RequestedField".into()
+    }
+}
+
+/// Extension trait to construct a `RequestedField` from a boolean flag.
+pub trait BoolRequestedField {
+    /// Returns `Requested(f())` when `true`, `NotRequested` when `false`.
+    fn then_requested<T>(self, f: impl FnOnce() -> Option<T>) -> RequestedField<T>;
+}
+
+impl BoolRequestedField for bool {
+    fn then_requested<T>(self, f: impl FnOnce() -> Option<T>) -> RequestedField<T> {
+        if self {
+            RequestedField::Requested(f())
+        } else {
+            RequestedField::NotRequested
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use serde_json::{Value, json};
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct Response {
+        name: String,
+        #[serde(default, skip_serializing_if = "IsDefault::is_default")]
+        data: RequestedField<Vec<i32>>,
+    }
+
+    #[rstest]
+    #[case::not_requested(RequestedField::NotRequested, None)]
+    #[case::requested_none(RequestedField::Requested(None), Some(Value::Null))]
+    #[case::requested_some(
+        RequestedField::Requested(Some(vec![1, 2, 3])),
+        Some(json!([1, 2, 3])),
+    )]
+    fn serialization(#[case] data: RequestedField<Vec<i32>>, #[case] expected: Option<Value>) {
+        let r = Response {
+            name: "test".into(),
+            data,
+        };
+        let v = serde_json::to_value(&r).expect("serialize");
+        assert_eq!(v.get("data").cloned(), expected);
+    }
+
+    #[rstest]
+    #[case::absent(json!({"name": "test"}), RequestedField::NotRequested)]
+    #[case::null(json!({"name": "test", "data": null}), RequestedField::Requested(None))]
+    #[case::value(
+        json!({"name": "test", "data": [1, 2]}),
+        RequestedField::Requested(Some(vec![1, 2])),
+    )]
+    fn deserialization(#[case] input: Value, #[case] expected: RequestedField<Vec<i32>>) {
+        let r: Response = serde_json::from_value(input).expect("deserialize");
+        assert_eq!(r.data, expected);
+    }
+
+    #[rstest]
+    #[case::not_requested(RequestedField::NotRequested)]
+    #[case::requested_none(RequestedField::Requested(None))]
+    #[case::requested_some(RequestedField::Requested(Some(vec![42])))]
+    fn round_trip(#[case] data: RequestedField<Vec<i32>>) {
+        let original = Response {
+            name: "test".into(),
+            data,
+        };
+        let json = serde_json::to_value(&original).expect("serialize");
+        let restored: Response = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(original.data, restored.data);
+    }
+
+    #[rstest]
+    #[case::some(Some(42), RequestedField::Requested(Some(42)))]
+    #[case::none(None, RequestedField::Requested(None))]
+    fn from_option(#[case] input: Option<i32>, #[case] expected: RequestedField<i32>) {
+        assert_eq!(RequestedField::from(input), expected);
+    }
+
+    #[rstest]
+    #[case::true_some(true, Some(42), RequestedField::Requested(Some(42)))]
+    #[case::true_none(true, None, RequestedField::Requested(None))]
+    #[case::false_some(false, Some(42), RequestedField::NotRequested)]
+    #[case::false_none(false, None, RequestedField::NotRequested)]
+    fn then_requested_cases(
+        #[case] flag: bool,
+        #[case] value: Option<i32>,
+        #[case] expected: RequestedField<i32>,
+    ) {
+        assert_eq!(flag.then_requested(|| value), expected);
+    }
+}

--- a/docs/adrs/00015-authoritative-advisory-scores.md
+++ b/docs/adrs/00015-authoritative-advisory-scores.md
@@ -47,9 +47,10 @@ row is deleted — the vulnerability's primary key `id` is never affected.
 
 ### Ingestion-time linking
 
-The `authoritative_advisory_id` is set during CVE ingestion only. The CVE loader checks whether the
-ingested record contributed a `base_score` and, if so, issues a separate `UPDATE` setting
-`authoritative_advisory_id`. Non-CVE ingestors (CSAF, OSV) never touch this column.
+The `authoritative_advisory_id` is set during CVE ingestion only. A CVE advisory is always the
+authoritative source for its vulnerability, regardless of whether it carries CVSS scores. The CVE
+loader unconditionally issues an `UPDATE` setting `authoritative_advisory_id` after creating the
+advisory. Non-CVE ingestors (CSAF, OSV) never touch this column.
 
 ### Migration backfill
 
@@ -69,8 +70,7 @@ FROM (
     WHERE a.labels->>'type' = 'cve'
     ORDER BY av.vulnerability_id, a.modified DESC NULLS LAST
 ) best
-WHERE best.vulnerability_id = vulnerability.id
-  AND vulnerability.base_score IS NOT NULL;
+WHERE best.vulnerability_id = vulnerability.id;
 ```
 
 ### Optional `scores` query parameter on `GET /api/v3/vulnerability/{id}`
@@ -80,7 +80,9 @@ A new `scores` boolean query parameter is added to the vulnerability detail endp
 authoritative advisory (the one identified by `authoritative_advisory_id`).
 
 When `scores` is omitted or `false`, the `scores` field is absent from the response entirely.
-When `scores=true` but no authoritative advisory is linked, the field is explicitly `null`.
+When `scores=true` but no authoritative advisory is linked (non-CVE vulnerabilities), the field is
+explicitly `null`. When the authoritative advisory exists but carries no CVSS scores, the field is
+an empty array (`[]`).
 
 No additional database queries are needed — the scores for all advisories of the vulnerability
 are already fetched in `VulnerabilityDetails::from_entity`. The authoritative scores are simply
@@ -118,7 +120,7 @@ ADR builds on that foundation:
 
 * The `vulnerability` table gains a new nullable column and composite FK. The FK references a
   composite unique key on `advisory_vulnerability`, ensuring referential integrity.
-* CVE ingestion performs one additional UPDATE per vulnerability (only when `base_score` is set).
+* CVE ingestion performs one additional UPDATE per vulnerability to set `authoritative_advisory_id`.
   This is a single-row update by primary key and has negligible performance impact.
 * Non-CVE ingestors (CSAF, OSV) are unaffected — they do not set `authoritative_advisory_id`.
 * The `scores` query parameter is opt-in. Existing clients see no change in the default response

--- a/docs/adrs/00015-authoritative-advisory-scores.md
+++ b/docs/adrs/00015-authoritative-advisory-scores.md
@@ -47,10 +47,9 @@ row is deleted — the vulnerability's primary key `id` is never affected.
 
 ### Ingestion-time linking
 
-The `authoritative_advisory_id` is set during CVE ingestion only. `VulnerabilityCreator::create`
-reports which vulnerabilities received a `base_score`, and the CVE loader uses this to issue a
-separate `UPDATE` setting `authoritative_advisory_id`. Non-CVE ingestors (CSAF, OSV) never touch
-this column.
+The `authoritative_advisory_id` is set during CVE ingestion only. The CVE loader checks whether the
+ingested record contributed a `base_score` and, if so, issues a separate `UPDATE` setting
+`authoritative_advisory_id`. Non-CVE ingestors (CSAF, OSV) never touch this column.
 
 ### Migration backfill
 
@@ -80,9 +79,8 @@ A new `scores` boolean query parameter is added to the vulnerability detail endp
 `true`, the response includes a `scores` array containing all `ScoredVector` entries from the
 authoritative advisory (the one identified by `authoritative_advisory_id`).
 
-When `scores` is omitted or `false`, the `scores` field is absent from the response entirely
-(via `skip_serializing_if`). When `scores=true` but no authoritative advisory is linked, the
-field is `null`.
+When `scores` is omitted or `false`, the `scores` field is absent from the response entirely.
+When `scores=true` but no authoritative advisory is linked, the field is explicitly `null`.
 
 No additional database queries are needed — the scores for all advisories of the vulnerability
 are already fetched in `VulnerabilityDetails::from_entity`. The authoritative scores are simply

--- a/docs/adrs/00015-authoritative-advisory-scores.md
+++ b/docs/adrs/00015-authoritative-advisory-scores.md
@@ -1,0 +1,129 @@
+# 00015. Link vulnerability to its authoritative advisory and expose full scores on demand
+
+Date: 2026-04-15
+
+## Status
+
+ACCEPTED
+
+## Context
+
+[ADR 00014](00014-advisory-vulnerability-scores.md) replaced average score fields with structured
+score lists on advisory and vulnerability endpoints. Each vulnerability now carries a `base_score`
+(type, score, severity) derived from the best available CVSS score during CVE ingestion.
+
+However, `base_score` only stores the single best score. Clients that need the full set of CVSS
+scores from the authoritative source (the CVE advisory that contributed the base score) cannot
+retrieve them without scanning all linked advisories and guessing which one is authoritative. This
+is both fragile and inefficient.
+
+Additionally, the vulnerability table had no persistent link to the advisory that contributed its
+base score. The relationship only existed implicitly: the CVE loader set `base_score` /
+`base_type` / `base_severity` columns but did not record which advisory provided them.
+
+## Decision
+
+### New column: `authoritative_advisory_id`
+
+A nullable `authoritative_advisory_id UUID` column is added to the `vulnerability` table. Together
+with the vulnerability's own `id`, it forms a composite foreign key referencing
+`advisory_vulnerability(advisory_id, vulnerability_id)`:
+
+```sql
+ALTER TABLE vulnerability
+    ADD CONSTRAINT fk_vulnerability_authoritative_advisory
+    FOREIGN KEY (authoritative_advisory_id, id)
+    REFERENCES advisory_vulnerability(advisory_id, vulnerability_id)
+    ON DELETE SET NULL (authoritative_advisory_id);
+```
+
+The composite FK is used instead of a simple FK to `advisory` because scores are stored per
+(advisory, vulnerability) pair in `advisory_vulnerability_score`, not per advisory alone. The
+composite FK guarantees that the referenced advisory-vulnerability relationship actually exists.
+
+The `ON DELETE SET NULL (authoritative_advisory_id)` clause uses the PG15+ column-list syntax so
+that only `authoritative_advisory_id` is set to NULL when the referenced `advisory_vulnerability`
+row is deleted — the vulnerability's primary key `id` is never affected.
+
+### Ingestion-time linking
+
+The `authoritative_advisory_id` is set during CVE ingestion only. `VulnerabilityCreator::create`
+reports which vulnerabilities received a `base_score`, and the CVE loader uses this to issue a
+separate `UPDATE` setting `authoritative_advisory_id`. Non-CVE ingestors (CSAF, OSV) never touch
+this column.
+
+### Migration backfill
+
+Existing data is backfilled during migration using the `type=cve` advisory label. When multiple
+CVE advisories exist for the same vulnerability, the most recently modified one is chosen via
+`DISTINCT ON ... ORDER BY modified DESC NULLS LAST`:
+
+```sql
+UPDATE vulnerability
+SET authoritative_advisory_id = best.advisory_id
+FROM (
+    SELECT DISTINCT ON (av.vulnerability_id)
+           av.vulnerability_id,
+           a.id AS advisory_id
+    FROM advisory a
+    JOIN advisory_vulnerability av ON a.id = av.advisory_id
+    WHERE a.labels->>'type' = 'cve'
+    ORDER BY av.vulnerability_id, a.modified DESC NULLS LAST
+) best
+WHERE best.vulnerability_id = vulnerability.id
+  AND vulnerability.base_score IS NOT NULL;
+```
+
+### Optional `scores` query parameter on `GET /api/v3/vulnerability/{id}`
+
+A new `scores` boolean query parameter is added to the vulnerability detail endpoint. When set to
+`true`, the response includes a `scores` array containing all `ScoredVector` entries from the
+authoritative advisory (the one identified by `authoritative_advisory_id`).
+
+When `scores` is omitted or `false`, the `scores` field is absent from the response entirely
+(via `skip_serializing_if`). When `scores=true` but no authoritative advisory is linked, the
+field is `null`.
+
+No additional database queries are needed — the scores for all advisories of the vulnerability
+are already fetched in `VulnerabilityDetails::from_entity`. The authoritative scores are simply
+filtered from the existing result set using `authoritative_advisory_id`.
+
+#### Example
+
+`GET /api/v3/vulnerability/CVE-2023-1234?scores=true`
+
+```json
+{
+  "identifier": "CVE-2023-1234",
+  "base_score": { "type": "3.1", "score": 9.8, "severity": "critical" },
+  "scores": [
+    { "type": "3.1", "value": 9.8, "severity": "critical", "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" },
+    { "type": "2.0", "value": 10.0, "severity": "high", "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C" }
+  ],
+  "advisories": [...]
+}
+```
+
+### Relationship to ADR 00014
+
+ADR 00014 introduced `base_score` on `VulnerabilityHead` and removed legacy average fields. This
+ADR builds on that foundation:
+
+* `base_score` remains the primary score indicator (unchanged).
+* `authoritative_advisory_id` records *which* advisory contributed the `base_score`, making the
+  relationship explicit and queryable.
+* The `scores` parameter provides access to the full score list from that same advisory, giving
+  clients the complete CVSS picture (all versions, all vectors) without requiring them to iterate
+  over all advisories.
+
+## Consequences
+
+* The `vulnerability` table gains a new nullable column and composite FK. The FK references a
+  composite unique key on `advisory_vulnerability`, ensuring referential integrity.
+* CVE ingestion performs one additional UPDATE per vulnerability (only when `base_score` is set).
+  This is a single-row update by primary key and has negligible performance impact.
+* Non-CVE ingestors (CSAF, OSV) are unaffected — they do not set `authoritative_advisory_id`.
+* The `scores` query parameter is opt-in. Existing clients see no change in the default response
+  shape. The field is only serialized when explicitly requested.
+* Requires PostgreSQL 15+ for the `ON DELETE SET NULL (column_list)` syntax. The project already
+  targets PostgreSQL 17.2, so this is not a new constraint.

--- a/entity/src/vulnerability.rs
+++ b/entity/src/vulnerability.rs
@@ -19,6 +19,9 @@ pub struct Model {
     pub base_score: Option<f64>,
     pub base_severity: Option<Severity>,
     pub base_type: Option<ScoreType>,
+    /// The advisory that contributed the base score for this vulnerability.
+    /// Together with `id`, forms a composite FK to advisory_vulnerability(advisory_id, vulnerability_id).
+    pub authoritative_advisory_id: Option<Uuid>,
     /// Generated column for sorting vulnerability IDs with proper numeric ordering
     /// This is a STORED generated column in the database and should not be set during insert/update
     /// Nullable to support LEFT JOIN queries where the vulnerability may not exist

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -57,6 +57,7 @@ mod m0002150_fix_advisory_labels_index;
 mod m0002160_fix_ref_fk;
 mod m0002170_drop_cvss_tables;
 mod m0002180_advisory_fk_indexes;
+mod m0002190_vulnerability_base_score_advisory;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -130,6 +131,7 @@ impl MigratorExt for Migrator {
             .normal(m0002160_fix_ref_fk::Migration)
             .normal(m0002170_drop_cvss_tables::Migration)
             .normal(m0002180_advisory_fk_indexes::Migration)
+            .normal(m0002190_vulnerability_base_score_advisory::Migration)
     }
 }
 

--- a/migration/src/m0002190_vulnerability_base_score_advisory.rs
+++ b/migration/src/m0002190_vulnerability_base_score_advisory.rs
@@ -1,0 +1,77 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Add the nullable column for linking the vulnerability to its authoritative advisory
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Vulnerability::Table)
+                    .add_column(ColumnDef::new(Vulnerability::AuthoritativeAdvisoryId).uuid())
+                    .to_owned(),
+            )
+            .await?;
+
+        // Add a composite FK referencing advisory_vulnerability(advisory_id, vulnerability_id).
+        // Uses ON DELETE SET NULL (authoritative_advisory_id) so only the advisory reference
+        // is cleared when the advisory_vulnerability row is removed, not the vulnerability PK.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE vulnerability
+                    ADD CONSTRAINT fk_vulnerability_authoritative_advisory
+                    FOREIGN KEY (authoritative_advisory_id, id)
+                    REFERENCES advisory_vulnerability(advisory_id, vulnerability_id)
+                    ON DELETE SET NULL (authoritative_advisory_id);
+                "#,
+            )
+            .await
+            .map(|_| ())?;
+
+        // Backfill existing CVE advisory references
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0002190_vulnerability_base_score_advisory/up.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE vulnerability
+                    DROP CONSTRAINT IF EXISTS fk_vulnerability_authoritative_advisory;
+                "#,
+            )
+            .await
+            .map(|_| ())?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Vulnerability::Table)
+                    .drop_column(Vulnerability::AuthoritativeAdvisoryId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Vulnerability {
+    Table,
+    AuthoritativeAdvisoryId,
+}

--- a/migration/src/m0002190_vulnerability_base_score_advisory/up.sql
+++ b/migration/src/m0002190_vulnerability_base_score_advisory/up.sql
@@ -1,6 +1,7 @@
--- Backfill authoritative_advisory_id from the CVE advisory that contributed
--- the base_score.  When multiple CVE advisories exist for the same
--- vulnerability, pick the most recently modified one.
+-- Backfill authoritative_advisory_id from the CVE advisory.  A CVE advisory
+-- is always the authoritative source for its vulnerability, regardless of
+-- whether it carries CVSS scores.  When multiple CVE advisories exist for the
+-- same vulnerability, pick the most recently modified one.
 UPDATE vulnerability
 SET authoritative_advisory_id = best.advisory_id
 FROM (
@@ -12,5 +13,4 @@ FROM (
     WHERE a.labels->>'type' = 'cve'
     ORDER BY av.vulnerability_id, a.modified DESC NULLS LAST
 ) best
-WHERE best.vulnerability_id = vulnerability.id
-  AND vulnerability.base_score IS NOT NULL;
+WHERE best.vulnerability_id = vulnerability.id;

--- a/migration/src/m0002190_vulnerability_base_score_advisory/up.sql
+++ b/migration/src/m0002190_vulnerability_base_score_advisory/up.sql
@@ -1,0 +1,16 @@
+-- Backfill authoritative_advisory_id from the CVE advisory that contributed
+-- the base_score.  When multiple CVE advisories exist for the same
+-- vulnerability, pick the most recently modified one.
+UPDATE vulnerability
+SET authoritative_advisory_id = best.advisory_id
+FROM (
+    SELECT DISTINCT ON (av.vulnerability_id)
+           av.vulnerability_id,
+           a.id AS advisory_id
+    FROM advisory a
+    JOIN advisory_vulnerability av ON a.id = av.advisory_id
+    WHERE a.labels->>'type' = 'cve'
+    ORDER BY av.vulnerability_id, a.modified DESC NULLS LAST
+) best
+WHERE best.vulnerability_id = vulnerability.id
+  AND vulnerability.base_score IS NOT NULL;

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -250,6 +250,7 @@ impl PurlAdvisory {
                 base_type: None,
                 base_severity: None,
                 base_score: None,
+                authoritative_advisory_id: None,
                 id_sort_key: None, // Fallback only; normally loaded from database
             });
 

--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -22,6 +22,14 @@ use trustify_common::{
 };
 use trustify_query::TrustifyQuery;
 use trustify_query_derive::Query;
+use utoipa::IntoParams;
+
+#[derive(Clone, Debug, PartialEq, Eq, Default, serde::Deserialize, IntoParams)]
+pub struct VulnerabilityGetParams {
+    /// Include the full scores array from the advisory that contributed the base_score.
+    #[serde(default)]
+    pub scores: bool,
+}
 
 pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, db: Database) {
     let service = VulnerabilityService::new();
@@ -81,7 +89,8 @@ pub async fn all(
     tag = "vulnerability",
     operation_id = "getVulnerability",
     params(
-        ("id", Path, description = "ID of the vulnerability")
+        ("id", Path, description = "ID of the vulnerability"),
+        VulnerabilityGetParams,
     ),
     responses(
         (status = 200, description = "Specified vulnerability", body = VulnerabilityDetails),
@@ -95,10 +104,13 @@ pub async fn get(
     db: web::Data<Database>,
     id: web::Path<String>,
     web::Query(Deprecation { deprecated }): web::Query<Deprecation>,
+    web::Query(VulnerabilityGetParams { scores }): web::Query<VulnerabilityGetParams>,
     _: Require<ReadAdvisory>,
 ) -> actix_web::Result<impl Responder> {
     let tx = db.begin_read().await?;
-    let vuln = state.fetch_vulnerability(&id, deprecated, &tx).await?;
+    let vuln = state
+        .fetch_vulnerability(&id, deprecated, scores, &tx)
+        .await?;
     if let Some(vuln) = vuln {
         Ok(HttpResponse::Ok().json(vuln))
     } else {

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -253,11 +253,11 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     "CVE-2021-32714",
     json!([{"type": "3.1", "value": 5.9, "severity": "medium", "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"}]),
 )]
-// CVE without CVSS scores — no authoritative advisory, scores is null
+// CVE without CVSS scores — authoritative advisory exists but has no scores
 #[case::cve_without_scores(
     &["cve/CVE-2024-26308.json"],
     "CVE-2024-26308",
-    json!(null),
+    json!([]),
 )]
 // Re-ingesting CVE that gains scores — scores reflect the updated advisory
 #[case::cve_reingestion(
@@ -287,17 +287,12 @@ async fn vulnerability_scores_param(
         without.get("scores").is_none(),
         "scores field must be absent when not requested"
     );
-    // then: scores field must always be present when requested (null or array, never absent)
+    // then: scores field must always be present when requested (null, empty, or array)
     assert_eq!(with["scores"], expected_scores);
-    if expected_scores.is_null() {
-        assert_eq!(
-            with.get("scores"),
-            Some(&Value::Null),
-            "scores field must be explicit null, not absent"
-        );
-    } else {
-        assert!(with.get("scores").is_some());
-    }
+    assert!(
+        with.get("scores").is_some(),
+        "scores field must be present when requested"
+    );
 
     Ok(())
 }

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -282,9 +282,22 @@ async fn vulnerability_scores_param(
     let with =
         get_vulnerability(ctx, &format!("/api/v3/vulnerability/{vuln_id}?scores=true")).await?;
 
-    // then: scores absent by default, present with expected value when requested
-    assert_eq!(without["scores"], Value::Null);
+    // then: scores field must be absent when not requested
+    assert!(
+        without.get("scores").is_none(),
+        "scores field must be absent when not requested"
+    );
+    // then: scores field must always be present when requested (null or array, never absent)
     assert_eq!(with["scores"], expected_scores);
+    if expected_scores.is_null() {
+        assert_eq!(
+            with.get("scores"),
+            Some(&Value::Null),
+            "scores field must be explicit null, not absent"
+        );
+    } else {
+        assert!(with.get("scores").is_some());
+    }
 
     Ok(())
 }

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -1,32 +1,42 @@
 use crate::test::caller;
 use actix_web::test::TestRequest;
+use rstest::rstest;
 use serde_json::{Value, json};
 use test_context::test_context;
-use test_log::test;
 use time::{OffsetDateTime, macros::datetime};
 use trustify_common::hashing::Digests;
 use trustify_entity::advisory_vulnerability_score::{ScoreType, Severity};
 use trustify_module_ingestor::graph::{
-    advisory::AdvisoryInformation,
+    Outcome,
+    advisory::{AdvisoryContext, AdvisoryInformation},
     cvss::{ScoreCreator, ScoreInformation},
     vulnerability::{BaseScore as VulnBaseScore, VulnerabilityInformation},
 };
 use trustify_test_context::{TrustifyContext, call::CallService};
 
-#[test_context(TrustifyContext)]
-#[test(actix_web::test)]
-async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+/// Perform a GET request and return the parsed JSON response.
+async fn get_vulnerability(ctx: &TrustifyContext, uri: &str) -> Result<Value, anyhow::Error> {
     let app = caller(ctx).await?;
+    Ok(app
+        .call_and_read_body_json(TestRequest::get().uri(uri).to_request())
+        .await)
+}
 
-    let advisory = ctx
+/// Ingest a minimal test advisory with only id, title, and published set.
+async fn ingest_test_advisory<'g>(
+    ctx: &'g TrustifyContext,
+    id: &str,
+    source: &str,
+) -> Result<Outcome<AdvisoryContext<'g>>, anyhow::Error> {
+    Ok(ctx
         .graph
         .ingest_advisory(
-            "CAPT-1",
-            ("source", "http://captpickles.com/"),
-            &Digests::digest("CAPT-1"),
+            id,
+            ("source", source),
+            &Digests::digest(id),
             AdvisoryInformation {
-                id: "CAPT-1".to_string(),
-                title: Some("CAPT-1".to_string()),
+                id: id.to_string(),
+                title: Some(id.to_string()),
                 version: None,
                 issuer: None,
                 published: Some(OffsetDateTime::now_utc()),
@@ -35,7 +45,13 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
             },
             &ctx.db,
         )
-        .await?;
+        .await?)
+}
+
+#[test_context(TrustifyContext)]
+#[test_log::test(actix_web::test)]
+async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let advisory = ingest_test_advisory(ctx, "CAPT-1", "http://captpickles.com/").await?;
 
     let advisory_vuln = advisory
         .link_to_vulnerability("CVE-123", None, &ctx.db)
@@ -51,24 +67,7 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
     });
     creator.create(&ctx.db).await?;
 
-    let advisory = ctx
-        .graph
-        .ingest_advisory(
-            "RHSA-2",
-            ("source", "http://redhat.com/"),
-            &Digests::digest("RHSA-2"),
-            AdvisoryInformation {
-                id: "RHSA-2".to_string(),
-                title: Some("RHSA-2".to_string()),
-                version: None,
-                issuer: None,
-                published: Some(OffsetDateTime::now_utc()),
-                modified: None,
-                withdrawn: None,
-            },
-            &ctx.db,
-        )
-        .await?;
+    let advisory = ingest_test_advisory(ctx, "RHSA-2", "http://redhat.com/").await?;
 
     advisory
         .link_to_vulnerability("CVE-345", None, &ctx.db)
@@ -92,11 +91,7 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
         .ingest_vulnerability("CVE-345", VulnerabilityInformation::default(), &ctx.db)
         .await?;
 
-    let uri = "/api/v3/vulnerability";
-
-    let request = TestRequest::get().uri(uri).to_request();
-
-    let response: Value = app.call_and_read_body_json(request).await;
+    let response = get_vulnerability(ctx, "/api/v3/vulnerability").await?;
 
     log::debug!("{response:#?}");
 
@@ -134,12 +129,10 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
 }
 
 #[test_context(TrustifyContext)]
-#[test(actix_web::test)]
+#[test_log::test(actix_web::test)]
 /// Verifies that `base_score` is present at the top level of the vulnerability detail response
 /// when it has been ingested, using the same type/score/severity shape as the list endpoint.
 async fn one_vulnerability_with_base_score(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let app = caller(ctx).await?;
-
     ctx.graph
         .ingest_vulnerability(
             "CVE-999",
@@ -155,13 +148,7 @@ async fn one_vulnerability_with_base_score(ctx: &TrustifyContext) -> Result<(), 
         )
         .await?;
 
-    let vuln: Value = app
-        .call_and_read_body_json(
-            TestRequest::get()
-                .uri("/api/v3/vulnerability/CVE-999")
-                .to_request(),
-        )
-        .await;
+    let vuln = get_vulnerability(ctx, "/api/v3/vulnerability/CVE-999").await?;
 
     assert_eq!(
         vuln["base_score"],
@@ -172,28 +159,9 @@ async fn one_vulnerability_with_base_score(ctx: &TrustifyContext) -> Result<(), 
 }
 
 #[test_context(TrustifyContext)]
-#[test(actix_web::test)]
+#[test_log::test(actix_web::test)]
 async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let app = caller(ctx).await?;
-
-    let advisory = ctx
-        .graph
-        .ingest_advisory(
-            "RHSA-1",
-            ("source", "http://redhat.com/"),
-            &Digests::digest("RHSA-1"),
-            AdvisoryInformation {
-                id: "RHSA-1".to_string(),
-                title: Some("RHSA-1".to_string()),
-                version: None,
-                issuer: None,
-                published: Some(OffsetDateTime::now_utc()),
-                modified: None,
-                withdrawn: None,
-            },
-            &ctx.db,
-        )
-        .await?;
+    let advisory = ingest_test_advisory(ctx, "RHSA-1", "http://redhat.com/").await?;
 
     let advisory_vuln = advisory
         .link_to_vulnerability("CVE-123", None, &ctx.db)
@@ -209,24 +177,7 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     });
     creator.create(&ctx.db).await?;
 
-    let advisory = ctx
-        .graph
-        .ingest_advisory(
-            "RHSA-2",
-            ("source", "http://redhat.com/"),
-            &Digests::digest("RHSA-2"),
-            AdvisoryInformation {
-                id: "RHSA-2".to_string(),
-                title: Some("RHSA-2".to_string()),
-                version: None,
-                issuer: None,
-                published: Some(OffsetDateTime::now_utc()),
-                modified: None,
-                withdrawn: None,
-            },
-            &ctx.db,
-        )
-        .await?;
+    let advisory = ingest_test_advisory(ctx, "RHSA-2", "http://redhat.com/").await?;
 
     advisory
         .link_to_vulnerability("CVE-345", None, &ctx.db)
@@ -248,9 +199,7 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let uri = "/api/v3/vulnerability/CVE-123";
-    let request = TestRequest::get().uri(uri).to_request();
-    let vuln: Value = app.call_and_read_body_json(request).await;
+    let vuln = get_vulnerability(ctx, "/api/v3/vulnerability/CVE-123").await?;
     log::debug!("{vuln:#?}");
 
     assert_eq!(vuln["identifier"], "CVE-123");
@@ -277,20 +226,76 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Verifies that `scores` is absent by default and returns the correct values with `?scores=true`.
 #[test_context(TrustifyContext)]
-#[test(actix_web::test)]
-async fn get_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+#[rstest]
+// CVE with CNA CVSS v3.1 score
+#[case::cve_only(
+    &["cve/CVE-2024-29025.json"],
+    "CVE-2024-29025",
+    json!([{"type": "3.1", "value": 5.3, "severity": "medium", "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}]),
+)]
+// CSAF after CVE — scores still from CVE advisory
+#[case::csaf_after_cve(
+    &["cve/CVE-2024-29025.json", "csaf/rhsa-2024-2705.json"],
+    "CVE-2024-29025",
+    json!([{"type": "3.1", "value": 5.3, "severity": "medium", "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}]),
+)]
+// CSAF before CVE — CVE still becomes authoritative
+#[case::csaf_before_cve(
+    &["csaf/rhsa-2024-2705.json", "cve/CVE-2024-29025.json"],
+    "CVE-2024-29025",
+    json!([{"type": "3.1", "value": 5.3, "severity": "medium", "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}]),
+)]
+// OSV after CVE — scores still from CVE advisory
+#[case::osv_after_cve(
+    &["cve/CVE-2021-32714.json", "osv/RUSTSEC-2021-0079.json"],
+    "CVE-2021-32714",
+    json!([{"type": "3.1", "value": 5.9, "severity": "medium", "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"}]),
+)]
+// CVE without CVSS scores — no authoritative advisory, scores is null
+#[case::cve_without_scores(
+    &["cve/CVE-2024-26308.json"],
+    "CVE-2024-26308",
+    json!(null),
+)]
+// Re-ingesting CVE that gains scores — scores reflect the updated advisory
+#[case::cve_reingestion(
+    &["cve/CVE-2024-26308.json", "cve/CVE-2024-26308-updated.json"],
+    "CVE-2024-26308",
+    json!([{"type": "3.1", "value": 5.5, "severity": "medium", "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"}]),
+)]
+#[test_log::test(actix_web::test)]
+async fn vulnerability_scores_param(
+    ctx: &TrustifyContext,
+    #[case] docs: impl IntoIterator<Item = impl AsRef<str>>,
+    #[case] vuln_id: &str,
+    #[case] expected_scores: Value,
+) -> Result<(), anyhow::Error> {
+    // given: documents are ingested
+    for doc in docs {
+        ctx.ingest_documents([doc.as_ref()]).await?;
+    }
+
+    // when: the vulnerability is fetched via the API
+    let without = get_vulnerability(ctx, &format!("/api/v3/vulnerability/{vuln_id}")).await?;
+    let with =
+        get_vulnerability(ctx, &format!("/api/v3/vulnerability/{vuln_id}?scores=true")).await?;
+
+    // then: scores absent by default, present with expected value when requested
+    assert_eq!(without["scores"], Value::Null);
+    assert_eq!(with["scores"], expected_scores);
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test_log::test(actix_web::test)]
+async fn get_vulnerability_and_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["cve/CVE-2024-26308.json", "spdx/SATELLITE-6.15-RHEL-8.json"])
         .await?;
 
-    let app = caller(ctx).await?;
-    let vuln: Value = app
-        .call_and_read_body_json(
-            TestRequest::get()
-                .uri("/api/v3/vulnerability/CVE-2024-26308")
-                .to_request(),
-        )
-        .await;
+    let vuln = get_vulnerability(ctx, "/api/v3/vulnerability/CVE-2024-26308").await?;
 
     log::debug!("{vuln:#?}");
 
@@ -301,6 +306,60 @@ async fn get_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         vuln["advisories"][0]["sboms"][0]["number_of_packages"],
         2084
     );
+
+    Ok(())
+}
+
+/// Verifies that base_score reflects the CVE's CVSS data regardless of ingestion order.
+#[test_context(TrustifyContext)]
+#[rstest]
+// CVE with CVSS scores only
+#[case::cve_only(
+    &["cve/CVE-2024-29025.json"],
+    "CVE-2024-29025",
+    json!({"type": "3.1", "score": 5.3, "severity": "medium"}),
+)]
+// CSAF ingested after CVE must not alter base_score
+#[case::csaf_after_cve(
+    &["cve/CVE-2024-29025.json", "csaf/rhsa-2024-2705.json"],
+    "CVE-2024-29025",
+    json!({"type": "3.1", "score": 5.3, "severity": "medium"}),
+)]
+// CSAF ingested before CVE — CVE still sets base_score
+#[case::csaf_before_cve(
+    &["csaf/rhsa-2024-2705.json", "cve/CVE-2024-29025.json"],
+    "CVE-2024-29025",
+    json!({"type": "3.1", "score": 5.3, "severity": "medium"}),
+)]
+// OSV ingested after CVE must not alter base_score
+#[case::osv_after_cve(
+    &["cve/CVE-2021-32714.json", "osv/RUSTSEC-2021-0079.json"],
+    "CVE-2021-32714",
+    json!({"type": "3.1", "score": 5.9, "severity": "medium"}),
+)]
+// CVE without CVSS scores — base_score must be null
+#[case::cve_without_scores(
+    &["cve/CVE-2024-26308.json"],
+    "CVE-2024-26308",
+    json!(null),
+)]
+#[test_log::test(actix_web::test)]
+async fn base_score_after_ingestion(
+    ctx: &TrustifyContext,
+    #[case] docs: impl IntoIterator<Item = impl AsRef<str>>,
+    #[case] vuln_id: &str,
+    #[case] expected_base_score: Value,
+) -> Result<(), anyhow::Error> {
+    // given: documents are ingested
+    for doc in docs {
+        ctx.ingest_document(doc.as_ref()).await?;
+    }
+
+    // when: the vulnerability is fetched via the API
+    let vuln = get_vulnerability(ctx, &format!("/api/v3/vulnerability/{vuln_id}")).await?;
+
+    // then: base_score matches the expected value
+    assert_eq!(vuln["base_score"], expected_base_score);
 
     Ok(())
 }

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -3,11 +3,15 @@ mod vulnerability_advisory;
 pub use vulnerability_advisory::*;
 
 use crate::{Error, common::model::ScoredVector, vulnerability::model::VulnerabilityHead};
+use isx::IsDefault;
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, ModelTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
 use tracing::{info_span, instrument};
 use tracing_futures::Instrument;
-use trustify_common::memo::Memo;
+use trustify_common::{
+    memo::Memo,
+    requested_field::{BoolRequestedField, RequestedField},
+};
 use trustify_entity::{advisory_vulnerability, advisory_vulnerability_score, vulnerability};
 use trustify_module_ingestor::common::{Deprecation, DeprecationForExt};
 use utoipa::ToSchema;
@@ -22,8 +26,8 @@ pub struct VulnerabilityDetails {
 
     /// Full CVSS scores from the authoritative advisory (the one that contributed the base_score).
     /// Only present when the `scores` query parameter is set to `true`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub scores: Option<Vec<ScoredVector>>,
+    #[serde(default, skip_serializing_if = "IsDefault::is_default")]
+    pub scores: RequestedField<Vec<ScoredVector>>,
 }
 
 impl VulnerabilityDetails {
@@ -54,18 +58,16 @@ impl VulnerabilityDetails {
             .await?;
 
         // Extract scores from the authoritative advisory when requested.
-        let authoritative_scores = if include_scores {
+        let authoritative_scores = include_scores.then_requested(|| {
             vulnerability.authoritative_advisory_id.map(|advisory_id| {
                 scores
                     .iter()
                     .filter(|s| s.advisory_id == advisory_id)
                     .cloned()
                     .map(ScoredVector::from)
-                    .collect::<Vec<_>>()
+                    .collect()
             })
-        } else {
-            None
-        };
+        });
 
         let advisories = VulnerabilityAdvisorySummary::from_entities(
             vulnerability,

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -2,7 +2,7 @@ mod vulnerability_advisory;
 
 pub use vulnerability_advisory::*;
 
-use crate::{Error, vulnerability::model::VulnerabilityHead};
+use crate::{Error, common::model::ScoredVector, vulnerability::model::VulnerabilityHead};
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, ModelTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
 use tracing::{info_span, instrument};
@@ -19,6 +19,11 @@ pub struct VulnerabilityDetails {
 
     /// Advisories addressing this vulnerability, if any.
     pub advisories: Vec<VulnerabilityAdvisorySummary>,
+
+    /// Full CVSS scores from the authoritative advisory (the one that contributed the base_score).
+    /// Only present when the `scores` query parameter is set to `true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scores: Option<Vec<ScoredVector>>,
 }
 
 impl VulnerabilityDetails {
@@ -32,6 +37,7 @@ impl VulnerabilityDetails {
     pub async fn from_entity<C: ConnectionTrait>(
         vulnerability: &vulnerability::Model,
         deprecation: Deprecation,
+        include_scores: bool,
         tx: &C,
     ) -> Result<Self, Error> {
         let advisory_vulnerabilities = vulnerability
@@ -46,6 +52,20 @@ impl VulnerabilityDetails {
             .all(tx)
             .instrument(info_span!("find scores"))
             .await?;
+
+        // Extract scores from the authoritative advisory when requested.
+        let authoritative_scores = if include_scores {
+            vulnerability.authoritative_advisory_id.map(|advisory_id| {
+                scores
+                    .iter()
+                    .filter(|s| s.advisory_id == advisory_id)
+                    .cloned()
+                    .map(ScoredVector::from)
+                    .collect::<Vec<_>>()
+            })
+        } else {
+            None
+        };
 
         let advisories = VulnerabilityAdvisorySummary::from_entities(
             vulnerability,
@@ -63,6 +83,7 @@ impl VulnerabilityDetails {
             )
             .await?,
             advisories,
+            scores: authoritative_scores,
         })
     }
 }

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -103,6 +103,7 @@ impl VulnerabilityService {
         &self,
         identifier: &str,
         deprecation: Deprecation,
+        include_scores: bool,
         connection: &C,
     ) -> Result<Option<VulnerabilityDetails>, Error> {
         if let Some(vulnerability) = vulnerability::Entity::find_by_id(identifier)
@@ -110,7 +111,13 @@ impl VulnerabilityService {
             .await?
         {
             Ok(Some(
-                VulnerabilityDetails::from_entity(&vulnerability, deprecation, connection).await?,
+                VulnerabilityDetails::from_entity(
+                    &vulnerability,
+                    deprecation,
+                    include_scores,
+                    connection,
+                )
+                .await?,
             ))
         } else {
             Ok(None)

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -58,7 +58,7 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await?;
 
     let vuln = service
-        .fetch_vulnerability("CVE-2021-32714", Default::default(), &ctx.db)
+        .fetch_vulnerability("CVE-2021-32714", Default::default(), false, &ctx.db)
         .await?;
 
     assert!(vuln.is_some());
@@ -109,7 +109,7 @@ async fn statuses_too(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     .await?;
 
     let vuln = service
-        .fetch_vulnerability("CVE-2024-29025", Default::default(), &ctx.db)
+        .fetch_vulnerability("CVE-2024-29025", Default::default(), false, &ctx.db)
         .await?;
 
     assert!(vuln.is_some());
@@ -179,7 +179,7 @@ async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert!(quarkus_sbom.advisories.is_empty());
 
     let vuln = vuln_service
-        .fetch_vulnerability("CVE-2024-26308", Default::default(), &ctx.db)
+        .fetch_vulnerability("CVE-2024-26308", Default::default(), false, &ctx.db)
         .await?
         .unwrap();
 
@@ -324,7 +324,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(quarkus_adv.packages[0].purl[0].head.purl, Purl::from_str("pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00004?repository_url=https://maven.repository.redhat.com/ga/&type=jar").unwrap());
 
     let vuln = vuln_service
-        .fetch_vulnerability("CVE-2023-0044", Default::default(), &ctx.db)
+        .fetch_vulnerability("CVE-2023-0044", Default::default(), false, &ctx.db)
         .await?;
 
     assert!(vuln.is_some());
@@ -401,7 +401,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     ctx.ingest_documents(["cve/CVE-2024-29025.json"]).await?;
 
     let vuln = service
-        .fetch_vulnerability("CVE-2024-29025", Default::default(), &ctx.db)
+        .fetch_vulnerability("CVE-2024-29025", Default::default(), false, &ctx.db)
         .await?
         .expect("Vulnerability not found");
 
@@ -414,7 +414,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
 
     assert!(
         service
-            .fetch_vulnerability("CVE-2024-29025", Default::default(), &ctx.db)
+            .fetch_vulnerability("CVE-2024-29025", Default::default(), false, &ctx.db)
             .await?
             .is_none()
     );

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -45,7 +45,7 @@ async fn simple(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2023-33201", Deprecation::Consider, &ctx.db)
+        .fetch_vulnerability("CVE-2023-33201", Deprecation::Consider, false, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -53,7 +53,7 @@ async fn simple(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2023-33201", Deprecation::Ignore, &ctx.db)
+        .fetch_vulnerability("CVE-2023-33201", Deprecation::Ignore, false, &ctx.db)
         .await?
         .expect("must exist");
 

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -36,7 +36,7 @@ async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2023-33201", Default::default(), &ctx.db)
+        .fetch_vulnerability("CVE-2023-33201", Default::default(), false, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -61,7 +61,7 @@ async fn change_ps_num_advisories(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2023-33201", Deprecation::Ignore, &ctx.db)
+        .fetch_vulnerability("CVE-2023-33201", Deprecation::Ignore, false, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -71,7 +71,7 @@ async fn change_ps_num_advisories(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2023-33201", Deprecation::Consider, &ctx.db)
+        .fetch_vulnerability("CVE-2023-33201", Deprecation::Consider, false, &ctx.db)
         .await?
         .expect("must exist");
 

--- a/modules/fundamental/tests/advisory/cve/delete.rs
+++ b/modules/fundamental/tests/advisory/cve/delete.rs
@@ -29,7 +29,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // check info
 
     let v = vuln
-        .fetch_vulnerability("CVE-2021-32714", Deprecation::Ignore, &ctx.db)
+        .fetch_vulnerability("CVE-2021-32714", Deprecation::Ignore, false, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -42,7 +42,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // check with deprecated, should be the same result
 
     let v = vuln
-        .fetch_vulnerability("CVE-2021-32714", Deprecation::Consider, &ctx.db)
+        .fetch_vulnerability("CVE-2021-32714", Deprecation::Consider, false, &ctx.db)
         .await?
         .expect("must exist");
 

--- a/modules/fundamental/tests/advisory/cve/reingest.rs
+++ b/modules/fundamental/tests/advisory/cve/reingest.rs
@@ -19,7 +19,7 @@ async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2021-32714", Default::default(), &ctx.db)
+        .fetch_vulnerability("CVE-2021-32714", Default::default(), false, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -44,7 +44,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2021-32714", Deprecation::Ignore, &ctx.db)
+        .fetch_vulnerability("CVE-2021-32714", Deprecation::Ignore, false, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -58,7 +58,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2021-32714", Deprecation::Consider, &ctx.db)
+        .fetch_vulnerability("CVE-2021-32714", Deprecation::Consider, false, &ctx.db)
         .await?
         .expect("must exist");
 

--- a/modules/fundamental/tests/advisory/osv/delete.rs
+++ b/modules/fundamental/tests/advisory/osv/delete.rs
@@ -29,7 +29,7 @@ async fn fixed(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // check info
 
     let v = vuln
-        .fetch_vulnerability("CVE-2020-5238", Deprecation::Ignore, &ctx.db)
+        .fetch_vulnerability("CVE-2020-5238", Deprecation::Ignore, false, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -38,7 +38,7 @@ async fn fixed(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // check with deprecated, should be the same result
 
     let v = vuln
-        .fetch_vulnerability("CVE-2020-5238", Deprecation::Consider, &ctx.db)
+        .fetch_vulnerability("CVE-2020-5238", Deprecation::Consider, false, &ctx.db)
         .await?
         .expect("must exist");
 

--- a/modules/fundamental/tests/advisory/osv/reingest.rs
+++ b/modules/fundamental/tests/advisory/osv/reingest.rs
@@ -30,7 +30,7 @@ async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2020-5238", Default::default(), &ctx.db)
+        .fetch_vulnerability("CVE-2020-5238", Default::default(), false, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -55,7 +55,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2020-5238", Deprecation::Ignore, &ctx.db)
+        .fetch_vulnerability("CVE-2020-5238", Deprecation::Ignore, false, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -67,7 +67,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2020-5238", Deprecation::Consider, &ctx.db)
+        .fetch_vulnerability("CVE-2020-5238", Deprecation::Consider, false, &ctx.db)
         .await?
         .expect("must exist");
 

--- a/modules/ingestor/src/graph/vulnerability/creator.rs
+++ b/modules/ingestor/src/graph/vulnerability/creator.rs
@@ -41,7 +41,7 @@ impl VulnerabilityCreator {
             .or_insert(information);
     }
 
-    /// Create all collected vulnerabilities in batches
+    /// Create all collected vulnerabilities in batches.
     #[instrument(skip_all, fields(num = self.entries.len()), err(level=tracing::Level::INFO))]
     pub async fn create<C>(self, connection: &C) -> Result<(), Error>
     where
@@ -55,27 +55,26 @@ impl VulnerabilityCreator {
         let mut with_data = Vec::new();
         let mut without_data = Vec::new();
 
+        let model = |id, info| vulnerability::ActiveModel::from(IdAndInformation(id, info));
+
         for (identifier, information) in self.entries {
             if information.has_data() {
-                with_data.push((identifier, information));
+                with_data.push(model(identifier, information));
             } else {
-                without_data.push((identifier, information));
+                without_data.push(model(identifier, information));
             }
         }
 
         // Sort by identifier to ensure consistent lock acquisition order
-        with_data.sort_by(|a, b| a.0.cmp(&b.0));
-        without_data.sort_by(|a, b| a.0.cmp(&b.0));
+        let sort = |a: &vulnerability::ActiveModel, b: &vulnerability::ActiveModel| {
+            a.id.try_as_ref().cmp(&b.id.try_as_ref())
+        };
+        with_data.sort_by(sort);
+        without_data.sort_by(sort);
 
         // Batch insert vulnerabilities with data (DO UPDATE)
         if !with_data.is_empty() {
-            let models: Vec<_> = with_data
-                .into_iter()
-                .map(|(id, info)| IdAndInformation(id, info))
-                .map(vulnerability::ActiveModel::from)
-                .collect();
-
-            for batch in &models.chunked() {
+            for batch in &with_data.chunked() {
                 vulnerability::Entity::insert_many(batch)
                     .on_conflict(
                         OnConflict::columns([vulnerability::Column::Id])
@@ -99,13 +98,7 @@ impl VulnerabilityCreator {
 
         // Batch insert vulnerabilities without data (DO NOTHING)
         if !without_data.is_empty() {
-            let models: Vec<_> = without_data
-                .into_iter()
-                .map(|(id, info)| IdAndInformation(id, info))
-                .map(vulnerability::ActiveModel::from)
-                .collect();
-
-            for batch in &models.chunked() {
+            for batch in &without_data.chunked() {
                 vulnerability::Entity::insert_many(batch)
                     .on_conflict(OnConflict::new().do_nothing().to_owned())
                     .do_nothing()

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -20,7 +20,7 @@ use trustify_entity::{advisory, advisory_vulnerability, vulnerability, vulnerabi
 use uuid::Uuid;
 
 /// Base score as defined by [`VulnerabilityInformation::base_score`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BaseScore {
     pub r#type: ScoreType,
     pub score: f64,
@@ -67,6 +67,9 @@ impl From<IdAndInformation> for vulnerability::ActiveModel {
             base_type: Set(r#type),
             base_score: Set(score),
             base_severity: Set(severity),
+            // Set separately by the CVE loader after the advisory is created,
+            // so that non-CVE ingestors don't overwrite it with NULL.
+            authoritative_advisory_id: NotSet,
             id_sort_key: NotSet,
         }
     }

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -120,18 +120,16 @@ impl<'g> CveLoader<'g> {
         extract_scores(&cve, &mut score_creator);
         score_creator.create(tx).await?;
 
-        // Link the vulnerability to its authoritative advisory when the CVE
-        // record contributed a base_score.
-        if information.base_score.is_some() {
-            vulnerability::Entity::update_many()
-                .col_expr(
-                    vulnerability::Column::AuthoritativeAdvisoryId,
-                    Expr::value(advisory.advisory.id),
-                )
-                .filter(vulnerability::Column::Id.eq(id))
-                .exec(tx)
-                .await?;
-        }
+        // A CVE advisory is always the authoritative source for its vulnerability,
+        // regardless of whether it carries CVSS scores.
+        vulnerability::Entity::update_many()
+            .col_expr(
+                vulnerability::Column::AuthoritativeAdvisoryId,
+                Expr::value(advisory.advisory.id),
+            )
+            .filter(vulnerability::Column::Id.eq(id))
+            .exec(tx)
+            .await?;
 
         // Initialize batch creator for efficient status ingestion
         let mut purl_status_creator = PurlStatusCreator::new();

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -23,7 +23,8 @@ use cve::{
     Cve, Timestamp,
     common::{Description, Product, Status, VersionRange},
 };
-use sea_orm::{ConnectionTrait, TransactionTrait};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, TransactionTrait};
+use sea_query::Expr;
 use serde_json::Value;
 use std::str::FromStr;
 use std::{collections::HashSet, fmt::Debug};
@@ -31,7 +32,7 @@ use time::OffsetDateTime;
 use tracing::instrument;
 use trustify_common::hashing::Digests;
 use trustify_entity::advisory_vulnerability_score::{ScoreType, Severity};
-use trustify_entity::{labels::Labels, version_scheme::VersionScheme};
+use trustify_entity::{labels::Labels, version_scheme::VersionScheme, vulnerability};
 
 /// Loader capable of parsing a CVE Record JSON file
 /// and manipulating the Graph to integrate it into
@@ -118,6 +119,19 @@ impl<'g> CveLoader<'g> {
         let mut score_creator = ScoreCreator::new(advisory.advisory.id);
         extract_scores(&cve, &mut score_creator);
         score_creator.create(tx).await?;
+
+        // Link the vulnerability to its authoritative advisory when the CVE
+        // record contributed a base_score.
+        if information.base_score.is_some() {
+            vulnerability::Entity::update_many()
+                .col_expr(
+                    vulnerability::Column::AuthoritativeAdvisoryId,
+                    Expr::value(advisory.advisory.id),
+                )
+                .filter(vulnerability::Column::Id.eq(id))
+                .exec(tx)
+                .await?;
+        }
 
         // Initialize batch creator for efficient status ingestion
         let mut purl_status_creator = PurlStatusCreator::new();

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5712,6 +5712,29 @@ components:
           type: string
           format: date-time
           description: Start of the import run
+    RequestedField_Vec_Vec_ScoredVector:
+      oneOf:
+      - type: 'null'
+      - type: array
+        items:
+          allOf:
+          - $ref: '#/components/schemas/Score'
+            description: The score type, value, and derived severity.
+          - type: object
+            required:
+            - vector
+            properties:
+              vector:
+                type: string
+                description: The raw CVSS vector string (e.g. `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`).
+          description: |-
+            A CVSS score combined with its raw vector string, for contexts where clients need both
+            the pre-parsed numeric values and the original vector for display or re-parsing.
+          example:
+            type: '3.1'
+            value: 7.5
+            severity: high
+            vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     Revisioned_Importer:
       type: object
       description: |-
@@ -6293,11 +6316,7 @@ components:
               $ref: '#/components/schemas/VulnerabilityAdvisorySummary'
             description: Advisories addressing this vulnerability, if any.
           scores:
-            type:
-            - array
-            - 'null'
-            items:
-              $ref: '#/components/schemas/ScoredVector'
+            $ref: '#/components/schemas/RequestedField_Vec_Vec_ScoredVector'
             description: |-
               Full CVSS scores from the authoritative advisory (the one that contributed the base_score).
               Only present when the `scores` query parameter is set to `true`.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3773,6 +3773,12 @@ paths:
         required: true
         schema:
           type: string
+      - name: scores
+        in: query
+        description: Include the full scores array from the advisory that contributed the base_score.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: Specified vulnerability
@@ -6286,6 +6292,15 @@ components:
             items:
               $ref: '#/components/schemas/VulnerabilityAdvisorySummary'
             description: Advisories addressing this vulnerability, if any.
+          scores:
+            type:
+            - array
+            - 'null'
+            items:
+              $ref: '#/components/schemas/ScoredVector'
+            description: |-
+              Full CVSS scores from the authoritative advisory (the one that contributed the base_score).
+              Only present when the `scores` query parameter is set to `true`.
     VulnerabilityHead:
       type: object
       required:


### PR DESCRIPTION
We do store the "base score" for a vulnerability. However, we don't track which advisory this came from. This change adds a reference back to the advisory's vulnerability which provided that information.

Closes: https://github.com/guacsec/trustify/issues/2328
Also see: TC-4160

## Summary by Sourcery

Link vulnerabilities to an authoritative advisory for base scores and expose full CVSS scores from that advisory via an optional query parameter on the vulnerability detail endpoint.

New Features:
- Add an optional scores query parameter to the vulnerability detail API to return full CVSS scores from the authoritative advisory.
- Expose an optional scores field in vulnerability details containing full CVSS vectors from the advisory that contributed the base_score.
- Introduce a tri-state RequestedField wrapper to control when optional response fields are included in API responses.

Enhancements:
- Record the authoritative advisory for each vulnerability in the database and set it during CVE ingestion, including backfilling via a new migration.
- Ensure CVE advisories remain the authoritative source for base_score regardless of ingestion order or presence of scores.
- Refactor vulnerability creation batching for clearer sorting logic and reuse of ActiveModel construction.
- Improve vulnerability tests with shared helpers, rstest-based parameterized cases, and additional coverage around scores and base_score behavior.
- Document the authoritative advisory and scores design in a new ADR.

Documentation:
- Add ADR documenting the authoritative advisory linkage and on-demand exposure of full CVSS scores.

Tests:
- Add parameterized tests verifying vulnerability scores behavior with the scores query parameter and different advisory ingestion orders.
- Extend tests to assert base_score stability and authoritative advisory behavior under various ingestion and re-ingestion scenarios.