### PR TITLE
Improve API for better pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2668,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4492,10 +4513,13 @@ version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
+ "async-lock",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
+ "event-listener",
+ "futures-util",
  "parking_lot",
  "portable-atomic",
  "smallvec",
@@ -8429,7 +8453,9 @@ dependencies = [
  "lenient_semver",
  "log",
  "lzma-rust2",
+ "moka",
  "native-tls",
+ "opentelemetry",
  "packageurl",
  "pem",
  "rand 0.10.1",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -26,7 +26,9 @@ itertools = { workspace = true }
 lenient_semver = { workspace = true }
 log = { workspace = true }
 lzma-rust2 = { workspace = true }
+moka = { workspace = true, features = ["future"] }
 native-tls = { workspace = true }
+opentelemetry = { workspace = true, features = ["metrics"] }
 packageurl = { workspace = true }
 pem = { workspace = true }
 regex = { workspace = true }

--- a/common/src/db/limiter.rs
+++ b/common/src/db/limiter.rs
@@ -1,81 +1,147 @@
 use crate::{
-    db::multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
+    db::{
+        multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
+        pagination_cache::PaginationCache,
+    },
     model::Paginated,
 };
 use sea_orm::{
     ConnectionTrait, DbErr, EntityTrait, FromQueryResult, Paginator, PaginatorTrait, QuerySelect,
-    Select, SelectModel, SelectThree, SelectThreeModel, SelectTwo, SelectTwoModel, Selector,
-    SelectorTrait,
+    QueryTrait, Select, SelectModel, SelectThree, SelectThreeModel, SelectTwo, SelectTwoModel,
+    Selector, SelectorTrait,
 };
+use sea_query::QueryStatementBuilder;
 use std::num::NonZeroU64;
 use tracing::instrument;
 
-pub struct Limiter<'db, C, S1, S2>
+pub struct Limiter<'a, C, S1, S2>
 where
     C: ConnectionTrait,
-    S1: SelectorTrait + 'db,
-    S2: SelectorTrait + 'db,
+    S1: SelectorTrait + 'a,
+    S2: SelectorTrait + 'a,
 {
-    db: &'db C,
+    db: &'a C,
     selector: Selector<S1>,
-    paginator: Paginator<'db, C, S2>,
+    paginator: Paginator<'a, C, S2>,
+    cache_key: String,
+    cache: &'a PaginationCache,
 }
 
-impl<'db, C, S1, S2> Limiter<'db, C, S1, S2>
+/// Result of fetching a limited query, with a deferred total count handle.
+pub struct LimitedResult<'a, T, C, S>
 where
     C: ConnectionTrait,
-    S1: SelectorTrait + 'db,
-    S2: SelectorTrait + 'db,
+    S: SelectorTrait + 'a,
 {
+    pub items: Vec<T>,
+    pub total: TotalCount<'a, C, S>,
+}
+
+/// Handle for computing the total count of a paginated query.
+pub struct TotalCount<'a, C, S>
+where
+    C: ConnectionTrait,
+    S: SelectorTrait + 'a,
+{
+    paginator: Paginator<'a, C, S>,
+    cache_key: String,
+    cache: &'a PaginationCache,
+}
+
+impl<'a, C, S> TotalCount<'a, C, S>
+where
+    C: ConnectionTrait,
+    S: SelectorTrait + 'a,
+{
+    /// Compute the total count, using the pagination cache when possible.
     #[instrument(skip(self), err(level=tracing::Level::INFO))]
-    pub async fn fetch(self) -> Result<Vec<S1::Item>, DbErr> {
-        self.selector.all(self.db).await
+    pub async fn total(self) -> Result<u64, DbErr> {
+        self.cache
+            .cached_total(self.cache_key, || self.paginator.num_items())
+            .await
     }
 
+    /// Compute the total only if requested.
     #[instrument(skip(self), err(level=tracing::Level::INFO))]
-    pub async fn total(&self) -> Result<u64, DbErr> {
-        self.paginator.num_items().await
+    pub async fn requested(self, requested: bool) -> Result<Option<u64>, DbErr> {
+        if requested {
+            self.total().await.map(Some)
+        } else {
+            Ok(None)
+        }
     }
 }
 
-pub trait LimiterTrait<'db, C>: Sized
+impl<'a, C, S1, S2> Limiter<'a, C, S1, S2>
+where
+    C: ConnectionTrait,
+    S1: SelectorTrait + 'a,
+    S2: SelectorTrait + 'a,
+{
+    /// Fetch the items and return a handle for computing the total count.
+    #[instrument(skip(self), err(level=tracing::Level::INFO))]
+    pub async fn fetch(self) -> Result<LimitedResult<'a, S1::Item, C, S2>, DbErr> {
+        let items = self.selector.all(self.db).await?;
+        Ok(LimitedResult {
+            items,
+            total: TotalCount {
+                paginator: self.paginator,
+                cache_key: self.cache_key,
+                cache: self.cache,
+            },
+        })
+    }
+}
+
+/// Build a cache key from a sea-query select statement.
+fn cache_key_from<Q: QueryTrait>(query: &Q) -> String {
+    let (sql, values) = query.as_query().build_any(&sea_query::PostgresQueryBuilder);
+    format!("{}|{:?}", sql, values)
+}
+
+pub trait LimiterTrait<'a, C>: Sized
 where
     C: ConnectionTrait,
 {
-    type FetchSelector: SelectorTrait + 'db;
-    type CountSelector: SelectorTrait + 'db;
+    type FetchSelector: SelectorTrait + 'a;
+    type CountSelector: SelectorTrait + 'a;
 
     fn limiting_pagination(
         self,
-        db: &'db C,
+        db: &'a C,
         paginated: Paginated,
-    ) -> Limiter<'db, C, Self::FetchSelector, Self::CountSelector> {
-        self.limiting(db, paginated.offset, paginated.limit)
+        cache: &'a PaginationCache,
+    ) -> Limiter<'a, C, Self::FetchSelector, Self::CountSelector> {
+        self.limiting(db, paginated.offset, paginated.limit, cache)
     }
 
     fn limiting(
         self,
-        db: &'db C,
+        db: &'a C,
         offset: u64,
         limit: u64,
-    ) -> Limiter<'db, C, Self::FetchSelector, Self::CountSelector>;
+        cache: &'a PaginationCache,
+    ) -> Limiter<'a, C, Self::FetchSelector, Self::CountSelector>;
 }
 
-impl<'db, C, E, M> LimiterTrait<'db, C> for Select<E>
+impl<'a, C, E, M> LimiterTrait<'a, C> for Select<E>
 where
     C: ConnectionTrait,
     E: EntityTrait<Model = M>,
-    M: FromQueryResult + Sized + Send + Sync + 'db,
+    M: FromQueryResult + Sized + Send + Sync + 'a,
 {
     type FetchSelector = SelectModel<M>;
     type CountSelector = SelectModel<M>;
 
     fn limiting(
         self,
-        db: &'db C,
+        db: &'a C,
         offset: u64,
         limit: u64,
-    ) -> Limiter<'db, C, Self::FetchSelector, Self::CountSelector> {
+        cache: &'a PaginationCache,
+    ) -> Limiter<'a, C, Self::FetchSelector, Self::CountSelector> {
+        let cache_key = cache_key_from(&self);
+
         let selector = self
             .clone()
             .limit(NonZeroU64::new(limit).map(|limit| limit.get()))
@@ -86,40 +152,47 @@ where
             db,
             paginator: self.paginate(db, 1),
             selector,
+            cache_key,
+            cache,
         }
     }
 }
 
-pub trait LimiterAsModelTrait<'db, C>
+pub trait LimiterAsModelTrait<'a, C>
 where
     C: ConnectionTrait,
 {
     fn limiting_as<M: FromQueryResult + Sync + Send>(
         self,
-        db: &'db C,
+        db: &'a C,
         offset: u64,
         limit: u64,
-    ) -> Limiter<'db, C, SelectModel<M>, SelectModel<M>>;
+        cache: &'a PaginationCache,
+    ) -> Limiter<'a, C, SelectModel<M>, SelectModel<M>>;
 
     fn try_limiting_as_multi_model<M: FromQueryResultMultiModel + Sync + Send>(
         self,
-        db: &'db C,
+        db: &'a C,
         offset: u64,
         limit: u64,
-    ) -> Result<Limiter<'db, C, SelectModel<M>, SelectModel<M>>, DbErr>;
+        cache: &'a PaginationCache,
+    ) -> Result<Limiter<'a, C, SelectModel<M>, SelectModel<M>>, DbErr>;
 }
 
-impl<'db, C, E> LimiterAsModelTrait<'db, C> for Select<E>
+impl<'a, C, E> LimiterAsModelTrait<'a, C> for Select<E>
 where
     C: ConnectionTrait,
     E: EntityTrait,
 {
     fn limiting_as<M: FromQueryResult + Sync + Send>(
         self,
-        db: &'db C,
+        db: &'a C,
         offset: u64,
         limit: u64,
-    ) -> Limiter<'db, C, SelectModel<M>, SelectModel<M>> {
+        cache: &'a PaginationCache,
+    ) -> Limiter<'a, C, SelectModel<M>, SelectModel<M>> {
+        let cache_key = cache_key_from(&self);
+
         let selector = self
             .clone()
             .limit(NonZeroU64::new(limit).map(|limit| limit.get()))
@@ -130,15 +203,20 @@ where
             db,
             paginator: self.into_model::<M>().paginate(db, 1),
             selector,
+            cache_key,
+            cache,
         }
     }
 
     fn try_limiting_as_multi_model<M: FromQueryResultMultiModel + Sync + Send>(
         self,
-        db: &'db C,
+        db: &'a C,
         offset: u64,
         limit: u64,
-    ) -> Result<Limiter<'db, C, SelectModel<M>, SelectModel<M>>, DbErr> {
+        cache: &'a PaginationCache,
+    ) -> Result<Limiter<'a, C, SelectModel<M>, SelectModel<M>>, DbErr> {
+        let cache_key = cache_key_from(&self);
+
         let selector = self
             .clone()
             .limit(NonZeroU64::new(limit).map(|limit| limit.get()))
@@ -149,22 +227,27 @@ where
             db,
             paginator: self.into_model::<M>().paginate(db, 1),
             selector,
+            cache_key,
+            cache,
         })
     }
 }
 
-pub fn limit_selector<'db, C, E, EM, M>(
-    db: &'db C,
+pub fn limit_selector<'a, C, E, EM, M>(
+    db: &'a C,
     select: Select<E>,
     offset: u64,
     limit: u64,
-) -> Limiter<'db, C, SelectModel<M>, SelectModel<EM>>
+    cache: &'a PaginationCache,
+) -> Limiter<'a, C, SelectModel<M>, SelectModel<EM>>
 where
     C: ConnectionTrait,
     E: EntityTrait<Model = EM>,
-    M: FromQueryResult + Sized + Send + Sync + 'db,
-    EM: FromQueryResult + Sized + Send + Sync + 'db,
+    M: FromQueryResult + Sized + Send + Sync + 'a,
+    EM: FromQueryResult + Sized + Send + Sync + 'a,
 {
+    let cache_key = cache_key_from(&select);
+
     let selector = select
         .clone()
         .limit(NonZeroU64::new(limit).map(|limit| limit.get()))
@@ -175,26 +258,31 @@ where
         db,
         paginator: select.paginate(db, 1),
         selector,
+        cache_key,
+        cache,
     }
 }
 
-impl<'db, C, M1, M2, E1, E2> LimiterTrait<'db, C> for SelectTwo<E1, E2>
+impl<'a, C, M1, M2, E1, E2> LimiterTrait<'a, C> for SelectTwo<E1, E2>
 where
     C: ConnectionTrait,
     E1: EntityTrait<Model = M1>,
     E2: EntityTrait<Model = M2>,
-    M1: FromQueryResult + Sized + Send + Sync + 'db,
-    M2: FromQueryResult + Sized + Send + Sync + 'db,
+    M1: FromQueryResult + Sized + Send + Sync + 'a,
+    M2: FromQueryResult + Sized + Send + Sync + 'a,
 {
     type FetchSelector = SelectTwoModel<M1, M2>;
     type CountSelector = SelectTwoModel<M1, M2>;
 
     fn limiting(
         self,
-        db: &'db C,
+        db: &'a C,
         offset: u64,
         limit: u64,
-    ) -> Limiter<'db, C, Self::FetchSelector, Self::CountSelector> {
+        cache: &'a PaginationCache,
+    ) -> Limiter<'a, C, Self::FetchSelector, Self::CountSelector> {
+        let cache_key = cache_key_from(&self);
+
         let selector = self
             .clone()
             .limit(NonZeroU64::new(limit).map(|limit| limit.get()))
@@ -205,29 +293,34 @@ where
             db,
             paginator: self.paginate(db, 1),
             selector,
+            cache_key,
+            cache,
         }
     }
 }
 
-impl<'db, C, M1, M2, M3, E1, E2, E3> LimiterTrait<'db, C> for SelectThree<E1, E2, E3>
+impl<'a, C, M1, M2, M3, E1, E2, E3> LimiterTrait<'a, C> for SelectThree<E1, E2, E3>
 where
     C: ConnectionTrait,
     E1: EntityTrait<Model = M1>,
     E2: EntityTrait<Model = M2>,
     E3: EntityTrait<Model = M3>,
-    M1: FromQueryResult + Sized + Send + Sync + 'db,
-    M2: FromQueryResult + Sized + Send + Sync + 'db,
-    M3: FromQueryResult + Sized + Send + Sync + 'db,
+    M1: FromQueryResult + Sized + Send + Sync + 'a,
+    M2: FromQueryResult + Sized + Send + Sync + 'a,
+    M3: FromQueryResult + Sized + Send + Sync + 'a,
 {
     type FetchSelector = SelectThreeModel<M1, M2, M3>;
     type CountSelector = SelectThreeModel<M1, M2, M3>;
 
     fn limiting(
         self,
-        db: &'db C,
+        db: &'a C,
         offset: u64,
         limit: u64,
-    ) -> Limiter<'db, C, Self::FetchSelector, Self::CountSelector> {
+        cache: &'a PaginationCache,
+    ) -> Limiter<'a, C, Self::FetchSelector, Self::CountSelector> {
+        let cache_key = cache_key_from(&self);
+
         let selector = self
             .clone()
             .limit(NonZeroU64::new(limit).map(|limit| limit.get()))
@@ -238,6 +331,8 @@ where
             db,
             paginator: self.paginate(db, 1),
             selector,
+            cache_key,
+            cache,
         }
     }
 }

--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -1,6 +1,7 @@
 pub mod chunk;
 pub mod limiter;
 pub mod multi_model;
+pub mod pagination_cache;
 pub mod query;
 
 mod create;

--- a/common/src/db/pagination_cache.rs
+++ b/common/src/db/pagination_cache.rs
@@ -1,0 +1,69 @@
+use moka::future::Cache;
+use opentelemetry::{global, metrics::Counter};
+use std::{sync::Arc, time::Duration};
+
+pub const DEFAULT_TTL: Duration = Duration::from_secs(60);
+
+/// Caches pagination total counts to avoid expensive COUNT queries on repeated pages.
+#[derive(Clone, Debug)]
+pub struct PaginationCache {
+    cache: Arc<Cache<String, u64>>,
+    total: Counter<u64>,
+    misses: Counter<u64>,
+}
+
+impl PaginationCache {
+    /// Create a new cache with the given TTL for total-count entries.
+    pub fn new(ttl: Duration) -> Self {
+        let meter = global::meter("PaginationCache");
+        Self {
+            cache: Arc::new(Cache::builder().time_to_live(ttl).build()),
+            total: meter.u64_counter("cache_total").build(),
+            misses: meter.u64_counter("cache_miss").build(),
+        }
+    }
+
+    /// Create a cache with zero TTL, intended for use in tests where mutations
+    /// between requests must be immediately visible.
+    pub fn for_test() -> Self {
+        Self::new(Duration::ZERO)
+    }
+
+    /// Return a cached total count, computing it at most once for concurrent requests with the same key.
+    pub async fn cached_total(
+        &self,
+        key: String,
+        compute: impl AsyncFnOnce() -> Result<u64, sea_orm::DbErr>,
+    ) -> Result<u64, sea_orm::DbErr> {
+        self.total.add(1, &[]);
+        let misses = self.misses.clone();
+        self.cache
+            .try_get_with(key, async {
+                misses.add(1, &[]);
+                compute().await
+            })
+            .await
+            .map_err(|e| sea_orm::DbErr::Custom(e.to_string()))
+    }
+}
+
+/// CLI/env configuration for the pagination cache.
+#[derive(clap::Args, Debug, Clone)]
+#[command(next_help_heading = "Pagination")]
+pub struct PaginationConfig {
+    /// TTL for cached pagination total counts (humantime, e.g. "60s", "5m")
+    #[arg(
+        id = "pagination-cache-ttl",
+        long,
+        env = "TRUSTD_PAGINATION_TOTAL_CACHE_TTL",
+        default_value = "60s"
+    )]
+    pub cache_ttl: humantime::Duration,
+}
+
+impl PaginationConfig {
+    /// Build a [`PaginationCache`] from this configuration.
+    pub fn into_cache(self) -> PaginationCache {
+        PaginationCache::new(*self.cache_ttl)
+    }
+}

--- a/common/src/model.rs
+++ b/common/src/model.rs
@@ -1,7 +1,7 @@
 mod bytesize;
 pub use bytesize::*;
 
-use crate::db::limiter::Limiter;
+use crate::db::limiter::{LimitedResult, Limiter};
 use sea_orm::{ConnectionTrait, DbErr, SelectorTrait};
 use std::cmp::min;
 use std::marker::PhantomData;
