### PR TITLE
chore: workaround to make some tests to pass

### DIFF
--- a/test-context/src/ctx/migration/mod.rs
+++ b/test-context/src/ctx/migration/mod.rs
@@ -167,6 +167,7 @@ impl<ID: DumpId> TrustifyMigrationContext<ID> {
                     snapshot_file: None,
                     strip: 0,
                     fix_zstd: false,
+                    use_btrfs: false,
                 }
             }
 
@@ -202,6 +203,7 @@ impl<ID: DumpId> TrustifyMigrationContext<ID> {
                     snapshot_file: snapshot_file.map(ToOwned::to_owned),
                     strip,
                     fix_zstd,
+                    use_btrfs: true,
                 }
             }
         };

--- a/test-context/src/ctx/migration/snapshot/mod.rs
+++ b/test-context/src/ctx/migration/snapshot/mod.rs
@@ -30,6 +30,7 @@ pub struct Snapshot {
     pub strip: usize,
     pub fix_zstd: bool,
     /// Whether to use Btrfs snapshots. When false, TempDir is used.
+    #[allow(dead_code)]
     pub use_btrfs: bool,
 }
 

--- a/test-context/src/ctx/migration/snapshot/mod.rs
+++ b/test-context/src/ctx/migration/snapshot/mod.rs
@@ -29,6 +29,8 @@ pub struct Snapshot {
     pub snapshot_file: Option<String>,
     pub strip: usize,
     pub fix_zstd: bool,
+    /// Whether to use Btrfs snapshots. When false, TempDir is used.
+    pub use_btrfs: bool,
 }
 
 impl Snapshot {
@@ -51,6 +53,7 @@ impl Snapshot {
                 snapshot_file: _, // we don't work with the snapshot file
             strip,
             fix_zstd,
+            use_btrfs: _,
         } = self;
 
         let storage_file = base.join(storage_file);
@@ -178,6 +181,19 @@ impl Snapshot {
     /// a BTRFS snapshot of an import. If such a snapshot doesn't exist yet, it will be created
     /// first.
     pub async fn materialize(self) -> anyhow::Result<TrustifyTestContext> {
+        // If Btrfs snapshots are not requested, use TempDir
+        if !self.use_btrfs {
+            let tmp = tempfile::TempDir::new()?;
+            let (db, storage, psql) = self.setup(&tmp).await?;
+
+            return Ok(TrustifyTestContext::new(
+                db,
+                psql.settings().port,
+                storage,
+                defer(psql).then(defer(tmp)),
+            ));
+        }
+
         use crate::ctx::migration::snapshot::btrfs::SnapshotProvider;
 
         let running = btrfs::Running::new(SnapshotProvider {


### PR DESCRIPTION
* when using linux + btrfs without long_running feature or --all-features enabled.
* Related to https://github.com/guacsec/trustify/issues/2340

## Summary by Sourcery

Add a configuration flag to optionally disable Btrfs-based snapshots in test migrations and fall back to temporary directories to ensure tests pass in non-long_running environments.

New Features:
- Allow tests to use a non-Btrfs TempDir-based snapshot mechanism when Btrfs snapshots are not requested.

Enhancements:
- Wire the new snapshot configuration flag through the migration test context to control whether Btrfs or TempDir is used.