### PR TITLE
chore: make clippy 1.95.0 happy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Cache Theseus Postgresql Installation
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.theseus/postgresql
           key: ${{ runner.os }}-theseus-postgresql-${{ hashFiles('**/Cargo.lock') }}

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -127,7 +127,7 @@ async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     assert_eq!(purl.advisories.len(), 1);
     purl.advisories
-        .sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
+        .sort_unstable_by_key(|a| a.head.modified);
     let adv1 = &mut purl.advisories[0];
 
     assert_eq!(

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -126,8 +126,7 @@ async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // must be 1, as we deleted the latter one
 
     assert_eq!(purl.advisories.len(), 1);
-    purl.advisories
-        .sort_unstable_by_key(|a| a.head.modified);
+    purl.advisories.sort_unstable_by_key(|a| a.head.modified);
     let adv1 = &mut purl.advisories[0];
 
     assert_eq!(

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -293,8 +293,7 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // must be 2, as we consider deprecated ones too
 
     assert_eq!(purl.advisories.len(), 2);
-    purl.advisories
-        .sort_unstable_by_key(|a| a.head.modified);
+    purl.advisories.sort_unstable_by_key(|a| a.head.modified);
     let (slice1, slice2) = purl.advisories.split_at_mut(1);
     let adv1 = &mut slice1[0];
     let adv2 = &mut slice2[0];

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -294,7 +294,7 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     assert_eq!(purl.advisories.len(), 2);
     purl.advisories
-        .sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
+        .sort_unstable_by_key(|a| a.head.modified);
     let (slice1, slice2) = purl.advisories.split_at_mut(1);
     let adv1 = &mut slice1[0];
     let adv2 = &mut slice2[0];

--- a/modules/fundamental/tests/advisory/osv/reingest.rs
+++ b/modules/fundamental/tests/advisory/osv/reingest.rs
@@ -112,8 +112,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // must be 2, as we consider deprecated ones too
 
     assert_eq!(purl.advisories.len(), 2);
-    purl.advisories
-        .sort_unstable_by_key(|a| a.head.modified);
+    purl.advisories.sort_unstable_by_key(|a| a.head.modified);
     let (slice1, slice2) = purl.advisories.split_at_mut(1);
     let adv1 = &mut slice1[0];
     let adv2 = &mut slice2[0];

--- a/modules/fundamental/tests/advisory/osv/reingest.rs
+++ b/modules/fundamental/tests/advisory/osv/reingest.rs
@@ -113,7 +113,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     assert_eq!(purl.advisories.len(), 2);
     purl.advisories
-        .sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
+        .sort_unstable_by_key(|a| a.head.modified);
     let (slice1, slice2) = purl.advisories.split_at_mut(1);
     let adv1 = &mut slice1[0];
     let adv2 = &mut slice2[0];

--- a/modules/ingestor/src/graph/advisory/mod.rs
+++ b/modules/ingestor/src/graph/advisory/mod.rs
@@ -474,7 +474,7 @@ mod test {
         let mut advs = system
             .get_advisories(Deprecation::Consider, &ctx.db)
             .await?;
-        advs.sort_unstable_by(|a, b| a.advisory.modified.cmp(&b.advisory.modified));
+        advs.sort_unstable_by_key(|a| a.advisory.modified);
         let deps = advs
             .iter()
             .map(|adv| (adv.advisory.id, adv.advisory.deprecated))


### PR DESCRIPTION
## Summary by Sourcery

Update advisory handling and tests to satisfy newer Clippy lint requirements.

Enhancements:
- Simplify zipping of vulnerability advisories with organizations by iterating directly over the organization collection.

Tests:
- Adjust advisory sorting in tests to use key-based unstable sorting on the modified field for clearer intent and Clippy compliance.