### PR TITLE
feat!: change limit=0 to return no items and enforce maximum limit

### DIFF
--- a/common/src/db/limiter.rs
+++ b/common/src/db/limiter.rs
@@ -1,10 +1,40 @@
 use crate::{
     db::{
         multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
-        pagination_cache::PaginationCache,
+        pagination_cache::{LimitError, PaginationCache},
     },
     model::Paginated,
 };
+
+/// Offset and limit for a paginated query.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Page {
+    /// The number of items to skip before returning results.
+    pub offset: u64,
+    /// The maximum number of items to return. Zero means no items are returned.
+    pub limit: u64,
+}
+
+impl From<Paginated> for Page {
+    fn from(
+        Paginated {
+            offset,
+            limit,
+            total: _,
+        }: Paginated,
+    ) -> Self {
+        Self { offset, limit }
+    }
+}
+
+/// Error from limiter construction, covering both DB and limit-exceeded errors.
+#[derive(Debug, thiserror::Error)]
+pub enum LimiterError {
+    #[error(transparent)]
+    Db(#[from] DbErr),
+    #[error(transparent)]
+    Limit(#[from] LimitError),
+}
 use sea_orm::{
     ConnectionTrait, DbErr, EntityTrait, FromQueryResult, Paginator, PaginatorTrait, QuerySelect,
     QueryTrait, Select, SelectModel, SelectThree, SelectThreeModel, SelectTwo, SelectTwoModel,
@@ -25,6 +55,7 @@ where
     paginator: Paginator<'a, C, S2>,
     cache_key: String,
     cache: &'a PaginationCache,
+    limit: u64,
 }
 
 /// Result of fetching a limited query, with a deferred total count handle.
@@ -79,9 +110,14 @@ where
     S2: SelectorTrait + 'a,
 {
     /// Fetch the items and return a handle for computing the total count.
+    /// If the limit is zero, no query is executed and an empty result is returned.
     #[instrument(skip(self), err(level=tracing::Level::INFO))]
     pub async fn fetch(self) -> Result<LimitedResult<'a, S1::Item, C, S2>, DbErr> {
-        let items = self.selector.all(self.db).await?;
+        let items = if self.limit == 0 {
+            vec![]
+        } else {
+            self.selector.all(self.db).await?
+        };
         Ok(LimitedResult {
             items,
             total: TotalCount {
@@ -106,22 +142,12 @@ where
     type FetchSelector: SelectorTrait + 'a;
     type CountSelector: SelectorTrait + 'a;
 
-    fn limiting_pagination(
-        self,
-        db: &'a C,
-        paginated: Paginated,
-        cache: &'a PaginationCache,
-    ) -> Limiter<'a, C, Self::FetchSelector, Self::CountSelector> {
-        self.limiting(db, paginated.offset, paginated.limit, cache)
-    }
-
     fn limiting(
         self,
         db: &'a C,
-        offset: u64,
-        limit: u64,
+        page: impl Into<Page>,
         cache: &'a PaginationCache,
-    ) -> Limiter<'a, C, Self::FetchSelector, Self::CountSelector>;
+    ) -> Result<Limiter<'a, C, Self::FetchSelector, Self::CountSelector>, LimitError>;
 }
 
 impl<'a, C, E, M> LimiterTrait<'a, C> for Select<E>
@@ -136,47 +162,47 @@ where
     fn limiting(
         self,
         db: &'a C,
-        offset: u64,
-        limit: u64,
+        page: impl Into<Page>,
         cache: &'a PaginationCache,
-    ) -> Limiter<'a, C, Self::FetchSelector, Self::CountSelector> {
+    ) -> Result<Limiter<'a, C, Self::FetchSelector, Self::CountSelector>, LimitError> {
+        let page = page.into();
+        let limit = cache.check_limit(page.limit)?;
         let cache_key = cache_key_from(&self);
 
         let selector = self
             .clone()
             .limit(NonZeroU64::new(limit).map(|limit| limit.get()))
-            .offset(NonZeroU64::new(offset).map(|offset| offset.get()))
+            .offset(NonZeroU64::new(page.offset).map(|offset| offset.get()))
             .into_model();
 
-        Limiter {
+        Ok(Limiter {
             db,
             paginator: self.paginate(db, 1),
             selector,
             cache_key,
             cache,
-        }
+            limit,
+        })
     }
 }
 
-pub trait LimiterAsModelTrait<'a, C>
+pub trait LimiterAsModelTrait<'a, C>: Sized
 where
     C: ConnectionTrait,
 {
     fn limiting_as<M: FromQueryResult + Sync + Send>(
         self,
         db: &'a C,
-        offset: u64,
-        limit: u64,
+        page: impl Into<Page>,
         cache: &'a PaginationCache,
-    ) -> Limiter<'a, C, SelectModel<M>, SelectModel<M>>;
+    ) -> Result<Limiter<'a, C, SelectModel<M>, SelectModel<M>>, LimitError>;
 
     fn try_limiting_as_multi_model<M: FromQueryResultMultiModel + Sync + Send>(
         self,
         db: &'a C,
-        offset: u64,
-        limit: u64,
+        page: impl Into<Page>,
         cache: &'a PaginationCache,
-    ) -> Result<Limiter<'a, C, SelectModel<M>, SelectModel<M>>, DbErr>;
+    ) -> Result<Limiter<'a, C, SelectModel<M>, SelectModel<M>>, LimiterError>;
 }
 
 impl<'a, C, E> LimiterAsModelTrait<'a, C> for Select<E>
@@ -187,40 +213,43 @@ where
     fn limiting_as<M: FromQueryResult + Sync + Send>(
         self,
         db: &'a C,
-        offset: u64,
-        limit: u64,
+        page: impl Into<Page>,
         cache: &'a PaginationCache,
-    ) -> Limiter<'a, C, SelectModel<M>, SelectModel<M>> {
+    ) -> Result<Limiter<'a, C, SelectModel<M>, SelectModel<M>>, LimitError> {
+        let page = page.into();
+        let limit = cache.check_limit(page.limit)?;
         let cache_key = cache_key_from(&self);
 
         let selector = self
             .clone()
             .limit(NonZeroU64::new(limit).map(|limit| limit.get()))
-            .offset(NonZeroU64::new(offset).map(|offset| offset.get()))
+            .offset(NonZeroU64::new(page.offset).map(|offset| offset.get()))
             .into_model::<M>();
 
-        Limiter {
+        Ok(Limiter {
             db,
             paginator: self.into_model::<M>().paginate(db, 1),
             selector,
             cache_key,
             cache,
-        }
+            limit,
+        })
     }
 
     fn try_limiting_as_multi_model<M: FromQueryResultMultiModel + Sync + Send>(
         self,
         db: &'a C,
-        offset: u64,
-        limit: u64,
+        page: impl Into<Page>,
         cache: &'a PaginationCache,
-    ) -> Result<Limiter<'a, C, SelectModel<M>, SelectModel<M>>, DbErr> {
+    ) -> Result<Limiter<'a, C, SelectModel<M>, SelectModel<M>>, LimiterError> {
+        let page = page.into();
+        let limit = cache.check_limit(page.limit)?;
         let cache_key = cache_key_from(&self);
 
         let selector = self
             .clone()
             .limit(NonZeroU64::new(limit).map(|limit| limit.get()))
-            .offset(NonZeroU64::new(offset).map(|offset| offset.get()))
+            .offset(NonZeroU64::new(page.offset).map(|offset| offset.get()))
             .try_into_multi_model::<M>()?;
 
         Ok(Limiter {
@@ -229,38 +258,42 @@ where
             selector,
             cache_key,
             cache,
+            limit,
         })
     }
 }
 
+/// Build a `Limiter` with separate fetch and count model types.
 pub fn limit_selector<'a, C, E, EM, M>(
     db: &'a C,
     select: Select<E>,
-    offset: u64,
-    limit: u64,
+    page: impl Into<Page>,
     cache: &'a PaginationCache,
-) -> Limiter<'a, C, SelectModel<M>, SelectModel<EM>>
+) -> Result<Limiter<'a, C, SelectModel<M>, SelectModel<EM>>, LimitError>
 where
     C: ConnectionTrait,
     E: EntityTrait<Model = EM>,
     M: FromQueryResult + Sized + Send + Sync + 'a,
     EM: FromQueryResult + Sized + Send + Sync + 'a,
 {
+    let page = page.into();
+    let limit = cache.check_limit(page.limit)?;
     let cache_key = cache_key_from(&select);
 
     let selector = select
         .clone()
         .limit(NonZeroU64::new(limit).map(|limit| limit.get()))
-        .offset(NonZeroU64::new(offset).map(|offset| offset.get()))
+        .offset(NonZeroU64::new(page.offset).map(|offset| offset.get()))
         .into_model();
 
-    Limiter {
+    Ok(Limiter {
         db,
         paginator: select.paginate(db, 1),
         selector,
         cache_key,
         cache,
-    }
+        limit,
+    })
 }
 
 impl<'a, C, M1, M2, E1, E2> LimiterTrait<'a, C> for SelectTwo<E1, E2>
@@ -277,25 +310,27 @@ where
     fn limiting(
         self,
         db: &'a C,
-        offset: u64,
-        limit: u64,
+        page: impl Into<Page>,
         cache: &'a PaginationCache,
-    ) -> Limiter<'a, C, Self::FetchSelector, Self::CountSelector> {
+    ) -> Result<Limiter<'a, C, Self::FetchSelector, Self::CountSelector>, LimitError> {
+        let page = page.into();
+        let limit = cache.check_limit(page.limit)?;
         let cache_key = cache_key_from(&self);
 
         let selector = self
             .clone()
             .limit(NonZeroU64::new(limit).map(|limit| limit.get()))
-            .offset(NonZeroU64::new(offset).map(|offset| offset.get()))
+            .offset(NonZeroU64::new(page.offset).map(|offset| offset.get()))
             .into_model();
 
-        Limiter {
+        Ok(Limiter {
             db,
             paginator: self.paginate(db, 1),
             selector,
             cache_key,
             cache,
-        }
+            limit,
+        })
     }
 }
 
@@ -315,24 +350,26 @@ where
     fn limiting(
         self,
         db: &'a C,
-        offset: u64,
-        limit: u64,
+        page: impl Into<Page>,
         cache: &'a PaginationCache,
-    ) -> Limiter<'a, C, Self::FetchSelector, Self::CountSelector> {
+    ) -> Result<Limiter<'a, C, Self::FetchSelector, Self::CountSelector>, LimitError> {
+        let page = page.into();
+        let limit = cache.check_limit(page.limit)?;
         let cache_key = cache_key_from(&self);
 
         let selector = self
             .clone()
             .limit(NonZeroU64::new(limit).map(|limit| limit.get()))
