### PR TITLE
fix: improve performance of advisory list

### DIFF
--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -42,7 +42,7 @@ impl AdvisoryService {
     ) -> Result<PaginatedResults<AdvisorySummary>, Error> {
         let limiter = advisory::Entity::find()
             .with_deprecation(deprecation)
-            .left_join(source_document::Entity)
+            .inner_join(source_document::Entity)
             .join(JoinType::LeftJoin, advisory::Relation::Issuer.def())
             .filtering_with(
                 search,
@@ -78,7 +78,7 @@ impl AdvisoryService {
         connection: &C,
     ) -> Result<Option<AdvisoryDetails>, Error> {
         let results = advisory::Entity::find()
-            .left_join(source_document::Entity)
+            .inner_join(source_document::Entity)
             .join(JoinType::LeftJoin, advisory::Relation::Issuer.def())
             .try_filter(id)?
             .try_into_multi_model::<AdvisoryCatcher>()?

--- a/modules/fundamental/src/license/service/mod.rs
+++ b/modules/fundamental/src/license/service/mod.rs
@@ -249,7 +249,7 @@ impl LicenseService {
     ) -> Result<Option<Vec<LicenseRefMapping>>, Error> {
         // check the SBOM exists searching by the provided Id
         let sbom = sbom::Entity::find()
-            .join(JoinType::LeftJoin, sbom::Relation::SourceDocument.def())
+            .join(JoinType::InnerJoin, sbom::Relation::SourceDocument.def())
             .try_filter(id)?
             .one(connection)
             .await?;

--- a/modules/ingestor/src/graph/sbom/mod.rs
+++ b/modules/ingestor/src/graph/sbom/mod.rs
@@ -79,7 +79,7 @@ impl Graph {
         connection: &C,
     ) -> Result<Option<SbomContext>, Error> {
         Ok(sbom::Entity::find()
-            .join(JoinType::LeftJoin, sbom::Relation::SourceDocument.def())
+            .join(JoinType::InnerJoin, sbom::Relation::SourceDocument.def())
             .filter(
                 Condition::any()
                     .add(source_document::Column::Sha256.eq(digest.to_string()))


### PR DESCRIPTION
The left join can be replaced with an inner join, as the source_document_id is never null and always matches a record.

This allows to speed up postgres doing the most frequent searches, especially the initial dashboard search.

This allows postgres to optimize the call, speeding it up from ~3.2 seconds to ~0.6 seconds on DS4.

## Summary by Sourcery

Enhancements:
- Replace left joins with inner/inner-typed joins for advisory-source_document and sbom-source_document queries to improve query performance in common paths.