@@ -37,22 +37,31 @@ pub struct Paginated {
     /// Zero means: no limit
     #[serde(default = "default::limit")]
     pub limit: u64,
+    /// Whether to compute and return the total count of matching items.
+    #[serde(default)]
+    pub total: bool,
 }
 
 impl Paginated {
+    /// Paginate an in-memory slice, optionally including the total count.
     pub fn paginate_array<T: Clone>(&self, vec: &[T]) -> PaginatedResults<T> {
-        // trying to start past the end of the vec
+        let total = if self.total {
+            Some(vec.len() as u64)
+        } else {
+            None
+        };
+
         if self.offset as usize > vec.len() {
             return PaginatedResults {
                 items: vec![],
-                total: vec.len() as u64,
+                total,
             };
         }
 
         if self.limit == 0 {
             return PaginatedResults {
                 items: Vec::from(&vec[self.offset as usize..]),
-                total: vec.len() as u64,
+                total,
             };
         }
 
@@ -60,7 +69,7 @@ impl Paginated {
 
         PaginatedResults {
             items: Vec::from(&vec[self.offset as usize..end]),
-            total: vec.len() as u64,
+            total,
         }
     }
 }
@@ -75,35 +84,33 @@ mod default {
 #[serde(rename_all = "camelCase")]
 pub struct PaginatedResults<R> {
     pub items: Vec<R>,
-    pub total: u64,
+    pub total: Option<u64>,
 }
 
 impl<T> Default for PaginatedResults<T> {
     fn default() -> Self {
         Self {
             items: vec![],
-            total: 0,
+            total: None,
         }
     }
 }
 
 impl<R> PaginatedResults<R> {
-    /// Create a new paginated result
+    /// Create a new paginated result, optionally computing the total count.
     pub async fn new<C, S1, S2>(
         limiter: Limiter<'_, C, S1, S2>,
+        paginated: Paginated,
     ) -> Result<PaginatedResults<S1::Item>, DbErr>
     where
         C: ConnectionTrait,
         S1: SelectorTrait,
         S2: SelectorTrait,
     {
-        let total = limiter.total().await?;
-        let results = limiter.fetch().await?;
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
-        Ok(PaginatedResults {
-            items: results,
-            total,
-        })
+        Ok(PaginatedResults { items, total })
     }
 
     pub fn map<O, F: FnMut(R) -> O>(self, f: F) -> PaginatedResults<O> {
@@ -129,52 +136,71 @@ mod test {
         let paginated = Paginated {
             offset: 0,
             limit: 0,
+            total: true,
         }
         .paginate_array(&data);
 
-        assert_eq!(10, paginated.total);
+        assert_eq!(Some(10), paginated.total);
         assert_eq!(10, paginated.items.len());
 
         let paginated = Paginated {
             offset: 0,
             limit: 5,
+            total: true,
         }
         .paginate_array(&data);
 
-        assert_eq!(10, paginated.total);
+        assert_eq!(Some(10), paginated.total);
         assert_eq!(5, paginated.items.len());
 
         let paginated = Paginated {
             offset: 5,
             limit: 0,
+            total: true,
         }
         .paginate_array(&data);
 
-        assert_eq!(10, paginated.total);
+        assert_eq!(Some(10), paginated.total);
         assert_eq!(5, paginated.items.len());
 
         let paginated = Paginated {
             offset: 12,
             limit: 0,
+            total: true,
         }
         .paginate_array(&data);
 
-        assert_eq!(10, paginated.total);
+        assert_eq!(Some(10), paginated.total);
         assert_eq!(0, paginated.items.len());
+    }
+
+    #[test]
+    fn paginated_vec_no_total() {
+        let data = [1, 2, 3];
+
+        let paginated = Paginated {
+            offset: 0,
+            limit: 0,
+            total: false,
+        }
+        .paginate_array(&data);
+
+        assert_eq!(None, paginated.total);
+        assert_eq!(3, paginated.items.len());
     }
 
     #[test]
     fn map() {
         let input = PaginatedResults {
             items: vec![1, 2, 3],
-            total: 10,
+            total: Some(10),
         };
 
         assert_eq!(
             input.map(|n| n.to_string()),
             PaginatedResults {
                 items: vec!["1".to_string(), "2".to_string(), "3".to_string()],
-                total: 10
+                total: Some(10)
             }
         )
     }

--- a/common/src/service/result.rs
+++ b/common/src/service/result.rs
@@ -1,16 +1,23 @@
 use crate::{
-    db::limiter::limit_selector,
+    db::{
+        limiter::{LimitedResult, limit_selector},
+        pagination_cache::PaginationCache,
+    },
     model::{Paginated, PaginatedResults},
 };
 use sea_orm::{ConnectionTrait, DbErr, EntityTrait, FromQueryResult, Select};
 use std::fmt::Debug;
 
-/// A
 #[allow(async_fn_in_trait)]
 pub trait Resulting: Sized + Debug {
     type Output<T>: Sized + Mappable<T>;
 
-    async fn get<C, E, EM, M>(self, db: &C, query: Select<E>) -> Result<Self::Output<M>, DbErr>
+    async fn get<C, E, EM, M>(
+        self,
+        db: &C,
+        query: Select<E>,
+        cache: &PaginationCache,
+    ) -> Result<Self::Output<M>, DbErr>
     where
         C: ConnectionTrait,
         E: EntityTrait<Model = EM>,
@@ -21,21 +28,21 @@ pub trait Resulting: Sized + Debug {
 impl Resulting for Paginated {
     type Output<T> = PaginatedResults<T>;
 
-    async fn get<C, E, EM, M>(self, db: &C, query: Select<E>) -> Result<Self::Output<M>, DbErr>
+    async fn get<C, E, EM, M>(
+        self,
+        db: &C,
+        query: Select<E>,
+        cache: &PaginationCache,
+    ) -> Result<Self::Output<M>, DbErr>
     where
         C: ConnectionTrait,
         E: EntityTrait<Model = EM>,
         EM: FromQueryResult + Send + Sync,
         M: FromQueryResult + Send + Sync,
     {
-        // limit and execute
-
-        let limiter = limit_selector(db, query, self.offset, self.limit);
-
-        let total = limiter.total().await?;
-        let items = limiter.fetch().await?;
-
-        // collect results
+        let limiter = limit_selector(db, query, self.offset, self.limit, cache);
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(self.total).await?;
 
         Ok(PaginatedResults { items, total })
     }
@@ -44,14 +51,18 @@ impl Resulting for Paginated {
 impl Resulting for () {
     type Output<T> = Vec<T>;
 
-    async fn get<C, E, EM, M>(self, db: &C, query: Select<E>) -> Result<Self::Output<M>, DbErr>
+    async fn get<C, E, EM, M>(
+        self,
+        db: &C,
+        query: Select<E>,
+        _cache: &PaginationCache,
+    ) -> Result<Self::Output<M>, DbErr>
     where
         C: ConnectionTrait,
         E: EntityTrait<Model = EM>,
         EM: FromQueryResult + Send + Sync,
         M: FromQueryResult + Send + Sync,
     {
-        // just fetch all
         query.into_model().all(db).await
     }
 }
@@ -70,7 +81,7 @@ pub trait Mappable<In>: Sized {
         F: FnMut(In) -> Option<Out>,
         Mapped: Mappable<Out>;
 
-    fn collect(total: u64, items: impl Iterator<Item = In>) -> Self;
+    fn collect(total: Option<u64>, items: impl Iterator<Item = In>) -> Self;
 }
 
 impl<In> Mappable<In> for Vec<In> {
@@ -79,10 +90,10 @@ impl<In> Mappable<In> for Vec<In> {
         F: FnMut(In) -> Option<Out>,
         Mapped: Mappable<Out>,
     {
-        Mapped::collect(self.len() as _, self.into_iter().flat_map(f))
+        Mapped::collect(Some(self.len() as _), self.into_iter().flat_map(f))
     }
 
-    fn collect(_: u64, items: impl Iterator<Item = In>) -> Self {
+    fn collect(_: Option<u64>, items: impl Iterator<Item = In>) -> Self {
         Vec::from_iter(items)
     }
 }
@@ -96,7 +107,7 @@ impl<In> Mappable<In> for PaginatedResults<In> {
         Mapped::collect(self.total, self.items.into_iter().flat_map(f))
     }
 
-    fn collect(total: u64, items: impl Iterator<Item = In>) -> Self {
+    fn collect(total: Option<u64>, items: impl Iterator<Item = In>) -> Self {
         PaginatedResults {
             total,
             items: items.collect(),

--- a/docs/adrs/00017-efficient-pagination.md
+++ b/docs/adrs/00017-efficient-pagination.md
@@ -96,8 +96,9 @@ of:
 * Normalized filter/search parameters (the `Query` and any additional filter parameters that
   affect the result set)
 
-The cache entry is valid for a configurable TTL, set via a server-wide configuration option
-(environment variable or config file), defaulting to 60 seconds:
+The cache entry is valid for a configurable TTL, set via CLI argument
+(`--pagination-cache-ttl`) or environment variable, defaulting to 60 seconds.
+The value uses humantime format (e.g. `60s`, `5m`, `1h`):
 
 ```
 TRUSTD_PAGINATION_TOTAL_CACHE_TTL=60s

--- a/docs/adrs/00017-efficient-pagination.md
+++ b/docs/adrs/00017-efficient-pagination.md
@@ -1,0 +1,206 @@
+# 00017. Make pagination more efficient by making total optional and caching it
+
+Date: 2026-04-21
+
+## Status
+
+APPROVED
+
+## Context
+
+Every paginated endpoint in the API returns a `PaginatedResults<T>` containing an `items` array
+and a `total` count. The `total` is computed by executing a `COUNT(*)` query on the full filtered
+result set (via sea-orm's `Paginator::num_items()`) on every single request, even when the client
+does not need it.
+
+For large tables (advisories, vulnerabilities, SBOMs), the `COUNT(*)` query can be expensive — it
+must scan the entire filtered result set regardless of the `OFFSET`/`LIMIT` applied to the data
+query. This cost is paid on every page navigation, even though the total rarely changes between
+consecutive page requests from the same user session.
+
+Two independent optimizations address this:
+
+1. **Make `total` optional** — allow clients to opt in to the count query only when they need it
+   (e.g. a UI that needs to render a page count). Clients that do not need the total (infinite
+   scroll, CLI tools fetching the next batch, subsequent page requests where the total is already
+   known) skip the count entirely.
+
+2. **Cache the total server-side** — when `total` is requested, cache the count result for a
+   configurable duration so that repeated paginated requests with the same filters reuse the
+   cached count instead of hitting the database again.
+
+## Decision
+
+### Optional total via query parameter
+
+A new boolean query parameter `total` is added to the `Paginated` struct:
+
+```rust
+pub struct Paginated {
+    pub offset: u64,
+    pub limit: u64,
+    pub total: Option<bool>,  // default: false
+}
+```
+
+When `total` is absent or `false` (the default), the server skips the `COUNT(*)` query entirely
+and returns `total: null` in the response. When `total` is `true`, the count is computed (with
+caching, see below) and returned as a number.
+
+The response type changes accordingly:
+
+```rust
+pub struct PaginatedResults<R> {
+    pub items: Vec<R>,
+    pub total: Option<u64>,   // null when total was not requested
+}
+```
+
+This is a breaking change: clients that previously relied on `total` always being present must now
+explicitly request it by passing `total=true`.
+
+#### Example
+
+Default request (no total):
+
+```
+GET /api/v3/advisory?offset=0&limit=25
+```
+
+```json
+{
+  "items": [...],
+  "total": null
+}
+```
+
+Request with total:
+
+```
+GET /api/v3/advisory?offset=0&limit=25&total=true
+```
+
+```json
+{
+  "items": [...],
+  "total": 4217
+}
+```
+
+### Server-side total caching
+
+When `total=true` is requested, the server caches the `COUNT(*)` result keyed by the combination
+of:
+
+* Endpoint path (e.g. `/api/v3/advisory`)
+* Normalized filter/search parameters (the `Query` and any additional filter parameters that
+  affect the result set)
+
+The cache entry is valid for a configurable TTL, set via a server-wide configuration option
+(environment variable or config file), defaulting to 60 seconds:
+
+```
+TRUSTD_PAGINATION_TOTAL_CACHE_TTL=60s
+```
+
+When a cached total is available and not expired, the server returns it without executing the
+`COUNT(*)` query. The data query (with `OFFSET`/`LIMIT`) is always executed — only the count is
+cached.
+
+#### Cache implementation
+
+The cache is implemented using [`moka`](https://github.com/moka-rs/moka), a high-performance
+concurrent cache crate built for async Rust. `moka` integrates well with tokio and actix-web: it
+supports TTL-based expiration natively, is lock-free for reads, and handles concurrent access
+without external synchronization.
+
+The cache key must include all parameters that affect the count — the entity type, all filter
+predicates, and search terms — but must exclude `offset` and `limit` since those do not affect
+the total. This ensures that navigating between pages of the same filtered result set reuses the
+cached total.
+
+#### Cache invalidation
+
+The cache relies on TTL-based expiration only. No explicit invalidation is performed on data
+mutations (ingestion, deletion). This is acceptable because:
+
+* The total is a convenience for UI pagination, not a consistency-critical value.
+* A briefly stale total (off by a few items) does not cause incorrect behavior — the client
+  may see a slightly wrong page count, but the items themselves are always fresh.
+* TTL-based expiration keeps the implementation simple and avoids coupling the cache to every
+  write path.
+
+Mutation-based invalidation is possible but challenging: because the filter is part of the cache
+key, a data change would require either re-evaluating cached filters to determine which entries
+are affected, or bulk-invalidating all entries for a given entity type (discarding unaffected
+entries). This could be revisited if TTL-based staleness turns out to be problematic in practice.
+
+### Changes to the Limiter
+
+The `Limiter` struct and its construction are updated to support the optional total:
+
+```rust
+impl<'db, C, S1, S2> Limiter<'db, C, S1, S2> {
+    /// Returns the total count, using the cache when available.
+    pub async fn total(&self, cache: &TotalCache) -> Result<u64, DbErr> {
+        cache.get_or_compute(&self.cache_key, || self.paginator.num_items()).await
+    }
+
+    /// Fetches the paginated items.
+    pub async fn fetch(self) -> Result<Vec<S1::Item>, DbErr> {
+        self.selector.all(self.db).await
+    }
+}
+```
+
+Service methods that build `PaginatedResults` check the `total` parameter and either call
+`limiter.total()` (with cache lookup) or skip it and set `total: None`.
+
+## Alternatives considered
+
+### External cache (e.g. Redis)
+
+Instead of an in-process cache, the total could be stored in an external cache such as Redis or
+Memcached. This would provide a shared cache across all server instances in a multi-instance
+deployment, meaning a count computed by one instance could be reused by another.
+
+**Advantages:**
+
+* Shared cache across instances — better hit rate in multi-instance deployments where different
+  instances serve requests from the same user session (e.g. behind a round-robin load balancer).
+* Centralized TTL management and potential for explicit invalidation via pub/sub or key deletion
+  on data mutations.
+
+**Disadvantages:**
+
+* Adds an external infrastructure dependency. Trustify currently does not require Redis or
+  similar services, so this would increase operational complexity for deployments.
+* Introduces network round-trip latency for every cache lookup. For a value as cheap as a cached
+  integer, the network overhead may negate much of the benefit compared to an in-process lookup.
+* Requires handling cache unavailability gracefully — the server must fall back to computing the
+  count when the external cache is down, adding error-handling complexity.
+
+**Why not chosen:** The pagination total is a performance optimization for a non-critical value.
+An in-process cache with `moka` is simpler to deploy, has zero network overhead, and provides
+sufficient benefit for the expected workload. In multi-instance deployments, each instance warms
+its own cache independently within the TTL — the worst case is one redundant `COUNT(*)` per
+instance per TTL window, which is acceptable. If Trustify later introduces Redis for other
+purposes, moving the pagination cache there could be reconsidered as a low-effort follow-up.
+
+## Consequences
+
+* The `PaginatedResults` response type changes `total` from `u64` to `Option<u64>`. This is a
+  **breaking change** — existing clients that assume `total` is always a number must be updated
+  to either pass `total=true` or handle `null`.
+* Clients that do not need the total (the common case) no longer pay the `COUNT(*)` overhead,
+  reducing response latency for large result sets.
+* Repeated pagination requests with the same filters within the TTL window avoid redundant
+  `COUNT(*)` queries, reducing database load during interactive browsing sessions.
+* The cache introduces a brief window (up to TTL) where the reported total may be stale after
+  data mutations. This is an acceptable trade-off for pagination UIs.
+* The cache is in-process and per-instance via `moka`. In multi-instance deployments, each
+  instance maintains its own cache. This is acceptable — the cache is a performance optimization,
+  not a consistency mechanism, and independent caches converge within the TTL.
+* No external infrastructure (Redis, Memcached) is required.
+* The TTL default of 60 seconds balances freshness against query reduction for interactive page
+  navigation. It can be tuned via configuration.

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -42,6 +42,7 @@
 | `TRUSTD_DB_PASSWORD`                     | Database password                                                                   | `trustify`                              |
 | `TRUSTD_DB_PORT`                         | Database port                                                                       | `5432`                                  |
 | `TRUSTD_DB_USER`                         | Database username                                                                   | `postgres`                              |
+| `TRUSTD_PAGINATION_TOTAL_CACHE_TTL`      | TTL for cached pagination total counts (humantime)                                  | `60s`                                   |
 | `TRUSTD_ISSUER_URL`                      | Issuer URL for `--devmode`                                                          | `http://localhost:8090/realms/trustify` |
 | `TRUSTD_MAX_CACHE_SIZE`                  | Maximum size of the graph cache.                                                    | `200 MiB`                               |
 | `TRUSTD_READ_ONLY`                       | Enable read-only mode, rejecting all mutating API requests                          | `false`                                 |

--- a/modules/analysis/src/endpoints/tests/latest_filters.rs
+++ b/modules/analysis/src/endpoints/tests/latest_filters.rs
@@ -76,7 +76,7 @@ async fn resolve_rh_variant_latest_filter_container_cdx(
         let _response = app.req(Req::default()).await?;
     }
 
-    let mut response = app.req(req).await?;
+    let mut response = app.req(req.with_total()).await?;
 
     sort(&mut response["items"]);
 
@@ -148,7 +148,7 @@ async fn resolve_rh_variant_latest_filter_rpms_cdx(
         let _response = app.req(Req::default()).await?;
     }
 
-    let response = app.req(req).await?;
+    let response = app.req(req.with_total()).await?;
 
     log::info!("{response:#?}");
     assert_eq!(total, response["total"]);
@@ -215,7 +215,7 @@ async fn resolve_rh_variant_latest_filter_middleware_cdx(
         let _response = app.req(Req::default()).await?;
     }
 
-    let response = app.req(req).await?;
+    let response = app.req(req.with_total()).await?;
 
     log::info!("{response:#?}");
     assert_eq!(total, response["total"]);
@@ -254,6 +254,7 @@ async fn test_tc2606(
             latest: true,
             what: What::Id("cpe:/a:redhat:rhel_eus:9.4::appstream"),
             descendants: Some(1),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -355,6 +356,7 @@ async fn test_tc2677(
             latest: true,
             what: What::Id("cpe:/a:redhat:3scale:2.15::el9"),
             descendants: Some(10),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -505,7 +507,7 @@ async fn parse_ids_find_only_exact_matches(
         let _response = app.req(Req::default()).await?;
     }
 
-    let response = app.req(req).await?;
+    let response = app.req(req.with_total()).await?;
     assert_eq!(total, response["total"]);
 
     Ok(())
@@ -544,6 +546,7 @@ async fn test_tc2758(
             latest: true,
             what: What::Id("cpe:/a:redhat:jboss_enterprise_application_platform:7.4"),
             descendants: Some(100),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -787,7 +790,7 @@ async fn resolve_rh_variant_latest_filter_tc_3278(
         let _response = app.req(Req::default()).await?;
     }
 
-    let mut response = app.req(req).await?;
+    let mut response = app.req(req.with_total()).await?;
 
     sort(&mut response["items"]);
 
@@ -879,7 +882,7 @@ async fn resolve_rh_variant_latest_filter_tc_2719(
         let _response = app.req(Req::default()).await?;
     }
 
-    let mut response = app.req(req).await?;
+    let mut response = app.req(req.with_total()).await?;
 
     sort(&mut response["items"]);
 
@@ -1014,7 +1017,7 @@ async fn test_tc3624(
         let _response = app.req(Req::default()).await?;
     }
 
-    let mut response = app.req(req).await?;
+    let mut response = app.req(req.with_total()).await?;
 
     sort(&mut response["items"]);
 

--- a/modules/analysis/src/endpoints/tests/mod.rs
+++ b/modules/analysis/src/endpoints/tests/mod.rs
@@ -29,6 +29,7 @@ async fn test_simple_retrieve_analysis_endpoint(
         .req(Req {
             what: What::Q("B"),
             ancestors: Some(10),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -45,6 +46,7 @@ async fn test_simple_retrieve_analysis_endpoint(
         .req(Req {
             what: What::Q("BB"),
             ancestors: Some(10),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -74,6 +76,7 @@ async fn test_simple_retrieve_by_name_analysis_endpoint(
         .req(Req {
             what: What::Id("B"),
             ancestors: Some(10),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -103,6 +106,7 @@ async fn test_simple_retrieve_by_purl_analysis_endpoint(
         .req(Req {
             what: What::Id("pkg:rpm/redhat/B@0.0.0"),
             ancestors: Some(10),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -137,6 +141,7 @@ async fn test_quarkus_retrieve_analysis_endpoint(
         .req(Req {
             what: What::Q("spymemcached"),
             ancestors: Some(10),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -174,6 +179,7 @@ async fn test_status_endpoint(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     let _response: Value = app
         .req(Req {
             what: What::Q("BB"),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -209,6 +215,7 @@ async fn test_simple_dep_endpoint(ctx: &TrustifyContext) -> Result<(), anyhow::E
             what: What::Q("A"),
             ancestors: Some(10),
             descendants: Some(10),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -264,6 +271,7 @@ async fn test_simple_dep_by_name_endpoint(ctx: &TrustifyContext) -> Result<(), a
         .req(Req {
             what: What::Id("A"),
             descendants: Some(10),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -294,6 +302,7 @@ async fn test_simple_dep_by_purl_endpoint(ctx: &TrustifyContext) -> Result<(), a
         .req(Req {
             what: What::Id(purl),
             descendants: Some(10),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -326,6 +335,7 @@ async fn test_quarkus_dep_endpoint(ctx: &TrustifyContext) -> Result<(), anyhow::
         .req(Req {
             what: What::Q("spymemcached"),
             descendants: Some(10),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -362,6 +372,7 @@ async fn quarkus_component_by_purl(ctx: &TrustifyContext) -> Result<(), anyhow::
     let response: Value = app
         .req(Req {
             what: What::Id(purl),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -392,6 +403,7 @@ async fn quarkus_component_by_cpe(ctx: &TrustifyContext) -> Result<(), anyhow::E
     let response: Value = app
         .req(Req {
             what: What::Id("cpe:/a:redhat:quarkus:3.2::el8"),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -419,6 +431,7 @@ async fn query(ctx: &TrustifyContext, query: &str) -> Value {
         .req(Req {
             what: What::Q(query),
             limit: Some(0),
+            total: true,
             ..Req::default()
         })
         .await
@@ -502,7 +515,7 @@ async fn find_components_without_namespace(
     Req {
         what: What::Q("node_id=SPDXRef-A"),
         descendants: Some(10),
-        ..Req::default()
+        total: true, ..Req::default()
     },
     Some("A"),
     1
@@ -511,7 +524,7 @@ async fn find_components_without_namespace(
     Req {
         what: What::Q("node_id=SPDXRef-B"),
         ancestors: Some(10),
-        ..Req::default()
+        total: true, ..Req::default()
     },
     Some("B"),
     1
@@ -520,7 +533,7 @@ async fn find_components_without_namespace(
     Req {
         what: What::Q("node_id=SPDXRef-B&name=B"),
         ancestors: Some(10),
-        ..Req::default()
+        total: true, ..Req::default()
     },
     Some("B"),
     1
@@ -529,7 +542,7 @@ async fn find_components_without_namespace(
     Req {
         what: What::Q("sbom_id=urn:uuid:99999999-9999-9999-9999-999999999999"),
         ancestors: Some(10),
-        ..Req::default()
+        total: true, ..Req::default()
     },
     None,
     0
@@ -538,7 +551,7 @@ async fn find_components_without_namespace(
     Req {
         what: What::Q("node_id=SPDXRef-B&name=A"),
         ancestors: Some(10),
-        ..Req::default()
+        total: true, ..Req::default()
     },
     None,
     0
@@ -553,7 +566,7 @@ async fn test_retrieve_query_params_endpoint(
     let app = caller(ctx).await?;
     ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-    let response: Value = app.req(req).await?;
+    let response: Value = app.req(req.with_total()).await?;
 
     if let Some(name) = expected_name {
         assert_eq!(response["items"][0]["name"], name);
@@ -576,6 +589,7 @@ async fn test_retrieve_query_params_endpoint_sbom_id(
         .req(Req {
             what: What::Q("node_id=SPDXRef-B&name=B"),
             ancestors: Some(10),
+            total: true,
             ..Req::default()
         })
         .await?;
@@ -586,6 +600,7 @@ async fn test_retrieve_query_params_endpoint_sbom_id(
         .req(Req {
             what: What::Q(&format!("sbom_id={sbom_id}")),
             ancestors: Some(10),
+            total: true,
             ..Req::default()
         })
         .await?;

--- a/modules/analysis/src/endpoints/tests/req.rs
+++ b/modules/analysis/src/endpoints/tests/req.rs
@@ -16,8 +16,18 @@ pub struct Req<'a> {
     pub limit: Option<u64>,
     /// Offset for pagination
     pub offset: Option<u64>,
+    /// Request total count
+    pub total: bool,
     /// What is being requested
     pub what: What<'a>,
+}
+
+impl Req<'_> {
+    /// Return a copy with total count requested.
+    pub const fn with_total(mut self) -> Self {
+        self.total = true;
+        self
+    }
 }
 
 /// Indication of what is being requested
@@ -46,6 +56,7 @@ impl<C: CallService> ReqExt for C {
             descendants,
             limit,
             offset,
+            total,
         } = req;
 
         let latest = match latest {
@@ -84,6 +95,10 @@ impl<C: CallService> ReqExt for C {
 
         if let Some(offset) = offset {
             uri = format!("{uri}offset={offset}&");
+        }
+
+        if total {
+            uri = format!("{uri}total=true&");
         }
 
         let request: Request = TestRequest::get().uri(&uri).to_request();

--- a/modules/analysis/src/endpoints/tests/temporal.rs
+++ b/modules/analysis/src/endpoints/tests/temporal.rs
@@ -99,7 +99,7 @@ async fn container_evolve(
         let _response = app.req(Req::default()).await?;
     }
 
-    let response = app.req(req).await?;
+    let response = app.req(req.with_total()).await?;
 
     log::info!("{response:#?}");
 

--- a/modules/analysis/src/model/roots.rs
+++ b/modules/analysis/src/model/roots.rs
@@ -11,11 +11,8 @@ pub trait Roots {
 impl Roots for PaginatedResults<Node> {
     fn roots(self) -> PaginatedResults<Node> {
         let items = self.items.roots();
-        let total = items.len();
-        Self {
-            items,
-            total: total as _,
-        }
+        let total = Some(items.len() as u64);
+        Self { items, total }
     }
 }
 
@@ -53,11 +50,8 @@ impl<'a> RootTraces for &'a PaginatedResults<Node> {
 
     fn root_traces(self) -> Self::Result {
         let items = self.items.root_traces();
-        let total = items.len();
-        Self::Result {
-            items,
-            total: total as _,
-        }
+        let total = Some(items.len() as u64);
+        Self::Result { items, total }
     }
 }
 

--- a/modules/analysis/src/service/test/mod.rs
+++ b/modules/analysis/src/service/test/mod.rs
@@ -57,7 +57,7 @@ async fn test_simple_analysis_service(ctx: &TrustifyContext) -> Result<(), anyho
             "doesn't match: {traces:#?}"
         );
     });
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     // ensure we set implicit relationship on components with no defined relationships
     let analysis_graph = service
@@ -73,7 +73,7 @@ async fn test_simple_analysis_service(ctx: &TrustifyContext) -> Result<(), anyho
     let analysis_graph = analysis_graph.roots();
     log::debug!("After: {analysis_graph:#?}");
 
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     Ok(())
 }
@@ -118,7 +118,7 @@ async fn test_simple_analysis_cyclonedx_service(
             "doesn't match: {traces:#?}"
         );
     });
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     // ensure we set implicit relationship on components with no defined relationships
     let analysis_graph = service
@@ -134,7 +134,7 @@ async fn test_simple_analysis_cyclonedx_service(
     let analysis_graph = analysis_graph.root_traces();
     log::debug!("After: {analysis_graph:#?}");
 
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     Ok(())
 }
@@ -181,7 +181,7 @@ async fn test_simple_by_name_analysis_service(ctx: &TrustifyContext) -> Result<(
         );
     });
 
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     Ok(())
 }
@@ -224,7 +224,7 @@ async fn simple_by_name_analysis_service_filter_rel(
         );
     });
 
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     Ok(())
 }
@@ -273,7 +273,7 @@ async fn test_simple_by_purl_analysis_service(ctx: &TrustifyContext) -> Result<(
         );
     });
 
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
     Ok(())
 }
 
@@ -325,7 +325,7 @@ async fn test_quarkus_analysis_service(ctx: &TrustifyContext) -> Result<(), anyh
         );
     });
 
-    assert_eq!(analysis_graph.total, 2);
+    assert_eq!(analysis_graph.total, Some(2));
 
     Ok(())
 }
@@ -421,12 +421,15 @@ async fn test_simple_deps_service(ctx: &TrustifyContext) -> Result<(), anyhow::E
         .retrieve(
             &Query::q("AA"),
             QueryOptions::descendants(),
-            Paginated::default(),
+            Paginated {
+                total: true,
+                ..Paginated::default()
+            },
             &ctx.db,
         )
         .await?;
 
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     // ensure we set implicit relationship on components with no defined relationships
     let analysis_graph = service
@@ -442,7 +445,7 @@ async fn test_simple_deps_service(ctx: &TrustifyContext) -> Result<(), anyhow::E
     let analysis_graph = analysis_graph.roots();
     log::debug!("After: {analysis_graph:#?}");
 
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     Ok(())
 }
@@ -458,12 +461,15 @@ async fn test_simple_deps_cyclonedx_service(ctx: &TrustifyContext) -> Result<(),
         .retrieve(
             &Query::q("AA"),
             QueryOptions::descendants(),
-            Paginated::default(),
+            Paginated {
+                total: true,
+                ..Paginated::default()
+            },
             &ctx.db,
         )
         .await?;
 
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     // ensure we set implicit relationship on component with no defined relationships
     let analysis_graph = service
@@ -475,7 +481,7 @@ async fn test_simple_deps_cyclonedx_service(ctx: &TrustifyContext) -> Result<(),
         )
         .await?
         .roots();
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     Ok(())
 }
@@ -491,13 +497,16 @@ async fn test_simple_by_name_deps_service(ctx: &TrustifyContext) -> Result<(), a
         .retrieve(
             ComponentReference::Name("A"),
             QueryOptions::descendants(),
-            Paginated::default(),
+            Paginated {
+                total: true,
+                ..Paginated::default()
+            },
             &ctx.db,
         )
         .await?;
 
     assert_eq!(analysis_graph.items.len(), 1);
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     assert_eq!(
         analysis_graph.items[0].purl,
@@ -525,7 +534,10 @@ async fn test_simple_by_purl_deps_service(ctx: &TrustifyContext) -> Result<(), a
         .retrieve(
             &component_purl,
             QueryOptions::descendants(),
-            Paginated::default(),
+            Paginated {
+                total: true,
+                ..Paginated::default()
+            },
             &ctx.db,
         )
         .await?;
@@ -535,7 +547,7 @@ async fn test_simple_by_purl_deps_service(ctx: &TrustifyContext) -> Result<(), a
         vec![Purl::from_str("pkg:rpm/redhat/AA@0.0.0?arch=src")?]
     );
 
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     Ok(())
 }
@@ -555,12 +567,15 @@ async fn test_quarkus_deps_service(ctx: &TrustifyContext) -> Result<(), anyhow::
         .retrieve(
             &Query::q("spymemcached"),
             QueryOptions::descendants(),
-            Paginated::default(),
+            Paginated {
+                total: true,
+                ..Paginated::default()
+            },
             &ctx.db,
         )
         .await?;
 
-    assert_eq!(analysis_graph.total, 2);
+    assert_eq!(analysis_graph.total, Some(2));
 
     Ok(())
 }

--- a/modules/analysis/src/service/test/recursive.rs
+++ b/modules/analysis/src/service/test/recursive.rs
@@ -29,7 +29,10 @@ async fn test_circular_deps_cyclonedx_service_count(
         .retrieve(
             ComponentReference::Name("junit-bom"),
             query,
-            Paginated::default(),
+            Paginated {
+                total: true,
+                ..Paginated::default()
+            },
             &ctx.db,
         )
         .await?;
@@ -43,7 +46,7 @@ async fn test_circular_deps_cyclonedx_service_count(
 
     // assert result count
 
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     Ok(())
 }
@@ -70,7 +73,10 @@ async fn test_circular_deps_cyclonedx_service<const N: usize>(
         .retrieve(
             ComponentReference::Name("A"),
             query,
-            Paginated::default(),
+            Paginated {
+                total: true,
+                ..Paginated::default()
+            },
             &ctx.db,
         )
         .await?;
@@ -92,7 +98,7 @@ async fn test_circular_deps_cyclonedx_service<const N: usize>(
         ]
     );
 
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     Ok(())
 }
@@ -116,7 +122,10 @@ async fn test_circular_deps_spdx_service<const N: usize>(
         .retrieve(
             ComponentReference::Name("A"),
             query,
-            Paginated::default(),
+            Paginated {
+                total: true,
+                ..Paginated::default()
+            },
             &ctx.db,
         )
         .await?;
@@ -138,7 +147,7 @@ async fn test_circular_deps_spdx_service<const N: usize>(
         ]
     );
 
-    assert_eq!(analysis_graph.total, 1);
+    assert_eq!(analysis_graph.total, Some(1));
 
     Ok(())
 }

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 use time::OffsetDateTime;
 use trustify_auth::{CreateAdvisory, DeleteAdvisory, ReadAdvisory, authorizer::Require};
 use trustify_common::{
-    db::{Database, query::Query},
+    db::{Database, pagination_cache::PaginationCache, query::Query},
     decompress::decompress_async,
     id::Id,
     model::{BinaryData, Paginated, PaginatedResults},
@@ -38,8 +38,9 @@ pub fn configure(
     config: &mut utoipa_actix_web::service_config::ServiceConfig,
     db: Database,
     upload_limit: usize,
+    cache: PaginationCache,
 ) {
-    let advisory_service = AdvisoryService::new(db.clone());
+    let advisory_service = AdvisoryService::new(db.clone(), cache);
 
     config
         .app_data(web::Data::new(db))

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -79,7 +79,7 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let uri = "/api/v3/advisory";
+    let uri = "/api/v3/advisory?total=true";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -335,7 +335,7 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
 async fn search_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     async fn query(app: &impl CallService, q: &str) -> PaginatedResults<AdvisorySummary> {
         let uri = format!(
-            "/api/v3/advisory?q={}&sort={}",
+            "/api/v3/advisory?total=true&q={}&sort={}",
             urlencoding::encode(q),
             urlencoding::encode("ingested:desc")
         );
@@ -346,30 +346,30 @@ async fn search_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // No results before ingestion
     let result = query(&app, "").await;
-    assert_eq!(result.total, 0);
+    assert_eq!(result.total, Some(0));
 
     // ingest some advisories
     ctx.ingest_documents(["mitre/CVE-2024-27088.json", "mitre/CVE-2024-28111.json"])
         .await?;
 
     let result = query(&app, "").await;
-    assert_eq!(result.total, 2);
+    assert_eq!(result.total, Some(2));
     assert_eq!(result.items[0].head.identifier, "CVE-2024-28111");
     let result = query(&app, "ingested>last week").await;
-    assert_eq!(result.total, 2);
+    assert_eq!(result.total, Some(2));
     assert_eq!(result.items[0].head.identifier, "CVE-2024-28111");
     let result = query(&app, "csv").await;
-    assert_eq!(result.total, 1);
+    assert_eq!(result.total, Some(1));
     assert_eq!(result.items[0].head.identifier, "CVE-2024-28111");
     let result = query(&app, "function#copy").await;
-    assert_eq!(result.total, 1);
+    assert_eq!(result.total, Some(1));
     assert_eq!(result.items[0].head.identifier, "CVE-2024-27088");
     let result = query(&app, "tostringtokens").await;
-    assert_eq!(result.total, 1);
+    assert_eq!(result.total, Some(1));
     assert_eq!(result.items[0].head.identifier, "CVE-2024-27088");
     let result = query(&app, "es5-ext").await;
     assert_eq!(result.items[0].head.identifier, "CVE-2024-27088");
-    assert_eq!(result.total, 1);
+    assert_eq!(result.total, Some(1));
 
     Ok(())
 }
@@ -379,7 +379,7 @@ async fn search_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn rejected_cve(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let query = async |expected_count, q| {
         let app = caller(ctx).await.unwrap();
-        let uri = format!("/api/v3/advisory?q={}", urlencoding::encode(q));
+        let uri = format!("/api/v3/advisory?total=true&q={}", urlencoding::encode(q));
         let req = TestRequest::get().uri(&uri).to_request();
         let response: Value = app.call_and_read_body_json(req).await;
         tracing::debug!(test = "", "{response:#?}");
@@ -610,9 +610,13 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let doc = ctx.ingest_document(DOC).await?;
 
     let advisory_list: PaginatedResults<AdvisorySummary> = app
-        .call_and_read_body_json(TestRequest::get().uri("/api/v3/advisory").to_request())
+        .call_and_read_body_json(
+            TestRequest::get()
+                .uri("/api/v3/advisory?total=true")
+                .to_request(),
+        )
         .await;
-    assert_eq!(advisory_list.total, 1);
+    assert_eq!(advisory_list.total, Some(1));
     let key: StorageKey = advisory_list.items[0].source_document.clone().try_into()?;
     assert!(storage.retrieve(key.clone()).await?.is_some());
 
@@ -631,9 +635,13 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // check that the document is gone
     let advisory_list: PaginatedResults<AdvisorySummary> = app
-        .call_and_read_body_json(TestRequest::get().uri("/api/v3/advisory").to_request())
+        .call_and_read_body_json(
+            TestRequest::get()
+                .uri("/api/v3/advisory?total=true")
+                .to_request(),
+        )
         .await;
-    assert_eq!(advisory_list.total, 0);
+    assert_eq!(advisory_list.total, Some(0));
 
     // second delete should fail
     let response = app
@@ -655,7 +663,7 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn query_advisories_by_label(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let query = async |q| {
         let app = caller(ctx).await.unwrap();
-        let uri = format!("/api/v3/advisory?q={}", encode(q));
+        let uri = format!("/api/v3/advisory?total=true&q={}", encode(q));
         let req = TestRequest::get().uri(&uri).to_request();
         let response: Value = app.call_and_read_body_json(req).await;
         assert_eq!(1, response["total"], "for {q}");

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -12,8 +12,9 @@ use tracing::instrument;
 use trustify_common::{
     db::{
         Database, UpdateDeprecatedAdvisory,
-        limiter::LimiterAsModelTrait,
+        limiter::{LimitedResult, LimiterAsModelTrait},
         multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
+        pagination_cache::PaginationCache,
         query::{Columns, Filtering, Query},
     },
     id::{Id, TrySelectForId},
@@ -25,11 +26,12 @@ use uuid::Uuid;
 
 pub struct AdvisoryService {
     db: Database,
+    cache: PaginationCache,
 }
 
 impl AdvisoryService {
-    pub fn new(db: Database) -> Self {
-        Self { db }
+    pub fn new(db: Database, cache: PaginationCache) -> Self {
+        Self { db, cache }
     }
 
     #[instrument(skip(self, connection))]
@@ -60,11 +62,11 @@ impl AdvisoryService {
                 connection,
                 paginated.offset,
                 paginated.limit,
+                &self.cache,
             )?;
 
-        let total = limiter.total().await?;
-
-        let items = limiter.fetch().await?;
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         Ok(PaginatedResults {
             total,

--- a/modules/fundamental/src/advisory/service/test.rs
+++ b/modules/fundamental/src/advisory/service/test.rs
@@ -1,20 +1,28 @@
 use super::*;
 use crate::{advisory::model::AdvisoryHead, source_document::model::SourceDocument};
-use std::collections::HashMap;
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
-use trustify_common::{db::query::q, hashing::Digests, model::Paginated, purl::Purl};
-use trustify_entity::advisory_vulnerability_score::{ScoreType, Severity};
-use trustify_entity::labels::Labels;
-use trustify_entity::version_scheme::VersionScheme;
-use trustify_module_ingestor::graph::Outcome;
-use trustify_module_ingestor::graph::advisory::{
-    AdvisoryContext, AdvisoryInformation,
-    version::{VersionInfo, VersionSpec},
+use trustify_common::{
+    db::{pagination_cache::PaginationCache, query::q},
+    hashing::Digests,
+    model::Paginated,
+    purl::Purl,
 };
-use trustify_module_ingestor::graph::cvss::{ScoreCreator, ScoreInformation};
+use trustify_entity::{
+    advisory_vulnerability_score::{ScoreType, Severity},
+    labels::Labels,
+    version_scheme::VersionScheme,
+};
+use trustify_module_ingestor::graph::{
+    Outcome,
+    advisory::{
+        AdvisoryContext, AdvisoryInformation,
+        version::{VersionInfo, VersionSpec},
+    },
+    cvss::{ScoreCreator, ScoreInformation},
+};
 use trustify_test_context::TrustifyContext;
 
 pub async fn ingest_sample_advisory<'a>(
@@ -68,12 +76,20 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     ingest_sample_advisory(ctx, "RHSA-2", "RHSA-2").await?;
 
-    let fetch = AdvisoryService::new(ctx.db.clone());
+    let fetch = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
     let fetched = fetch
-        .fetch_advisories(q(""), Paginated::default(), Default::default(), &ctx.db)
+        .fetch_advisories(
+            q(""),
+            Paginated {
+                total: true,
+                ..Default::default()
+            },
+            Default::default(),
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(fetched.total, 2);
+    assert_eq!(fetched.total, Some(2));
     Ok(())
 }
 
@@ -125,7 +141,7 @@ async fn single_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     ingest_sample_advisory(ctx, "RHSA-2", "RHSA-2").await?;
 
-    let fetch = AdvisoryService::new(ctx.db.clone());
+    let fetch = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
     let jenny256 = Id::sha256(&digests.sha256);
     let jenny384 = Id::sha384(&digests.sha384);
     let jenny512 = Id::sha512(&digests.sha512);
@@ -210,7 +226,7 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let fetch = AdvisoryService::new(ctx.db.clone());
+    let fetch = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
     let jenny256 = Id::sha256(&digests.sha256);
     let fetched = fetch.fetch_advisory(jenny256.clone(), &ctx.db).await?;
 
@@ -268,7 +284,7 @@ async fn set_advisory_label(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
         )
         .await?;
 
-    let advisory_service = AdvisoryService::new(ctx.db.clone());
+    let advisory_service = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
     let jenny256 = Id::sha256(&digests.sha256);
 
     let fetched = advisory_service
@@ -344,7 +360,7 @@ async fn update_advisory_label(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
         )
         .await?;
 
-    let advisory_service = AdvisoryService::new(ctx.db.clone());
+    let advisory_service = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
     let jenny256 = Id::sha256(&digests.sha256);
 
     let fetched = advisory_service

--- a/modules/fundamental/src/endpoints.rs
+++ b/modules/fundamental/src/endpoints.rs
@@ -1,5 +1,5 @@
 use actix_web::web;
-use trustify_common::db::Database;
+use trustify_common::db::{Database, pagination_cache::PaginationCache};
 use trustify_module_analysis::service::AnalysisService;
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_ingestor::service::IngestorService;
@@ -19,19 +19,25 @@ pub fn configure(
     db: Database,
     storage: impl Into<DispatchBackend>,
     analysis: AnalysisService,
+    cache: PaginationCache,
 ) {
     let ingestor_service = IngestorService::new(Graph::new(db.clone()), storage, Some(analysis));
     svc.app_data(web::Data::new(ingestor_service));
 
-    crate::advisory::endpoints::configure(svc, db.clone(), config.advisory_upload_limit);
+    crate::advisory::endpoints::configure(
+        svc,
+        db.clone(),
+        config.advisory_upload_limit,
+        cache.clone(),
+    );
     crate::license::endpoints::configure(svc, db.clone());
-    crate::organization::endpoints::configure(svc, db.clone());
-    crate::purl::endpoints::configure(svc, db.clone());
-    crate::product::endpoints::configure(svc, db.clone());
-    crate::sbom::endpoints::configure(svc, db.clone(), config.sbom_upload_limit);
-    crate::vulnerability::endpoints::configure(svc, db.clone());
-    crate::weakness::endpoints::configure(svc, db.clone());
-    crate::sbom_group::endpoints::configure(svc, db, config.max_group_name_length);
+    crate::organization::endpoints::configure(svc, db.clone(), cache.clone());
+    crate::purl::endpoints::configure(svc, db.clone(), cache.clone());
+    crate::product::endpoints::configure(svc, db.clone(), cache.clone());
+    crate::sbom::endpoints::configure(svc, db.clone(), config.sbom_upload_limit, cache.clone());
+    crate::vulnerability::endpoints::configure(svc, db.clone(), cache.clone());
+    crate::weakness::endpoints::configure(svc, db.clone(), cache.clone());
+    crate::sbom_group::endpoints::configure(svc, db, config.max_group_name_length, cache);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default, ToSchema, serde::Deserialize, IntoParams)]

--- a/modules/fundamental/src/license/endpoints/test.rs
+++ b/modules/fundamental/src/license/endpoints/test.rs
@@ -12,13 +12,13 @@ use trustify_test_context::{TrustifyContext, call::CallService};
 async fn list_spdx_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/license/spdx/license";
+    let uri = "/api/v2/license/spdx/license?total=true";
 
     let request = TestRequest::get().uri(uri).to_request();
 
     let response: PaginatedResults<SpdxLicenseSummary> = app.call_and_read_body_json(request).await;
 
-    assert_eq!(734, response.total);
+    assert_eq!(Some(734), response.total);
 
     Ok(())
 }
@@ -46,13 +46,13 @@ async fn get_spdx_license(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn list_licenses_no_data(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/license";
+    let uri = "/api/v2/license?total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
     // Should have the preloaded licenses from DB init when no SBOMs are loaded
     assert_eq!(response.items.len(), 25);
-    assert_eq!(response.total, 652);
+    assert_eq!(response.total, Some(652));
 
     Ok(())
 }
@@ -66,12 +66,12 @@ async fn list_licenses_with_spdx_sbom(ctx: &TrustifyContext) -> Result<(), anyho
     ctx.ingest_document("spdx/OCP-TOOLS-4.11-RHEL-8.json")
         .await?;
 
-    let uri = "/api/v2/license?sort=license:asc";
+    let uri = "/api/v2/license?sort=license:asc&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
     assert_eq!(response.items.len(), 25); // 25 is the default for pagination
-    assert_eq!(response.total, 732);
+    assert_eq!(response.total, Some(732));
 
     // Check that we have some expected licenses from the SPDX SBOM
     let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
@@ -103,12 +103,12 @@ async fn list_licenses_no_license_ref(ctx: &TrustifyContext) -> Result<(), anyho
     ctx.ingest_document("spdx/OCP-TOOLS-4.11-RHEL-8.json")
         .await?;
 
-    let uri = "/api/v2/license?sort=license:asc&limit=733";
+    let uri = "/api/v2/license?sort=license:asc&limit=733&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
     assert_eq!(response.items.len(), 732);
-    assert_eq!(response.total, 732);
+    assert_eq!(response.total, Some(732));
 
     // Check that we have some expected licenses from the SPDX SBOM
     let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
@@ -138,12 +138,12 @@ async fn list_licenses_with_cyclonedx_sbom(ctx: &TrustifyContext) -> Result<(), 
     ctx.ingest_document("zookeeper-3.9.2-cyclonedx.json")
         .await?;
 
-    let uri = "/api/v2/license?sort=license:asc";
+    let uri = "/api/v2/license?sort=license:asc&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
     assert_eq!(response.items.len(), 25);
-    assert_eq!(response.total, 659);
+    assert_eq!(response.total, Some(659));
 
     // Check that we have some expected licenses from the CycloneDX SBOM
     let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
@@ -169,11 +169,11 @@ async fn list_licenses_with_mixed_sboms(ctx: &TrustifyContext) -> Result<(), any
     ])
     .await?;
 
-    let uri = "/api/v2/license?sort=license:asc";
+    let uri = "/api/v2/license?sort=license:asc&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
-    assert_eq!(response.total, 736);
+    assert_eq!(response.total, Some(736));
     assert_eq!(response.items.len(), 25);
 
     let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
@@ -206,47 +206,47 @@ async fn list_licenses_with_search_filter(ctx: &TrustifyContext) -> Result<(), a
     .await?;
 
     // Test search filter for "ASL" (Apache Software License)
-    let uri = "/api/v2/license?q=license~ASL";
+    let uri = "/api/v2/license?q=license~ASL&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
-    assert_eq!(response.total, 4);
+    assert_eq!(response.total, Some(4));
 
     // Test full text search filter for "ASL" (Apache Software License)
-    let uri = "/api/v2/license?q=ASL";
+    let uri = "/api/v2/license?q=ASL&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
-    assert_eq!(response.total, 4);
+    assert_eq!(response.total, Some(4));
 
     // Test case-insensitive search filter for "asl"
-    let uri = "/api/v2/license?q=asl";
+    let uri = "/api/v2/license?q=asl&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
-    assert_eq!(response.total, 4);
+    assert_eq!(response.total, Some(4));
 
     // Test case-insensitive search filter for "AsL"
-    let uri = "/api/v2/license?q=AsL";
+    let uri = "/api/v2/license?q=AsL&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
-    assert_eq!(response.total, 4);
+    assert_eq!(response.total, Some(4));
 
     // Test for non-existent license
-    let uri = "/api/v2/license?q=NonExistentLicense";
+    let uri = "/api/v2/license?q=NonExistentLicense&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
-    assert_eq!(0, response.total);
+    assert_eq!(Some(0), response.total);
     assert_eq!(0, response.items.len());
 
     // Test search filter for "ASL" (Apache Software License) and sorting (default asc)
-    let uri = "/api/v2/license?q=license~ASL&sort=license";
+    let uri = "/api/v2/license?q=license~ASL&sort=license&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
-    assert_eq!(response.total, 4);
+    assert_eq!(response.total, Some(4));
     // Verify licenses are sorted in ascending order
     let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
     let mut sorted_licenses = license_names.clone();
@@ -254,11 +254,11 @@ async fn list_licenses_with_search_filter(ctx: &TrustifyContext) -> Result<(), a
     assert_eq!(license_names, sorted_licenses);
 
     // Test full text search filter for "ASL" (Apache Software License) and sorting desc
-    let uri = "/api/v2/license?q=ASL&sort=license:desc";
+    let uri = "/api/v2/license?q=ASL&sort=license:desc&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
-    assert_eq!(response.total, 4);
+    assert_eq!(response.total, Some(4));
     // Verify licenses are sorted in descending order
     let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();
     let mut sorted_licenses = license_names.clone();
@@ -275,11 +275,11 @@ async fn list_licenses_with_pagination(ctx: &TrustifyContext) -> Result<(), anyh
     let app = caller(ctx).await?;
 
     // Test pagination - first page
-    let uri = "/api/v2/license?limit=5&offset=0";
+    let uri = "/api/v2/license?limit=5&offset=0&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
-    let total_licenses = response.total;
+    let total_licenses = response.total.expect("total should be present");
     assert!(total_licenses > 0);
 
     if total_licenses > 5 {
@@ -290,11 +290,11 @@ async fn list_licenses_with_pagination(ctx: &TrustifyContext) -> Result<(), anyh
 
     // Test pagination - second page (if there are enough items)
     if total_licenses > 5 {
-        let uri = "/api/v2/license?limit=5&offset=5";
+        let uri = "/api/v2/license?limit=5&offset=5&total=true";
         let request = TestRequest::get().uri(uri).to_request();
         let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
-        assert_eq!(total_licenses, response.total); // Total should remain the same
+        assert_eq!(Some(total_licenses), response.total); // Total should remain the same
 
         if total_licenses > 10 {
             assert_eq!(5, response.items.len());
@@ -304,11 +304,14 @@ async fn list_licenses_with_pagination(ctx: &TrustifyContext) -> Result<(), anyh
     }
 
     // Test pagination with offset beyond available items
-    let uri = format!("/api/v2/license?limit=5&offset={}", total_licenses + 10);
+    let uri = format!(
+        "/api/v2/license?limit=5&offset={}&total=true",
+        total_licenses + 10
+    );
     let request = TestRequest::get().uri(&uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
-    assert_eq!(total_licenses, response.total); // Total should remain the same
+    assert_eq!(Some(total_licenses), response.total); // Total should remain the same
     assert_eq!(0, response.items.len()); // No items should be returned
 
     Ok(())
@@ -390,12 +393,12 @@ async fn list_licenses_sorting(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     ctx.ingest_document("spdx/OCP-TOOLS-4.11-RHEL-8.json")
         .await?;
 
-    let uri = "/api/v2/license?sort=license:asc&limit=733";
+    let uri = "/api/v2/license?sort=license:asc&limit=733&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
     assert_eq!(response.items.len(), 732);
-    assert_eq!(response.total, 732);
+    assert_eq!(response.total, Some(732));
 
     // Verify licenses are sorted
     let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();

--- a/modules/fundamental/src/license/service/mod.rs
+++ b/modules/fundamental/src/license/service/mod.rs
@@ -188,10 +188,16 @@ impl LicenseService {
             )
             .collect::<Vec<_>>();
 
+        let total = if paginated.total {
+            Some(all_matching.len() as u64)
+        } else {
+            None
+        };
+
         if all_matching.len() < paginated.offset as usize {
             return Ok(PaginatedResults {
                 items: vec![],
-                total: all_matching.len() as u64,
+                total,
             });
         }
 
@@ -200,12 +206,12 @@ impl LicenseService {
         if paginated.limit > 0 && matching.len() > paginated.limit as usize {
             Ok(PaginatedResults {
                 items: SpdxLicenseSummary::from_details(&matching[..paginated.limit as usize]),
-                total: all_matching.len() as u64,
+                total,
             })
         } else {
             Ok(PaginatedResults {
                 items: SpdxLicenseSummary::from_details(matching),
-                total: all_matching.len() as u64,
+                total,
             })
         }
     }
@@ -375,16 +381,22 @@ impl LicenseService {
             num_items: i64,
         }
 
-        let (sql_count, values) = count_query.build(PostgresQueryBuilder);
-        let total = Count::find_by_statement(Statement::from_sql_and_values(
-            DatabaseBackend::Postgres,
-            sql_count,
-            values,
-        ))
-        .one(connection)
-        .await?
-        .unwrap_or(Count { num_items: 0 })
-        .num_items as u64;
+        let total = if paginated.total {
+            let (sql_count, values) = count_query.build(PostgresQueryBuilder);
+            Some(
+                Count::find_by_statement(Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    sql_count,
+                    values,
+                ))
+                .one(connection)
+                .await?
+                .unwrap_or(Count { num_items: 0 })
+                .num_items as u64,
+            )
+        } else {
+            None
+        };
 
         // Apply pagination
         union_query = union_query

--- a/modules/fundamental/src/license/service/test.rs
+++ b/modules/fundamental/src/license/service/test.rs
@@ -18,7 +18,14 @@ async fn test_licenses_union_spdx_and_cyclonedx(
 
     // RED: Before ingestion
     let result_before = service
-        .licenses(Query::default(), Paginated::default(), &ctx.db)
+        .licenses(
+            Query::default(),
+            Paginated {
+                total: true,
+                ..Default::default()
+            },
+            &ctx.db,
+        )
         .await?;
     let baseline_count = result_before.total;
 
@@ -36,6 +43,7 @@ async fn test_licenses_union_spdx_and_cyclonedx(
             Paginated {
                 offset: 0,
                 limit: 1000,
+                total: true,
             },
             &ctx.db,
         )
@@ -199,6 +207,7 @@ async fn test_cyclonedx_uses_raw_license_text(ctx: &TrustifyContext) -> Result<(
             Paginated {
                 offset: 0,
                 limit: 100,
+                ..Default::default()
             },
             &ctx.db,
         )
@@ -271,6 +280,7 @@ async fn test_license_count_accuracy(ctx: &TrustifyContext) -> Result<(), anyhow
             Paginated {
                 offset: 0,
                 limit: 1000,
+                total: true,
             },
             &ctx.db,
         )
@@ -290,6 +300,7 @@ async fn test_license_count_accuracy(ctx: &TrustifyContext) -> Result<(), anyhow
             Paginated {
                 offset: 0,
                 limit: 1000,
+                total: true,
             },
             &ctx.db,
         )
@@ -307,13 +318,14 @@ async fn test_license_count_accuracy(ctx: &TrustifyContext) -> Result<(), anyhow
             Paginated {
                 offset: 0,
                 limit: 10000,
+                total: true,
             },
             &ctx.db,
         )
         .await?;
     assert_eq!(
         all_items.total,
-        all_items.items.len() as u64,
+        Some(all_items.items.len() as u64),
         "Total count should match number of items when all fetched"
     );
 
@@ -341,6 +353,7 @@ async fn test_license_ordering_by_coalesce(ctx: &TrustifyContext) -> Result<(), 
             Paginated {
                 offset: 0,
                 limit: 100,
+                ..Default::default()
             },
             &ctx.db,
         )
@@ -386,13 +399,17 @@ async fn test_license_filtering_on_coalesce(ctx: &TrustifyContext) -> Result<(),
             Paginated {
                 offset: 0,
                 limit: 100,
+                total: true,
             },
             &ctx.db,
         )
         .await?;
 
     // REFACTOR: Verify filtering works on COALESCE result
-    assert!(apache_results.total > 0, "Should find Apache licenses");
+    assert!(
+        apache_results.total > Some(0),
+        "Should find Apache licenses"
+    );
 
     for license in &apache_results.items {
         assert!(
@@ -423,6 +440,7 @@ async fn test_coalesce_null_handling(ctx: &TrustifyContext) -> Result<(), anyhow
             Paginated {
                 offset: 0,
                 limit: 100,
+                total: true,
             },
             &ctx.db,
         )
@@ -430,7 +448,7 @@ async fn test_coalesce_null_handling(ctx: &TrustifyContext) -> Result<(), anyhow
 
     // REFACTOR: Verify COALESCE fallback to license.text works when expanded_text is NULL
     assert!(
-        result.total > 0,
+        result.total > Some(0),
         "Should get CycloneDX licenses via COALESCE fallback to license.text"
     );
 
@@ -465,6 +483,7 @@ async fn test_license_pagination_with_count(ctx: &TrustifyContext) -> Result<(),
             Paginated {
                 offset: 0,
                 limit: 5,
+                total: true,
             },
             &ctx.db,
         )
@@ -474,7 +493,7 @@ async fn test_license_pagination_with_count(ctx: &TrustifyContext) -> Result<(),
     // REFACTOR: Verify pagination works correctly with refactored COUNT
     assert!(page1.items.len() <= 5, "Page 1 should have at most 5 items");
     assert!(
-        total >= page1.items.len() as u64,
+        total >= Some(page1.items.len() as u64),
         "Total should be >= page 1 items"
     );
 
@@ -484,6 +503,7 @@ async fn test_license_pagination_with_count(ctx: &TrustifyContext) -> Result<(),
             Paginated {
                 offset: 5,
                 limit: 5,
+                total: true,
             },
             &ctx.db,
         )
@@ -516,12 +536,19 @@ async fn test_preloaded_licenses_visible(ctx: &TrustifyContext) -> Result<(), an
 
     // Baseline: Get initial license count (includes pre-loaded SPDX dictionary)
     let before = service
-        .licenses(Query::default(), Paginated::default(), &ctx.db)
+        .licenses(
+            Query::default(),
+            Paginated {
+                total: true,
+                ..Default::default()
+            },
+            &ctx.db,
+        )
         .await?;
 
     // Pre-loaded licenses should be visible even before any SBOM ingestion
     assert!(
-        before.total > 0,
+        before.total > Some(0),
         "Pre-loaded SPDX dictionary entries should be visible"
     );
 

--- a/modules/fundamental/src/organization/endpoints/mod.rs
+++ b/modules/fundamental/src/organization/endpoints/mod.rs
@@ -11,13 +11,17 @@ use crate::{
 use actix_web::{HttpResponse, Responder, get, web};
 use trustify_auth::{ReadMetadata, authorizer::Require};
 use trustify_common::{
-    db::{Database, query::Query},
+    db::{Database, pagination_cache::PaginationCache, query::Query},
     model::Paginated,
 };
 use uuid::Uuid;
 
-pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, db: Database) {
-    let service = OrganizationService::new();
+pub fn configure(
+    config: &mut utoipa_actix_web::service_config::ServiceConfig,
+    db: Database,
+    cache: PaginationCache,
+) {
+    let service = OrganizationService::new(cache);
     config
         .app_data(web::Data::new(db))
         .app_data(web::Data::new(service))

--- a/modules/fundamental/src/organization/endpoints/test.rs
+++ b/modules/fundamental/src/organization/endpoints/test.rs
@@ -1,13 +1,12 @@
 use crate::test::caller;
-use actix_web::cookie::time::OffsetDateTime;
-use actix_web::test::TestRequest;
+use actix_web::{cookie::time::OffsetDateTime, test::TestRequest};
 use jsonpath_rust::JsonPath;
 use serde_json::{Value, json};
 use test_context::test_context;
 use test_log::test;
-use trustify_common::db::query::Query;
-use trustify_common::hashing::Digests;
-use trustify_common::model::Paginated;
+use trustify_common::{
+    db::pagination_cache::PaginationCache, db::query::Query, hashing::Digests, model::Paginated,
+};
 use trustify_module_ingestor::graph::advisory::AdvisoryInformation;
 use trustify_test_context::{TrustifyContext, call::CallService};
 
@@ -99,13 +98,21 @@ async fn one_organization(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .link_to_vulnerability("CVE-123", None, &ctx.db)
         .await?;
 
-    let service = crate::organization::service::OrganizationService::new();
+    let service =
+        crate::organization::service::OrganizationService::new(PaginationCache::for_test());
 
     let orgs = service
-        .fetch_organizations(Query::default(), Paginated::default(), &ctx.db)
+        .fetch_organizations(
+            Query::default(),
+            Paginated {
+                total: true,
+                ..Default::default()
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(1, orgs.total);
+    assert_eq!(Some(1), orgs.total);
 
     let first_org = &orgs.items[0];
     let org_id = first_org.head.id;

--- a/modules/fundamental/src/organization/service/mod.rs
+++ b/modules/fundamental/src/organization/service/mod.rs
@@ -5,7 +5,8 @@ use crate::{
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
 use trustify_common::{
     db::{
-        limiter::LimiterTrait,
+        limiter::{LimitedResult, LimiterTrait},
+        pagination_cache::PaginationCache,
         query::{Filtering, Query},
     },
     model::{Paginated, PaginatedResults},
@@ -13,12 +14,13 @@ use trustify_common::{
 use trustify_entity::organization;
 use uuid::Uuid;
 
-#[derive(Default)]
-pub struct OrganizationService {}
+pub struct OrganizationService {
+    cache: PaginationCache,
+}
 
 impl OrganizationService {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(cache: PaginationCache) -> Self {
+        Self { cache }
     }
 
     pub async fn fetch_organizations<C: ConnectionTrait>(
@@ -31,13 +33,15 @@ impl OrganizationService {
             connection,
             paginated.offset,
             paginated.limit,
+            &self.cache,
         );
 
-        let total = limiter.total().await?;
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         Ok(PaginatedResults {
             total,
-            items: OrganizationSummary::from_entities(&limiter.fetch().await?),
+            items: OrganizationSummary::from_entities(&items),
         })
     }
     pub async fn fetch_organization<C: ConnectionTrait>(

--- a/modules/fundamental/src/organization/service/test.rs
+++ b/modules/fundamental/src/organization/service/test.rs
@@ -1,6 +1,7 @@
 use actix_web::cookie::time::OffsetDateTime;
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::db::query::Query;
 use trustify_common::hashing::Digests;
 use trustify_common::model::Paginated;
@@ -28,13 +29,21 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let service = crate::organization::service::OrganizationService::new();
+    let service =
+        crate::organization::service::OrganizationService::new(PaginationCache::for_test());
 
     let orgs = service
-        .fetch_organizations(Query::default(), Paginated::default(), &ctx.db)
+        .fetch_organizations(
+            Query::default(),
+            Paginated {
+                total: true,
+                ..Default::default()
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(1, orgs.total);
+    assert_eq!(Some(1), orgs.total);
     assert_eq!(1, orgs.items.len());
 
     Ok(())

--- a/modules/fundamental/src/product/endpoints/mod.rs
+++ b/modules/fundamental/src/product/endpoints/mod.rs
@@ -13,13 +13,17 @@ use actix_web::{HttpResponse, Responder, delete, get, web};
 use sea_orm::TransactionTrait;
 use trustify_auth::{DeleteMetadata, ReadMetadata, authorizer::Require};
 use trustify_common::{
-    db::{Database, query::Query},
+    db::{Database, pagination_cache::PaginationCache, query::Query},
     model::{Paginated, PaginatedResults},
 };
 use uuid::Uuid;
 
-pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, db: Database) {
-    let service = ProductService::new();
+pub fn configure(
+    config: &mut utoipa_actix_web::service_config::ServiceConfig,
+    db: Database,
+    cache: PaginationCache,
+) {
+    let service = ProductService::new(cache);
     config
         .app_data(web::Data::new(db))
         .app_data(web::Data::new(service))

--- a/modules/fundamental/src/product/endpoints/test.rs
+++ b/modules/fundamental/src/product/endpoints/test.rs
@@ -5,6 +5,7 @@ use jsonpath_rust::JsonPath;
 use serde_json::{Value, json};
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::db::query::Query;
 use trustify_common::model::Paginated;
 use trustify_module_ingestor::graph::product::ProductInformation;
@@ -69,13 +70,20 @@ async fn one_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let service = crate::product::service::ProductService::new();
+    let service = crate::product::service::ProductService::new(PaginationCache::for_test());
 
     let products = service
-        .fetch_products(Query::default(), Paginated::default(), &ctx.db)
+        .fetch_products(
+            Query::default(),
+            Paginated {
+                total: true,
+                ..Default::default()
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(1, products.total);
+    assert_eq!(Some(1), products.total);
 
     let first_product = &products.items[0];
     let product_id = first_product.head.id;
@@ -109,13 +117,20 @@ async fn delete_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let service = crate::product::service::ProductService::new();
+    let service = crate::product::service::ProductService::new(PaginationCache::for_test());
 
     let products = service
-        .fetch_products(Query::default(), Paginated::default(), &ctx.db)
+        .fetch_products(
+            Query::default(),
+            Paginated {
+                total: true,
+                ..Default::default()
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(1, products.total);
+    assert_eq!(Some(1), products.total);
 
     let first_product = &products.items[0];
     let product_id = first_product.head.id;
@@ -129,10 +144,17 @@ async fn delete_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(response.status(), StatusCode::OK);
 
     let products = service
-        .fetch_products(Query::default(), Paginated::default(), &ctx.db)
+        .fetch_products(
+            Query::default(),
+            Paginated {
+                total: true,
+                ..Default::default()
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(0, products.total);
+    assert_eq!(Some(0), products.total);
 
     let request = TestRequest::delete().uri(&uri).to_request();
 

--- a/modules/fundamental/src/product/service/mod.rs
+++ b/modules/fundamental/src/product/service/mod.rs
@@ -3,7 +3,8 @@ use crate::{Error, product::model::details::ProductDetails};
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
 use trustify_common::{
     db::{
-        limiter::LimiterTrait,
+        limiter::{LimitedResult, LimiterTrait},
+        pagination_cache::PaginationCache,
         query::{Filtering, Query},
     },
     model::{Paginated, PaginatedResults},
@@ -11,12 +12,13 @@ use trustify_common::{
 use trustify_entity::product;
 use uuid::Uuid;
 
-#[derive(Default)]
-pub struct ProductService {}
+pub struct ProductService {
+    cache: PaginationCache,
+}
 
 impl ProductService {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(cache: PaginationCache) -> Self {
+        Self { cache }
     }
 
     pub async fn fetch_products<C: ConnectionTrait + Sync + Send>(
@@ -29,13 +31,15 @@ impl ProductService {
             connection,
             paginated.offset,
             paginated.limit,
+            &self.cache,
         );
 
-        let total = limiter.total().await?;
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         Ok(PaginatedResults {
             total,
-            items: ProductSummary::from_entities(&limiter.fetch().await?, connection).await?,
+            items: ProductSummary::from_entities(&items, connection).await?,
         })
     }
 

--- a/modules/fundamental/src/product/service/test.rs
+++ b/modules/fundamental/src/product/service/test.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::cpe::Cpe;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::db::query::Query;
 use trustify_common::hashing::Digests;
 use trustify_common::model::Paginated;
@@ -38,13 +39,20 @@ async fn all_products(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .ingest_product_version("1.0.0".to_string(), Some(sbom.sbom.sbom_id), &ctx.db)
         .await?;
 
-    let service = crate::product::service::ProductService::new();
+    let service = crate::product::service::ProductService::new(PaginationCache::for_test());
 
     let prods = service
-        .fetch_products(Query::default(), Paginated::default(), &ctx.db)
+        .fetch_products(
+            Query::default(),
+            Paginated {
+                total: true,
+                ..Default::default()
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(1, prods.total);
+    assert_eq!(Some(1), prods.total);
     assert_eq!(1, prods.items.len());
 
     let ver_sbom = ver.get_sbom(&ctx.db).await?.expect("No sbom found");
@@ -129,13 +137,20 @@ async fn delete_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let service = crate::product::service::ProductService::new();
+    let service = crate::product::service::ProductService::new(PaginationCache::for_test());
 
     let prods = service
-        .fetch_products(Query::default(), Paginated::default(), &ctx.db)
+        .fetch_products(
+            Query::default(),
+            Paginated {
+                total: true,
+                ..Default::default()
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(1, prods.total);
+    assert_eq!(Some(1), prods.total);
     assert_eq!(1, prods.items.len());
 
     let result = service.delete_product(pr.product.id, &ctx.db).await?;

--- a/modules/fundamental/src/purl/endpoints/mod.rs
+++ b/modules/fundamental/src/purl/endpoints/mod.rs
@@ -15,7 +15,7 @@ use sea_orm::prelude::Uuid;
 use std::str::FromStr;
 use trustify_auth::{ReadAdvisory, ReadSbom, authorizer::Require};
 use trustify_common::{
-    db::{Database, query::Query},
+    db::{Database, pagination_cache::PaginationCache, query::Query},
     id::IdError,
     model::{Paginated, PaginatedResults},
     purl::Purl,
@@ -23,8 +23,12 @@ use trustify_common::{
 
 mod base;
 
-pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, db: Database) {
-    let purl_service = PurlService::new();
+pub fn configure(
+    config: &mut utoipa_actix_web::service_config::ServiceConfig,
+    db: Database,
+    cache: PaginationCache,
+) {
+    let purl_service = PurlService::new(cache);
 
     config
         .app_data(web::Data::new(db))

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -25,7 +25,8 @@ use tracing::{Instrument, info_span, instrument};
 use trustify_common::{
     db::{
         chunk::chunked_with,
-        limiter::LimiterTrait,
+        limiter::{LimitedResult, LimiterTrait},
+        pagination_cache::PaginationCache,
         query::{Columns, Filtering, IntoColumns, Query, q},
     },
     model::{Paginated, PaginatedResults},
@@ -119,12 +120,13 @@ impl InputPurl {
     }
 }
 
-#[derive(Default)]
-pub struct PurlService {}
+pub struct PurlService {
+    cache: PaginationCache,
+}
 
 impl PurlService {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(cache: PaginationCache) -> Self {
+        Self { cache }
     }
 
     #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
@@ -164,12 +166,13 @@ impl PurlService {
         let limiter = base_purl::Entity::find()
             .filter(base_purl::Column::Type.eq(r#type))
             .filtering(query)?
-            .limiting(connection, paginated.offset, paginated.limit);
+            .limiting(connection, paginated.offset, paginated.limit, &self.cache);
 
-        let total = limiter.total().await?;
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         Ok(PaginatedResults {
-            items: BasePurlSummary::from_entities(&limiter.fetch().await?).await?,
+            items: BasePurlSummary::from_entities(&items).await?,
             total,
         })
     }
@@ -377,12 +380,14 @@ impl PurlService {
             connection,
             paginated.offset,
             paginated.limit,
+            &self.cache,
         );
 
-        let total = limiter.total().await?;
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         Ok(PaginatedResults {
-            items: BasePurlSummary::from_entities(&limiter.fetch().await?).await?,
+            items: BasePurlSummary::from_entities(&items).await?,
             total,
         })
     }
@@ -472,11 +477,12 @@ impl PurlService {
                 select.filter(qualified_purl::Column::Id.in_subquery(spdx_select.into_query()));
         }
 
-        let limiter = select.limiting(connection, paginated.offset, paginated.limit);
-        let total = limiter.total().await?;
+        let limiter = select.limiting(connection, paginated.offset, paginated.limit, &self.cache);
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         Ok(PaginatedResults {
-            items: PurlSummary::from_entities(&limiter.fetch().await?),
+            items: PurlSummary::from_entities(&items),
             total,
         })
     }

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -3,7 +3,10 @@ use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::{
-    db::query::{Query, q},
+    db::{
+        pagination_cache::PaginationCache,
+        query::{Query, q},
+    },
     model::Paginated,
     purl::Purl,
 };
@@ -23,7 +26,7 @@ async fn ingest_extra_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn types(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     let log4j = ctx
         .graph
@@ -80,7 +83,7 @@ async fn types(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn packages_for_type(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     let log4j = ctx
         .graph
@@ -111,10 +114,18 @@ async fn packages_for_type(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ingest_extra_packages(ctx).await?;
 
     let packages = service
-        .base_purls_by_type("maven", Query::default(), Paginated::default(), &ctx.db)
+        .base_purls_by_type(
+            "maven",
+            Query::default(),
+            Paginated {
+                total: true,
+                ..Default::default()
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(packages.total, 2);
+    assert_eq!(packages.total, Some(2));
 
     assert!(
         packages
@@ -136,7 +147,7 @@ async fn packages_for_type(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn packages_for_type_with_filtering(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     let log4j = ctx
         .graph
@@ -167,10 +178,18 @@ async fn packages_for_type_with_filtering(ctx: &TrustifyContext) -> Result<(), a
     ingest_extra_packages(ctx).await?;
 
     let packages = service
-        .base_purls_by_type("maven", q("myspace"), Paginated::default(), &ctx.db)
+        .base_purls_by_type(
+            "maven",
+            q("myspace"),
+            Paginated {
+                total: true,
+                ..Default::default()
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(packages.total, 1);
+    assert_eq!(packages.total, Some(1));
 
     assert!(
         packages
@@ -185,7 +204,7 @@ async fn packages_for_type_with_filtering(ctx: &TrustifyContext) -> Result<(), a
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     let log4j = ctx
         .graph
@@ -266,7 +285,7 @@ async fn package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn package_version(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     let log4j = ctx
         .graph
@@ -356,7 +375,7 @@ async fn package_version(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn package_version_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     let log4j = ctx
         .graph
@@ -440,7 +459,7 @@ async fn package_version_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Er
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     let log4j = ctx
         .graph
@@ -538,7 +557,7 @@ async fn packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn qualified_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     let log4j = ctx
         .graph
@@ -619,7 +638,7 @@ async fn qualified_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn qualified_packages_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     let _mtv = ctx.ingest_document("spdx/mtv-2.6.json").await?;
 
@@ -754,6 +773,7 @@ async fn qualified_packages_filter_by_license(ctx: &TrustifyContext) -> Result<(
             Paginated {
                 offset: 0,
                 limit: 1,
+                total: true,
             },
             &ctx.db,
         )
@@ -761,7 +781,7 @@ async fn qualified_packages_filter_by_license(ctx: &TrustifyContext) -> Result<(
 
     log::debug!("{results:#?}");
     assert_eq!(1, results.items.len());
-    assert_eq!(4, results.total);
+    assert_eq!(Some(4), results.total);
 
     Ok(())
 }
@@ -769,7 +789,7 @@ async fn qualified_packages_filter_by_license(ctx: &TrustifyContext) -> Result<(
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
     ctx.ingest_documents(["osv/RUSTSEC-2021-0079.json", "cve/CVE-2021-32714.json"])
         .await?;
 
@@ -797,7 +817,7 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn contextual_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     ctx.ingest_document("csaf/rhsa-2024_3666.json").await?;
 
@@ -898,7 +918,7 @@ async fn ingest_some_log4j_data(ctx: &TrustifyContext) -> Result<(), anyhow::Err
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn unqualified_purl_by_purl(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     ingest_some_log4j_data(ctx).await?;
 
@@ -919,7 +939,7 @@ async fn unqualified_purl_by_purl(ctx: &TrustifyContext) -> Result<(), anyhow::E
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn base_purl_by_purl(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     ingest_some_log4j_data(ctx).await?;
 
@@ -938,7 +958,7 @@ async fn base_purl_by_purl(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn versioned_base_purl_by_purl(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
 
     ingest_some_log4j_data(ctx).await?;
 

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -37,7 +37,7 @@ use trustify_auth::{
     authorizer::{Authorizer, Require},
 };
 use trustify_common::{
-    db::{Database, query::Query},
+    db::{Database, pagination_cache::PaginationCache, query::Query},
     decompress::decompress_async,
     id::Id,
     model::{BinaryData, Paginated, PaginatedResults},
@@ -53,8 +53,9 @@ pub fn configure(
     config: &mut utoipa_actix_web::service_config::ServiceConfig,
     db: Database,
     upload_limit: usize,
+    cache: PaginationCache,
 ) {
-    let sbom_service = SbomService::new(db.clone());
+    let sbom_service = SbomService::new(db.clone(), cache);
 
     config
         .app_data(web::Data::new(db))

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -588,7 +588,7 @@ async fn get_packages_sbom_by_query(ctx: &TrustifyContext) -> Result<(), anyhow:
 
     async fn query_value(app: &impl CallService, id: &str, q: &str) -> Value {
         let uri = format!(
-            "/api/v2/sbom/urn:uuid:{id}/packages?q={}",
+            "/api/v2/sbom/urn:uuid:{id}/packages?total=true&q={}",
             urlencoding::encode(q)
         );
         let req = TestRequest::get().uri(&uri).to_request();
@@ -1124,29 +1124,32 @@ async fn filter_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .to_string();
 
     async fn query(app: &impl CallService, id: &str, q: &str) -> PaginatedResults<SbomPackage> {
-        let uri = format!("/api/v2/sbom/urn:uuid:{id}/packages?q={}", encode(q));
+        let uri = format!(
+            "/api/v2/sbom/urn:uuid:{id}/packages?total=true&q={}",
+            encode(q)
+        );
         let req = TestRequest::get().uri(&uri).to_request();
         app.call_and_read_body_json(req).await
     }
 
     let result = query(&app, &id, "").await;
-    assert_eq!(result.total, 41);
+    assert_eq!(result.total, Some(41));
 
     let result = query(&app, &id, "netty-common").await;
-    assert_eq!(result.total, 1);
+    assert_eq!(result.total, Some(1));
     assert_eq!(result.items[0].name, "netty-common");
 
     let result = query(&app, &id, r"type\=jar").await;
-    assert_eq!(result.total, 41);
+    assert_eq!(result.total, Some(41));
 
     let result = query(&app, &id, "version=4.1.105.Final").await;
-    assert_eq!(result.total, 9);
+    assert_eq!(result.total, Some(9));
 
     let result = query(&app, &id, "license=Apache-2.0").await;
-    assert_eq!(result.total, 35);
+    assert_eq!(result.total, Some(35));
 
     let result = query(&app, &id, "license~GNU Lesser General Public License").await;
-    assert_eq!(result.total, 2);
+    assert_eq!(result.total, Some(2));
 
     let result = query(
         &app,
@@ -1154,7 +1157,7 @@ async fn filter_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         "license~Apache-2.0|GNU Lesser General Public License",
     )
     .await;
-    assert_eq!(result.total, 37);
+    assert_eq!(result.total, Some(37));
 
     let result = query(
         &app,
@@ -1162,7 +1165,7 @@ async fn filter_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         "license~EPL-1.0|GNU Lesser General Public License",
     )
     .await;
-    assert_eq!(result.total, 10);
+    assert_eq!(result.total, Some(10));
 
     Ok(())
 }
@@ -1375,7 +1378,7 @@ async fn get_advisories_with_deprecated_filtering(
 async fn query_sboms_by_ingested_time(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     async fn query(app: &impl CallService, q: &str) -> Value {
         let uri = format!(
-            "/api/v2/sbom?q={}&sort={}",
+            "/api/v2/sbom?total=true&q={}&sort={}",
             urlencoding::encode(q),
             urlencoding::encode("ingested:desc")
         );
@@ -1413,7 +1416,7 @@ async fn query_sboms_by_ingested_time(ctx: &TrustifyContext) -> Result<(), anyho
 async fn query_sboms_by_label(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let query = async |total, q| {
         let app = caller(ctx).await.unwrap();
-        let uri = format!("/api/v2/sbom?q={}", encode(q));
+        let uri = format!("/api/v2/sbom?total=true&q={}", encode(q));
         let req = TestRequest::get().uri(&uri).to_request();
         let response: Value = app.call_and_read_body_json(req).await;
         assert_eq!(total, response["total"], "for {q}");
@@ -1486,7 +1489,7 @@ async fn query_sboms_by_package(ctx: &TrustifyContext) -> Result<(), anyhow::Err
     let query = async |purl, sort| {
         let app = caller(ctx).await.unwrap();
         let uri = format!(
-            "/api/v2/sbom/by-package?purl={}&sort={}",
+            "/api/v2/sbom/by-package?total=true&purl={}&sort={}",
             encode(purl),
             encode(sort)
         );
@@ -1527,7 +1530,7 @@ async fn query_sboms_by_array_values(ctx: &TrustifyContext) -> Result<(), anyhow
 
     let query = async |expected_count, q| {
         let app = caller(ctx).await.unwrap();
-        let uri = format!("/api/v2/sbom?q={}", encode(q));
+        let uri = format!("/api/v2/sbom?total=true&q={}", encode(q));
         let req = TestRequest::get().uri(&uri).to_request();
         let response: Value = app.call_and_read_body_json(req).await;
         tracing::debug!(test = "", "{response:#?}");
@@ -1669,7 +1672,7 @@ async fn get_cbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(labels["kind"], "cbom");
     assert_eq!(labels["type"], "cyclonedx");
 
-    let uri = format!("/api/v2/sbom/{id}/packages");
+    let uri = format!("/api/v2/sbom/{id}/packages?total=true");
     let req = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(req).await;
     log::info!("{:#}", json!(response));
@@ -1711,7 +1714,7 @@ async fn get_aibom_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
     assert_eq!(labels["kind"], "aibom");
     assert_eq!(labels["type"], "cyclonedx");
 
-    let uri = format!("/api/v2/sbom/{id}/packages");
+    let uri = format!("/api/v2/sbom/{id}/packages?total=true");
     let req = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(req).await;
     log::info!("{:#}", json!(response));
@@ -1774,7 +1777,7 @@ async fn get_aibom_models(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .id
         .to_string();
 
-    let uri = format!("/api/v2/sbom/{id}/models");
+    let uri = format!("/api/v2/sbom/{id}/models?total=true");
     let req = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(req).await;
     log::info!("response:\n{:#}", json!(response));
@@ -1849,7 +1852,7 @@ async fn query_aibom_models(
         .id
         .to_string();
 
-    let uri = format!("/api/v2/sbom/{id}/models?q={}", encode(q));
+    let uri = format!("/api/v2/sbom/{id}/models?total=true&q={}", encode(q));
     let req = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(req).await;
 
@@ -1892,16 +1895,16 @@ async fn query_all_aibom_models(
     .await?;
 
     let uri = if let Some(q) = q {
-        format!("/api/v2/sbom/models?q={}", encode(q))
+        format!("/api/v2/sbom/models?total=true&q={}", encode(q))
     } else {
-        "/api/v2/sbom/models".into()
+        "/api/v2/sbom/models?total=true".into()
     };
     let req = TestRequest::get().uri(&uri).to_request();
     let app = caller(ctx).await?;
 
     #[derive(serde::Deserialize)]
     struct Page<T> {
-        total: usize,
+        total: Option<usize>,
         items: Vec<T>,
     }
     #[derive(serde::Deserialize)]
@@ -1913,7 +1916,7 @@ async fn query_all_aibom_models(
     let mut v: Vec<_> = response.items.into_iter().map(|i| i.name).collect();
     v.sort();
 
-    assert_eq!(response.total, names.len());
+    assert_eq!(response.total, Some(names.len()));
     assert_eq!(v, names);
 
     Ok(())
@@ -1960,7 +1963,7 @@ async fn filter_sboms_by_group(
         .await?;
 
     let query = resolve_group_refs(&ids, groups);
-    let uri = format!("/api/v2/sbom?{query}");
+    let uri = format!("/api/v2/sbom?total=true&{query}");
     log::info!("URI: {uri}");
     let req = TestRequest::get().uri(&uri).to_request();
 
@@ -1974,7 +1977,7 @@ async fn filter_sboms_by_group(
 
     let result: PaginatedResults<Value> = serde_json::from_slice(&body).unwrap();
 
-    assert_eq!(result.total, expected_total);
+    assert_eq!(result.total, Some(expected_total));
 
     Ok(())
 }
@@ -1997,13 +2000,13 @@ async fn packages_by_hash(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // Fetch packages by UUID
     let req = TestRequest::get()
-        .uri(&format!("/api/v2/sbom/urn:uuid:{id}/packages"))
+        .uri(&format!("/api/v2/sbom/urn:uuid:{id}/packages?total=true"))
         .to_request();
     let by_uuid: Value = app.call_and_read_body_json(req).await;
 
     // Fetch packages by SHA-256
     let req = TestRequest::get()
-        .uri(&format!("/api/v2/sbom/{sha256}/packages"))
+        .uri(&format!("/api/v2/sbom/{sha256}/packages?total=true"))
         .to_request();
     let by_hash: Value = app.call_and_read_body_json(req).await;
 

--- a/modules/fundamental/src/sbom/service/mod.rs
+++ b/modules/fundamental/src/sbom/service/mod.rs
@@ -5,14 +5,15 @@ pub mod sbom;
 #[cfg(test)]
 mod test;
 
-use trustify_common::db::Database;
+use trustify_common::db::{Database, pagination_cache::PaginationCache};
 
 pub struct SbomService {
     db: Database,
+    pub(crate) cache: PaginationCache,
 }
 
 impl SbomService {
-    pub fn new(db: Database) -> Self {
-        Self { db }
+    pub fn new(db: Database, cache: PaginationCache) -> Self {
+        Self { db, cache }
     }
 }

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -22,7 +22,7 @@ use tracing::{Instrument, info_span, instrument};
 use trustify_common::{
     cpe::Cpe,
     db::{
-        limiter::{LimiterTrait, limit_selector},
+        limiter::{LimitedResult, LimiterTrait, limit_selector},
         multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
         query::{Columns, Filtering, IntoColumns, Query, q},
     },
@@ -286,10 +286,13 @@ impl SbomService {
                         },
                     }),
             )?
-            .limiting(connection, paginated.offset, paginated.limit);
+            .limiting(connection, paginated.offset, paginated.limit, &self.cache);
 
-        let total = limiter.total().await?;
-        let sboms = limiter.fetch().await?;
+        let LimitedResult {
+            items: sboms,
+            total,
+        } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         let items = stream::iter(
             sboms
@@ -415,20 +418,17 @@ impl SbomService {
 
         // limit and execute
 
-        let limiter = limit_selector::<'_, _, _, _, PackageCatcher>(
+        let limiter = limit_selector::<_, _, _, PackageCatcher>(
             connection,
             query,
             paginated.offset,
             paginated.limit,
+            &self.cache,
         );
 
-        let total = limiter.total().await?;
-        let items = limiter
-            .fetch()
-            .await?
-            .into_iter()
-            .map(SbomPackage::from_row)
-            .collect();
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
+        let items = items.into_iter().map(SbomPackage::from_row).collect();
 
         Ok(PaginatedResults { items, total })
     }
@@ -470,20 +470,17 @@ impl SbomService {
             query = query.filter(sbom_ai::Column::SbomId.eq(id));
         }
 
-        let limiter = limit_selector::<'_, _, _, _, ModelCatcher>(
+        let limiter = limit_selector::<_, _, _, ModelCatcher>(
             connection,
             query,
             paginated.offset,
             paginated.limit,
+            &self.cache,
         );
 
-        let total = limiter.total().await?;
-        let items = limiter
-            .fetch()
-            .await?
-            .into_iter()
-            .map(SbomModel::from_row)
-            .collect();
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
+        let items = items.into_iter().map(SbomModel::from_row).collect();
 
         Ok(PaginatedResults { items, total })
     }
@@ -627,10 +624,13 @@ impl SbomService {
 
         // limit and execute
 
-        let limiter = query.limiting(connection, paginated.offset, paginated.limit);
+        let limiter = query.limiting(connection, paginated.offset, paginated.limit, &self.cache);
 
-        let total = limiter.total().await?;
-        let sboms = limiter.fetch().await?;
+        let LimitedResult {
+            items: sboms,
+            total,
+        } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         // collect results
 
@@ -730,7 +730,7 @@ impl SbomService {
             package: P,
         }
 
-        let r: R::Output<Row<P::Row>> = R::get(options, db, query).await?;
+        let r: R::Output<Row<P::Row>> = R::get(options, db, query, &self.cache).await?;
 
         Ok(r.flat_map_all(|row| {
             Some(SbomPackageRelation {
@@ -1079,6 +1079,7 @@ mod test {
     use super::*;
     use test_context::test_context;
     use test_log::test;
+    use trustify_common::db::pagination_cache::PaginationCache;
     use trustify_common::db::query::q;
     use trustify_common::hashing::Digests;
     use trustify_entity::labels::Labels;
@@ -1132,19 +1133,22 @@ mod test {
         assert_eq!(sbom_v1.sbom.sbom_id, sbom_v1_again.sbom.sbom_id);
         assert_ne!(sbom_v1.sbom.sbom_id, sbom_v2.sbom.sbom_id);
 
-        let fetch = SbomService::new(ctx.db.clone());
+        let fetch = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
         let fetched = fetch
             .fetch_sboms::<_, SbomPackage>(
                 q("MySpAcE").sort("name,authors,published"),
-                Paginated::default(),
+                Paginated {
+                    total: true,
+                    ..Default::default()
+                },
                 Default::default(),
                 &ctx.db,
             )
             .await?;
 
         log::debug!("{:#?}", fetched.items);
-        assert_eq!(1, fetched.total);
+        assert_eq!(Some(1), fetched.total);
 
         Ok(())
     }
@@ -1194,67 +1198,72 @@ mod test {
             )
             .await?;
 
-        let service = SbomService::new(ctx.db.clone());
+        let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
+
+        let paginated_with_total = Paginated {
+            total: true,
+            ..Default::default()
+        };
 
         let fetched = service
             .fetch_sboms::<_, SbomPackage>(
                 Query::default(),
-                Paginated::default(),
+                paginated_with_total,
                 FetchOptions::default().labels(("ci", "job1")),
                 &ctx.db,
             )
             .await?;
-        assert_eq!(1, fetched.total);
+        assert_eq!(Some(1), fetched.total);
 
         let fetched = service
             .fetch_sboms::<_, SbomPackage>(
                 Query::default(),
-                Paginated::default(),
+                paginated_with_total,
                 FetchOptions::default().labels(("ci", "job2")),
                 &ctx.db,
             )
             .await?;
-        assert_eq!(2, fetched.total);
+        assert_eq!(Some(2), fetched.total);
 
         let fetched = service
             .fetch_sboms::<_, SbomPackage>(
                 Query::default(),
-                Paginated::default(),
+                paginated_with_total,
                 FetchOptions::default().labels(("ci", "job3")),
                 &ctx.db,
             )
             .await?;
-        assert_eq!(0, fetched.total);
+        assert_eq!(Some(0), fetched.total);
 
         let fetched = service
             .fetch_sboms::<_, SbomPackage>(
                 Query::default(),
-                Paginated::default(),
+                paginated_with_total,
                 FetchOptions::default().labels(("foo", "bar")),
                 &ctx.db,
             )
             .await?;
-        assert_eq!(0, fetched.total);
+        assert_eq!(Some(0), fetched.total);
 
         let fetched = service
             .fetch_sboms::<_, SbomPackage>(
                 Query::default(),
-                Paginated::default(),
+                paginated_with_total,
                 Default::default(),
                 &ctx.db,
             )
             .await?;
-        assert_eq!(3, fetched.total);
+        assert_eq!(Some(3), fetched.total);
 
         let fetched = service
             .fetch_sboms::<_, SbomPackage>(
                 Query::default(),
-                Paginated::default(),
+                paginated_with_total,
                 FetchOptions::default().labels([("ci", "job2"), ("team", "a")]),
                 &ctx.db,
             )
             .await?;
-        assert_eq!(1, fetched.total);
+        assert_eq!(Some(1), fetched.total);
 
         Ok(())
     }
@@ -1273,7 +1282,7 @@ mod test {
             )
             .await?;
 
-        let service = SbomService::new(ctx.db.clone());
+        let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
         assert!(service.delete_sbom(sbom_v1.sbom.sbom_id, &ctx.db).await?);
         assert!(!service.delete_sbom(sbom_v1.sbom.sbom_id, &ctx.db).await?);

--- a/modules/fundamental/src/sbom/service/test.rs
+++ b/modules/fundamental/src/sbom/service/test.rs
@@ -9,7 +9,10 @@ use test_context::test_context;
 use test_log::test;
 use trustify_common::{
     cpe::Cpe,
-    db::query::{Query, q},
+    db::{
+        pagination_cache::PaginationCache,
+        query::{Query, q},
+    },
     id::Id,
     model::Paginated,
     purl::Purl,
@@ -30,7 +33,7 @@ async fn sbom_details_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
         ])
         .await?;
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let id_3_2_12 = results[3].id.clone();
 
@@ -67,7 +70,7 @@ async fn count_sboms(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         ])
         .await?;
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let neither_purl = Purl::from_str(
         "pkg:maven/io.smallrye/smallrye-graphql@0.0.0.redhat-00000?repository_url=https://maven.repository.redhat.com/ga/&type=jar",
@@ -114,7 +117,7 @@ async fn sbom_set_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         ])
         .await?;
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let id_3_2_12 = Id::parse_uuid(&results[3].id)?;
 
@@ -150,7 +153,7 @@ async fn sbom_update_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
         ])
         .await?;
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let id_3_2_12 = Id::parse_uuid(&results[3].id)?;
 
@@ -188,7 +191,12 @@ async fn sbom_update_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
+
+    let paginated_with_total = Paginated {
+        total: true,
+        ..Default::default()
+    };
 
     // Ingest SBOMs with license information
     ctx.ingest_document("spdx/mtv-2.6.json").await?;
@@ -198,7 +206,7 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
     let results = service
         .fetch_sboms::<_, SbomPackage>(
             q("license=GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"),
-            Paginated::default(),
+            paginated_with_total,
             Default::default(),
             &ctx.db,
         )
@@ -206,14 +214,14 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
 
     log::debug!("License filter results: {results:#?}");
     // Both SBOMs contain packages with this license combination
-    assert_eq!(results.total, 2);
+    assert_eq!(results.total, Some(2));
     assert_eq!(results.items.len(), 2);
 
     // Test 2: Filter by partial license match
     let results = service
         .fetch_sboms::<_, SbomPackage>(
             q("license~GPLv3+ with exceptions"),
-            Paginated::default(),
+            paginated_with_total,
             Default::default(),
             &ctx.db,
         )
@@ -221,14 +229,14 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
 
     log::debug!("Partial license filter results: {results:#?}");
     // Both SBOMs contain packages with 'GPLv3+ with exceptions' license
-    assert_eq!(results.total, 2);
+    assert_eq!(results.total, Some(2));
     assert_eq!(results.items.len(), 2);
 
     // Test 3: Filter by license found in single SBOMs
     let results = service
         .fetch_sboms::<_, SbomPackage>(
             q("license~OFL"),
-            Paginated::default(),
+            paginated_with_total,
             Default::default(),
             &ctx.db,
         )
@@ -236,14 +244,14 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
 
     log::debug!("OFL license filter results: {results:#?}");
     // Only SPDX SBOMs contain packages with OFL license
-    assert_eq!(results.total, 1);
+    assert_eq!(results.total, Some(1));
     assert_eq!(results.items[0].head.name, "MTV-2.6");
 
     // Test 3b: Filter by license found in single SBOMs
     let results = service
         .fetch_sboms::<_, SbomPackage>(
             q("license=Apache 2.0"),
-            Paginated::default(),
+            paginated_with_total,
             Default::default(),
             &ctx.db,
         )
@@ -251,7 +259,7 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
 
     log::debug!("Apache 2.0 license filter results: {results:#?}");
     // Only CycloneDX SBOM has Apache 2.0
-    assert_eq!(results.total, 1);
+    assert_eq!(results.total, Some(1));
     assert_eq!(
         results.items[0].head.name,
         "quay/quay-builder-qemu-rhcos-rhel8"
@@ -261,7 +269,7 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
     let results = service
         .fetch_sboms::<_, SbomPackage>(
             q("license=OFL|Apache 2.0"),
-            Paginated::default(),
+            paginated_with_total,
             Default::default(),
             &ctx.db,
         )
@@ -269,14 +277,14 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
 
     log::debug!("Multiple license OR filter results: {results:#?}");
     // Both SBOMs contain packages with these licenses
-    assert_eq!(results.total, 2);
+    assert_eq!(results.total, Some(2));
     assert_eq!(results.items.len(), 2);
 
     // Test 5: Negative test - license that doesn't exist
     let results = service
         .fetch_sboms::<_, SbomPackage>(
             q("license=NONEXISTENT_LICENSE"),
-            Paginated::default(),
+            paginated_with_total,
             Default::default(),
             &ctx.db,
         )
@@ -284,14 +292,14 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
 
     log::debug!("Nonexistent license filter results: {results:#?}");
     // Should return no SBOMs
-    assert_eq!(results.total, 0);
+    assert_eq!(results.total, Some(0));
     assert!(results.items.is_empty());
 
     // Test 6: Empty license query
     let results = service
         .fetch_sboms::<_, SbomPackage>(
             q("license="),
-            Paginated::default(),
+            paginated_with_total,
             Default::default(),
             &ctx.db,
         )
@@ -299,14 +307,14 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
 
     log::debug!("Empty license query results: {results:#?}");
     // Should return no SBOMs or handle gracefully
-    assert_eq!(results.total, 0);
+    assert_eq!(results.total, Some(0));
     assert!(results.items.is_empty());
 
     // Test 7: Combine license filter with other filters (should work together)
     let results = service
         .fetch_sboms::<_, SbomPackage>(
             q("license~Apache&name~quay"),
-            Paginated::default(),
+            paginated_with_total,
             Default::default(),
             &ctx.db,
         )
@@ -315,7 +323,7 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
     log::debug!("Combined license + name filter results: {results:#?}");
     // Should find SBOMs that have both Apache license and name containing "quay"
     // CycloneDX SBOM has Apache license and "quay" in name
-    assert_eq!(results.total, 1);
+    assert_eq!(results.total, Some(1));
     assert_eq!(
         results.items[0].head.name,
         "quay/quay-builder-qemu-rhcos-rhel8"
@@ -328,6 +336,7 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
             Paginated {
                 offset: 0,
                 limit: 1,
+                total: true,
             },
             Default::default(),
             &ctx.db,
@@ -342,7 +351,7 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
         results.items[0].head.name,
         "quay/quay-builder-qemu-rhcos-rhel8"
     );
-    assert_eq!(results.total, 2);
+    assert_eq!(results.total, Some(2));
 
     // Test 8b: Pagination with license filtering and offset > 0
     let results_offset = service
@@ -351,6 +360,7 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
             Paginated {
                 offset: 1,
                 limit: 1,
+                total: true,
             },
             Default::default(),
             &ctx.db,
@@ -360,13 +370,13 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
     // Should return the second item and total should still be 2
     assert_eq!(results_offset.items.len(), 1);
     assert_eq!(results_offset.items[0].head.name, "MTV-2.6");
-    assert_eq!(results_offset.total, 2);
+    assert_eq!(results_offset.total, Some(2));
 
     // Test 9: Verify that SBOMs without license filters still work
     let all_results = service
         .fetch_sboms::<_, SbomPackage>(
             Query::default(),
-            Paginated::default(),
+            paginated_with_total,
             Default::default(),
             &ctx.db,
         )
@@ -374,7 +384,7 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
 
     log::debug!("All SBOMs results: {all_results:#?}");
     // Should return all SBOMs
-    assert_eq!(all_results.total, 2); // We ingested exactly 2 SBOMs
+    assert_eq!(all_results.total, Some(2)); // We ingested exactly 2 SBOMs
 
     Ok(())
 }
@@ -382,25 +392,34 @@ async fn fetch_sboms_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyh
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn fetch_sbom_packages_filter_by_license(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
+
+    let paginated_with_total = Paginated {
+        total: true,
+        ..Default::default()
+    };
 
     // Ingest an SBOM with license information
     let sbom_id = Uuid::parse_str(&ctx.ingest_document("spdx/mtv-2.6.json").await?.id).unwrap();
 
     // Test 1: No license filter - should return all packages
     let all_packages = service
-        .fetch_sbom_packages(sbom_id, Query::default(), Paginated::default(), &ctx.db)
+        .fetch_sbom_packages(sbom_id, Query::default(), paginated_with_total, &ctx.db)
         .await?;
 
-    log::debug!("All packages count: {}", all_packages.total);
-    assert_eq!(all_packages.total, 5388, "Should have packages in the SBOM");
+    log::debug!("All packages count: {:?}", all_packages.total);
+    assert_eq!(
+        all_packages.total,
+        Some(5388),
+        "Should have packages in the SBOM"
+    );
 
     // Test 2: Filter by specific license that exists
     let license_filtered = service
         .fetch_sbom_packages(
             sbom_id,
             q("license=GPLv2 AND GPLv2+ AND CC-BY"),
-            Paginated::default(),
+            paginated_with_total,
             &ctx.db,
         )
         .await?;
@@ -408,30 +427,31 @@ async fn fetch_sbom_packages_filter_by_license(ctx: &TrustifyContext) -> Result<
     log::debug!("License filtered packages: {license_filtered:#?}");
     // Should find packages with this specific license
     // This validates that the license filtering is applied correctly
-    assert_eq!(license_filtered.total, 14);
+    assert_eq!(license_filtered.total, Some(14));
 
     // Test 3: Filter by partial license match
     let partial_license_filtered = service
-        .fetch_sbom_packages(sbom_id, q("license~GPL"), Paginated::default(), &ctx.db)
+        .fetch_sbom_packages(sbom_id, q("license~GPL"), paginated_with_total, &ctx.db)
         .await?;
 
     log::debug!("Partial license filtered packages: {partial_license_filtered:#?}");
     // Should find packages with licenses containing "GPL"
-    assert_eq!(partial_license_filtered.total, 448);
+    assert_eq!(partial_license_filtered.total, Some(448));
 
     // Test 4: Filter by non-existent license
     let no_match = service
         .fetch_sbom_packages(
             sbom_id,
             q("license=NONEXISTENT_LICENSE"),
-            Paginated::default(),
+            paginated_with_total,
             &ctx.db,
         )
         .await?;
 
     log::debug!("No match packages: {no_match:#?}");
     assert_eq!(
-        no_match.total, 0,
+        no_match.total,
+        Some(0),
         "Should return no packages for non-existent license"
     );
     assert!(
@@ -444,17 +464,17 @@ async fn fetch_sbom_packages_filter_by_license(ctx: &TrustifyContext) -> Result<
         .fetch_sbom_packages(
             sbom_id,
             q("license~GPLv2 AND GPLv2+ AND CC-BY&name~qemu-kvm-"),
-            Paginated::default(),
+            paginated_with_total,
             &ctx.db,
         )
         .await?;
 
     log::debug!("Combined filter packages: {combined_filter:#?}");
     // Should apply both license and name filters
-    assert_eq!(combined_filter.total, 11);
+    assert_eq!(combined_filter.total, Some(11));
 
     // Test 6: Pagination with license filtering
-    if partial_license_filtered.total > 1 {
+    if partial_license_filtered.total > Some(1) {
         let paginated = service
             .fetch_sbom_packages(
                 sbom_id,
@@ -462,6 +482,7 @@ async fn fetch_sbom_packages_filter_by_license(ctx: &TrustifyContext) -> Result<
                 Paginated {
                     offset: 0,
                     limit: 1,
+                    total: true,
                 },
                 &ctx.db,
             )
@@ -481,7 +502,7 @@ async fn fetch_sbom_packages_filter_by_license(ctx: &TrustifyContext) -> Result<
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn delete_sbom_orphaned_purl_test(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let purl_service = PurlService::new();
+    let purl_service = PurlService::new(PaginationCache::for_test());
     assert_eq!(
         0,
         purl_service
@@ -520,7 +541,7 @@ async fn delete_sbom_orphaned_purl_test(ctx: &TrustifyContext) -> Result<(), any
     );
 
     let tx = ctx.db.begin().await?;
-    let sbom_service = SbomService::new(ctx.db.clone());
+    let sbom_service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
     // delete the UBI SBOM
     assert!(sbom_service.delete_sbom(ubi9_sbom.id.parse()?, &tx).await?);
     tx.commit().await?;
@@ -574,23 +595,28 @@ async fn delete_sbom_preserves_advisory_referenced_packages(
         ])
         .await?;
 
-    let purl_service = PurlService::new();
+    let purl_service = PurlService::new(PaginationCache::for_test());
 
     // Count all PURLs before deletion
+    let paginated_with_total = Paginated {
+        total: true,
+        ..Default::default()
+    };
     let packages_before = purl_service
-        .purls(Query::default(), Paginated::default(), &ctx.db)
+        .purls(Query::default(), paginated_with_total, &ctx.db)
         .await?;
     log::debug!(
-        "Total packages before SBOM deletion: {}",
+        "Total packages before SBOM deletion: {:?}",
         packages_before.total
     );
     assert_eq!(
-        packages_before.total, 2087,
+        packages_before.total,
+        Some(2087),
         "Should have packages after ingestion"
     );
 
     // Delete one of the SBOMs
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
     let sbom_uuid = results[1].id.parse().expect("SBOM should have a UUID");
     let tx = ctx.db.begin().await?;
     assert!(
@@ -601,14 +627,15 @@ async fn delete_sbom_preserves_advisory_referenced_packages(
 
     // Count all packages after deletion
     let packages_after = purl_service
-        .purls(Query::default(), Paginated::default(), &ctx.db)
+        .purls(Query::default(), paginated_with_total, &ctx.db)
         .await?;
     log::debug!(
-        "Total packages after SBOM deletion: {}",
+        "Total packages after SBOM deletion: {:?}",
         packages_before.total
     );
     assert_eq!(
-        packages_after.total, 2083,
+        packages_after.total,
+        Some(2083),
         "Should have packages after deletion"
     );
 
@@ -622,7 +649,8 @@ async fn delete_sbom_preserves_advisory_referenced_packages(
     // - AND not referenced by the advisory
     //
     // We verify that MOST packages are preserved (conservative approach).
-    let packages_deleted = packages_before.total - packages_after.total;
+    let packages_deleted = packages_before.total.expect("total requested")
+        - packages_after.total.expect("total requested");
     log::debug!("Qualified PURLs deleted: {}", packages_deleted);
 
     assert_eq!(packages_deleted, 4, "Should have deleted 4 packages");
@@ -638,14 +666,15 @@ async fn delete_sbom_preserves_advisory_referenced_packages(
 
     // Count all packages after deletion
     let packages_after = purl_service
-        .purls(Query::default(), Paginated::default(), &ctx.db)
+        .purls(Query::default(), paginated_with_total, &ctx.db)
         .await?;
     log::debug!(
-        "Total packages after second SBOM deletion: {}",
+        "Total packages after second SBOM deletion: {:?}",
         packages_before.total
     );
     assert_eq!(
-        packages_after.total, 2082,
+        packages_after.total,
+        Some(2082),
         "Should have packages after second deletion"
     );
 
@@ -660,14 +689,15 @@ async fn delete_sbom_preserves_advisory_referenced_packages(
 
     // Count all packages after deletion
     let packages_after = purl_service
-        .purls(Query::default(), Paginated::default(), &ctx.db)
+        .purls(Query::default(), paginated_with_total, &ctx.db)
         .await?;
     log::debug!(
-        "Total packages after third SBOM deletion: {}",
+        "Total packages after third SBOM deletion: {:?}",
         packages_before.total
     );
     assert_eq!(
-        packages_after.total, 1472,
+        packages_after.total,
+        Some(1472),
         "Should have packages after second deletion"
     );
 
@@ -679,7 +709,7 @@ async fn delete_sbom_preserves_advisory_referenced_packages(
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn test_sbom_package_licenses_coalesce(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // RED: No packages before ingestion
     // GREEN: Ingest SPDX (uses expanded_license) and CycloneDX (uses raw license.text)
@@ -700,6 +730,7 @@ async fn test_sbom_package_licenses_coalesce(ctx: &TrustifyContext) -> Result<()
             Paginated {
                 offset: 0,
                 limit: 100,
+                ..Default::default()
             },
             &ctx.db,
         )
@@ -712,6 +743,7 @@ async fn test_sbom_package_licenses_coalesce(ctx: &TrustifyContext) -> Result<()
             Paginated {
                 offset: 0,
                 limit: 100,
+                ..Default::default()
             },
             &ctx.db,
         )
@@ -758,7 +790,7 @@ async fn test_sbom_package_licenses_coalesce(ctx: &TrustifyContext) -> Result<()
 async fn test_sbom_package_license_filtering_with_coalesce(
     ctx: &TrustifyContext,
 ) -> Result<(), anyhow::Error> {
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // RED: No packages before ingestion
     // GREEN: Ingest SPDX with Apache licenses
@@ -775,6 +807,7 @@ async fn test_sbom_package_license_filtering_with_coalesce(
             Paginated {
                 offset: 0,
                 limit: 100,
+                total: true,
             },
             &ctx.db,
         )
@@ -782,7 +815,7 @@ async fn test_sbom_package_license_filtering_with_coalesce(
 
     // REFACTOR: Verify filtering works on COALESCE result
     assert!(
-        apache_packages.total > 0,
+        apache_packages.total > Some(0),
         "Expected at least one package to match Apache filter"
     );
     let has_apache = apache_packages.items.iter().any(|p| {
@@ -805,7 +838,7 @@ async fn test_sbom_package_license_filtering_with_coalesce(
 async fn test_sbom_package_license_not_null_filter(
     ctx: &TrustifyContext,
 ) -> Result<(), anyhow::Error> {
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // RED: No packages before ingestion
     // GREEN: Ingest SBOM with licenses
@@ -821,6 +854,7 @@ async fn test_sbom_package_license_not_null_filter(
             Paginated {
                 offset: 0,
                 limit: 1000,
+                ..Default::default()
             },
             &ctx.db,
         )

--- a/modules/fundamental/src/sbom_group/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom_group/endpoints/mod.rs
@@ -19,7 +19,7 @@ use trustify_auth::{
     authorizer::Require,
 };
 use trustify_common::{
-    db::{Database, query::Query},
+    db::{Database, pagination_cache::PaginationCache, query::Query},
     endpoints::extract_revision,
     model::{Paginated, Revisioned},
 };
@@ -29,8 +29,9 @@ pub fn configure(
     config: &mut utoipa_actix_web::service_config::ServiceConfig,
     db: Database,
     max_group_name_length: usize,
+    cache: PaginationCache,
 ) {
-    let service = SbomGroupService::new(max_group_name_length);
+    let service = SbomGroupService::new(max_group_name_length, cache);
 
     config
         .app_data(web::Data::new(db))

--- a/modules/fundamental/src/sbom_group/endpoints/test/list.rs
+++ b/modules/fundamental/src/sbom_group/endpoints/test/list.rs
@@ -284,7 +284,10 @@ async fn run_list_test(
     expected_items: impl IntoIterator<Item = Item>,
     expected_referenced: Option<Vec<&'static [&'static str]>>,
 ) -> anyhow::Result<()> {
-    let mut uri = format!("/api/v2/group/sbom?q={}&", urlencoding::encode(q));
+    let mut uri = format!(
+        "/api/v2/group/sbom?total=true&q={}&",
+        urlencoding::encode(q)
+    );
     if options.totals {
         uri.push_str("totals=true&");
     }
@@ -312,7 +315,7 @@ async fn run_list_test(
 
     let expected_items = into_actual(expected_items, &ids);
 
-    assert_eq!(response.result.total, expected_items.len() as u64);
+    assert_eq!(response.result.total, Some(expected_items.len() as u64));
     assert_eq!(response.result.items, expected_items);
 
     // Assert referenced groups

--- a/modules/fundamental/src/sbom_group/service.rs
+++ b/modules/fundamental/src/sbom_group/service.rs
@@ -18,6 +18,7 @@ use trustify_common::{
     db::{
         DatabaseErrors,
         limiter::LimiterTrait,
+        pagination_cache::PaginationCache,
         query::{Filtering, Query},
     },
     model::{Paginated, PaginatedResults, Revisioned},
@@ -74,12 +75,14 @@ impl ParentsMode {
 
 pub struct SbomGroupService {
     max_group_name_length: usize,
+    cache: PaginationCache,
 }
 
 impl SbomGroupService {
-    pub fn new(max_group_name_length: usize) -> Self {
+    pub fn new(max_group_name_length: usize, cache: PaginationCache) -> Self {
         Self {
             max_group_name_length,
+            cache,
         }
     }
 
@@ -94,9 +97,9 @@ impl SbomGroupService {
 
         let query = sbom_group::Entity::find().filtering(query)?;
 
-        let limiter = query.limiting_pagination(db, paginated);
+        let limiter = query.limiting_pagination(db, paginated, &self.cache);
 
-        let result = PaginatedResults::<sbom_group::Model>::new(limiter).await?;
+        let result = PaginatedResults::<sbom_group::Model>::new(limiter, paginated).await?;
 
         let mut items = Vec::with_capacity(result.items.len());
         let total = result.total;
@@ -829,6 +832,7 @@ fn query_by_revision<Q: QueryFilter>(id: &str, revision: Option<&str>, query: Q)
 mod test {
     use super::*;
     use rstest::rstest;
+    use trustify_common::db::pagination_cache::PaginationCache;
 
     /// Ensure that we validate grounames
     #[rstest]
@@ -842,7 +846,7 @@ mod test {
     #[case("Foo Bar 1.2", 0)]
     #[test_log::test]
     fn ensure_valid_names(#[case] input: &str, #[case] violations: usize) {
-        let service = SbomGroupService::new(32);
+        let service = SbomGroupService::new(32, PaginationCache::for_test());
         let result = service.validate_group_name(input);
         assert_eq!(result.len(), violations);
     }
@@ -850,7 +854,7 @@ mod test {
     /// Ensure that the default configuration works
     #[test_log::test]
     fn ensure_default_works() {
-        let service = SbomGroupService::new(Default::default());
+        let service = SbomGroupService::new(Default::default(), PaginationCache::for_test());
         let result = service.validate_group_name("foo bar");
         assert!(result.is_empty());
     }

--- a/modules/fundamental/src/test/common.rs
+++ b/modules/fundamental/src/test/common.rs
@@ -1,3 +1,4 @@
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_module_analysis::config::AnalysisConfig;
 use trustify_module_analysis::service::AnalysisService;
 use trustify_test_context::{
@@ -21,6 +22,7 @@ async fn caller_with(
             ctx.db.clone(),
             ctx.storage.clone(),
             analysis.clone(),
+            PaginationCache::for_test(),
         );
         trustify_module_analysis::endpoints::configure(svc, ctx.db.clone(), analysis);
     })

--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -17,7 +17,7 @@ use actix_web::{HttpResponse, Responder, get, post, web};
 use time::OffsetDateTime;
 use trustify_auth::{ReadAdvisory, authorizer::Require};
 use trustify_common::{
-    db::{Database, query::Query},
+    db::{Database, pagination_cache::PaginationCache, query::Query},
     model::{Paginated, PaginatedResults},
 };
 use trustify_query::TrustifyQuery;
@@ -31,8 +31,12 @@ pub struct VulnerabilityGetParams {
     pub scores: bool,
 }
 
-pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, db: Database) {
-    let service = VulnerabilityService::new();
+pub fn configure(
+    config: &mut utoipa_actix_web::service_config::ServiceConfig,
+    db: Database,
+    cache: PaginationCache,
+) {
+    let service = VulnerabilityService::new(cache);
     config
         .app_data(web::Data::new(service))
         .app_data(web::Data::new(db))

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -91,7 +91,7 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
         .ingest_vulnerability("CVE-345", VulnerabilityInformation::default(), &ctx.db)
         .await?;
 
-    let response = get_vulnerability(ctx, "/api/v3/vulnerability").await?;
+    let response = get_vulnerability(ctx, "/api/v3/vulnerability?total=true").await?;
 
     log::debug!("{response:#?}");
 

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -24,7 +24,8 @@ use std::{
 use tracing::instrument;
 use trustify_common::{
     db::{
-        limiter::LimiterTrait,
+        limiter::{LimitedResult, LimiterTrait},
+        pagination_cache::PaginationCache,
         query::{Columns, Filtering, Query},
     },
     memo::Memo,
@@ -51,12 +52,13 @@ struct AnalysisData {
     cpe_map: HashMap<Uuid, cpe::Model>,
 }
 
-#[derive(Default)]
-pub struct VulnerabilityService {}
+pub struct VulnerabilityService {
+    cache: PaginationCache,
+}
 
 impl VulnerabilityService {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(cache: PaginationCache) -> Self {
+        Self { cache }
     }
 
     pub async fn fetch_vulnerabilities<C: ConnectionTrait + Sync + Send>(
@@ -84,10 +86,13 @@ impl VulnerabilityService {
                     },
                 ),
             )?
-            .limiting(connection, paginated.offset, paginated.limit);
+            .limiting(connection, paginated.offset, paginated.limit, &self.cache);
 
-        let total = limiter.total().await?;
-        let vulnerabilities = limiter.fetch().await?;
+        let LimitedResult {
+            items: vulnerabilities,
+            total,
+        } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         Ok(PaginatedResults {
             total,

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -9,7 +9,10 @@ use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::{
-    db::query::{Query, q},
+    db::{
+        pagination_cache::PaginationCache,
+        query::{Query, q},
+    },
     id::Id,
     model::Paginated,
     purl::Purl,
@@ -21,7 +24,7 @@ use uuid::Uuid;
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     ctx.ingest_documents(["osv/RUSTSEC-2021-0079.json", "cve/CVE-2021-32714.json"])
         .await?;
@@ -52,7 +55,7 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     ctx.ingest_documents(["osv/RUSTSEC-2021-0079.json", "cve/CVE-2021-32714.json"])
         .await?;
@@ -98,7 +101,7 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn statuses_too(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     ctx.ingest_documents([
         "cve/CVE-2024-29025.json",
@@ -126,8 +129,8 @@ async fn statuses_too(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let vuln_service = VulnerabilityService::new();
-    let sbom_service = SbomService::new(ctx.db.clone());
+    let vuln_service = VulnerabilityService::new(PaginationCache::for_test());
+    let sbom_service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // Ingest a CVE declaring the vulnerability present in versions
     // [1.21,1.26.0) of commons-compress, along with 2 sboms, each of
@@ -225,7 +228,7 @@ async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn sbom_without_cpe_matching(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let sbom_service = SbomService::new(ctx.db.clone());
+    let sbom_service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let ingest_results = ctx
         .ingest_documents([
@@ -265,7 +268,7 @@ async fn sbom_without_cpe_matching(ctx: &TrustifyContext) -> Result<(), anyhow::
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn sbom_with_multiple_cpes_not_breaking(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let sbom_service = SbomService::new(ctx.db.clone());
+    let sbom_service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let ingest_results = ctx
         .ingest_documents([
@@ -290,9 +293,9 @@ async fn sbom_with_multiple_cpes_not_breaking(ctx: &TrustifyContext) -> Result<(
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let vuln_service = VulnerabilityService::new();
-    let sbom_service = SbomService::new(ctx.db.clone());
-    let purl_service = PurlService::new();
+    let vuln_service = VulnerabilityService::new(PaginationCache::for_test());
+    let sbom_service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
+    let purl_service = PurlService::new(PaginationCache::for_test());
 
     let ingest_results = ctx
         .ingest_documents([
@@ -396,7 +399,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     ctx.ingest_documents(["cve/CVE-2024-29025.json"]).await?;
 
@@ -511,7 +514,7 @@ async fn vulnerability_query(
         base_score: Option<BaseScore>,
     }
 
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     ctx.ingest_documents(VULNERABILITY_QUERY_DOCS).await?;
 
@@ -544,7 +547,7 @@ async fn vulnerability_query(
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn vulnerability_numeric_sorting(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     // Test various OSV ID formats, including edge cases, to ensure generic numeric sorting works
     for id in [
@@ -628,7 +631,7 @@ async fn vulnerability_numeric_sorting(ctx: &TrustifyContext) -> Result<(), anyh
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     ctx.ingest_documents([
         "osv/RUSTSEC-2021-0079.json",
@@ -706,7 +709,7 @@ async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn analyze_purls_no_score(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     const PURL: &str = "pkg:cargo/hyper@0.14.9";
 
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     ctx.ingest_documents(["osv/RUSTSEC-2022-0022.json"]).await?;
 
@@ -727,7 +730,7 @@ async fn analyze_purls_no_score(ctx: &TrustifyContext) -> Result<(), anyhow::Err
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn analyze_purls_v2(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     ctx.ingest_documents([
         "osv/RUSTSEC-2021-0079.json",
@@ -802,7 +805,7 @@ async fn analyze_purls_v2(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn analyze_purls_remediations_synthetic(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     ctx.ingest_documents(["csaf/synthetic-affected-with-purl.json"])
         .await?;
@@ -920,7 +923,7 @@ async fn analyze_purls_remediations_synthetic(ctx: &TrustifyContext) -> Result<(
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn analyze_purls_remediations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     ctx.ingest_documents(["csaf/cve-2023-33201.json"]).await?;
 
@@ -963,7 +966,7 @@ async fn analyze_purls_remediations(ctx: &TrustifyContext) -> Result<(), anyhow:
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn analyze_purls_product_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     ctx.ingest_documents(["csaf/CVE-2023-20862.json"]).await?;
 
@@ -1037,7 +1040,7 @@ async fn analyze_purls_product_status(ctx: &TrustifyContext) -> Result<(), anyho
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn analyze_purls_product_status_0044(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     ctx.ingest_documents(["csaf/cve-2023-0044.json"]).await?;
 

--- a/modules/fundamental/src/weakness/endpoints/mod.rs
+++ b/modules/fundamental/src/weakness/endpoints/mod.rs
@@ -2,12 +2,16 @@ use crate::{license::model::LicenseSummary, weakness::service::WeaknessService};
 use actix_web::{HttpResponse, Responder, get, web};
 use trustify_auth::{ReadWeakness, authorizer::Require};
 use trustify_common::{
-    db::{Database, query::Query},
+    db::{Database, pagination_cache::PaginationCache, query::Query},
     model::{Paginated, PaginatedResults},
 };
 
-pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, db: Database) {
-    let weakness_service = WeaknessService::new(db);
+pub fn configure(
+    config: &mut utoipa_actix_web::service_config::ServiceConfig,
+    db: Database,
+    cache: PaginationCache,
+) {
+    let weakness_service = WeaknessService::new(db, cache);
 
     config
         .app_data(web::Data::new(weakness_service))

--- a/modules/fundamental/src/weakness/endpoints/test.rs
+++ b/modules/fundamental/src/weakness/endpoints/test.rs
@@ -21,13 +21,13 @@ async fn list_weaknesses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/weakness";
+    let uri = "/api/v2/weakness?total=true";
 
     let request = TestRequest::get().uri(uri).to_request();
 
     let response: PaginatedResults<WeaknessSummary> = app.call_and_read_body_json(request).await;
 
-    assert!(response.total > 900);
+    assert!(response.total.expect("total should be present") > 900);
 
     Ok(())
 }
@@ -45,13 +45,13 @@ async fn query_weaknesses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/weakness?q=struts";
+    let uri = "/api/v2/weakness?q=struts&total=true";
 
     let request = TestRequest::get().uri(uri).to_request();
 
     let response: PaginatedResults<WeaknessSummary> = app.call_and_read_body_json(request).await;
 
-    assert_eq!(response.total, 4);
+    assert_eq!(response.total, Some(4));
 
     Ok(())
 }

--- a/modules/fundamental/src/weakness/service/mod.rs
+++ b/modules/fundamental/src/weakness/service/mod.rs
@@ -6,7 +6,8 @@ use sea_orm::EntityTrait;
 use trustify_common::{
     db::{
         Database,
-        limiter::LimiterTrait,
+        limiter::{LimitedResult, LimiterTrait},
+        pagination_cache::PaginationCache,
         query::{Filtering, Query},
     },
     model::{Paginated, PaginatedResults},
@@ -15,11 +16,12 @@ use trustify_entity::weakness;
 
 pub struct WeaknessService {
     db: Database,
+    cache: PaginationCache,
 }
 
 impl WeaknessService {
-    pub fn new(db: Database) -> Self {
-        Self { db }
+    pub fn new(db: Database, cache: PaginationCache) -> Self {
+        Self { db, cache }
     }
 
     pub async fn list_weaknesses(
@@ -31,10 +33,11 @@ impl WeaknessService {
             &self.db,
             paginated.offset,
             paginated.limit,
+            &self.cache,
         );
 
-        let total = limiter.total().await?;
-        let items = limiter.fetch().await?;
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         Ok(PaginatedResults {
             items: WeaknessSummary::from_entities(&items).await?,

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -4,6 +4,7 @@ use super::prepare_ps_state_change;
 use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::purl::Purl;
 use trustify_entity::labels::Labels;
 use trustify_module_fundamental::advisory::model::AdvisoryHead;
@@ -36,14 +37,14 @@ async fn simple(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // now delete the newer one
 
-    let service = AdvisoryService::new(ctx.db.clone());
+    let service = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
     service
         .delete_advisory(r2.id.parse().expect("must be a UUID variant"), &ctx.db)
         .await?;
 
     // now test, find only one, for either ignore or consider
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
     let v = vuln
         .fetch_vulnerability("CVE-2023-33201", Deprecation::Consider, false, &ctx.db)
         .await?
@@ -51,7 +52,7 @@ async fn simple(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     assert_eq!(v.advisories.len(), 1);
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
     let v = vuln
         .fetch_vulnerability("CVE-2023-33201", Deprecation::Ignore, false, &ctx.db)
         .await?
@@ -76,14 +77,14 @@ async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // now delete the newer one
 
-    let service = AdvisoryService::new(ctx.db.clone());
+    let service = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
     service
         .delete_advisory(r2.id.parse().expect("must be a UUID variant"), &ctx.db)
         .await?;
 
     // check info
 
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
     let purls = service
         .purls(Default::default(), Default::default(), &ctx.db)
         .await?;

--- a/modules/fundamental/tests/advisory/csaf/parallel.rs
+++ b/modules/fundamental/tests/advisory/csaf/parallel.rs
@@ -1,6 +1,7 @@
 use test_context::test_context;
 use test_log::test;
 use tracing::instrument;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::{db::query::Query, model::Paginated};
 use trustify_module_fundamental::advisory::service::AdvisoryService;
 use trustify_module_ingestor::common::Deprecation;
@@ -16,17 +17,21 @@ async fn ingest_10(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .ingest_parallel(["csaf/cve-2023-33201.json"; 10])
         .await?;
 
-    let service = AdvisoryService::new(ctx.db.clone());
+    let service = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let result = service
         .fetch_advisories(
             Query::default(),
-            Paginated::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             Deprecation::Consider,
             &ctx.db,
         )
         .await?;
-    assert_eq!(1, result.total);
+    assert_eq!(Some(1), result.total);
 
     Ok(())
 }

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -4,6 +4,7 @@ use super::{prepare_ps_state_change, twice};
 use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::purl::Purl;
 use trustify_entity::labels::Labels;
 use trustify_module_fundamental::advisory::model::AdvisoryHead;
@@ -34,7 +35,7 @@ async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
     let v = vuln
         .fetch_vulnerability("CVE-2023-33201", Default::default(), false, &ctx.db)
         .await?
@@ -59,7 +60,7 @@ async fn change_ps_num_advisories(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info - non-deprecated
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
     let v = vuln
         .fetch_vulnerability("CVE-2023-33201", Deprecation::Ignore, false, &ctx.db)
         .await?
@@ -69,7 +70,7 @@ async fn change_ps_num_advisories(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info - with-deprecated
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
     let v = vuln
         .fetch_vulnerability("CVE-2023-33201", Deprecation::Consider, false, &ctx.db)
         .await?
@@ -94,7 +95,7 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info
 
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
     let purls = service
         .purls(Default::default(), Default::default(), &ctx.db)
         .await?;
@@ -240,7 +241,7 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info
 
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
     let purls = service
         .purls(Default::default(), Default::default(), &ctx.db)
         .await?;

--- a/modules/fundamental/tests/advisory/csaf/timeout.rs
+++ b/modules/fundamental/tests/advisory/csaf/timeout.rs
@@ -1,6 +1,7 @@
 use test_context::test_context;
 use test_log::test;
 use tracing::instrument;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::{db::query::Query, model::Paginated};
 use trustify_module_fundamental::advisory::service::AdvisoryService;
 use trustify_module_ingestor::common::Deprecation;
@@ -25,18 +26,22 @@ async fn timeout(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         ])
         .await?;
 
-    let service = AdvisoryService::new(ctx.db.clone());
+    let service = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let result = service
         .fetch_advisories(
             Query::default(),
-            Paginated::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             Deprecation::Consider,
             &ctx.db,
         )
         .await?;
 
-    assert_eq!(10, result.total);
+    assert_eq!(Some(10), result.total);
 
     Ok(())
 }

--- a/modules/fundamental/tests/advisory/cve/delete.rs
+++ b/modules/fundamental/tests/advisory/cve/delete.rs
@@ -1,6 +1,7 @@
 use crate::advisory::cve::{twice, update_mark_rejected};
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_module_fundamental::{
     advisory::service::AdvisoryService, vulnerability::service::VulnerabilityService,
 };
@@ -13,7 +14,7 @@ use trustify_test_context::TrustifyContext;
 async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let (r1, r2) = twice(ctx, |cve| cve, update_mark_rejected).await?;
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
 
     // must be changed
 
@@ -21,7 +22,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // now delete the newer one
 
-    let service = AdvisoryService::new(ctx.db.clone());
+    let service = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
     service
         .delete_advisory(r2.id.parse().expect("must be a UUID variant"), &ctx.db)
         .await?;

--- a/modules/fundamental/tests/advisory/cve/parallel.rs
+++ b/modules/fundamental/tests/advisory/cve/parallel.rs
@@ -1,6 +1,7 @@
 use test_context::test_context;
 use test_log::test;
 use tracing::instrument;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::{db::query::Query, model::Paginated};
 use trustify_module_fundamental::advisory::service::AdvisoryService;
 use trustify_module_ingestor::common::Deprecation;
@@ -19,17 +20,21 @@ async fn ingest_10(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     futures_util::future::try_join_all(f).await?;
 
-    let service = AdvisoryService::new(ctx.db.clone());
+    let service = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let result = service
         .fetch_advisories(
             Query::default(),
-            Paginated::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             Deprecation::Consider,
             &ctx.db,
         )
         .await?;
-    assert_eq!(1, result.total);
+    assert_eq!(Some(1), result.total);
 
     Ok(())
 }

--- a/modules/fundamental/tests/advisory/cve/reingest.rs
+++ b/modules/fundamental/tests/advisory/cve/reingest.rs
@@ -1,6 +1,7 @@
 use super::{twice, update_mark_rejected};
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_module_fundamental::vulnerability::service::VulnerabilityService;
 use trustify_module_ingestor::common::Deprecation;
 use trustify_test_context::TrustifyContext;
@@ -17,7 +18,7 @@ async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
     let v = vuln
         .fetch_vulnerability("CVE-2021-32714", Default::default(), false, &ctx.db)
         .await?
@@ -42,7 +43,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check without deprecated
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
     let v = vuln
         .fetch_vulnerability("CVE-2021-32714", Deprecation::Ignore, false, &ctx.db)
         .await?
@@ -56,7 +57,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check with deprecated
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
     let v = vuln
         .fetch_vulnerability("CVE-2021-32714", Deprecation::Consider, false, &ctx.db)
         .await?

--- a/modules/fundamental/tests/advisory/osv/delete.rs
+++ b/modules/fundamental/tests/advisory/osv/delete.rs
@@ -1,6 +1,7 @@
 use super::{twice, update_mark_fixed_again, update_unmark_fixed};
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_module_fundamental::{
     advisory::service::AdvisoryService, vulnerability::service::VulnerabilityService,
 };
@@ -13,7 +14,7 @@ use trustify_test_context::TrustifyContext;
 async fn fixed(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let (r1, r2) = twice(ctx, update_unmark_fixed, update_mark_fixed_again).await?;
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
 
     // must be changed
 
@@ -21,7 +22,7 @@ async fn fixed(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // now delete the newer one
 
-    let service = AdvisoryService::new(ctx.db.clone());
+    let service = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
     service
         .delete_advisory(r2.id.parse().expect("must be a UUID variant"), &ctx.db)
         .await?;

--- a/modules/fundamental/tests/advisory/osv/parallel.rs
+++ b/modules/fundamental/tests/advisory/osv/parallel.rs
@@ -1,6 +1,7 @@
 use test_context::test_context;
 use test_log::test;
 use tracing::instrument;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::{db::query::Query, model::Paginated};
 use trustify_module_fundamental::advisory::service::AdvisoryService;
 use trustify_module_ingestor::common::Deprecation;
@@ -19,17 +20,21 @@ async fn ingest_10(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     futures_util::future::try_join_all(f).await?;
 
-    let service = AdvisoryService::new(ctx.db.clone());
+    let service = AdvisoryService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let result = service
         .fetch_advisories(
             Query::default(),
-            Paginated::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             Deprecation::Consider,
             &ctx.db,
         )
         .await?;
-    assert_eq!(1, result.total);
+    assert_eq!(Some(1), result.total);
 
     Ok(())
 }

--- a/modules/fundamental/tests/advisory/osv/reingest.rs
+++ b/modules/fundamental/tests/advisory/osv/reingest.rs
@@ -2,6 +2,7 @@ use super::{twice, update_mark_fixed_again, update_unmark_fixed};
 use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::purl::Purl;
 use trustify_entity::labels::Labels;
 use trustify_module_fundamental::{
@@ -28,7 +29,7 @@ async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
     let v = vuln
         .fetch_vulnerability("CVE-2020-5238", Default::default(), false, &ctx.db)
         .await?
@@ -53,7 +54,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check without deprecated
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
     let v = vuln
         .fetch_vulnerability("CVE-2020-5238", Deprecation::Ignore, false, &ctx.db)
         .await?
@@ -65,7 +66,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check with deprecated
 
-    let vuln = VulnerabilityService::new();
+    let vuln = VulnerabilityService::new(PaginationCache::for_test());
     let v = vuln
         .fetch_vulnerability("CVE-2020-5238", Deprecation::Consider, false, &ctx.db)
         .await?
@@ -78,7 +79,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check status
 
-    let service = PurlService::new();
+    let service = PurlService::new(PaginationCache::for_test());
     let purls = service
         .purls(Default::default(), Default::default(), &ctx.db)
         .await?;

--- a/modules/fundamental/tests/dataset.rs
+++ b/modules/fundamental/tests/dataset.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 use test_context::test_context;
 use test_log::test;
 use tracing::instrument;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::id::Id;
 use trustify_module_fundamental::sbom::service::SbomService;
 use trustify_module_storage::service::StorageBackend;
@@ -17,7 +18,7 @@ use trustify_test_context::{Dataset, TrustifyContext};
 #[test(tokio::test)]
 #[instrument]
 async fn ingest(ctx: TrustifyContext) -> anyhow::Result<()> {
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
     let storage = &ctx.storage;
 
     let start = Instant::now();

--- a/modules/fundamental/tests/issues/oom.rs
+++ b/modules/fundamental/tests/issues/oom.rs
@@ -3,6 +3,7 @@
 use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::id::Id;
 use trustify_module_fundamental::sbom::service::SbomService;
 use trustify_test_context::TrustifyContext;
@@ -15,7 +16,7 @@ use trustify_test_context::TrustifyContext;
 async fn fetch(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // this requires an imported dataset
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
     // update this digest to point to a "large SBOM"
     // the following statement can be used"
     /*

--- a/modules/fundamental/tests/sbom/cyclonedx/cpe.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/cpe.rs
@@ -1,5 +1,6 @@
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::model::Paginated;
 use trustify_module_fundamental::sbom::model::SbomPackage;
 use trustify_module_fundamental::sbom::service::SbomService;
@@ -11,17 +12,21 @@ use trustify_test_context::TrustifyContext;
 async fn simple(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let result = ctx.ingest_document("cyclonedx/simple_cpe.json").await?;
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let packages = service
         .describes_packages::<_, _, SbomPackage>(
             result.id.parse().expect("Must be a UID"),
-            Paginated::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             &ctx.db,
         )
         .await?;
 
-    assert_eq!(packages.total, 1);
+    assert_eq!(packages.total, Some(1));
     assert_eq!(packages.items.len(), 1);
 
     let package = &packages.items[0];
@@ -36,17 +41,21 @@ async fn simple(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let result = ctx.ingest_document("cyclonedx/simple_cpe_2.json").await?;
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let packages = service
         .describes_packages::<_, _, SbomPackage>(
             result.id.parse().expect("Must be a UID"),
-            Paginated::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             &ctx.db,
         )
         .await?;
 
-    assert_eq!(packages.total, 1);
+    assert_eq!(packages.total, Some(1));
     assert_eq!(packages.items.len(), 1);
 
     let package = &packages.items[0];
@@ -61,17 +70,21 @@ async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn simple_comp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let result = ctx.ingest_document("cyclonedx/simple_cpe_3.json").await?;
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let packages = service
         .describes_packages::<_, _, SbomPackage>(
             result.id.parse().expect("Must be a UID"),
-            Paginated::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             &ctx.db,
         )
         .await?;
 
-    assert_eq!(packages.total, 1);
+    assert_eq!(packages.total, Some(1));
     assert_eq!(packages.items.len(), 1);
 
     let package = &packages.items[0];
@@ -83,12 +96,16 @@ async fn simple_comp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .fetch_sbom_packages(
             result.id.parse().expect("Must be a UID"),
             Default::default(),
-            Default::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             &ctx.db,
         )
         .await?;
 
-    assert_eq!(packages.total, 3);
+    assert_eq!(packages.total, Some(3));
     assert_eq!(packages.items.len(), 3);
 
     // ensure the cpe one is present

--- a/modules/fundamental/tests/sbom/cyclonedx/external/rh.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/external/rh.rs
@@ -3,6 +3,7 @@
 
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_module_fundamental::sbom::service::SbomService;
 use trustify_test_context::TrustifyContext;
 use uuid::Uuid;
@@ -20,7 +21,7 @@ async fn cdx_prod_comp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let _prod: Uuid = result.pop().unwrap().id.parse().expect("must have a uid");
     let _comp: Uuid = result.pop().unwrap().id.parse().expect("must have a uid");
 
-    let _service = SbomService::new(ctx.db.clone());
+    let _service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // TODO: implement when we have the tools
 

--- a/modules/fundamental/tests/sbom/cyclonedx/mod.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/mod.rs
@@ -73,6 +73,7 @@ async fn test_parse_cyclonedx(ctx: &TrustifyContext) -> Result<(), anyhow::Error
                     Paginated {
                         offset: 0,
                         limit: 1,
+                        total: true,
                     },
                     &ctx.db,
                 )
@@ -80,7 +81,7 @@ async fn test_parse_cyclonedx(ctx: &TrustifyContext) -> Result<(), anyhow::Error
 
             log::debug!("{packages:?}");
 
-            assert_eq!(41, packages.total);
+            assert_eq!(Some(41), packages.total);
 
             Ok(())
         },
@@ -120,6 +121,7 @@ async fn parse_cyclonedx_1dot6(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
                     Paginated {
                         offset: 0,
                         limit: 1,
+                        total: true,
                     },
                     &ctx.db,
                 )
@@ -127,7 +129,7 @@ async fn parse_cyclonedx_1dot6(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
 
             log::debug!("{packages:?}");
 
-            assert_eq!(9, packages.total);
+            assert_eq!(Some(9), packages.total);
 
             assert_eq!(sbom.sbom.authors, vec!["Some Author".to_string()]);
             assert_eq!(sbom.sbom.suppliers, vec!["Some Supplier".to_string()]);

--- a/modules/fundamental/tests/sbom/cyclonedx/parallel.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/parallel.rs
@@ -1,6 +1,7 @@
 use test_context::test_context;
 use test_log::test;
 use tracing::instrument;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::{db::query::Query, model::Paginated};
 use trustify_module_fundamental::sbom::model::SbomPackage;
 use trustify_module_fundamental::sbom::service::SbomService;
@@ -21,17 +22,21 @@ async fn ingest_10(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     futures_util::future::try_join_all(f).await?;
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let result = service
         .fetch_sboms::<_, SbomPackage>(
             Query::default(),
-            Paginated::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             Default::default(),
             &ctx.db,
         )
         .await?;
-    assert_eq!(1, result.total);
+    assert_eq!(Some(1), result.total);
 
     Ok(())
 }

--- a/modules/fundamental/tests/sbom/cyclonedx/purl.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/purl.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::model::Paginated;
 use trustify_entity::relationship::Relationship;
 use trustify_module_fundamental::sbom::model::{SbomNodeReference, SbomPackage, Which};
@@ -21,7 +22,7 @@ fn to_strings(purls: &[PurlSummary]) -> Vec<String> {
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let result = ctx
         .ingest_document("cyclonedx/openssl-3.0.7-18.el9_2.cdx_1.6_aliases.sbom.json")
@@ -32,10 +33,18 @@ async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // fetch describes
 
     let packages = service
-        .describes_packages::<_, _, SbomPackage>(sbom_id, Paginated::default(), &ctx.db)
+        .describes_packages::<_, _, SbomPackage>(
+            sbom_id,
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(packages.total, 1);
+    assert_eq!(packages.total, Some(1));
     assert_eq!(packages.items.len(), 1);
 
     let package = &packages.items[0];
@@ -54,7 +63,11 @@ async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .fetch_related_packages::<_, _, SbomPackage>(
             sbom_id,
             Default::default(),
-            Paginated::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             Which::Right,
             SbomNodeReference::Package("pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src" /* this is actually the bom-ref value */),
             Some(Relationship::AncestorOf),
@@ -62,7 +75,7 @@ async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    assert_eq!(result.total, 1);
+    assert_eq!(result.total, Some(1));
     let relation = &result.items[0];
     assert_eq!(
         to_strings(&relation.package.purl),

--- a/modules/fundamental/tests/sbom/cyclonedx/reingest.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/reingest.rs
@@ -4,6 +4,7 @@ use anyhow::bail;
 use sea_orm::EntityTrait;
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::model::Paginated;
 use trustify_entity::sbom;
 use trustify_module_fundamental::sbom::model::SbomPackage;
@@ -24,7 +25,7 @@ async fn reingest(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             .await?
             .expect("must be found");
 
-        let service = SbomService::new(ctx.db.clone());
+        let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
         let packages = service
             .describes_packages::<_, _, SbomPackage>(

--- a/modules/fundamental/tests/sbom/details.rs
+++ b/modules/fundamental/tests/sbom/details.rs
@@ -1,6 +1,7 @@
 use test_context::test_context;
 use test_log::test;
 use tracing::instrument;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::id::Id;
 use trustify_module_fundamental::common::model::{Score, ScoreType, ScoredVector, Severity};
 use trustify_module_fundamental::sbom::{model::details::SbomDetails, service::SbomService};
@@ -10,7 +11,7 @@ use trustify_test_context::TrustifyContext;
 #[test(tokio::test)]
 #[instrument]
 async fn sbom_details_cyclonedx_osv(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let sbom = SbomService::new(ctx.db.clone());
+    let sbom = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // ingest the SBOM
     let result1 = ctx.ingest_document("cyclonedx/ghsa_test.json").await?;

--- a/modules/fundamental/tests/sbom/graph.rs
+++ b/modules/fundamental/tests/sbom/graph.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::hashing::Digests;
 use trustify_common::purl::Purl;
 use trustify_common::sbom::SbomLocator;
@@ -276,7 +277,7 @@ async fn ingest_package_relates_to_package_dependency_of(
     ctx: &TrustifyContext,
 ) -> Result<(), anyhow::Error> {
     let system = &ctx.graph;
-    let fetch = SbomService::new(ctx.db.clone());
+    let fetch = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let sbom1 = system
         .ingest_sbom(

--- a/modules/fundamental/tests/sbom/mod.rs
+++ b/modules/fundamental/tests/sbom/mod.rs
@@ -11,6 +11,7 @@ mod spdx;
 use sea_orm::{DatabaseTransaction, TransactionTrait};
 use std::time::Instant;
 use tracing::{Instrument, info_span, instrument};
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::{db::Database, hashing::Digests};
 use trustify_module_fundamental::sbom::service::SbomService;
 use trustify_module_ingestor::{
@@ -51,7 +52,7 @@ where
 
     let db = &ctx.db;
     let graph = Graph::new(db.clone());
-    let service = SbomService::new(db.clone());
+    let service = SbomService::new(db.clone(), PaginationCache::for_test());
 
     let start = Instant::now();
     let sbom = info_span!("parse json")

--- a/modules/fundamental/tests/sbom/reingest.rs
+++ b/modules/fundamental/tests/sbom/reingest.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
 use tracing::instrument;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::db::query::Query;
 use trustify_common::id::Id;
 use trustify_common::model::Paginated;
@@ -33,7 +34,7 @@ fn assert_by_cleaning_id(sbom1: &mut SbomDetails, sbom2: &mut SbomDetails) {
 #[instrument]
 #[test(tokio::test)]
 async fn quarkus(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let sbom = SbomService::new(ctx.db.clone());
+    let sbom = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // ingest the first version
     let result1 = ctx
@@ -89,13 +90,17 @@ async fn quarkus(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let sboms = sbom
         .find_related_sboms(
             SbomExternalPackageReference::Purl(&Purl::from_str(purl).expect("must parse")),
-            Paginated::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             Query::default(),
             &ctx.db,
         )
         .await?;
 
-    assert_eq!(sboms.total, 2);
+    assert_eq!(sboms.total, Some(2));
 
     // done
 
@@ -108,7 +113,7 @@ async fn quarkus(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[instrument]
 #[test(tokio::test)]
 async fn nhc(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let sbom = SbomService::new(ctx.db.clone());
+    let sbom = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // ingest the first version
     let result1 = ctx.ingest_document("nhc/v1/nhc-0.4.z.json.xz").await?;
@@ -159,7 +164,7 @@ async fn nhc(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[instrument]
 #[test(tokio::test)]
 async fn nhc_same(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let sbom = SbomService::new(ctx.db.clone());
+    let sbom = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // ingest the first version
     let result1 = ctx.ingest_document("nhc/v1/nhc-0.4.z.json.xz").await?;
@@ -213,7 +218,7 @@ async fn nhc_same(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[instrument]
 #[test(tokio::test)]
 async fn nhc_same_content(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let sbom = SbomService::new(ctx.db.clone());
+    let sbom = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // ingest the first version
     let result1 = ctx.ingest_document("nhc/v1/nhc-0.4.z.json.xz").await?;
@@ -290,7 +295,7 @@ async fn nhc_same_content(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[instrument]
 #[test(tokio::test)]
 async fn syft_rerun(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let sbom = SbomService::new(ctx.db.clone());
+    let sbom = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // ingest the first version
     let result1 = ctx.ingest_document("syft-ubi-example/v1.json.xz").await?;

--- a/modules/fundamental/tests/sbom/spdx.rs
+++ b/modules/fundamental/tests/sbom/spdx.rs
@@ -14,6 +14,7 @@ use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
 use tracing::instrument;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::model::Paginated;
 use trustify_common::{id::Id, purl::Purl, sbom::spdx::parse_spdx};
 use trustify_entity::relationship::Relationship;
@@ -91,12 +92,16 @@ async fn test_parse_spdx(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             let described = service
                 .describes_packages::<_, _, SbomPackage>(
                     sbom.sbom.sbom_id,
-                    Paginated::default(),
+                    Paginated {
+                        offset: 0,
+                        limit: 0,
+                        total: true,
+                    },
                     &ctx.db,
                 )
                 .await?;
 
-            assert_eq!(1, described.total);
+            assert_eq!(Some(1), described.total);
             let first = &described.items[0];
 
             let contains = service
@@ -125,7 +130,7 @@ async fn test_parse_spdx(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn ingest_spdx_broken_refs(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let sbom = SbomService::new(ctx.db.clone());
+    let sbom = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let err = ctx
         .ingest_document("spdx/broken-refs.json")
@@ -140,14 +145,18 @@ async fn ingest_spdx_broken_refs(ctx: &TrustifyContext) -> Result<(), anyhow::Er
     let result = sbom
         .fetch_sboms::<_, SbomPackage>(
             Default::default(),
-            Default::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             Default::default(),
             &ctx.db,
         )
         .await?;
 
     // there must be no traces, everything must be rolled back
-    assert_eq!(result.total, 0);
+    assert_eq!(result.total, Some(0));
 
     Ok(())
 }

--- a/modules/fundamental/tests/sbom/spdx/corner_cases.rs
+++ b/modules/fundamental/tests/sbom/spdx/corner_cases.rs
@@ -42,7 +42,7 @@ async fn related_packages_transitively<'a, C: ConnectionTrait>(
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn infinite_loop(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let result = ctx.ingest_document("spdx/loop.json").await?;
 
@@ -57,20 +57,37 @@ async fn infinite_loop(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .expect("must be found");
 
     let packages = service
-        .fetch_sbom_packages(id, Default::default(), Default::default(), &ctx.db)
+        .fetch_sbom_packages(
+            id,
+            Default::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(packages.total, 3);
+    assert_eq!(packages.total, Some(3));
 
     let packages = related_packages_transitively(&sbom, &ctx.db).await?;
 
     assert_eq!(packages.len(), 3);
 
     let packages = service
-        .describes_packages::<_, _, SbomPackage>(id, Paginated::default(), &ctx.db)
+        .describes_packages::<_, _, SbomPackage>(
+            id,
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(packages.total, 1);
+    assert_eq!(packages.total, Some(1));
 
     let packages = service
         .related_packages(id, None, SbomNodeReference::All, &ctx.db)
@@ -97,12 +114,21 @@ async fn double_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await?
         .expect("must be found");
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
     let packages = service
-        .fetch_sbom_packages(id, Default::default(), Default::default(), &ctx.db)
+        .fetch_sbom_packages(
+            id,
+            Default::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(packages.total, 3);
+    assert_eq!(packages.total, Some(3));
 
     let packages = related_packages_transitively(&sbom, &ctx.db).await?;
 
@@ -133,12 +159,21 @@ async fn self_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await?
         .expect("must be found");
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
     let packages = service
-        .fetch_sbom_packages(id, Default::default(), Default::default(), &ctx.db)
+        .fetch_sbom_packages(
+            id,
+            Default::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(packages.total, 0);
+    assert_eq!(packages.total, Some(0));
 
     let packages = related_packages_transitively(&sbom, &ctx.db).await?;
 
@@ -169,12 +204,21 @@ async fn self_ref_package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await?
         .expect("must be found");
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
     let packages = service
-        .fetch_sbom_packages(id, Default::default(), Default::default(), &ctx.db)
+        .fetch_sbom_packages(
+            id,
+            Default::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(packages.total, 1);
+    assert_eq!(packages.total, Some(1));
 
     let packages = related_packages_transitively(&sbom, &ctx.db).await?;
 
@@ -208,12 +252,21 @@ async fn special_char(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         bail!("must be an id")
     };
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
     let packages = service
-        .fetch_sbom_packages(id, Default::default(), Default::default(), &ctx.db)
+        .fetch_sbom_packages(
+            id,
+            Default::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
+            &ctx.db,
+        )
         .await?;
 
-    assert_eq!(packages.total, 105);
+    assert_eq!(packages.total, Some(105));
 
     let sbom = service
         .fetch_sbom_summary(Id::Uuid(id), &ctx.db)

--- a/modules/fundamental/tests/sbom/spdx/external/rh.rs
+++ b/modules/fundamental/tests/sbom/spdx/external/rh.rs
@@ -3,6 +3,7 @@
 
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_module_fundamental::sbom::service::SbomService;
 use trustify_test_context::TrustifyContext;
 use uuid::Uuid;
@@ -20,7 +21,7 @@ async fn spdx_prod_comp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let _prod: Uuid = result.pop().unwrap().id.parse().expect("must have a uid");
     let _comp: Uuid = result.pop().unwrap().id.parse().expect("must have a uid");
 
-    let _service = SbomService::new(ctx.db.clone());
+    let _service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // TODO: implement when we have the tools
 

--- a/modules/fundamental/tests/sbom/spdx/issue_1417.rs
+++ b/modules/fundamental/tests/sbom/spdx/issue_1417.rs
@@ -1,6 +1,7 @@
 use anyhow::bail;
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::{db::query::Query, model::Paginated};
 use trustify_module_fundamental::sbom::service::SbomService;
 use trustify_test_context::TrustifyContext;
@@ -17,7 +18,7 @@ async fn multi_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         bail!("must be an id")
     };
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let sbom = service
         .fetch_sbom_packages(id, Query::default(), Paginated::default(), &ctx.db)

--- a/modules/fundamental/tests/sbom/spdx/parallel.rs
+++ b/modules/fundamental/tests/sbom/spdx/parallel.rs
@@ -1,6 +1,7 @@
 use test_context::test_context;
 use test_log::test;
 use tracing::instrument;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::{db::query::Query, model::Paginated};
 use trustify_module_fundamental::sbom::model::SbomPackage;
 use trustify_module_fundamental::sbom::service::SbomService;
@@ -19,17 +20,21 @@ async fn ingest_10(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     futures_util::future::try_join_all(f).await?;
 
-    let service = SbomService::new(ctx.db.clone());
+    let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let result = service
         .fetch_sboms::<_, SbomPackage>(
             Query::default(),
-            Paginated::default(),
+            Paginated {
+                offset: 0,
+                limit: 0,
+                total: true,
+            },
             Default::default(),
             &ctx.db,
         )
         .await?;
-    assert_eq!(1, result.total);
+    assert_eq!(Some(1), result.total);
 
     Ok(())
 }

--- a/modules/fundamental/tests/sbom/spdx/perf.rs
+++ b/modules/fundamental/tests/sbom/spdx/perf.rs
@@ -57,12 +57,13 @@ async fn ingest_spdx_medium(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
                     Paginated {
                         offset: 0,
                         limit: 1,
+                        total: true,
                     },
                     &ctx.db,
                 )
                 .await?;
             assert_eq!(1, packages.items.len());
-            assert_eq!(7994, packages.total);
+            assert_eq!(Some(7994), packages.total);
 
             Ok(())
         },
@@ -150,12 +151,13 @@ async fn ingest_spdx_medium_cpes(ctx: &TrustifyContext) -> Result<(), anyhow::Er
                     Paginated {
                         offset: 0,
                         limit: 1,
+                        total: true,
                     },
                     &ctx.db,
                 )
                 .await?;
             assert_eq!(1, packages.items.len());
-            assert_eq!(50668, packages.total);
+            assert_eq!(Some(50668), packages.total);
 
             Ok(())
         },

--- a/modules/fundamental/tests/sbom/spdx/reingest.rs
+++ b/modules/fundamental/tests/sbom/spdx/reingest.rs
@@ -4,6 +4,7 @@ use anyhow::bail;
 use sea_orm::EntityTrait;
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::model::Paginated;
 use trustify_entity::sbom;
 use trustify_module_fundamental::sbom::model::SbomPackage;
@@ -24,7 +25,7 @@ async fn reingest(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             .await?
             .expect("must be found");
 
-        let service = SbomService::new(ctx.db.clone());
+        let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
         let packages = service
             .describes_packages::<_, _, SbomPackage>(

--- a/modules/fundamental/tests/vuln/mod.rs
+++ b/modules/fundamental/tests/vuln/mod.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use serde_json::json;
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_module_fundamental::vulnerability::service::VulnerabilityService;
 use trustify_test_context::{Dataset, TrustifyContext, subset::ContainsSubset};
 
@@ -12,7 +13,7 @@ use trustify_test_context::{Dataset, TrustifyContext, subset::ContainsSubset};
 async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_dataset(Dataset::DS3).await?;
 
-    let service = VulnerabilityService::new();
+    let service = VulnerabilityService::new(PaginationCache::for_test());
 
     let result = service
         .analyze_purls_v3(["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"], &ctx.db)

--- a/modules/fundamental/tests/weakness/mod.rs
+++ b/modules/fundamental/tests/weakness/mod.rs
@@ -4,6 +4,7 @@ use roxmltree::Document;
 use std::io::Read;
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::{hashing::HashingRead, model::Paginated};
 use trustify_entity::labels::Labels;
 use trustify_module_fundamental::weakness::service::WeaknessService;
@@ -17,7 +18,7 @@ async fn simple(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     const TOTAL_ITEMS_FOUND: u64 = 964;
 
     let loader = CweCatalogLoader::new();
-    let service = WeaknessService::new(ctx.db.clone());
+    let service = WeaknessService::new(ctx.db.clone(), PaginationCache::for_test());
 
     // extract document from zip file
 
@@ -47,11 +48,12 @@ async fn simple(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Paginated {
                 offset: 0,
                 limit: 10,
+                total: true,
             },
         )
         .await?;
 
-    assert_eq!(TOTAL_ITEMS_FOUND, all.total);
+    assert_eq!(Some(TOTAL_ITEMS_FOUND), all.total);
 
     let w = service
         .get_weakness("CWE-1004")
@@ -84,13 +86,14 @@ async fn simple(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Paginated {
                 offset: 0,
                 limit: 10,
+                total: true,
             },
         )
         .await?;
 
     // must be the same number of items
 
-    assert_eq!(964, all.total);
+    assert_eq!(Some(964), all.total);
 
     let w = service
         .get_weakness("CWE-1004")

--- a/modules/importer/src/endpoints.rs
+++ b/modules/importer/src/endpoints.rs
@@ -11,14 +11,18 @@ use trustify_auth::{
     CreateImporter, DeleteImporter, ReadImporter, UpdateImporter, authorizer::Require,
 };
 use trustify_common::{
-    db::{Database, query::Query},
+    db::{Database, pagination_cache::PaginationCache, query::Query},
     endpoints::extract_revision,
     model::{Paginated, PaginatedResults, Revisioned},
 };
 
-/// mount the "importer" module
-pub fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfig, db: Database) {
-    svc.app_data(web::Data::new(ImporterService::new(db)))
+/// Mount the "importer" module.
+pub fn configure(
+    svc: &mut utoipa_actix_web::service_config::ServiceConfig,
+    db: Database,
+    cache: PaginationCache,
+) {
+    svc.app_data(web::Data::new(ImporterService::new(db, cache)))
         .service(list)
         .service(create)
         .service(read)

--- a/modules/importer/src/server/mod.rs
+++ b/modules/importer/src/server/mod.rs
@@ -17,7 +17,7 @@ use time::OffsetDateTime;
 use tokio::{task::LocalSet, time::MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
-use trustify_common::db::Database;
+use trustify_common::db::{Database, pagination_cache::PaginationCache};
 use trustify_module_analysis::service::AnalysisService;
 use trustify_module_storage::service::dispatch::DispatchBackend;
 
@@ -26,6 +26,7 @@ use trustify_module_storage::service::dispatch::DispatchBackend;
 /// When `read_only` is true, the loop stays alive but no imports are started.
 pub async fn importer(
     db: Database,
+    cache: PaginationCache,
     storage: DispatchBackend,
     working_dir: Option<PathBuf>,
     analysis: Option<AnalysisService>,
@@ -34,6 +35,7 @@ pub async fn importer(
 ) -> anyhow::Result<()> {
     Server {
         db,
+        cache,
         storage,
         working_dir,
         analysis,
@@ -62,6 +64,7 @@ impl From<Report> for RunOutput {
 /// Single node, single process importer processor.
 struct Server {
     db: Database,
+    cache: PaginationCache,
     storage: DispatchBackend,
     working_dir: Option<PathBuf>,
     analysis: Option<AnalysisService>,
@@ -81,7 +84,7 @@ impl Server {
         let meter = global::meter("importer::Server");
         let running_importers = meter.u64_gauge("running_importers").build();
 
-        let service = ImporterService::new(self.db.clone());
+        let service = ImporterService::new(self.db.clone(), self.cache.clone());
         let runner = ImportRunner {
             db: self.db.clone(),
             storage: self.storage.clone(),

--- a/modules/importer/src/service.rs
+++ b/modules/importer/src/service.rs
@@ -11,7 +11,8 @@ use tracing::instrument;
 use trustify_common::{
     db::{
         Database, DatabaseErrors,
-        limiter::LimiterTrait,
+        limiter::{LimitedResult, LimiterTrait},
+        pagination_cache::PaginationCache,
         query::{Filtering, Query},
     },
     error::ErrorInformation,
@@ -123,11 +124,12 @@ where
 #[derive(Clone, Debug)]
 pub struct ImporterService {
     db: Database,
+    cache: PaginationCache,
 }
 
 impl ImporterService {
-    pub fn new(db: Database) -> Self {
-        Self { db }
+    pub fn new(db: Database, cache: PaginationCache) -> Self {
+        Self { db, cache }
     }
 
     pub async fn list(&self) -> Result<Vec<Importer>, Error> {
@@ -479,16 +481,14 @@ impl ImporterService {
             .filter(importer_report::Column::Importer.eq(name))
             .filtering(search)?
             .order_by_desc(importer_report::Column::Creation)
-            .limiting(&self.db, paginated.offset, paginated.limit);
+            .limiting(&self.db, paginated.offset, paginated.limit, &self.cache);
+
+        let LimitedResult { items, total } = limiting.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         Ok(PaginatedResults {
-            total: limiting.total().await?,
-            items: limiting
-                .fetch()
-                .await?
-                .into_iter()
-                .map(ImporterReport::from)
-                .collect(),
+            total,
+            items: items.into_iter().map(ImporterReport::from).collect(),
         })
     }
 }

--- a/modules/importer/src/test.rs
+++ b/modules/importer/src/test.rs
@@ -14,6 +14,7 @@ use serde_json::json;
 use std::time::Duration;
 use test_context::test_context;
 use test_log::test;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_test_context::{ReadOnly, TrustifyContext, app::TestApp};
 use utoipa_actix_web::AppExt;
 
@@ -63,8 +64,9 @@ async fn app(
             .into_utoipa_app()
             .add_test_authorizer()
             .service(
-                utoipa_actix_web::scope("/api")
-                    .configure(|svc| super::endpoints::configure(svc, db)),
+                utoipa_actix_web::scope("/api").configure(|svc| {
+                    super::endpoints::configure(svc, db, PaginationCache::for_test())
+                }),
             )
             .into_app(),
     )

--- a/modules/ingestor/src/graph/purl/mod.rs
+++ b/modules/ingestor/src/graph/purl/mod.rs
@@ -18,7 +18,11 @@ use std::{
 };
 use tracing::instrument;
 use trustify_common::{
-    db::{chunk::EntityChunkedIter, limiter::LimiterTrait},
+    db::{
+        chunk::EntityChunkedIter,
+        limiter::{LimitedResult, LimiterTrait},
+        pagination_cache::PaginationCache,
+    },
     model::{Paginated, PaginatedResults},
     purl::{Purl, PurlErr},
 };
@@ -314,17 +318,19 @@ impl<'g> PackageContext<'g> {
         &self,
         paginated: Paginated,
         connection: &C,
+        cache: &PaginationCache,
     ) -> Result<PaginatedResults<PackageVersionContext<'_>>, Error> {
         let limiter = entity::versioned_purl::Entity::find()
             .filter(entity::versioned_purl::Column::BasePurlId.eq(self.base_purl.id))
-            .limiting(connection, paginated.limit, paginated.offset);
+            .limiting(connection, paginated.limit, paginated.offset, cache);
+
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         Ok(PaginatedResults {
-            total: limiter.total().await?,
-            items: limiter
-                .fetch()
-                .await?
-                .drain(0..)
+            total,
+            items: items
+                .into_iter()
                 .map(|each| PackageVersionContext::new(self, each))
                 .collect(),
         })
@@ -379,6 +385,7 @@ mod tests {
     use test_context::test_context;
     use test_log::test;
 
+    use trustify_common::db::pagination_cache::PaginationCache;
     use trustify_common::model::Paginated;
     use trustify_common::purl::Purl;
     use trustify_entity::qualified_purl;
@@ -491,12 +498,14 @@ mod tests {
                 Paginated {
                     offset: 50,
                     limit: 50,
+                    total: true,
                 },
                 &ctx.db,
+                &PaginationCache::for_test(),
             )
             .await?;
 
-        assert_eq!(TOTAL_ITEMS, paginated.total);
+        assert_eq!(Some(TOTAL_ITEMS), paginated.total);
         assert_eq!(50, paginated.items.len());
 
         let _next_paginated = pkg
@@ -504,12 +513,14 @@ mod tests {
                 Paginated {
                     offset: 100,
                     limit: 50,
+                    total: true,
                 },
                 &ctx.db,
+                &PaginationCache::for_test(),
             )
             .await?;
 
-        assert_eq!(TOTAL_ITEMS, paginated.total);
+        assert_eq!(Some(TOTAL_ITEMS), paginated.total);
         assert_eq!(50, paginated.items.len());
 
         Ok(())

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -302,6 +302,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       - name: ancestors
         in: query
         description: |-
@@ -380,6 +386,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       - name: ancestors
         in: query
         description: |-
@@ -526,6 +538,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       - name: ancestors
         in: query
         description: |-
@@ -604,6 +622,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       - name: ancestors
         in: query
         description: |-
@@ -779,6 +803,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       - name: q
         in: query
         description: |
@@ -1414,6 +1444,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       - name: name
         in: path
         required: true
@@ -1501,6 +1537,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: Matching licenses
@@ -1611,6 +1653,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: Matching licenses
@@ -1740,6 +1788,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: Matching organizations
@@ -1872,6 +1926,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: Matching products
@@ -2025,6 +2085,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: All relevant matching qualified PURLs
@@ -2135,6 +2201,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: All relevant matching versionless base PURL
@@ -2283,6 +2355,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       - name: group
         in: query
         description: |-
@@ -2508,6 +2586,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       - name: purl
         in: query
         description: Find by PURL
@@ -2678,6 +2762,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: AI Models
@@ -2926,6 +3016,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: AI Models
@@ -3042,6 +3138,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: Packages
@@ -3185,6 +3287,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: Packages
@@ -3463,6 +3571,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: Matching weaknesses
@@ -3566,6 +3680,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       - name: deprecated
         in: query
         required: false
@@ -3733,6 +3853,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       - name: group
         in: query
         description: |-
@@ -3848,6 +3974,12 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: Matching vulnerabilities
@@ -4900,7 +5032,6 @@ components:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -4919,14 +5050,15 @@ components:
                     $ref: '#/components/schemas/AdvisoryVulnerabilityHead'
                   description: Vulnerabilities addressed within this advisory.
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_BasePurlSummary:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -4934,14 +5066,15 @@ components:
             allOf:
             - $ref: '#/components/schemas/BasePurlHead'
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_GroupDetails:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -4982,14 +5115,15 @@ components:
                     This information is only present when requested.
             description: Detailed group information, extends [`Group`]
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_ImporterReport:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5021,14 +5155,15 @@ components:
                 - $ref: '#/components/schemas/Report'
                   description: Detailed report information
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_LicenseSummary:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5058,14 +5193,15 @@ components:
                 items:
                   type: string
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_LicenseText:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5077,14 +5213,15 @@ components:
               license:
                 type: string
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_Node:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5118,14 +5255,15 @@ components:
                     type: string
                   description: Warnings when processing this node.
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_ProductSummary:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5146,14 +5284,15 @@ components:
                   items:
                     $ref: '#/components/schemas/ProductVersionHead'
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_PurlSummary:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5178,14 +5317,15 @@ components:
                 version:
                   $ref: '#/components/schemas/VersionedPurlHead'
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_SbomModel:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5215,14 +5355,15 @@ components:
                   $ref: '#/components/schemas/PurlSummary'
                 description: The model's PURL
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_SbomPackage:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5279,14 +5420,15 @@ components:
                 - 'null'
                 description: An optional version for an SBOM package
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_SbomPackageRelation_SbomPackage:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5351,14 +5493,15 @@ components:
               relationship:
                 $ref: '#/components/schemas/Relationship'
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_SbomPackageSummary:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5385,14 +5528,15 @@ components:
                 - 'null'
                 description: An optional version for an SBOM package
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_SbomSummary:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5409,14 +5553,15 @@ components:
                   items:
                     $ref: '#/components/schemas/SbomPackage'
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_SpdxLicenseSummary:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5431,14 +5576,15 @@ components:
               name:
                 type: string
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     PaginatedResults_VulnerabilitySummary:
       type: object
       required:
       - items
-      - total
       properties:
         items:
           type: array
@@ -5446,7 +5592,9 @@ components:
             allOf:
             - $ref: '#/components/schemas/VulnerabilityHead'
         total:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           minimum: 0
     ProductDetails:

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -1,5 +1,6 @@
 use crate::profile::api::{Config, ModuleConfig, configure, default_openapi_info};
 use actix_web::App;
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_module_analysis::{config::AnalysisConfig, service::AnalysisService};
 use trustify_module_storage::service::fs::FileSystemBackend;
 use utoipa_actix_web::AppExt;
@@ -17,6 +18,7 @@ pub async fn create_openapi() -> anyhow::Result<utoipa::openapi::OpenApi> {
                 Config {
                     config: ModuleConfig::default(),
                     db,
+                    cache: PaginationCache::for_test(),
                     storage: storage.into(),
                     auth: None,
                     analysis,

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -13,7 +13,15 @@ use trustify_auth::{
     devmode::{FRONTEND_CLIENT_ID, ISSUER_URL},
     swagger_ui::{SwaggerUiOidc, SwaggerUiOidcConfig},
 };
-use trustify_common::{config::Database, db, middleware::ReadOnlyState, model::BinaryByteSize};
+use trustify_common::{
+    config::Database,
+    db::{
+        self,
+        pagination_cache::{PaginationCache, PaginationConfig},
+    },
+    middleware::ReadOnlyState,
+    model::BinaryByteSize,
+};
 use trustify_infrastructure::{
     Infrastructure, InfrastructureConfig, InitContext,
     app::{
@@ -111,6 +119,9 @@ pub struct Run {
     pub swagger_ui_oidc: SwaggerUiOidcConfig,
 
     #[command(flatten)]
+    pub pagination: PaginationConfig,
+
+    #[command(flatten)]
     pub ui: UiConfig,
 }
 
@@ -166,6 +177,7 @@ struct InitData {
     authenticator: Option<Arc<Authenticator>>,
     authorizer: Authorizer,
     db: db::Database,
+    cache: PaginationCache,
     storage: DispatchBackend,
     http: HttpServerConfig<Trustify>,
     tracing: Tracing,
@@ -240,8 +252,10 @@ impl InitData {
             trustify_db::Database(&db).migrate().await?;
         }
 
+        let cache = run.pagination.into_cache();
+
         if run.devmode || run.sample_data {
-            sample_data(db.clone()).await?;
+            sample_data(db.clone(), cache.clone()).await?;
         }
 
         context
@@ -280,6 +294,7 @@ impl InitData {
             authenticator,
             authorizer,
             db,
+            cache,
             config,
             http: run.http,
             tracing: run.infra.tracing,
@@ -310,6 +325,7 @@ impl InitData {
                         Config {
                             config: self.config.clone(),
                             db: self.db.clone(),
+                            cache: self.cache.clone(),
                             storage: self.storage.clone(),
                             auth: self.authenticator.clone(),
                             analysis: self.analysis.clone(),
@@ -358,6 +374,7 @@ pub fn default_openapi_info() -> Info {
 pub(crate) struct Config {
     pub(crate) config: ModuleConfig,
     pub(crate) db: db::Database,
+    pub(crate) cache: PaginationCache,
     pub(crate) storage: DispatchBackend,
     pub(crate) analysis: AnalysisService,
     pub(crate) auth: Option<Arc<Authenticator>>,
@@ -373,6 +390,7 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
                 ui,
             },
         db,
+        cache,
         storage,
         auth,
         analysis,
@@ -394,7 +412,7 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
         utoipa_actix_web::scope("/api")
             .map(|scope| scope.wrap(new_auth(auth)))
             .configure(|svc| {
-                trustify_module_importer::endpoints::configure(svc, db.clone());
+                trustify_module_importer::endpoints::configure(svc, db.clone(), cache.clone());
                 trustify_module_ingestor::endpoints::configure(
                     svc,
                     ingestor,
@@ -408,6 +426,7 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
                     db.clone(),
                     storage,
                     analysis.clone(),
+                    cache,
                 );
                 trustify_module_analysis::endpoints::configure(svc, db.clone(), analysis);
                 trustify_module_user::endpoints::configure(svc, db.clone());
@@ -481,6 +500,7 @@ mod test {
                         Config {
                             config: ModuleConfig::default(),
                             db: ctx.db.clone(),
+                            cache: PaginationCache::for_test(),
                             storage: ctx.storage.clone().into(),
                             auth: None,
                             analysis,
@@ -551,6 +571,7 @@ mod test {
                     config: ModuleConfig::default(),
                     db: ctx.db.clone(),
                     storage: ctx.storage.clone().into(),
+                    cache: PaginationCache::for_test(),
                     auth: None,
                     analysis,
                     read_only,

--- a/server/src/profile/importer.rs
+++ b/server/src/profile/importer.rs
@@ -1,7 +1,13 @@
 use crate::profile::spawn_db_check;
 use futures::FutureExt;
 use std::{path::PathBuf, process::ExitCode};
-use trustify_common::{config::Database, db};
+use trustify_common::{
+    config::Database,
+    db::{
+        self,
+        pagination_cache::{PaginationCache, PaginationConfig},
+    },
+};
 use trustify_infrastructure::{Infrastructure, InfrastructureConfig, InitContext};
 use trustify_module_importer::server::importer;
 use trustify_module_storage::{config::StorageConfig, service::dispatch::DispatchBackend};
@@ -28,6 +34,10 @@ pub struct Run {
 
     // flattened commands must go last
     //
+    /// Pagination configuration
+    #[command(flatten)]
+    pub pagination: PaginationConfig,
+
     /// Database configuration
     #[command(flatten)]
     pub database: Database,
@@ -44,6 +54,7 @@ const SERVICE_ID: &str = "trustify-importer";
 
 struct InitData {
     db: db::Database,
+    cache: PaginationCache,
     storage: DispatchBackend,
     working_dir: Option<PathBuf>,
     concurrency: usize,
@@ -79,6 +90,7 @@ impl InitData {
 
         Ok(InitData {
             db,
+            cache: run.pagination.into_cache(),
             storage,
             working_dir: run.working_dir,
             concurrency: run.concurrency,
@@ -93,6 +105,7 @@ impl InitData {
         let importer = async {
             importer(
                 db,
+                self.cache,
                 storage,
                 self.working_dir,
                 None, // Running the importer, we don't need an analysis graph update

--- a/server/src/sample_data.rs
+++ b/server/src/sample_data.rs
@@ -1,5 +1,6 @@
 use bytesize::ByteSize;
 use std::{collections::HashSet, time::Duration};
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_module_importer::model::{
     ClearlyDefinedImporter, ClearlyDefinedPackageType, CveImporter, CweImporter,
     DEFAULT_SOURCE_CLEARLY_DEFINED_CURATION, DEFAULT_SOURCE_CVEPROJECT, DEFAULT_SOURCE_CWE_CATALOG,
@@ -171,8 +172,11 @@ async fn add_quay(
 }
 
 /// Insert example importers, ignoring existing ones
-pub async fn sample_data(db: trustify_common::db::Database) -> anyhow::Result<()> {
-    let importer = ImporterService::new(db);
+pub async fn sample_data(
+    db: trustify_common::db::Database,
+    cache: PaginationCache,
+) -> anyhow::Result<()> {
+    let importer = ImporterService::new(db, cache);
 
     add(&importer, "redhat-sbom",  ImporterConfiguration::Sbom(SbomImporter {
         common: CommonImporter {
@@ -349,9 +353,9 @@ mod test {
     #[test_context(TrustifyContext, skip_teardown)]
     #[test(tokio::test)]
     async fn add_samples(ctx: TrustifyContext) -> anyhow::Result<()> {
-        sample_data(ctx.db.clone()).await?;
+        sample_data(ctx.db.clone(), PaginationCache::for_test()).await?;
 
-        let service = ImporterService::new(ctx.db.clone());
+        let service = ImporterService::new(ctx.db.clone(), PaginationCache::for_test());
         let result = service.list().await?;
 
         assert_eq!(result.len(), 16);


### PR DESCRIPTION
## Summary by Sourcery

Make pagination more efficient and flexible by making total counts optional and cached across the API.

New Features:
- Allow API clients to opt in to total count computation via a new total=true pagination parameter, returning total as an optional field in paginated responses.

Enhancements:
- Change pagination models and services so total counts are optional, avoiding COUNT queries when not requested.
- Introduce a shared pagination total-count cache based on query shape to reduce repeated COUNT(*) database calls for identical filters.
- Update services across SBOMs, advisories, licenses, products, organizations, vulnerabilities, weaknesses, PURLs, and importers to honor the optional total flag and use the new pagination utilities.

Documentation:
- Add an ADR documenting the design and trade-offs of optional totals and cached pagination counts across the API.

Tests:
- Adjust existing tests and add new ones to cover the optional total semantics, total=true query handling, and pagination behavior with and without totals.