### PR TITLE
Add a count of sboms to the models response

### DIFF
--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -5,6 +5,7 @@ mod query;
 mod test;
 
 pub use query::*;
+use utoipa::IntoParams;
 use uuid::Uuid;
 
 use crate::{
@@ -48,6 +49,13 @@ use trustify_module_ingestor::{
     service::{Cache, Format, IngestorService},
 };
 use trustify_module_storage::service::StorageBackend;
+
+#[derive(Clone, Debug, PartialEq, Eq, Default, serde::Deserialize, IntoParams)]
+pub struct ModelGetParams {
+    /// Include SBOM counts for each model
+    #[serde(default)]
+    pub counts: bool,
+}
 
 pub fn configure(
     config: &mut utoipa_actix_web::service_config::ServiceConfig,
@@ -464,6 +472,7 @@ pub async fn packages(
         ("id", Path, description = "ID of the SBOM to get models for"),
         Query,
         Paginated,
+        ModelGetParams,
     ),
     responses(
         (status = 200, description = "AI Models", body = PaginatedResults<SbomModel>),
@@ -476,11 +485,12 @@ pub async fn models(
     id: web::Path<Uuid>,
     web::Query(search): web::Query<Query>,
     web::Query(paginated): web::Query<Paginated>,
+    web::Query(ModelGetParams { counts }): web::Query<ModelGetParams>,
     _: Require<ReadSbom>,
 ) -> actix_web::Result<impl Responder> {
     let tx = db.begin_read().await?;
     let result = fetch
-        .fetch_sbom_models(Some(id.into_inner()), search, paginated, &tx)
+        .fetch_sbom_models(Some(id.into_inner()), search, paginated, counts, &tx)
         .await?;
     Ok(HttpResponse::Ok().json(result))
 }
@@ -492,6 +502,7 @@ pub async fn models(
     params(
         Query,
         Paginated,
+        ModelGetParams,
     ),
     responses(
         (status = 200, description = "AI Models", body = PaginatedResults<SbomModel>),
@@ -503,11 +514,12 @@ pub async fn all_models(
     db: web::Data<Database>,
     web::Query(search): web::Query<Query>,
     web::Query(paginated): web::Query<Paginated>,
+    web::Query(ModelGetParams { counts }): web::Query<ModelGetParams>,
     _: Require<ReadSbom>,
 ) -> actix_web::Result<impl Responder> {
     let tx = db.begin_read().await?;
     let result = fetch
-        .fetch_sbom_models(None, search, paginated, &tx)
+        .fetch_sbom_models(None, search, paginated, counts, &tx)
         .await?;
     Ok(HttpResponse::Ok().json(result))
 }

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1804,6 +1804,7 @@ async fn get_aibom_models(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                     "serialNumber": "urn:uuid:ibm-granite-granite-docling-258M",
                     "primaryPurpose": "image-text-to-text",
                 },
+                "sbom_count": 1,
             },
         ],
         "total": 1

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1777,7 +1777,7 @@ async fn get_aibom_models(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .id
         .to_string();
 
-    let uri = format!("/api/v2/sbom/{id}/models?total=true");
+    let uri = format!("/api/v2/sbom/{id}/models?total=true&counts=true");
     let req = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(req).await;
     log::info!("response:\n{:#}", json!(response));

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use tracing::{info_span, instrument};
 use tracing_futures::Instrument;
-use trustify_common::{cpe::Cpe, purl::Purl};
+use trustify_common::{cpe::Cpe, purl::Purl, requested_field::RequestedField};
 use trustify_entity::{
     labels::Labels, relationship::Relationship, sbom, sbom_node, sbom_package, source_document,
 };
@@ -114,7 +114,7 @@ pub struct ModelCatcher {
     pub properties: serde_json::Value,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, ToSchema)]
 pub struct SbomModel {
     /// The internal ID of a model
     pub id: String,
@@ -125,7 +125,7 @@ pub struct SbomModel {
     /// The properties associated with the model
     pub properties: serde_json::Map<String, serde_json::Value>,
     /// Number of SBOMs containing this model
-    pub sbom_count: i64,
+    pub sbom_count: RequestedField<i64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, Default)]

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -124,22 +124,8 @@ pub struct SbomModel {
     pub purls: Vec<PurlSummary>,
     /// The properties associated with the model
     pub properties: serde_json::Map<String, serde_json::Value>,
-}
-
-impl SbomModel {
-    pub fn from_row(row: ModelCatcher) -> Self {
-        let purls = PurlSummary::from_values(row.purls);
-        let properties = match row.properties {
-            serde_json::Value::Object(m) => m,
-            _ => serde_json::Map::new(),
-        };
-        Self {
-            id: row.id,
-            name: row.name,
-            purls,
-            properties,
-        }
-    }
+    /// Number of SBOMs containing this model
+    pub sbom_count: i64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, Default)]

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -478,9 +478,63 @@ impl SbomService {
             &self.cache,
         );
 
-        let LimitedResult { items, total } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
-        let items = items.into_iter().map(SbomModel::from_row).collect();
+        let total = limiter.total().await?;
+        let model_catchers = limiter.fetch().await?;
+
+        // Parse PURLs once per model and collect all unique PURL UUIDs
+        let parsed: Vec<(String, String, serde_json::Value, Vec<PurlSummary>)> = model_catchers
+            .into_iter()
+            .map(|c| {
+                let purls = PurlSummary::from_values(c.purls);
+                (c.id, c.name, c.properties, purls)
+            })
+            .collect();
+
+        let mut all_purl_uuids = Vec::new();
+        for (.., purls) in &parsed {
+            all_purl_uuids.extend(purls.iter().map(|p| p.head.uuid));
+        }
+        all_purl_uuids.sort_unstable();
+        all_purl_uuids.dedup();
+
+        // Batch count: how many distinct SBOMs reference each PURL
+        let counts_by_uuid: HashMap<Uuid, i64> = if all_purl_uuids.is_empty() {
+            HashMap::new()
+        } else {
+            sbom_node_purl_ref::Entity::find()
+                .select_only()
+                .column(sbom_node_purl_ref::Column::QualifiedPurlId)
+                .column_as(sbom_node_purl_ref::Column::SbomId.count(), "count")
+                .filter(sbom_node_purl_ref::Column::QualifiedPurlId.is_in(all_purl_uuids))
+                .group_by(sbom_node_purl_ref::Column::QualifiedPurlId)
+                .into_tuple::<(Uuid, i64)>()
+                .all(connection)
+                .await?
+                .into_iter()
+                .collect()
+        };
+
+        let items = parsed
+            .into_iter()
+            .map(|(id, name, properties, purls)| {
+                let sbom_count = purls
+                    .iter()
+                    .flat_map(|p| counts_by_uuid.get(&p.head.uuid).copied())
+                    .max()
+                    .unwrap_or(0);
+                let properties = match properties {
+                    serde_json::Value::Object(m) => m,
+                    _ => serde_json::Map::new(),
+                };
+                SbomModel {
+                    id,
+                    name,
+                    purls,
+                    properties,
+                    sbom_count,
+                }
+            })
+            .collect();
 
         Ok(PaginatedResults { items, total })
     }

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -29,6 +29,7 @@ use trustify_common::{
     id::{Id, TrySelectForId},
     model::{Paginated, PaginatedResults},
     purl::Purl,
+    requested_field::BoolRequestedField,
     service::{Mappable, Resulting},
 };
 use trustify_entity::{
@@ -440,6 +441,7 @@ impl SbomService {
         sbom_id: Option<Uuid>,
         search: Query,
         paginated: Paginated,
+        include_counts: bool,
         connection: &C,
     ) -> Result<PaginatedResults<SbomModel>, Error> {
         let mut query = join_purls_and_cpes(
@@ -478,11 +480,11 @@ impl SbomService {
             &self.cache,
         );
 
-        let total = limiter.total().await?;
-        let model_catchers = limiter.fetch().await?;
+        let LimitedResult { items, total } = limiter.fetch().await?;
+        let total = total.requested(paginated.total).await?;
 
         // Parse PURLs once per model and collect all unique PURL UUIDs
-        let parsed: Vec<(String, String, serde_json::Value, Vec<PurlSummary>)> = model_catchers
+        let parsed: Vec<(String, String, serde_json::Value, Vec<PurlSummary>)> = items
             .into_iter()
             .map(|c| {
                 let purls = PurlSummary::from_values(c.purls);
@@ -498,7 +500,7 @@ impl SbomService {
         all_purl_uuids.dedup();
 
         // Batch count: how many distinct SBOMs reference each PURL
-        let counts_by_uuid: HashMap<Uuid, i64> = if all_purl_uuids.is_empty() {
+        let counts_by_uuid: HashMap<Uuid, i64> = if all_purl_uuids.is_empty() || !include_counts {
             HashMap::new()
         } else {
             sbom_node_purl_ref::Entity::find()
@@ -509,6 +511,7 @@ impl SbomService {
                 .group_by(sbom_node_purl_ref::Column::QualifiedPurlId)
                 .into_tuple::<(Uuid, i64)>()
                 .all(connection)
+                .instrument(info_span!("count sboms per model"))
                 .await?
                 .into_iter()
                 .collect()
@@ -517,11 +520,12 @@ impl SbomService {
         let items = parsed
             .into_iter()
             .map(|(id, name, properties, purls)| {
-                let sbom_count = purls
-                    .iter()
-                    .flat_map(|p| counts_by_uuid.get(&p.head.uuid).copied())
-                    .max()
-                    .unwrap_or(0);
+                let sbom_count = include_counts.then_requested(|| {
+                    purls
+                        .iter()
+                        .flat_map(|p| counts_by_uuid.get(&p.head.uuid).copied())
+                        .max()
+                });
                 let properties = match properties {
                     serde_json::Value::Object(m) => m,
                     _ => serde_json::Map::new(),

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2768,6 +2768,12 @@ paths:
         required: false
         schema:
           type: boolean
+      - name: counts
+        in: query
+        description: Include SBOM counts for each model
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: AI Models
@@ -3019,6 +3025,12 @@ paths:
       - name: total
         in: query
         description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
+      - name: counts
+        in: query
+        description: Include SBOM counts for each model
         required: false
         schema:
           type: boolean
@@ -5356,8 +5368,7 @@ components:
                   $ref: '#/components/schemas/PurlSummary'
                 description: The model's PURL
               sbom_count:
-                type: integer
-                format: int64
+                $ref: '#/components/schemas/RequestedField_i64_i64'
                 description: Number of SBOMs containing this model
         total:
           type:
@@ -6001,6 +6012,11 @@ components:
             value: 7.5
             severity: high
             vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    RequestedField_i64_i64:
+      oneOf:
+      - type: 'null'
+      - type: integer
+        format: int64
     Revisioned_Importer:
       type: object
       description: |-
@@ -6142,8 +6158,7 @@ components:
             $ref: '#/components/schemas/PurlSummary'
           description: The model's PURL
         sbom_count:
-          type: integer
-          format: int64
+          $ref: '#/components/schemas/RequestedField_i64_i64'
           description: Number of SBOMs containing this model
     SbomPackage:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5336,6 +5336,7 @@ components:
             - name
             - purls
             - properties
+            - sbom_count
             properties:
               id:
                 type: string
@@ -5354,6 +5355,10 @@ components:
                 items:
                   $ref: '#/components/schemas/PurlSummary'
                 description: The model's PURL
+              sbom_count:
+                type: integer
+                format: int64
+                description: Number of SBOMs containing this model
         total:
           type:
           - integer
@@ -6117,6 +6122,7 @@ components:
       - name
       - purls
       - properties
+      - sbom_count
       properties:
         id:
           type: string
@@ -6135,6 +6141,10 @@ components:
           items:
             $ref: '#/components/schemas/PurlSummary'
           description: The model's PURL
+        sbom_count:
+          type: integer
+          format: int64
+          description: Number of SBOMs containing this model
     SbomPackage:
       type: object
       required:


### PR DESCRIPTION
Fixes: #2332

## Summary by Sourcery

Add an SBOM usage count to model responses and propagate it through the API and tests.

New Features:
- Include the number of SBOMs containing each model in the SBOM models API response.

Enhancements:
- Batch compute SBOM counts for model PURLs to avoid per-item queries.

Documentation:
- Document the sbom_count field in the OpenAPI schema for SBOM model responses.

Tests:
- Extend SBOM endpoint tests to assert the new sbom_count field in model responses.