### PR TITLE
docs: refresh documentation

### DIFF
--- a/docs/design/products.md
+++ b/docs/design/products.md
@@ -48,6 +48,13 @@ erDiagram
         string name
     }
 
+    Cpe {
+        uuid id
+        string vendor
+        string product
+        string version
+    }
+
     BasePurl {
         uuid id
         string type
@@ -60,8 +67,19 @@ erDiagram
         uuid advisory_id
         uuid vulnerability_id
         uuid status_id
-        uuid base_purl_id
+        string package
         uuid product_version_range_id
+        uuid context_cpe_id
+    }
+
+    PurlStatus {
+        uuid id
+        uuid advisory_id
+        uuid vulnerability_id
+        uuid status_id
+        uuid base_purl_id
+        uuid version_range_id
+        uuid context_cpe_id
     }
 
     Sbom {
@@ -69,18 +87,23 @@ erDiagram
     }
 
     Organization || -- o{ Product : produces
-    Product || -- o{ ProductVersion : have
+    Product || -- o{ ProductVersion : has
     ProductVersion || -- || Sbom : describes
 
-    Product || -- o{ ProductVersionRange : have
+    Product || -- o{ ProductVersionRange : has
     ProductVersionRange || -- || VersionRange : belongs
 
-    BasePurl || -- || ProductVersionRange : belongs
+    ProductStatus }o -- || Advisory : describes
+    ProductStatus }o -- || Vulnerability : describes
+    ProductStatus }o -- || Status : describes
+    ProductStatus }o -- || ProductVersionRange : describes
+    ProductStatus }o -- o| Cpe : "context"
 
-    ProductStatus || -- || Advisory : describes
-    ProductStatus || -- || Vulnerability : describes
-    ProductStatus || -- || BasePurl : describes
-    ProductStatus || -- || Status : describes
-    ProductStatus || -- || ProductVersionRange : describe
+    PurlStatus }o -- || Advisory : describes
+    PurlStatus }o -- || Vulnerability : describes
+    PurlStatus }o -- || Status : describes
+    PurlStatus }o -- || BasePurl : describes
+    PurlStatus }o -- || VersionRange : describes
+    PurlStatus }o -- o| Cpe : "context"
 
 ```

--- a/docs/design/sbom.md
+++ b/docs/design/sbom.md
@@ -16,7 +16,7 @@ An SBOM contains a list of nodes, which are connected by relationships (like A d
 (e.g. SPDX), this may include references to the document itself (A describes SBOM), or to external documents
 (SBOM-A amends SBOM-B) and nodes in external documents (A depends on SBOM-B/C).
 
-A node can be either the SBOM itself, packages (aka components), or files.
+A node can be either the SBOM itself, packages (aka components), files, or other parts of the SBOM.
 
 To represent this graph of SBOM, packages, files and relationships, the model of SPDX is being used, as it also covers
 the features of CycloneDX. In the database, this is being represented by the following structure:
@@ -75,8 +75,8 @@ erDiagram
     versioned_purl 0+ to 1 base_purl: refines
     cpe
 
-    sbom_package 1 optionally to 0+ qualified_purl: names
-    sbom_package 1 optionally to 0+ cpe: names
+    sbom_node 1 optionally to 0+ qualified_purl: names
+    sbom_node 1 optionally to 0+ cpe: names
 
     sbom_node 1 to zero or one sbom_file: inherits
     sbom_node 1 to zero or one sbom_package: inherits

--- a/docs/design/sbom.md
+++ b/docs/design/sbom.md
@@ -16,7 +16,7 @@ An SBOM contains a list of nodes, which are connected by relationships (like A d
 (e.g. SPDX), this may include references to the document itself (A describes SBOM), or to external documents
 (SBOM-A amends SBOM-B) and nodes in external documents (A depends on SBOM-B/C).
 
-A node can be either the SBOM itself, packages (aka components), files, or other parts of the SBOM.
+A node can be the SBOM itself, a package (aka component), a file, or another part of the SBOM.
 
 To represent this graph of SBOM, packages, files and relationships, the model of SPDX is being used, as it also covers
 the features of CycloneDX. In the database, this is being represented by the following structure:


### PR DESCRIPTION
## Summary by Sourcery

Update design documentation diagrams to reflect new CPE and PURL status modeling and expanded SBOM node capabilities.

Documentation:
- Document CPE as a first-class entity and introduce separate ProductStatus and PurlStatus relationships in the product design diagram.
- Clarify that SBOM nodes can represent additional SBOM sub-parts and adjust SBOM naming relationships from packages to generic nodes.