-            .offset(NonZeroU64::new(offset).map(|offset| offset.get()))
+            .offset(NonZeroU64::new(page.offset).map(|offset| offset.get()))
             .into_model();
 
-        Limiter {
+        Ok(Limiter {
             db,
             paginator: self.paginate(db, 1),
             selector,
             cache_key,
             cache,
-        }
+            limit,
+        })
     }
 }

--- a/common/src/db/limiter.rs
+++ b/common/src/db/limiter.rs
@@ -3,7 +3,7 @@ use crate::{
         multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
         pagination_cache::{LimitError, PaginationCache},
     },
-    model::Paginated,
+    model::Pagination,
 };
 
 /// Offset and limit for a paginated query.
@@ -15,15 +15,12 @@ pub struct Page {
     pub limit: u64,
 }
 
-impl From<Paginated> for Page {
-    fn from(
-        Paginated {
-            offset,
-            limit,
-            total: _,
-        }: Paginated,
-    ) -> Self {
-        Self { offset, limit }
+impl<T: Pagination> From<T> for Page {
+    fn from(p: T) -> Self {
+        Self {
+            offset: p.offset(),
+            limit: p.limit(),
+        }
     }
 }
 

--- a/common/src/db/pagination_cache.rs
+++ b/common/src/db/pagination_cache.rs
@@ -1,6 +1,31 @@
+use actix_web::{HttpResponse, ResponseError, body::BoxBody};
 use moka::future::Cache;
 use opentelemetry::{global, metrics::Counter};
 use std::{sync::Arc, time::Duration};
+
+use crate::error::ErrorInformation;
+
+/// The requested pagination limit exceeds the configured maximum.
+#[derive(Clone, Debug, thiserror::Error)]
+#[error("pagination limit exceeds maximum of {max_limit}")]
+pub struct LimitError {
+    pub max_limit: u64,
+}
+
+impl ResponseError for LimitError {
+    fn error_response(&self) -> HttpResponse<BoxBody> {
+        HttpResponse::BadRequest()
+            .append_header(("X-Pagination-Max-Limit", self.max_limit.to_string()))
+            .json(ErrorInformation {
+                error: "LimitExceeded".into(),
+                message: format!(
+                    "requested pagination limit exceeds the maximum of {}",
+                    self.max_limit
+                ),
+                details: None,
+            })
+    }
+}
 
 pub const DEFAULT_TTL: Duration = Duration::from_secs(60);
 
@@ -10,23 +35,25 @@ pub struct PaginationCache {
     cache: Arc<Cache<String, u64>>,
     total: Counter<u64>,
     misses: Counter<u64>,
+    max_limit: u64,
 }
 
 impl PaginationCache {
-    /// Create a new cache with the given TTL for total-count entries.
-    pub fn new(ttl: Duration) -> Self {
+    /// Create a new cache with the given TTL for total-count entries and an optional maximum limit.
+    pub fn new(ttl: Duration, max_limit: u64) -> Self {
         let meter = global::meter("PaginationCache");
         Self {
             cache: Arc::new(Cache::builder().time_to_live(ttl).build()),
             total: meter.u64_counter("cache_total").build(),
             misses: meter.u64_counter("cache_miss").build(),
+            max_limit,
         }
     }
 
-    /// Create a cache with zero TTL, intended for use in tests where mutations
-    /// between requests must be immediately visible.
+    /// Create a cache with zero TTL and no maximum limit, intended for use in tests
+    /// where mutations between requests must be immediately visible.
     pub fn for_test() -> Self {
-        Self::new(Duration::ZERO)
+        Self::new(Duration::ZERO, 0)
     }
 
     /// Return a cached total count, computing it at most once for concurrent requests with the same key.
@@ -45,6 +72,23 @@ impl PaginationCache {
             .await
             .map_err(|e| sea_orm::DbErr::Custom(e.to_string()))
     }
+
+    /// Check that the given limit does not exceed the configured maximum.
+    /// Returns the limit unchanged, or an error if it exceeds the maximum.
+    pub(crate) fn check_limit(&self, limit: u64) -> Result<u64, LimitError> {
+        if self.max_limit > 0 && limit > self.max_limit {
+            Err(LimitError {
+                max_limit: self.max_limit,
+            })
+        } else {
+            Ok(limit)
+        }
+    }
+
+    /// Return the configured maximum pagination limit (0 = no maximum).
+    pub fn max_limit(&self) -> u64 {
+        self.max_limit
+    }
 }
 
 /// CLI/env configuration for the pagination cache.
@@ -59,11 +103,93 @@ pub struct PaginationConfig {
         default_value = "60s"
     )]
     pub cache_ttl: humantime::Duration,
+
+    /// Maximum allowed limit for pagination queries (0 = no maximum)
+    #[arg(
+        id = "pagination-max-limit",
+        long,
+        env = "TRUSTD_PAGINATION_MAX_LIMIT",
+        default_value_t = 1000
+    )]
+    pub max_limit: u64,
 }
 
 impl PaginationConfig {
     /// Build a [`PaginationCache`] from this configuration.
     pub fn into_cache(self) -> PaginationCache {
-        PaginationCache::new(*self.cache_ttl)
+        PaginationCache::new(*self.cache_ttl, self.max_limit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{App, HttpResponse, body::MessageBody, test as actix_test, web};
+    use rstest::rstest;
+
+    /// Limits pass through when no maximum is configured.
+    #[test]
+    fn check_limit_no_max() {
+        let cache = PaginationCache::new(Duration::ZERO, 0);
+        assert_eq!(cache.check_limit(100).unwrap(), 100);
+        assert_eq!(cache.check_limit(0).unwrap(), 0);
+    }
+
+    /// Limits at or below the maximum pass; exceeding it returns an error.
+    #[test]
+    fn check_limit_with_max() {
+        let cache = PaginationCache::new(Duration::ZERO, 50);
+        assert_eq!(cache.check_limit(25).unwrap(), 25);
+        assert_eq!(cache.check_limit(50).unwrap(), 50);
+        assert!(cache.check_limit(100).is_err());
+    }
+
+    /// A zero limit is always allowed, even when a maximum is set.
+    #[test]
+    fn check_limit_zero_unchanged() {
+        let cache = PaginationCache::new(Duration::ZERO, 50);
+        assert_eq!(cache.check_limit(0).unwrap(), 0);
+    }
+
+    /// Handler that always returns a LimitError for the given max_limit.
+    async fn limit_error_handler(max_limit: web::Path<u64>) -> Result<HttpResponse, LimitError> {
+        Err(LimitError {
+            max_limit: max_limit.into_inner(),
+        })
+    }
+
+    /// Verify the HTTP error response: status 400, X-Pagination-Max-Limit header, and JSON body.
+    #[rstest]
+    #[case(50)]
+    #[case(100)]
+    #[case(1000)]
+    #[actix_web::test]
+    async fn limit_error_response(#[case] max_limit: u64) {
+        let app = actix_test::init_service(
+            App::new().route("/test/{max_limit}", web::get().to(limit_error_handler)),
+        )
+        .await;
+
+        let req = actix_test::TestRequest::get()
+            .uri(&format!("/test/{max_limit}"))
+            .to_request();
+        let response = actix_test::call_service(&app, req).await;
+
+        assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
+
+        let header = response
+            .headers()
+            .get("X-Pagination-Max-Limit")
+            .expect("missing X-Pagination-Max-Limit header");
+        assert_eq!(header.to_str().unwrap(), max_limit.to_string());
+
+        let body = response.into_body().try_into_bytes().unwrap();
+        let info: ErrorInformation =
+            serde_json::from_slice(&body).expect("response body should be valid JSON");
+        assert_eq!(info.error, "LimitExceeded");
+        assert!(
+            info.message.contains(&max_limit.to_string()),
+            "message should contain the max limit value"
+        );
     }
 }

--- a/common/src/model.rs
+++ b/common/src/model.rs
@@ -3,8 +3,7 @@ pub use bytesize::*;
 
 use crate::db::limiter::{LimitedResult, Limiter};
 use sea_orm::{ConnectionTrait, DbErr, SelectorTrait};
-use std::cmp::min;
-use std::marker::PhantomData;
+use std::{cmp::min, fmt::Debug, marker::PhantomData};
 use utoipa::{IntoParams, ToSchema};
 
 /// A struct wrapping an item with a revision.
@@ -40,44 +39,86 @@ pub struct Paginated {
     pub total: bool,
 }
 
+/// Trait for types that carry pagination parameters.
+pub trait Pagination: Copy + Debug {
+    fn offset(&self) -> u64;
+    fn limit(&self) -> u64;
+    fn total(&self) -> bool;
+
+    /// Paginate an in-memory slice, optionally including the total count.
+    fn paginate_array<T: Clone>(&self, vec: &[T]) -> PaginatedResults<T> {
+        let total = if self.total() {
+            Some(vec.len() as u64)
+        } else {
+            None
+        };
+
+        if self.limit() == 0 {
+            return PaginatedResults {
+                items: vec![],
+                total,
+            };
+        }
+
+        if self.offset() as usize > vec.len() {
+            return PaginatedResults {
+                items: vec![],
+                total,
+            };
+        }
+
+        let end = min(self.offset() as usize + self.limit() as usize, vec.len());
+
+        PaginatedResults {
+            items: Vec::from(&vec[self.offset() as usize..end]),
+            total,
+        }
+    }
+}
+
+impl Pagination for Paginated {
+    fn offset(&self) -> u64 {
+        self.offset
+    }
+    fn limit(&self) -> u64 {
+        self.limit
+    }
+    fn total(&self) -> bool {
+        self.total
+    }
+}
+
+/// A pagination limit, convertible into a full `Paginated` with default offset and no total.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Limit(pub u64);
+
+impl Pagination for Limit {
+    fn offset(&self) -> u64 {
+        0
+    }
+    fn limit(&self) -> u64 {
+        self.0
+    }
+    fn total(&self) -> bool {
+        false
+    }
+}
+
+impl From<Limit> for Paginated {
+    fn from(Limit(limit): Limit) -> Self {
+        Self {
+            limit,
+            ..Default::default()
+        }
+    }
+}
+
 impl Default for Paginated {
     fn default() -> Self {
         Self {
             offset: 0,
             limit: default::limit(),
             total: false,
-        }
-    }
-}
-
-impl Paginated {
-    /// Paginate an in-memory slice, optionally including the total count.
-    pub fn paginate_array<T: Clone>(&self, vec: &[T]) -> PaginatedResults<T> {
-        let total = if self.total {
-            Some(vec.len() as u64)
-        } else {
-            None
-        };
-
-        if self.limit == 0 {
-            return PaginatedResults {
-                items: vec![],
-                total,
-            };
-        }
-
-        if self.offset as usize > vec.len() {
-            return PaginatedResults {
-                items: vec![],
-                total,
-            };
-        }
-
-        let end = min(self.offset as usize + self.limit as usize, vec.len());
-
-        PaginatedResults {
-            items: Vec::from(&vec[self.offset as usize..end]),
-            total,
         }
     }
 }
@@ -108,7 +149,7 @@ impl<R> PaginatedResults<R> {
     /// Create a new paginated result, optionally computing the total count.
     pub async fn new<C, S1, S2>(
         limiter: Limiter<'_, C, S1, S2>,
-        paginated: Paginated,
+        paginated: impl Pagination,
     ) -> Result<PaginatedResults<S1::Item>, DbErr>
     where
         C: ConnectionTrait,
@@ -116,7 +157,7 @@ impl<R> PaginatedResults<R> {
         S2: SelectorTrait,
     {
         let LimitedResult { items, total } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         Ok(PaginatedResults { items, total })
     }
@@ -135,7 +176,7 @@ pub struct BinaryData(PhantomData<Vec<u8>>);
 
 #[cfg(test)]
 mod test {
-    use crate::model::{Paginated, PaginatedResults};
+    use crate::model::{Paginated, PaginatedResults, Pagination};
 
     #[test_log::test(test)]
     fn paginated_vec() {

--- a/common/src/model.rs
+++ b/common/src/model.rs
@@ -22,9 +22,7 @@ pub struct Revisioned<T> {
     pub revision: String,
 }
 
-#[derive(
-    IntoParams, Copy, Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize,
-)]
+#[derive(IntoParams, Copy, Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Paginated {
     /// The first item to return, skipping all that come before it.
@@ -34,12 +32,22 @@ pub struct Paginated {
     pub offset: u64,
     /// The maximum number of entries to return.
     ///
-    /// Zero means: no limit
+    /// Zero means: return no items (the total count is still computed if requested).
     #[serde(default = "default::limit")]
     pub limit: u64,
     /// Whether to compute and return the total count of matching items.
     #[serde(default)]
     pub total: bool,
+}
+
+impl Default for Paginated {
+    fn default() -> Self {
+        Self {
+            offset: 0,
+            limit: default::limit(),
+            total: false,
+        }
+    }
 }
 
 impl Paginated {
@@ -51,16 +59,16 @@ impl Paginated {
             None
         };
 
-        if self.offset as usize > vec.len() {
+        if self.limit == 0 {
             return PaginatedResults {
                 items: vec![],
                 total,
             };
         }
 
-        if self.limit == 0 {
+        if self.offset as usize > vec.len() {
             return PaginatedResults {
-                items: Vec::from(&vec[self.offset as usize..]),
+                items: vec![],
                 total,
             };
         }
@@ -133,6 +141,7 @@ mod test {
     fn paginated_vec() {
         let data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
+        // limit=0 returns no items but still computes total
         let paginated = Paginated {
             offset: 0,
             limit: 0,
@@ -141,7 +150,7 @@ mod test {
         .paginate_array(&data);
 
         assert_eq!(Some(10), paginated.total);
-        assert_eq!(10, paginated.items.len());
+        assert_eq!(0, paginated.items.len());
 
         let paginated = Paginated {
             offset: 0,
@@ -153,6 +162,7 @@ mod test {
         assert_eq!(Some(10), paginated.total);
         assert_eq!(5, paginated.items.len());
 
+        // limit=0 with offset still returns no items
         let paginated = Paginated {
             offset: 5,
             limit: 0,
@@ -161,7 +171,7 @@ mod test {
         .paginate_array(&data);
 
         assert_eq!(Some(10), paginated.total);
-        assert_eq!(5, paginated.items.len());
+        assert_eq!(0, paginated.items.len());
 
         let paginated = Paginated {
             offset: 12,
@@ -186,7 +196,7 @@ mod test {
         .paginate_array(&data);
 
         assert_eq!(None, paginated.total);
-        assert_eq!(3, paginated.items.len());
+        assert_eq!(0, paginated.items.len());
     }
 
     #[test]

--- a/common/src/service/result.rs
+++ b/common/src/service/result.rs
@@ -1,11 +1,11 @@
 use crate::{
     db::{
-        limiter::{LimitedResult, limit_selector},
+        limiter::{LimitedResult, LimiterError, limit_selector},
         pagination_cache::PaginationCache,
     },
     model::{Paginated, PaginatedResults},
 };
-use sea_orm::{ConnectionTrait, DbErr, EntityTrait, FromQueryResult, Select};
+use sea_orm::{ConnectionTrait, EntityTrait, FromQueryResult, Select};
 use std::fmt::Debug;
 
 #[allow(async_fn_in_trait)]
@@ -17,7 +17,7 @@ pub trait Resulting: Sized + Debug {
         db: &C,
         query: Select<E>,
         cache: &PaginationCache,
-    ) -> Result<Self::Output<M>, DbErr>
+    ) -> Result<Self::Output<M>, LimiterError>
     where
         C: ConnectionTrait,
         E: EntityTrait<Model = EM>,
@@ -33,14 +33,14 @@ impl Resulting for Paginated {
         db: &C,
         query: Select<E>,
         cache: &PaginationCache,
-    ) -> Result<Self::Output<M>, DbErr>
+    ) -> Result<Self::Output<M>, LimiterError>
     where
         C: ConnectionTrait,
         E: EntityTrait<Model = EM>,
         EM: FromQueryResult + Send + Sync,
         M: FromQueryResult + Send + Sync,
     {
-        let limiter = limit_selector(db, query, self.offset, self.limit, cache);
+        let limiter = limit_selector(db, query, self, cache)?;
         let LimitedResult { items, total } = limiter.fetch().await?;
         let total = total.requested(self.total).await?;
 
@@ -56,14 +56,14 @@ impl Resulting for () {
         db: &C,
         query: Select<E>,
         _cache: &PaginationCache,
-    ) -> Result<Self::Output<M>, DbErr>
+    ) -> Result<Self::Output<M>, LimiterError>
     where
         C: ConnectionTrait,
         E: EntityTrait<Model = EM>,
         EM: FromQueryResult + Send + Sync,
         M: FromQueryResult + Send + Sync,
     {
-        query.into_model().all(db).await
+        Ok(query.into_model().all(db).await?)
     }
 }
 

--- a/docs/adrs/00017-efficient-pagination.md
+++ b/docs/adrs/00017-efficient-pagination.md
@@ -1,4 +1,4 @@
-# 00017. Make pagination more efficient by making total optional and caching it
+# 00017. Improve pagination: optional total, caching, limit enforcement
 
 Date: 2026-04-21
 
@@ -18,7 +18,7 @@ must scan the entire filtered result set regardless of the `OFFSET`/`LIMIT` appl
 query. This cost is paid on every page navigation, even though the total rarely changes between
 consecutive page requests from the same user session.
 
-Two independent optimizations address this:
+Three changes address this:
 
 1. **Make `total` optional** — allow clients to opt in to the count query only when they need it
    (e.g. a UI that needs to render a page count). Clients that do not need the total (infinite
@@ -28,6 +28,10 @@ Two independent optimizations address this:
 2. **Cache the total server-side** — when `total` is requested, cache the count result for a
    configurable duration so that repeated paginated requests with the same filters reuse the
    cached count instead of hitting the database again.
+
+3. **Enforce a maximum pagination limit** — reject requests with a `limit` value exceeding a
+   configurable maximum (default 1000) with HTTP 400, preventing clients from requesting
+   unbounded result sets that could overwhelm the database.
 
 ## Decision
 
@@ -136,6 +140,35 @@ key, a data change would require either re-evaluating cached filters to determin
 are affected, or bulk-invalidating all entries for a given entity type (discarding unaffected
 entries). This could be revisited if TTL-based staleness turns out to be problematic in practice.
 
+### Maximum pagination limit
+
+A configurable maximum is enforced on the `limit` query parameter. When a request exceeds it,
+the server returns HTTP 400 Bad Request with:
+
+* An `X-Pagination-Max-Limit` response header containing the configured maximum, so clients can
+  discover and adapt to the limit programmatically.
+* A JSON body using the standard `ErrorInformation` format:
+
+```json
+{
+  "error": "LimitExceeded",
+  "message": "requested pagination limit exceeds the maximum of 1000"
+}
+```
+
+The maximum is set via CLI argument (`--pagination-max-limit`) or environment variable,
+defaulting to 1000. Setting it to 0 disables the limit check entirely:
+
+```
+TRUSTD_PAGINATION_MAX_LIMIT=1000
+```
+
+### Behavior of limit=0
+
+When `limit=0` is passed, the server returns an empty `items` array without executing the data
+query. The `total` is still computed if `total=true` is requested. This is a **breaking change**
+from the previous behavior where `limit=0` meant "no limit" and returned all items.
+
 ### Changes to the Limiter
 
 The `Limiter` struct and its construction are updated to support the optional total:
@@ -193,6 +226,11 @@ purposes, moving the pagination cache there could be reconsidered as a low-effor
 * The `PaginatedResults` response type changes `total` from `u64` to `Option<u64>`. This is a
   **breaking change** — existing clients that assume `total` is always a number must be updated
   to either pass `total=true` or handle `null`.
+* `limit=0` now returns zero items instead of all items. This is a **breaking change** — clients
+  that relied on `limit=0` to fetch everything must be updated to use an explicit limit.
+* Requests with a `limit` exceeding the configured maximum (default 1000) are rejected with
+  HTTP 400. Clients can read the `X-Pagination-Max-Limit` response header to discover the
+  server's maximum.
 * Clients that do not need the total (the common case) no longer pay the `COUNT(*)` overhead,
   reducing response latency for large result sets.
 * Repeated pagination requests with the same filters within the TTL window avoid redundant

--- a/modules/analysis/src/endpoints/tests/mod.rs
+++ b/modules/analysis/src/endpoints/tests/mod.rs
@@ -430,7 +430,7 @@ async fn query(ctx: &TrustifyContext, query: &str) -> Value {
     let response: Value = app
         .req(Req {
             what: What::Q(query),
-            limit: Some(0),
+            limit: Some(1000),
             total: true,
             ..Req::default()
         })

--- a/modules/analysis/src/endpoints/tests/mod.rs
+++ b/modules/analysis/src/endpoints/tests/mod.rs
@@ -425,6 +425,7 @@ async fn quarkus_component_by_cpe(ctx: &TrustifyContext) -> Result<(), anyhow::E
     Ok(())
 }
 
+/// Query the analysis endpoint with a high limit to fetch all matching items.
 async fn query(ctx: &TrustifyContext, query: &str) -> Value {
     let app = caller(ctx).await.unwrap();
     let response: Value = app

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -47,7 +47,7 @@ use tokio::{
 use tracing::instrument;
 use trustify_common::{
     db::query::{Value, ValueContext},
-    model::{Paginated, PaginatedResults},
+    model::{PaginatedResults, Pagination},
 };
 use trustify_entity::{
     relationship::Relationship,
@@ -572,7 +572,7 @@ impl AnalysisService {
         sbom_id: Uuid,
         query: impl Into<GraphQuery<'_>> + Debug,
         options: impl Into<QueryOptions> + Debug,
-        paginated: Paginated,
+        paginated: impl Pagination,
         connection: &C,
     ) -> Result<PaginatedResults<Node>, Error> {
         let distinct_sbom_ids = vec![sbom_id];
@@ -594,7 +594,7 @@ impl AnalysisService {
         &self,
         query: impl Into<GraphQuery<'_>> + Debug,
         options: impl Into<QueryOptions> + Debug,
-        paginated: Paginated,
+        paginated: impl Pagination,
         connection: &C,
     ) -> Result<PaginatedResults<Node>, Error> {
         let query = query.into();
@@ -622,7 +622,7 @@ impl AnalysisService {
         &self,
         query: impl Into<GraphQuery<'_>> + Debug,
         options: impl Into<QueryOptions> + Debug,
-        paginated: Paginated,
+        paginated: impl Pagination,
         connection: &C,
     ) -> Result<PaginatedResults<Node>, Error> {
         let query = query.into();

--- a/modules/analysis/src/service/test/mod.rs
+++ b/modules/analysis/src/service/test/mod.rs
@@ -614,7 +614,7 @@ async fn test_retrieve_all_sbom_roots_by_name(ctx: &TrustifyContext) -> Result<(
             sbom_id,
             ComponentReference::Name(&component_name),
             QueryOptions::ancestors(),
-            Default::default(),
+            Paginated::default(),
             &ctx.db,
         )
         .await?;

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -1,17 +1,21 @@
 use crate::{
     advisory::model::{AdvisoryDetails, AdvisorySummary},
-    test::{caller, label::Api},
+    test::{caller, caller_with, label::Api},
 };
 use actix_http::StatusCode;
-use actix_web::test::TestRequest;
+use actix_web::{body::MessageBody, test::TestRequest};
 use hex::ToHex;
 use jsonpath_rust::JsonPath;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
+use std::time::Duration;
 use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
-use trustify_common::{hashing::Digests, model::PaginatedResults};
+use trustify_common::{
+    db::pagination_cache::PaginationCache, error::ErrorInformation, hashing::Digests,
+    model::PaginatedResults,
+};
 use trustify_entity::{advisory_vulnerability_score, labels::Labels};
 use trustify_module_ingestor::{
     graph::{advisory::AdvisoryInformation, cvss::ScoreCreator},
@@ -803,6 +807,35 @@ async fn all_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         ]),
     )
     .await?;
+
+    Ok(())
+}
+
+/// Verify that exceeding the configured max limit returns 400 with the correct header and body.
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn list_advisories_limit_exceeded(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let cache = PaginationCache::new(Duration::ZERO, 10);
+    let app = caller_with(ctx, Default::default(), cache).await?;
+
+    let request = TestRequest::get()
+        .uri("/api/v3/advisory?limit=50")
+        .to_request();
+    let response = app.call_service(request).await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let header = response
+        .headers()
+        .get("X-Pagination-Max-Limit")
+        .expect("missing X-Pagination-Max-Limit header");
+    assert_eq!(header.to_str().unwrap(), "10");
+
+    let body = response.into_body().try_into_bytes().unwrap();
+    let info: ErrorInformation =
+        serde_json::from_slice(&body).expect("response body should be valid JSON");
+    assert_eq!(info.error, "LimitExceeded");
+    assert!(info.message.contains("10"));
 
     Ok(())
 }

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -18,7 +18,7 @@ use trustify_common::{
         query::{Columns, Filtering, Query},
     },
     id::{Id, TrySelectForId},
-    model::{Paginated, PaginatedResults},
+    model::{PaginatedResults, Pagination},
 };
 use trustify_entity::{advisory, labels::Labels, organization, source_document};
 use trustify_module_ingestor::common::{Deprecation, DeprecationExt};
@@ -38,7 +38,7 @@ impl AdvisoryService {
     pub async fn fetch_advisories<C: ConnectionTrait + Sync + Send>(
         &self,
         search: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
         deprecation: Deprecation,
         connection: &C,
     ) -> Result<PaginatedResults<AdvisorySummary>, Error> {
@@ -61,7 +61,7 @@ impl AdvisoryService {
             .try_limiting_as_multi_model::<AdvisoryCatcher>(connection, paginated, &self.cache)?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         Ok(PaginatedResults {
             total,

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -58,12 +58,7 @@ impl AdvisoryService {
                         _ => None,
                     }),
             )?
-            .try_limiting_as_multi_model::<AdvisoryCatcher>(
-                connection,
-                paginated.offset,
-                paginated.limit,
-                &self.cache,
-            )?;
+            .try_limiting_as_multi_model::<AdvisoryCatcher>(connection, paginated, &self.cache)?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
         let total = total.requested(paginated.total).await?;

--- a/modules/fundamental/src/error.rs
+++ b/modules/fundamental/src/error.rs
@@ -2,7 +2,11 @@ use actix_web::{HttpResponse, ResponseError, body::BoxBody};
 use sea_orm::DbErr;
 use std::borrow::Cow;
 use trustify_common::{
-    db::DatabaseErrors, decompress, error::ErrorInformation, id::IdError, purl::PurlErr,
+    db::{DatabaseErrors, limiter::LimiterError, pagination_cache::LimitError},
+    decompress,
+    error::ErrorInformation,
+    id::IdError,
+    purl::PurlErr,
 };
 use trustify_entity::labels;
 use trustify_module_storage::service::StorageKeyError;
@@ -49,6 +53,8 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error(transparent)]
     Label(#[from] labels::Error),
+    #[error(transparent)]
+    Limit(#[from] LimitError),
     #[error("revision not found")]
     RevisionNotFound,
     #[error("unavailable")]
@@ -70,6 +76,15 @@ impl From<DbErr> for Error {
             Self::Unavailable
         } else {
             Self::Database(value)
+        }
+    }
+}
+
+impl From<LimiterError> for Error {
+    fn from(value: LimiterError) -> Self {
+        match value {
+            LimiterError::Db(e) => e.into(),
+            LimiterError::Limit(e) => e.into(),
         }
     }
 }
@@ -116,6 +131,7 @@ impl ResponseError for Error {
             Self::Label(err) => {
                 HttpResponse::BadRequest().json(ErrorInformation::new("Label", err))
             }
+            Self::Limit(err) => err.error_response(),
             Self::Unavailable => {
                 HttpResponse::ServiceUnavailable().json(ErrorInformation::new("Unavailable", self))
             }

--- a/modules/fundamental/src/license/service/mod.rs
+++ b/modules/fundamental/src/license/service/mod.rs
@@ -24,7 +24,7 @@ use tracing::instrument;
 use trustify_common::{
     db::query::{Columns, Filtering, IntoColumns, Query, q},
     id::{Id, TrySelectForId},
-    model::{Paginated, PaginatedResults},
+    model::{PaginatedResults, Pagination},
 };
 use trustify_entity::{
     expanded_license, license, licensing_infos, qualified_purl, sbom, sbom_license_expanded,
@@ -171,7 +171,7 @@ impl LicenseService {
     pub async fn list_spdx_licenses(
         &self,
         search: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
     ) -> Result<PaginatedResults<SpdxLicenseSummary>, Error> {
         let all_matching = spdx::identifiers::LICENSES
             .iter()
@@ -188,24 +188,24 @@ impl LicenseService {
             )
             .collect::<Vec<_>>();
 
-        let total = if paginated.total {
+        let total = if paginated.total() {
             Some(all_matching.len() as u64)
         } else {
             None
         };
 
-        if all_matching.len() < paginated.offset as usize {
+        if all_matching.len() < paginated.offset() as usize {
             return Ok(PaginatedResults {
                 items: vec![],
                 total,
             });
         }
 
-        let matching = &all_matching[paginated.offset as usize..];
+        let matching = &all_matching[paginated.offset() as usize..];
 
-        if paginated.limit > 0 && matching.len() > paginated.limit as usize {
+        if paginated.limit() > 0 && matching.len() > paginated.limit() as usize {
             Ok(PaginatedResults {
-                items: SpdxLicenseSummary::from_details(&matching[..paginated.limit as usize]),
+                items: SpdxLicenseSummary::from_details(&matching[..paginated.limit() as usize]),
                 total,
             })
         } else {
@@ -298,7 +298,7 @@ impl LicenseService {
     pub async fn licenses<C: ConnectionTrait>(
         &self,
         search: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
         connection: &C,
     ) -> Result<PaginatedResults<LicenseText>, Error> {
         const LICENSE_TEXT: &str = "text";
@@ -381,7 +381,7 @@ impl LicenseService {
             num_items: i64,
         }
 
-        let total = if paginated.total {
+        let total = if paginated.total() {
             let (sql_count, values) = count_query.build(PostgresQueryBuilder);
             Some(
                 Count::find_by_statement(Statement::from_sql_and_values(
@@ -400,8 +400,8 @@ impl LicenseService {
 
         // Apply pagination
         union_query = union_query
-            .offset(paginated.offset)
-            .limit(paginated.limit)
+            .offset(paginated.offset())
+            .limit(paginated.limit())
             .to_owned();
 
         let (sql, values) = union_query.build(PostgresQueryBuilder);

--- a/modules/fundamental/src/organization/service/mod.rs
+++ b/modules/fundamental/src/organization/service/mod.rs
@@ -31,10 +31,9 @@ impl OrganizationService {
     ) -> Result<PaginatedResults<OrganizationSummary>, Error> {
         let limiter = organization::Entity::find().filtering(search)?.limiting(
             connection,
-            paginated.offset,
-            paginated.limit,
+            paginated,
             &self.cache,
-        );
+        )?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
         let total = total.requested(paginated.total).await?;

--- a/modules/fundamental/src/organization/service/mod.rs
+++ b/modules/fundamental/src/organization/service/mod.rs
@@ -9,7 +9,7 @@ use trustify_common::{
         pagination_cache::PaginationCache,
         query::{Filtering, Query},
     },
-    model::{Paginated, PaginatedResults},
+    model::{PaginatedResults, Pagination},
 };
 use trustify_entity::organization;
 use uuid::Uuid;
@@ -26,7 +26,7 @@ impl OrganizationService {
     pub async fn fetch_organizations<C: ConnectionTrait>(
         &self,
         search: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
         connection: &C,
     ) -> Result<PaginatedResults<OrganizationSummary>, Error> {
         let limiter = organization::Entity::find().filtering(search)?.limiting(
@@ -36,7 +36,7 @@ impl OrganizationService {
         )?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         Ok(PaginatedResults {
             total,

--- a/modules/fundamental/src/product/service/mod.rs
+++ b/modules/fundamental/src/product/service/mod.rs
@@ -29,10 +29,9 @@ impl ProductService {
     ) -> Result<PaginatedResults<ProductSummary>, Error> {
         let limiter = product::Entity::find().filtering(search)?.limiting(
             connection,
-            paginated.offset,
-            paginated.limit,
+            paginated,
             &self.cache,
-        );
+        )?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
         let total = total.requested(paginated.total).await?;

--- a/modules/fundamental/src/product/service/mod.rs
+++ b/modules/fundamental/src/product/service/mod.rs
@@ -7,7 +7,7 @@ use trustify_common::{
         pagination_cache::PaginationCache,
         query::{Filtering, Query},
     },
-    model::{Paginated, PaginatedResults},
+    model::{PaginatedResults, Pagination},
 };
 use trustify_entity::product;
 use uuid::Uuid;
@@ -24,7 +24,7 @@ impl ProductService {
     pub async fn fetch_products<C: ConnectionTrait + Sync + Send>(
         &self,
         search: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
         connection: &C,
     ) -> Result<PaginatedResults<ProductSummary>, Error> {
         let limiter = product::Entity::find().filtering(search)?.limiting(
@@ -34,7 +34,7 @@ impl ProductService {
         )?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         Ok(PaginatedResults {
             total,

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -166,7 +166,7 @@ impl PurlService {
         let limiter = base_purl::Entity::find()
             .filter(base_purl::Column::Type.eq(r#type))
             .filtering(query)?
-            .limiting(connection, paginated.offset, paginated.limit, &self.cache);
+            .limiting(connection, paginated, &self.cache)?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
         let total = total.requested(paginated.total).await?;
@@ -378,10 +378,9 @@ impl PurlService {
     ) -> Result<PaginatedResults<BasePurlSummary>, Error> {
         let limiter = base_purl::Entity::find().filtering(query)?.limiting(
             connection,
-            paginated.offset,
-            paginated.limit,
+            paginated,
             &self.cache,
-        );
+        )?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
         let total = total.requested(paginated.total).await?;
@@ -477,7 +476,7 @@ impl PurlService {
                 select.filter(qualified_purl::Column::Id.in_subquery(spdx_select.into_query()));
         }
 
-        let limiter = select.limiting(connection, paginated.offset, paginated.limit, &self.cache);
+        let limiter = select.limiting(connection, paginated, &self.cache)?;
         let LimitedResult { items, total } = limiter.fetch().await?;
         let total = total.requested(paginated.total).await?;
 

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -29,7 +29,7 @@ use trustify_common::{
         pagination_cache::PaginationCache,
         query::{Columns, Filtering, IntoColumns, Query, q},
     },
-    model::{Paginated, PaginatedResults},
+    model::{PaginatedResults, Pagination},
     purl::{Purl, PurlErr},
 };
 use trustify_entity::{
@@ -160,7 +160,7 @@ impl PurlService {
         &self,
         r#type: &str,
         query: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
         connection: &C,
     ) -> Result<PaginatedResults<BasePurlSummary>, Error> {
         let limiter = base_purl::Entity::find()
@@ -169,7 +169,7 @@ impl PurlService {
             .limiting(connection, paginated, &self.cache)?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         Ok(PaginatedResults {
             items: BasePurlSummary::from_entities(&items).await?,
@@ -373,7 +373,7 @@ impl PurlService {
     pub async fn base_purls<C: ConnectionTrait>(
         &self,
         query: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
         connection: &C,
     ) -> Result<PaginatedResults<BasePurlSummary>, Error> {
         let limiter = base_purl::Entity::find().filtering(query)?.limiting(
@@ -383,7 +383,7 @@ impl PurlService {
         )?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         Ok(PaginatedResults {
             items: BasePurlSummary::from_entities(&items).await?,
@@ -395,7 +395,7 @@ impl PurlService {
     pub async fn purls<C: ConnectionTrait>(
         &self,
         query: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
         connection: &C,
     ) -> Result<PaginatedResults<PurlSummary>, Error> {
         let mut select = qualified_purl::Entity::find().filtering_with(
@@ -478,7 +478,7 @@ impl PurlService {
 
         let limiter = select.limiting(connection, paginated, &self.cache)?;
         let LimitedResult { items, total } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         Ok(PaginatedResults {
             items: PurlSummary::from_entities(&items),

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -7,7 +7,7 @@ use trustify_common::{
         pagination_cache::PaginationCache,
         query::{Query, q},
     },
-    model::Paginated,
+    model::{Limit, Paginated},
     purl::Purl,
 };
 use trustify_test_context::{Dataset, TrustifyContext};
@@ -676,10 +676,12 @@ async fn qualified_packages_filter_by_license(ctx: &TrustifyContext) -> Result<(
     log::debug!("{results:#?}");
     assert_eq!(4, results.items.len());
 
+    // use a high limit to fetch all 57 expected matches
     let results = service
         .purls(
             q("license~GPLv3+ with exceptions|Apache"),
-            Paginated::default(),
+            // use a high limit to fetch all expected matches
+            Limit(100),
             &ctx.db,
         )
         .await?;

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -27,7 +27,7 @@ use trustify_common::{
         query::{Columns, Filtering, IntoColumns, Query, q},
     },
     id::{Id, TrySelectForId},
-    model::{Paginated, PaginatedResults},
+    model::{PaginatedResults, Pagination},
     purl::Purl,
     requested_field::BoolRequestedField,
     service::{Mappable, Resulting},
@@ -194,7 +194,7 @@ impl SbomService {
     pub async fn fetch_sboms<C, P>(
         &self,
         search: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
         options: FetchOptions,
         connection: &C,
     ) -> Result<PaginatedResults<SbomSummary<P>>, Error>
@@ -293,7 +293,7 @@ impl SbomService {
             items: sboms,
             total,
         } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         let items = stream::iter(
             sboms
@@ -317,7 +317,7 @@ impl SbomService {
         &self,
         sbom_id: Uuid,
         search: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
         connection: &C,
     ) -> Result<PaginatedResults<SbomPackage>, Error> {
         let mut query = sbom_package::Entity::find()
@@ -423,7 +423,7 @@ impl SbomService {
             limit_selector::<_, _, _, PackageCatcher>(connection, query, paginated, &self.cache)?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
         let items = items.into_iter().map(SbomPackage::from_row).collect();
 
         Ok(PaginatedResults { items, total })
@@ -435,7 +435,7 @@ impl SbomService {
         &self,
         sbom_id: Option<Uuid>,
         search: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
         include_counts: bool,
         connection: &C,
     ) -> Result<PaginatedResults<SbomModel>, Error> {
@@ -471,7 +471,7 @@ impl SbomService {
             limit_selector::<_, _, _, ModelCatcher>(connection, query, paginated, &self.cache)?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         // Parse PURLs once per model and collect all unique PURL UUIDs
         let parsed: Vec<(String, String, serde_json::Value, Vec<PurlSummary>)> = items
@@ -645,7 +645,7 @@ impl SbomService {
     pub async fn find_related_sboms<C: ConnectionTrait>(
         &self,
         package_ref: SbomExternalPackageReference<'_>,
-        paginated: Paginated,
+        paginated: impl Pagination,
         query: Query,
         connection: &C,
     ) -> Result<PaginatedResults<SbomSummary>, Error> {
@@ -678,7 +678,7 @@ impl SbomService {
             items: sboms,
             total,
         } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         // collect results
 
@@ -1130,6 +1130,7 @@ mod test {
     use trustify_common::db::pagination_cache::PaginationCache;
     use trustify_common::db::query::q;
     use trustify_common::hashing::Digests;
+    use trustify_common::model::Paginated;
     use trustify_entity::labels::Labels;
     use trustify_test_context::TrustifyContext;
 

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -287,7 +287,7 @@ impl SbomService {
                         },
                     }),
             )?
-            .limiting(connection, paginated.offset, paginated.limit, &self.cache);
+            .limiting(connection, paginated, &self.cache)?;
 
         let LimitedResult {
             items: sboms,
@@ -419,13 +419,8 @@ impl SbomService {
 
         // limit and execute
 
-        let limiter = limit_selector::<_, _, _, PackageCatcher>(
-            connection,
-            query,
-            paginated.offset,
-            paginated.limit,
-            &self.cache,
-        );
+        let limiter =
+            limit_selector::<_, _, _, PackageCatcher>(connection, query, paginated, &self.cache)?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
         let total = total.requested(paginated.total).await?;
@@ -472,13 +467,8 @@ impl SbomService {
             query = query.filter(sbom_ai::Column::SbomId.eq(id));
         }
 
-        let limiter = limit_selector::<_, _, _, ModelCatcher>(
-            connection,
-            query,
-            paginated.offset,
-            paginated.limit,
-            &self.cache,
-        );
+        let limiter =
+            limit_selector::<_, _, _, ModelCatcher>(connection, query, paginated, &self.cache)?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
         let total = total.requested(paginated.total).await?;
@@ -682,7 +672,7 @@ impl SbomService {
 
         // limit and execute
 
-        let limiter = query.limiting(connection, paginated.offset, paginated.limit, &self.cache);
+        let limiter = query.limiting(connection, paginated, &self.cache)?;
 
         let LimitedResult {
             items: sboms,

--- a/modules/fundamental/src/sbom/service/test.rs
+++ b/modules/fundamental/src/sbom/service/test.rs
@@ -14,7 +14,7 @@ use trustify_common::{
         query::{Query, q},
     },
     id::Id,
-    model::Paginated,
+    model::{Limit, Paginated},
     purl::Purl,
 };
 use trustify_entity::labels::Labels;
@@ -503,10 +503,12 @@ async fn fetch_sbom_packages_filter_by_license(ctx: &TrustifyContext) -> Result<
 #[test(actix_web::test)]
 async fn delete_sbom_orphaned_purl_test(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let purl_service = PurlService::new(PaginationCache::for_test());
+    // use a high limit to fetch all items for count assertions
+    let all = Limit(2000);
     assert_eq!(
         0,
         purl_service
-            .purls(Query::default(), Paginated::default(), &ctx.db)
+            .purls(Query::default(), all, &ctx.db)
             .await?
             .items
             .len()
@@ -521,7 +523,7 @@ async fn delete_sbom_orphaned_purl_test(ctx: &TrustifyContext) -> Result<(), any
     assert_eq!(
         880,
         purl_service
-            .purls(Query::default(), Paginated::default(), &ctx.db)
+            .purls(Query::default(), all, &ctx.db)
             .await?
             .items
             .len()
@@ -534,7 +536,7 @@ async fn delete_sbom_orphaned_purl_test(ctx: &TrustifyContext) -> Result<(), any
     assert_eq!(
         1490,
         purl_service
-            .purls(Query::default(), Paginated::default(), &ctx.db)
+            .purls(Query::default(), all, &ctx.db)
             .await?
             .items
             .len()
@@ -547,9 +549,7 @@ async fn delete_sbom_orphaned_purl_test(ctx: &TrustifyContext) -> Result<(), any
     tx.commit().await?;
 
     // it should not leave behind orphaned purls
-    let result = purl_service
-        .purls(Query::default(), Paginated::default(), &ctx.db)
-        .await?;
+    let result = purl_service.purls(Query::default(), all, &ctx.db).await?;
     // running the deletion, should have deleted those orphaned purls
     assert_eq!(880, result.items.len());
 
@@ -563,9 +563,7 @@ async fn delete_sbom_orphaned_purl_test(ctx: &TrustifyContext) -> Result<(), any
     tx.commit().await?;
 
     // running the deletion, should have deleted those orphaned purls
-    let result = purl_service
-        .purls(Query::default(), Paginated::default(), &ctx.db)
-        .await?;
+    let result = purl_service.purls(Query::default(), all, &ctx.db).await?;
 
     assert_eq!(0, result.items.len());
     Ok(())

--- a/modules/fundamental/src/sbom_group/service.rs
+++ b/modules/fundamental/src/sbom_group/service.rs
@@ -21,7 +21,7 @@ use trustify_common::{
         pagination_cache::PaginationCache,
         query::{Filtering, Query},
     },
-    model::{Paginated, PaginatedResults, Revisioned},
+    model::{PaginatedResults, Pagination, Revisioned},
 };
 use trustify_entity::{sbom, sbom_group, sbom_group_assignment};
 use utoipa::{IntoParams, ToSchema};
@@ -89,7 +89,7 @@ impl SbomGroupService {
     pub async fn list(
         &self,
         options: ListOptions,
-        paginated: Paginated,
+        paginated: impl Pagination,
         query: Query,
         db: &impl ConnectionTrait,
     ) -> Result<GroupListResult, Error> {

--- a/modules/fundamental/src/sbom_group/service.rs
+++ b/modules/fundamental/src/sbom_group/service.rs
@@ -97,7 +97,7 @@ impl SbomGroupService {
 
         let query = sbom_group::Entity::find().filtering(query)?;
 
-        let limiter = query.limiting_pagination(db, paginated, &self.cache);
+        let limiter = query.limiting(db, paginated, &self.cache)?;
 
         let result = PaginatedResults::<sbom_group::Model>::new(limiter, paginated).await?;
 

--- a/modules/fundamental/src/test/common.rs
+++ b/modules/fundamental/src/test/common.rs
@@ -7,12 +7,13 @@ use trustify_test_context::{
 };
 
 pub async fn caller(ctx: &TrustifyContext) -> anyhow::Result<impl CallService + '_> {
-    caller_with(ctx, Config::default()).await
+    caller_with(ctx, Config::default(), PaginationCache::for_test()).await
 }
 
-async fn caller_with(
+pub async fn caller_with(
     ctx: &TrustifyContext,
     config: Config,
+    cache: PaginationCache,
 ) -> anyhow::Result<impl CallService + '_> {
     let analysis = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
     call::caller(|svc| {
@@ -22,7 +23,7 @@ async fn caller_with(
             ctx.db.clone(),
             ctx.storage.clone(),
             analysis.clone(),
-            PaginationCache::for_test(),
+            cache,
         );
         trustify_module_analysis::endpoints::configure(svc, ctx.db.clone(), analysis);
     })

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -29,7 +29,7 @@ use trustify_common::{
         query::{Columns, Filtering, Query},
     },
     memo::Memo,
-    model::{Paginated, PaginatedResults},
+    model::{PaginatedResults, Pagination},
     purl::Purl,
 };
 use trustify_entity::{
@@ -64,7 +64,7 @@ impl VulnerabilityService {
     pub async fn fetch_vulnerabilities<C: ConnectionTrait + Sync + Send>(
         &self,
         search: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
         _deprecation: Deprecation,
         connection: &C,
     ) -> Result<PaginatedResults<VulnerabilitySummary>, Error> {
@@ -92,7 +92,7 @@ impl VulnerabilityService {
             items: vulnerabilities,
             total,
         } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         Ok(PaginatedResults {
             total,

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -86,7 +86,7 @@ impl VulnerabilityService {
                     },
                 ),
             )?
-            .limiting(connection, paginated.offset, paginated.limit, &self.cache);
+            .limiting(connection, paginated, &self.cache)?;
 
         let LimitedResult {
             items: vulnerabilities,

--- a/modules/fundamental/src/weakness/service/mod.rs
+++ b/modules/fundamental/src/weakness/service/mod.rs
@@ -31,10 +31,9 @@ impl WeaknessService {
     ) -> Result<PaginatedResults<WeaknessSummary>, Error> {
         let limiter = weakness::Entity::find().filtering(query)?.limiting(
             &self.db,
-            paginated.offset,
-            paginated.limit,
+            paginated,
             &self.cache,
-        );
+        )?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
         let total = total.requested(paginated.total).await?;

--- a/modules/fundamental/src/weakness/service/mod.rs
+++ b/modules/fundamental/src/weakness/service/mod.rs
@@ -10,7 +10,7 @@ use trustify_common::{
         pagination_cache::PaginationCache,
         query::{Filtering, Query},
     },
-    model::{Paginated, PaginatedResults},
+    model::{PaginatedResults, Pagination},
 };
 use trustify_entity::weakness;
 
@@ -27,7 +27,7 @@ impl WeaknessService {
     pub async fn list_weaknesses(
         &self,
         query: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
     ) -> Result<PaginatedResults<WeaknessSummary>, Error> {
         let limiter = weakness::Entity::find().filtering(query)?.limiting(
             &self.db,
@@ -36,7 +36,7 @@ impl WeaknessService {
         )?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         Ok(PaginatedResults {
             items: WeaknessSummary::from_entities(&items).await?,

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -5,6 +5,7 @@ use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
 use trustify_common::db::pagination_cache::PaginationCache;
+use trustify_common::model::Limit;
 use trustify_common::purl::Purl;
 use trustify_entity::labels::Labels;
 use trustify_module_fundamental::advisory::model::AdvisoryHead;
@@ -86,7 +87,12 @@ async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let service = PurlService::new(PaginationCache::for_test());
     let purls = service
-        .purls(Default::default(), Default::default(), &ctx.db)
+        .purls(
+            Default::default(),
+            // high limit to find the specific purl among all entries
+            Limit(1000),
+            &ctx.db,
+        )
         .await?;
 
     // pkg:rpm/redhat/eap7-bouncycastle-util@1.76.0-4.redhat_00001.1.el9eap?arch=noarch

--- a/modules/fundamental/tests/advisory/csaf/parallel.rs
+++ b/modules/fundamental/tests/advisory/csaf/parallel.rs
@@ -24,7 +24,7 @@ async fn ingest_10(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Query::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             Deprecation::Consider,

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -5,6 +5,7 @@ use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
 use trustify_common::db::pagination_cache::PaginationCache;
+use trustify_common::model::Limit;
 use trustify_common::purl::Purl;
 use trustify_entity::labels::Labels;
 use trustify_module_fundamental::advisory::model::AdvisoryHead;
@@ -97,7 +98,12 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let service = PurlService::new(PaginationCache::for_test());
     let purls = service
-        .purls(Default::default(), Default::default(), &ctx.db)
+        .purls(
+            Default::default(),
+            // high limit to find the specific purl among all entries
+            Limit(1000),
+            &ctx.db,
+        )
         .await?;
 
     // pkg:rpm/redhat/eap7-bouncycastle@1.76.0-4.redhat_00001.1.el9eap?arch=noarch
@@ -243,7 +249,12 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let service = PurlService::new(PaginationCache::for_test());
     let purls = service
-        .purls(Default::default(), Default::default(), &ctx.db)
+        .purls(
+            Default::default(),
+            // high limit to find the specific purl among all entries
+            Limit(1000),
+            &ctx.db,
+        )
         .await?;
 
     // pkg:rpm/redhat/eap7-bouncycastle-util@1.76.0-4.redhat_00001.1.el9eap?arch=noarch

--- a/modules/fundamental/tests/advisory/csaf/timeout.rs
+++ b/modules/fundamental/tests/advisory/csaf/timeout.rs
@@ -33,7 +33,7 @@ async fn timeout(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Query::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             Deprecation::Consider,

--- a/modules/fundamental/tests/advisory/cve/parallel.rs
+++ b/modules/fundamental/tests/advisory/cve/parallel.rs
@@ -27,7 +27,7 @@ async fn ingest_10(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Query::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             Deprecation::Consider,

--- a/modules/fundamental/tests/advisory/osv/parallel.rs
+++ b/modules/fundamental/tests/advisory/osv/parallel.rs
@@ -27,7 +27,7 @@ async fn ingest_10(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Query::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             Deprecation::Consider,

--- a/modules/fundamental/tests/advisory/osv/reingest.rs
+++ b/modules/fundamental/tests/advisory/osv/reingest.rs
@@ -3,6 +3,7 @@ use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
 use trustify_common::db::pagination_cache::PaginationCache;
+use trustify_common::model::Paginated;
 use trustify_common::purl::Purl;
 use trustify_entity::labels::Labels;
 use trustify_module_fundamental::{
@@ -81,7 +82,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let service = PurlService::new(PaginationCache::for_test());
     let purls = service
-        .purls(Default::default(), Default::default(), &ctx.db)
+        .purls(Default::default(), Paginated::default(), &ctx.db)
         .await?;
 
     let purl = purls

--- a/modules/fundamental/tests/analysis.rs
+++ b/modules/fundamental/tests/analysis.rs
@@ -24,7 +24,7 @@ async fn assert_status(app: &impl CallService, sboms: usize, graphs: usize) {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn upload_lazy_load(ctx: &TrustifyContext) -> anyhow::Result<()> {
-    let app = caller_with(ctx, Config::default()).await?;
+    let app = caller_with(ctx, Config::default(), PaginationCache::for_test()).await?;
 
     let request = TestRequest::post()
         .uri("/api/v2/sbom")

--- a/modules/fundamental/tests/limit.rs
+++ b/modules/fundamental/tests/limit.rs
@@ -17,6 +17,7 @@ async fn upload_bomb_sbom(ctx: &TrustifyContext) -> anyhow::Result<()> {
             advisory_upload_limit: 1024 * 1024,
             max_group_name_length: 32,
         },
+        PaginationCache::for_test(),
     )
     .await?;
 
@@ -41,6 +42,7 @@ async fn upload_bomb_advisory(ctx: &TrustifyContext) -> anyhow::Result<()> {
             advisory_upload_limit: 1024 * 1024,
             max_group_name_length: 32,
         },
+        PaginationCache::for_test(),
     )
     .await?;
 

--- a/modules/fundamental/tests/sbom/cyclonedx/cpe.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/cpe.rs
@@ -19,7 +19,7 @@ async fn simple(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             result.id.parse().expect("Must be a UID"),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             &ctx.db,
@@ -48,7 +48,7 @@ async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             result.id.parse().expect("Must be a UID"),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             &ctx.db,
@@ -77,7 +77,7 @@ async fn simple_comp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             result.id.parse().expect("Must be a UID"),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             &ctx.db,
@@ -98,7 +98,7 @@ async fn simple_comp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Default::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             &ctx.db,

--- a/modules/fundamental/tests/sbom/cyclonedx/parallel.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/parallel.rs
@@ -29,7 +29,7 @@ async fn ingest_10(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Query::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             Default::default(),

--- a/modules/fundamental/tests/sbom/cyclonedx/purl.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/purl.rs
@@ -37,7 +37,7 @@ async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             sbom_id,
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             &ctx.db,
@@ -65,7 +65,7 @@ async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Default::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             Which::Right,

--- a/modules/fundamental/tests/sbom/reingest.rs
+++ b/modules/fundamental/tests/sbom/reingest.rs
@@ -92,7 +92,7 @@ async fn quarkus(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             SbomExternalPackageReference::Purl(&Purl::from_str(purl).expect("must parse")),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             Query::default(),

--- a/modules/fundamental/tests/sbom/spdx.rs
+++ b/modules/fundamental/tests/sbom/spdx.rs
@@ -94,7 +94,7 @@ async fn test_parse_spdx(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                     sbom.sbom.sbom_id,
                     Paginated {
                         offset: 0,
-                        limit: 0,
+                        limit: 1000,
                         total: true,
                     },
                     &ctx.db,
@@ -147,7 +147,7 @@ async fn ingest_spdx_broken_refs(ctx: &TrustifyContext) -> Result<(), anyhow::Er
             Default::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             Default::default(),

--- a/modules/fundamental/tests/sbom/spdx.rs
+++ b/modules/fundamental/tests/sbom/spdx.rs
@@ -108,7 +108,11 @@ async fn test_parse_spdx(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 .fetch_related_packages::<_, _, SbomPackage>(
                     sbom.sbom.sbom_id,
                     Default::default(),
-                    Paginated::default(),
+                    // high limit to fetch all contained packages
+                    Paginated {
+                        limit: 1000,
+                        ..Default::default()
+                    },
                     Which::Left,
                     first,
                     Some(Relationship::Contains),

--- a/modules/fundamental/tests/sbom/spdx/aliases.rs
+++ b/modules/fundamental/tests/sbom/spdx/aliases.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use test_context::test_context;
 use test_log::test;
+use trustify_common::model::Paginated;
 use trustify_module_analysis::{
     config::AnalysisConfig,
     service::{AnalysisService, ComponentReference},
@@ -21,7 +22,7 @@ async fn cpe_purl(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .retrieve(
             ComponentReference::Id("SPDXRef-SRPM"),
             (),
-            Default::default(),
+            Paginated::default(),
             &ctx.db,
         )
         .await?;

--- a/modules/fundamental/tests/sbom/spdx/corner_cases.rs
+++ b/modules/fundamental/tests/sbom/spdx/corner_cases.rs
@@ -62,7 +62,7 @@ async fn infinite_loop(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Default::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             &ctx.db,
@@ -80,7 +80,7 @@ async fn infinite_loop(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             id,
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             &ctx.db,
@@ -121,7 +121,7 @@ async fn double_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Default::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             &ctx.db,
@@ -166,7 +166,7 @@ async fn self_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Default::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             &ctx.db,
@@ -211,7 +211,7 @@ async fn self_ref_package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Default::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             &ctx.db,
@@ -259,7 +259,7 @@ async fn special_char(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Default::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             &ctx.db,

--- a/modules/fundamental/tests/sbom/spdx/issue_1417.rs
+++ b/modules/fundamental/tests/sbom/spdx/issue_1417.rs
@@ -2,7 +2,7 @@ use anyhow::bail;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::db::pagination_cache::PaginationCache;
-use trustify_common::{db::query::Query, model::Paginated};
+use trustify_common::{db::query::Query, model::Limit};
 use trustify_module_fundamental::sbom::service::SbomService;
 use trustify_test_context::TrustifyContext;
 
@@ -21,7 +21,13 @@ async fn multi_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let service = SbomService::new(ctx.db.clone(), PaginationCache::for_test());
 
     let sbom = service
-        .fetch_sbom_packages(id, Query::default(), Paginated::default(), &ctx.db)
+        .fetch_sbom_packages(
+            id,
+            Query::default(),
+            // high limit to find the specific package among all SBOM entries
+            Limit(1000),
+            &ctx.db,
+        )
         .await?;
 
     // this package shows up with 4 purls, despite there being only one

--- a/modules/fundamental/tests/sbom/spdx/parallel.rs
+++ b/modules/fundamental/tests/sbom/spdx/parallel.rs
@@ -27,7 +27,7 @@ async fn ingest_10(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Query::default(),
             Paginated {
                 offset: 0,
-                limit: 0,
+                limit: 1000,
                 total: true,
             },
             Default::default(),

--- a/modules/importer/src/service.rs
+++ b/modules/importer/src/service.rs
@@ -16,7 +16,7 @@ use trustify_common::{
         query::{Filtering, Query},
     },
     error::ErrorInformation,
-    model::{Paginated, PaginatedResults, Revisioned},
+    model::{PaginatedResults, Pagination, Revisioned},
 };
 use trustify_entity::{importer, importer_report, labels};
 use uuid::Uuid;
@@ -478,7 +478,7 @@ impl ImporterService {
         &self,
         name: &str,
         search: Query,
-        paginated: Paginated,
+        paginated: impl Pagination,
     ) -> Result<PaginatedResults<ImporterReport>, Error> {
         let limiting = importer_report::Entity::find()
             .filter(importer_report::Column::Importer.eq(name))
@@ -487,7 +487,7 @@ impl ImporterService {
             .limiting(&self.db, paginated, &self.cache)?;
 
         let LimitedResult { items, total } = limiting.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         Ok(PaginatedResults {
             total,

--- a/modules/importer/src/service.rs
+++ b/modules/importer/src/service.rs
@@ -39,6 +39,8 @@ pub enum Error {
     Query(#[from] trustify_common::db::query::Error),
     #[error(transparent)]
     Label(#[from] labels::Error),
+    #[error(transparent)]
+    Limit(#[from] trustify_common::db::pagination_cache::LimitError),
 }
 
 impl From<sea_orm::DbErr> for Error {
@@ -96,6 +98,7 @@ impl ResponseError for Error {
                 message: self.to_string(),
                 details: None,
             }),
+            Self::Limit(err) => err.error_response(),
             _ => HttpResponse::InternalServerError().json(ErrorInformation {
                 error: "Internal".into(),
                 message: self.to_string(),
@@ -481,7 +484,7 @@ impl ImporterService {
             .filter(importer_report::Column::Importer.eq(name))
             .filtering(search)?
             .order_by_desc(importer_report::Column::Creation)
-            .limiting(&self.db, paginated.offset, paginated.limit, &self.cache);
+            .limiting(&self.db, paginated, &self.cache)?;
 
         let LimitedResult { items, total } = limiting.fetch().await?;
         let total = total.requested(paginated.total).await?;

--- a/modules/ingestor/src/graph/error.rs
+++ b/modules/ingestor/src/graph/error.rs
@@ -1,5 +1,5 @@
 use sea_orm::DbErr;
-use trustify_common::purl::PurlErr;
+use trustify_common::{db::pagination_cache::LimitError, purl::PurlErr};
 use trustify_entity::labels;
 
 #[derive(Debug, thiserror::Error)]
@@ -24,4 +24,7 @@ pub enum Error {
 
     #[error(transparent)]
     Label(#[from] labels::Error),
+
+    #[error(transparent)]
+    Limit(#[from] LimitError),
 }

--- a/modules/ingestor/src/graph/purl/mod.rs
+++ b/modules/ingestor/src/graph/purl/mod.rs
@@ -322,7 +322,7 @@ impl<'g> PackageContext<'g> {
     ) -> Result<PaginatedResults<PackageVersionContext<'_>>, Error> {
         let limiter = entity::versioned_purl::Entity::find()
             .filter(entity::versioned_purl::Column::BasePurlId.eq(self.base_purl.id))
-            .limiting(connection, paginated.limit, paginated.offset, cache);
+            .limiting(connection, paginated.offset, paginated.limit, cache);
 
         let LimitedResult { items, total } = limiter.fetch().await?;
         let total = total.requested(paginated.total).await?;
@@ -376,7 +376,6 @@ pub async fn batch_create_base_purls<C: ConnectionTrait>(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use std::collections::BTreeMap;
-    use std::num::NonZeroU64;
     use std::str::FromStr;
 
     use sea_orm::{EntityTrait, IntoSimpleExpr, QueryFilter, QuerySelect, QueryTrait};
@@ -385,6 +384,7 @@ mod tests {
     use test_context::test_context;
     use test_log::test;
 
+    use rstest::rstest;
     use trustify_common::db::pagination_cache::PaginationCache;
     use trustify_common::model::Paginated;
     use trustify_common::purl::Purl;
@@ -471,16 +471,26 @@ mod tests {
     }
 
     #[test_context(TrustifyContext, skip_teardown)]
-    #[test(tokio::test)]
-    async fn get_versions_paginated(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
+    #[rstest]
+    #[case::basic_page(50, 50, true, Some(200), 50)]
+    #[case::second_page(100, 50, true, Some(200), 50)]
+    #[case::asymmetric(0, 10, true, Some(200), 10)]
+    #[case::asymmetric_page2(10, 10, true, Some(200), 10)]
+    #[case::zero_limit_with_total(0, 0, true, Some(200), 0)]
+    #[case::zero_limit_no_total(0, 0, false, None, 0)]
+    #[tokio::test]
+    async fn get_versions_paginated(
+        ctx: TrustifyContext,
+        #[case] offset: u64,
+        #[case] limit: u64,
+        #[case] total: bool,
+        #[case] expected_total: Option<u64>,
+        #[case] expected_len: usize,
+    ) -> Result<(), anyhow::Error> {
         let system = Graph::new(ctx.db.clone());
 
-        const TOTAL_ITEMS: u64 = 200;
-        let _page_size = NonZeroU64::new(50).unwrap();
-
-        for v in 0..TOTAL_ITEMS {
+        for v in 0..200u64 {
             let version = format!("pkg:maven/io.quarkus/quarkus-core@{v}").try_into()?;
-
             let _ = system.ingest_package_version(&version, &ctx.db).await?;
         }
 
@@ -489,39 +499,67 @@ mod tests {
             .await?
             .unwrap();
 
-        let all_versions = pkg.get_versions(&ctx.db).await?;
-
-        assert_eq!(TOTAL_ITEMS, all_versions.len() as u64);
-
-        let paginated = pkg
+        let result = pkg
             .get_versions_paginated(
                 Paginated {
-                    offset: 50,
-                    limit: 50,
-                    total: true,
+                    offset,
+                    limit,
+                    total,
                 },
                 &ctx.db,
                 &PaginationCache::for_test(),
             )
             .await?;
 
-        assert_eq!(Some(TOTAL_ITEMS), paginated.total);
-        assert_eq!(50, paginated.items.len());
+        assert_eq!(expected_total, result.total);
+        assert_eq!(expected_len, result.items.len());
 
-        let _next_paginated = pkg
+        Ok(())
+    }
+
+    #[test_context(TrustifyContext, skip_teardown)]
+    #[rstest]
+    #[case::clamped(0, 30, 10)]
+    #[case::within_max(0, 5, 5)]
+    #[tokio::test]
+    async fn get_versions_paginated_max_limit(
+        ctx: TrustifyContext,
+        #[case] offset: u64,
+        #[case] limit: u64,
+        #[case] expected_len: usize,
+    ) -> Result<(), anyhow::Error> {
+        use std::time::Duration;
+
+        let system = Graph::new(ctx.db.clone());
+
+        const TOTAL_ITEMS: u64 = 50;
+
+        for v in 0..TOTAL_ITEMS {
+            let version = format!("pkg:maven/io.quarkus/quarkus-core@{v}").try_into()?;
+            let _ = system.ingest_package_version(&version, &ctx.db).await?;
+        }
+
+        let pkg = system
+            .get_package(&"pkg:maven/io.quarkus/quarkus-core".try_into()?, &ctx.db)
+            .await?
+            .unwrap();
+
+        let cache = PaginationCache::new(Duration::ZERO, 10);
+
+        let result = pkg
             .get_versions_paginated(
                 Paginated {
-                    offset: 100,
-                    limit: 50,
+                    offset,
+                    limit,
                     total: true,
                 },
                 &ctx.db,
-                &PaginationCache::for_test(),
+                &cache,
             )
             .await?;
 
-        assert_eq!(Some(TOTAL_ITEMS), paginated.total);
-        assert_eq!(50, paginated.items.len());
+        assert_eq!(Some(TOTAL_ITEMS), result.total);
+        assert_eq!(expected_len, result.items.len());
 
         Ok(())
     }

--- a/modules/ingestor/src/graph/purl/mod.rs
+++ b/modules/ingestor/src/graph/purl/mod.rs
@@ -23,7 +23,7 @@ use trustify_common::{
         limiter::{LimitedResult, LimiterTrait},
         pagination_cache::PaginationCache,
     },
-    model::{Paginated, PaginatedResults},
+    model::{PaginatedResults, Pagination},
     purl::{Purl, PurlErr},
 };
 use trustify_entity as entity;
@@ -316,7 +316,7 @@ impl<'g> PackageContext<'g> {
 
     pub async fn get_versions_paginated<C: ConnectionTrait>(
         &self,
-        paginated: Paginated,
+        paginated: impl Pagination,
         connection: &C,
         cache: &PaginationCache,
     ) -> Result<PaginatedResults<PackageVersionContext<'_>>, Error> {
@@ -325,7 +325,7 @@ impl<'g> PackageContext<'g> {
             .limiting(connection, paginated, cache)?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
-        let total = total.requested(paginated.total).await?;
+        let total = total.requested(paginated.total()).await?;
 
         Ok(PaginatedResults {
             total,

--- a/modules/ingestor/src/graph/purl/mod.rs
+++ b/modules/ingestor/src/graph/purl/mod.rs
@@ -322,7 +322,7 @@ impl<'g> PackageContext<'g> {
     ) -> Result<PaginatedResults<PackageVersionContext<'_>>, Error> {
         let limiter = entity::versioned_purl::Entity::find()
             .filter(entity::versioned_purl::Column::BasePurlId.eq(self.base_purl.id))
-            .limiting(connection, paginated.offset, paginated.limit, cache);
+            .limiting(connection, paginated, cache)?;
 
         let LimitedResult { items, total } = limiter.fetch().await?;
         let total = total.requested(paginated.total).await?;
@@ -518,15 +518,9 @@ mod tests {
     }
 
     #[test_context(TrustifyContext, skip_teardown)]
-    #[rstest]
-    #[case::clamped(0, 30, 10)]
-    #[case::within_max(0, 5, 5)]
     #[tokio::test]
-    async fn get_versions_paginated_max_limit(
+    async fn get_versions_paginated_within_max_limit(
         ctx: TrustifyContext,
-        #[case] offset: u64,
-        #[case] limit: u64,
-        #[case] expected_len: usize,
     ) -> Result<(), anyhow::Error> {
         use std::time::Duration;
 
@@ -549,8 +543,8 @@ mod tests {
         let result = pkg
             .get_versions_paginated(
                 Paginated {
-                    offset,
-                    limit,
+                    offset: 0,
+                    limit: 5,
                     total: true,
                 },
                 &ctx.db,
@@ -559,7 +553,50 @@ mod tests {
             .await?;
 
         assert_eq!(Some(TOTAL_ITEMS), result.total);
-        assert_eq!(expected_len, result.items.len());
+        assert_eq!(5, result.items.len());
+
+        Ok(())
+    }
+
+    #[test_context(TrustifyContext, skip_teardown)]
+    #[tokio::test]
+    async fn get_versions_paginated_exceeds_max_limit(
+        ctx: TrustifyContext,
+    ) -> Result<(), anyhow::Error> {
+        use crate::graph::error::Error;
+        use std::time::Duration;
+
+        let system = Graph::new(ctx.db.clone());
+
+        for v in 0..10u64 {
+            let version = format!("pkg:maven/io.quarkus/quarkus-core@{v}").try_into()?;
+            let _ = system.ingest_package_version(&version, &ctx.db).await?;
+        }
+
+        let pkg = system
+            .get_package(&"pkg:maven/io.quarkus/quarkus-core".try_into()?, &ctx.db)
+            .await?
+            .unwrap();
+
+        let cache = PaginationCache::new(Duration::ZERO, 10);
+
+        let err = pkg
+            .get_versions_paginated(
+                Paginated {
+                    offset: 0,
+                    limit: 30,
+                    total: true,
+                },
+                &ctx.db,
+                &cache,
+            )
+            .await
+            .expect_err("should reject limit exceeding max");
+
+        match err {
+            Error::Limit(limit_err) => assert_eq!(limit_err.max_limit, 10),
+            other => panic!("expected LimitError, got: {other:?}"),
+        }
 
         Ok(())
     }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -296,7 +296,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -380,7 +380,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -532,7 +532,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -616,7 +616,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -797,7 +797,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -1438,7 +1438,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -1531,7 +1531,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -1647,7 +1647,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -1782,7 +1782,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -1920,7 +1920,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -2079,7 +2079,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -2195,7 +2195,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -2349,7 +2349,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -2580,7 +2580,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -2756,7 +2756,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -3016,7 +3016,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -3144,7 +3144,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -3293,7 +3293,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -3577,7 +3577,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -3686,7 +3686,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -3859,7 +3859,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer
@@ -3980,7 +3980,7 @@ paths:
         description: |-
           The maximum number of entries to return.
 
-          Zero means: no limit
+          Zero means: return no items (the total count is still computed if requested).
         required: false
         schema:
           type: integer


### PR DESCRIPTION
~~This is based on PR #2338 … only take a look at the most recent commits.~~

## Summary by Sourcery

Enforce configurable maximum pagination limits and change limit=0 semantics while propagating limit validation and error handling across services and APIs.

New Features:
- Add configurable maximum pagination limit with HTTP 400 responses including X-Pagination-Max-Limit header and structured error body when exceeded.

Enhancements:
- Change limit=0 semantics so that no items are returned while still allowing optional total count computation, avoiding unnecessary data queries.
- Propagate pagination limit validation through Limiter utilities and service layers, returning explicit Limit errors instead of silently accepting oversized limits.
- Extend pagination configuration and documentation (ADR and OpenAPI) to describe maximum limit enforcement and the new limit=0 behavior.
- Refine Paginated defaulting and in-memory pagination behavior to align with new semantics and simplify construction.

Documentation:
- Update ADR 00017 and OpenAPI documentation to capture maximum pagination limit enforcement and the new meaning of limit=0.

Tests:
- Add and update unit and integration tests to cover limit enforcement, limit=0 behavior, HTTP error responses, and service-specific pagination scenarios.