### PR TITLE
test: check for btrfs mount option too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4381,7 +4381,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix 0.29.0",
+ "nix",
  "serde",
  "winapi",
 ]
@@ -4537,18 +4537,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
 ]
 
 [[package]]
@@ -5660,6 +5648,27 @@ dependencies = [
  "syn 2.0.117",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "procfs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
+dependencies = [
+ "bitflags",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
+dependencies = [
+ "bitflags",
+ "hex",
 ]
 
 [[package]]
@@ -8948,10 +8957,10 @@ dependencies = [
  "hex",
  "indicatif",
  "log",
- "nix 0.31.2",
  "osv",
  "peak_alloc",
  "postgresql_embedded",
+ "procfs",
  "reqwest 0.13.2",
  "serde",
  "serde_json",

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -64,4 +64,5 @@
 | `EXTERNAL_TEST_DB`           | Run tests against external test database if set                                                             |               |
 | `EXTERNAL_TEST_DB_BOOTSTRAP` | Run tests against external test database if set                                                             |               |
 | `MEM_LIMIT_MB`               | Set memory limit for tests that use TrustifyContext, shows the memory usage when the test reaches the limit | `500 MiB`     |
+| `TRUST_TEST_BTRFS_DISABLE`   | Disable BTRFS snapshot support even if available                                                            |               |
 | `TRUST_TEST_BTRFS_STORE`     | Path to a BTRFS-backed directory for using snapshots for tests                                              | User's home   |

--- a/docs/test-snapshots.md
+++ b/docs/test-snapshots.md
@@ -14,6 +14,9 @@ a freshly instantiated snapshot from that import. This takes seconds rather than
 * Have a BTRFS volume mounted, with the following options: `defaults,user,exec,user_subvol_rm_allowed`
 * Set `TRUST_TEST_BTRFS_STORE` to a directory which is on such a volume, otherwise the current working directory is used, which must be on a BTRFS volume with those options
 
+If the requirements are not met, tests will automatically fall back to creating a temporary directory per test and
+run import operations every time. This is slower, but still does run tests.
+
 ## Maintenance
 
 It may happen that, at the end of a run, subvolumes don't get cleaned up. You can check using the following command:
@@ -27,8 +30,4 @@ short-lived and removed after a test was run.
 
 ## Alternatives
 
-If the requirements are not met (non-Linux platform, missing `btrfs` tool, or the store path is not on a BTRFS
-filesystem), tests will automatically fall back to creating a temporary directory per test and running import
-operations every time. This is slower, but does run tests.
-
-The temporary directory will be the sytem temporary directory, but can be overridden by using the `TMPDIR` variable.
+The temporary directory will be the system temporary directory, but can be overridden by using the `TMPDIR` variable.

--- a/test-context/Cargo.toml
+++ b/test-context/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.21.0", features = ["v4"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 async-compression = { workspace = true, features = ["tokio", "zstd", "xz"] }
-nix = { version = "0.31.2", features = ["fs"] }
+procfs = { version = "0.18", default-features = false }
 
 [dev-dependencies]
 hex = { workspace = true }

--- a/test-context/src/ctx/migration/snapshot/btrfs.rs
+++ b/test-context/src/ctx/migration/snapshot/btrfs.rs
@@ -36,15 +36,23 @@ impl Command {
 
 #[cfg(target_os = "linux")]
 impl Command {
-    pub fn is_btrfs(path: impl AsRef<Path>) -> io::Result<bool> {
-        const BTRFS_SUPER_MAGIC: nix::libc::c_long = 0x9123683E;
+    /// Find the mount info entry for the given path (longest mount point prefix match).
+    fn find_mount_entry(path: impl AsRef<Path>) -> io::Result<Option<procfs::process::MountInfo>> {
+        let path = path.as_ref().canonicalize()?;
+        let me = procfs::process::Process::myself().map_err(io::Error::other)?;
+        let mountinfo = me.mountinfo().map_err(io::Error::other)?;
 
-        let stat = nix::sys::statfs::statfs(path.as_ref()).map_err(io::Error::from)?;
-
-        Ok(stat.filesystem_type().0 == BTRFS_SUPER_MAGIC)
+        Ok(mountinfo
+            .into_iter()
+            .filter(|m| path.starts_with(&m.mount_point))
+            .max_by_key(|m| m.mount_point.as_os_str().len()))
     }
 
     pub fn new() -> anyhow::Result<Self> {
+        if std::env::var_os("TRUST_TEST_BTRFS_DISABLE").is_some() {
+            bail!("btrfs support disabled via TRUST_TEST_BTRFS_DISABLE");
+        }
+
         let btrfs = which::which("btrfs").context(
             r#"unable to locate btrfs:
 
@@ -60,11 +68,32 @@ You can install `btrfs`:
         }
         .ok_or_else(|| anyhow!("unable to locate btrfs store"))?;
 
-        if !Self::is_btrfs(store.as_path())? {
+        let mount_entry = Self::find_mount_entry(store.as_path())?.ok_or_else(|| {
+            anyhow!(
+                "unable to find mount entry for btrfs store ({})",
+                store.display()
+            )
+        })?;
+
+        if mount_entry.fs_type != "btrfs" {
             bail!(
                 r#"btrfs store ({}) is not on a btrfs volume.
 
 You can set `TRUST_TEST_BTRFS_STORE` to a directory on a BTRFS volume mounted with: defaults,user,exec,user_subvol_rm_allowed
+"#,
+                store.display()
+            );
+        }
+
+        if !mount_entry
+            .super_options
+            .contains_key("user_subvol_rm_allowed")
+        {
+            bail!(
+                r#"btrfs store ({}) is missing the `user_subvol_rm_allowed` mount option.
+
+Remount the volume with: defaults,user,exec,user_subvol_rm_allowed
+Or update /etc/fstab and remount.
 "#,
                 store.display()
             );


### PR DESCRIPTION
Check if the volume was mounted with the required mount option. If not, log and fall back to the non-btrfs tests.

## Summary by Sourcery

Validate BTRFS snapshot test setup using mount information and document new behavior and controls.

New Features:
- Verify that the BTRFS test store resides on a BTRFS filesystem with the required mount options before enabling snapshot-based tests.
- Introduce an environment variable to explicitly disable BTRFS snapshot support even when available.

Enhancements:
- Replace statfs-based filesystem detection with procfs-based mount info lookup for more accurate BTRFS mount resolution.

Build:
- Update Linux-specific test-context dependencies to use procfs instead of nix for filesystem inspection.

Documentation:
- Document the automatic fallback behavior when BTRFS snapshot requirements are not met and describe the new environment variable for disabling BTRFS support.