### PR TITLE
chore!: change all APIs to v3, or mark them deprecated

### DIFF
--- a/.github/scripts/benchmark.sh
+++ b/.github/scripts/benchmark.sh
@@ -16,7 +16,7 @@ zip --version
 # Send
 
 start_time=$(date +%s)
-http --ignore-stdin POST localhost:8080/api/v2/dataset "Authorization:$(oidc token trustify -bf)" @etc/datasets/ds3.zip
+http --ignore-stdin POST localhost:8080/api/v3/dataset "Authorization:$(oidc token trustify -bf)" @etc/datasets/ds3.zip
 end_time=$(date +%s)
 
 runtime=$((end_time - start_time))

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -27,7 +27,7 @@
 - Entity models: `Model` struct inside each entity module, table names are snake_case (`sbom`, `advisory`, `sbom_group`)
 - Service structs: `<Domain>Service` (e.g., `SbomService`, `AdvisoryService`)
 - Endpoint functions: short verbs — `get`, `all`, `delete`, `upload`, `download`, `packages`, `related`
-- API routes: `/v2/<resource>` (e.g., `/v2/sbom`, `/v2/advisory/{key}`)
+- API routes: `/v3/<resource>` (e.g., `/v3/sbom`, `/v3/advisory/{key}`)
 - OpenAPI operation IDs: camelCase (`getSbom`, `listSboms`)
 - Test functions: descriptive snake_case (`upload_with_groups`, `filter_packages`, `query_sboms_by_label`)
 
@@ -139,7 +139,7 @@ Any files modified by steps 1–2 (e.g., `openapi.yaml`, JSON schema files) must
 - Read operations acquire a read transaction: `let tx = db.begin_read().await?;`
 - List endpoints accept `Query` (search/filter), `Paginated` (pagination), and return `PaginatedResults<T>`
 - Every endpoint has a `#[utoipa::path(...)]` attribute for OpenAPI documentation with `tag`, `operation_id`, `params`, and `responses`
-- Route attributes use Actix macros: `#[get("/v2/...")]`, `#[post("/v2/...")]`, `#[delete("/v2/...")]`
+- Route attributes use Actix macros: `#[get("/v3/...")]`, `#[post("/v3/...")]`, `#[delete("/v3/...")]`
 
 ## Entity Model Patterns
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ zipped archive of SBOMs and/or Advisories like so:
 ```shell
 cd etc/datasets
 make
-http POST localhost:8080/api/v2/dataset @ds1.zip
+http POST localhost:8080/api/v3/dataset @ds1.zip
 ```
 
 #### Upload
@@ -74,8 +74,8 @@ There is an "Upload" menu option in the GUI: http://localhost:8080/upload
 You can also interact with the API directly in a shell:
 
 ```shell
-cat some-sbom.json | http POST localhost:8080/api/v2/sbom
-cat some-advisory.json | http POST localhost:8080/api/v2/advisory
+cat some-sbom.json | http POST localhost:8080/api/v3/sbom
+cat some-advisory.json | http POST localhost:8080/api/v3/advisory
 ```
 
 #### Importers

--- a/cli/README.md
+++ b/cli/README.md
@@ -95,7 +95,7 @@ Get an OAuth2 access token for use with other tools.
 
 ```bash
 TOKEN=$(trustify auth token)
-curl -H "Authorization: Bearer $TOKEN" $TRUSTIFY_URL/api/v2/sbom
+curl -H "Authorization: Bearer $TOKEN" $TRUSTIFY_URL/api/v3/sbom
 ```
 
 ---
@@ -150,7 +150,7 @@ trustify sbom duplicates find --output out.json # Custom output file
 
 **Output file format:**
 
-```json
+```json5
 [
   {
     "document_id": "urn:example:sbom-1.0",
@@ -193,7 +193,7 @@ trustify sbom prune --output results.json --quiet            # Save results to f
 
 **Output file format:**
 
-```json
+```json5
 {
   "deleted": [
     {

--- a/cli/src/api/advisory.rs
+++ b/cli/src/api/advisory.rs
@@ -4,7 +4,7 @@ use crate::common::{
     new_delete_result,
 };
 
-const ADVISORY_PATH: &str = "/v2/advisory";
+const ADVISORY_PATH: &str = "/v3/advisory";
 
 pub async fn list(client: &ApiClient, params: &ListParams) -> Result<String, ApiError> {
     client.get_with_query(ADVISORY_PATH, params).await

--- a/cli/src/api/sbom.rs
+++ b/cli/src/api/sbom.rs
@@ -19,7 +19,7 @@ use crate::common::{
     new_delete_result,
 };
 
-const SBOM_PATH: &str = "/v2/sbom";
+const SBOM_PATH: &str = "/v3/sbom";
 
 /// Parameters for find duplicates
 pub struct FindDuplicatesParams {

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -52,7 +52,7 @@ async fn cli_sbom_list_full_format() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .respond_with(ResponseTemplate::new(200).set_body_json(sample_sbom_response()))
         .mount(&server)
         .await;
@@ -77,7 +77,7 @@ async fn cli_sbom_list_id_format() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .respond_with(ResponseTemplate::new(200).set_body_json(sample_sbom_response()))
         .mount(&server)
         .await;
@@ -99,7 +99,7 @@ async fn cli_sbom_list_name_format() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .respond_with(ResponseTemplate::new(200).set_body_json(sample_sbom_response()))
         .mount(&server)
         .await;
@@ -122,7 +122,7 @@ async fn cli_sbom_list_short_format() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .respond_with(ResponseTemplate::new(200).set_body_json(sample_sbom_response()))
         .mount(&server)
         .await;
@@ -147,7 +147,7 @@ async fn cli_sbom_list_with_query() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .and(query_param("q", "name=my-app"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [sample_sbom_response()["items"][0]],
@@ -181,7 +181,7 @@ async fn cli_sbom_list_with_pagination() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .and(query_param("limit", "10"))
         .and(query_param("offset", "20"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -216,7 +216,7 @@ async fn cli_sbom_list_with_sort() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .and(query_param("sort", "published:desc"))
         .respond_with(ResponseTemplate::new(200).set_body_json(sample_sbom_response()))
         .mount(&server)
@@ -247,7 +247,7 @@ async fn cli_sbom_get_by_id() {
     let sbom_id = "019c99b2-32cb-7ce0-a1f4-353e398627e4";
 
     Mock::given(method("GET"))
-        .and(path(format!("/api/v2/sbom/{}", sbom_id)))
+        .and(path(format!("/api/v3/sbom/{}", sbom_id)))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "id": sbom_id,
             "name": "my-app",
@@ -277,7 +277,7 @@ async fn cli_sbom_delete_by_id() {
     let sbom_id = "019c99b2-32cb-7ce0-a1f4-353e398627e4";
 
     Mock::given(method("DELETE"))
-        .and(path(format!("/api/v2/sbom/{}", sbom_id)))
+        .and(path(format!("/api/v3/sbom/{}", sbom_id)))
         .respond_with(ResponseTemplate::new(200).set_body_string(""))
         .mount(&server)
         .await;
@@ -299,7 +299,7 @@ async fn cli_sbom_delete_by_id_dry_run() {
     let sbom_id = "019c99b2-32cb-7ce0-a1f4-353e398627e4";
 
     Mock::given(method("DELETE"))
-        .and(path(format!("/api/v2/sbom/{}", sbom_id)))
+        .and(path(format!("/api/v3/sbom/{}", sbom_id)))
         .respond_with(ResponseTemplate::new(200).set_body_string(""))
         .mount(&server)
         .await;
@@ -333,7 +333,7 @@ async fn cli_sbom_delete_by_query_dry_run() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [{
                 "id": "019c99b2-32cb-7ce0-a1f4-353e398627e4",
@@ -368,7 +368,7 @@ async fn cli_sbom_duplicates_find_default() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [],
             "total": 0
@@ -392,7 +392,7 @@ async fn cli_sbom_duplicates_find_custom_params() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [],
             "total": 0
@@ -474,7 +474,7 @@ async fn cli_sbom_prune_dry_run() {
         .to_string();
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [],
             "total": 0
@@ -510,7 +510,7 @@ async fn cli_sbom_prune_published_before() {
         .to_string();
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [],
             "total": 0
@@ -545,7 +545,7 @@ async fn cli_sbom_prune_by_label() {
         .to_string();
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [],
             "total": 0
@@ -580,7 +580,7 @@ async fn cli_sbom_prune_keep_latest() {
         .to_string();
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/sbom"))
+        .and(path("/api/v3/sbom"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [],
             "total": 0
@@ -611,7 +611,7 @@ async fn cli_advisory_list() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/advisory"))
+        .and(path("/api/v3/advisory"))
         .respond_with(ResponseTemplate::new(200).set_body_json(sample_advisory_response()))
         .mount(&server)
         .await;
@@ -637,7 +637,7 @@ async fn cli_advisory_list_with_query() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/advisory"))
+        .and(path("/api/v3/advisory"))
         .and(query_param("q", "identifier=CVE-2024-1234"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [sample_advisory_response()["items"][0]],
@@ -671,7 +671,7 @@ async fn cli_advisory_list_with_pagination() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/advisory"))
+        .and(path("/api/v3/advisory"))
         .and(query_param("limit", "10"))
         .and(query_param("offset", "20"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -710,7 +710,7 @@ async fn cli_advisory_prune_dry_run() {
         .to_string();
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/advisory"))
+        .and(path("/api/v3/advisory"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [],
             "total": 0
@@ -746,7 +746,7 @@ async fn cli_advisory_prune_older_than() {
         .to_string();
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/advisory"))
+        .and(path("/api/v3/advisory"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [],
             "total": 0
@@ -781,7 +781,7 @@ async fn cli_advisory_prune_keep_latest() {
         .to_string();
 
     Mock::given(method("GET"))
-        .and(path("/api/v2/advisory"))
+        .and(path("/api/v3/advisory"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [],
             "total": 0

--- a/e2e/ds3.hurl
+++ b/e2e/ds3.hurl
@@ -1,5 +1,5 @@
 # Upload the dataset
-POST http://localhost:8080/api/v2/dataset
+POST http://localhost:8080/api/v3/dataset
 file,etc/datasets/ds3.zip;
 
 HTTP 201
@@ -16,7 +16,7 @@ advisory_id: jsonpath "$.files.['csaf/2023/cve-2023-0044.json'].id"
 
 
 # Check vulnerabilities for UBI 8 SBOM
-GET http://localhost:8080/api/v2/sbom/{{ubi8_sbom_id}}/advisory
+GET http://localhost:8080/api/v3/sbom/{{ubi8_sbom_id}}/advisory
 
 HTTP 200
 
@@ -24,7 +24,7 @@ HTTP 200
 jsonpath "$[?(@.document_id == 'CVE-2024-28834')].status[?(@.context.cpe == 'cpe:/a:redhat:enterprise_linux:8:*:appstream:*')]" count == 1
 
 # Check purl vulnerability date
-GET http://localhost:8080/api/v2/purl/3a5c8e1e-17c4-5715-b74c-f8b61c4d7d8c
+GET http://localhost:8080/api/v3/purl/3a5c8e1e-17c4-5715-b74c-f8b61c4d7d8c
 HTTP 200
 
 [Asserts]
@@ -32,18 +32,18 @@ jsonpath "$.advisories[*].status[*].vulnerability.published" not isEmpty
 
 
 # Check vulnerability title
-GET http://localhost:8080/api/v2/vulnerability/CVE-2023-21971
+GET http://localhost:8080/api/v3/vulnerability/CVE-2023-21971
 HTTP 200
 
 [Asserts]
 jsonpath "$.title" not isEmpty
 
 ## Test delete and re-upload advisory
-DELETE http://localhost:8080/api/v2/advisory/{{advisory_id}}
+DELETE http://localhost:8080/api/v3/advisory/{{advisory_id}}
 
 HTTP 200
 
-POST http://localhost:8080/api/v2/advisory
+POST http://localhost:8080/api/v3/advisory
 file,etc/datasets/ds3/csaf/2023/cve-2023-0044.json;
 
 HTTP 201

--- a/etc/datasets/README.md
+++ b/etc/datasets/README.md
@@ -37,7 +37,7 @@ make ds3-sboms
 You can then upload it to the existing instance like
 
 ```shell
-http POST localhost:8080/api/v2/dataset @etc/datasets/ds3-sboms.zip
+http POST localhost:8080/api/v3/dataset @etc/datasets/ds3-sboms.zip
 ```
 
 ## DS4

--- a/etc/gensbom/gensbom.sh
+++ b/etc/gensbom/gensbom.sh
@@ -147,7 +147,7 @@ _SBOM_COUNTER=0
 _CURL_FLAGS="-LsSf"
 
 # Service ping: curl will report when token and/or certs are not valid
-curl ${_CURL_FLAGS} ${_CA_OPTS[@]} ${_AUTH_HEADER:+-H "${_AUTH_HEADER}"} "${TPA_SERVICE_URL}/api/v2/sbom?limit=1" > /dev/null || :
+curl ${_CURL_FLAGS} ${_CA_OPTS[@]} ${_AUTH_HEADER:+-H "${_AUTH_HEADER}"} "${TPA_SERVICE_URL}/api/v3/sbom?limit=1" > /dev/null || :
 
 while IFS="" read -r _IMAGE || [[ -n "${_IMAGE}" ]]; do
     if [[ -z "${_IMAGE}" ]]; then
@@ -176,7 +176,7 @@ while IFS="" read -r _IMAGE || [[ -n "${_IMAGE}" ]]; do
         ${_AUTH_HEADER:+-H "${_AUTH_HEADER}"} \
         -H "Content-Type: application/json" \
         -d "@${_SBOM}" \
-        "${TPA_SERVICE_URL}/api/v2/sbom"; \
+        "${TPA_SERVICE_URL}/api/v3/sbom"; \
     then
         warning "Failed to ingest \`${_SBOM}\`"
     else

--- a/modules/analysis/README.md
+++ b/modules/analysis/README.md
@@ -3,7 +3,7 @@
 ## Get a root component
 
 ```bash
-http localhost:8080/api/v2/analysis/root-component/B
+http localhost:8080/api/v3/analysis/root-component/B
 ```
 
 ## Get a component
@@ -11,13 +11,13 @@ http localhost:8080/api/v2/analysis/root-component/B
 With the name `B`:
 
 ```bash
-http localhost:8080/api/v2/analysis/component/B
+http localhost:8080/api/v3/analysis/component/B
 ```
 
 With the PURL ``:
 
 ```bash
-http localhost:8080/api/v2/analysis/component/B
+http localhost:8080/api/v3/analysis/component/B
 ```
 
 ## Status
@@ -25,11 +25,11 @@ http localhost:8080/api/v2/analysis/component/B
 You can get information about the graph status using:
 
 ```bash
-http localhost:8080/api/v2/analysis/status
+http localhost:8080/api/v3/analysis/status
 ```
 
 You can also request more details using:
 
 ```bash
-http localhost:8080/api/v2/analysis/status?details=true
+http localhost:8080/api/v3/analysis/status?details=true
 ```

--- a/modules/analysis/src/endpoints/mod.rs
+++ b/modules/analysis/src/endpoints/mod.rs
@@ -53,7 +53,7 @@ struct StatusQuery {
         (status = 200, description = "Analysis status", body = AnalysisStatus),
     ),
 )]
-#[get("/v2/analysis/status")]
+#[get("/v3/analysis/status")]
 /// Get the status of the analysis service.
 pub async fn analysis_status(
     service: web::Data<AnalysisService>,
@@ -80,7 +80,7 @@ pub async fn analysis_status(
         (status = 200, description = "Retrieved component(s) located by an exact match of name, pURL, or CPE", body = PaginatedResults<Node>),
     ),
 )]
-#[get("/v2/analysis/component/{key}")]
+#[get("/v3/analysis/component/{key}")]
 /// Retrieve SBOM components (packages) by name, Package URL, or CPE.
 pub async fn get_component(
     service: web::Data<AnalysisService>,
@@ -112,7 +112,7 @@ pub async fn get_component(
         (status = 200, description = "Retrieved component(s) located by search", body = PaginatedResults<Node>),
     ),
 )]
-#[get("/v2/analysis/component")]
+#[get("/v3/analysis/component")]
 /// Retrieve SBOM components (packages) by a complex search.
 pub async fn search_component(
     service: web::Data<AnalysisService>,
@@ -143,7 +143,7 @@ pub async fn search_component(
         (status = 415, description = "Unsupported rendering format"),
     ),
 )]
-#[get("/v2/analysis/sbom/{sbom}/render.{ext}")]
+#[get("/v3/analysis/sbom/{sbom}/render.{ext}")]
 /// Render an SBOM graph
 pub async fn render_sbom_graph(
     service: web::Data<AnalysisService>,
@@ -181,7 +181,7 @@ pub async fn render_sbom_graph(
         (status = 200, description = "Retrieved latest component(s) located by search", body = PaginatedResults<Node>),
     ),
 )]
-#[get("/v2/analysis/latest/component")]
+#[get("/v3/analysis/latest/component")]
 /// Retrieve latest SBOM components (packages) by a complex search.
 pub async fn search_latest_component(
     service: web::Data<AnalysisService>,
@@ -211,7 +211,7 @@ pub async fn search_latest_component(
         (status = 200, description = "Retrieved latest component(s) located by an exact match of name, pURL, or CPE", body = PaginatedResults<Node>),
     ),
 )]
-#[get("/v2/analysis/latest/component/{key}")]
+#[get("/v3/analysis/latest/component/{key}")]
 /// Retrieve latest SBOM components (packages) by name, Package URL, or CPE.
 pub async fn get_latest_component(
     service: web::Data<AnalysisService>,

--- a/modules/analysis/src/endpoints/tests/dot.rs
+++ b/modules/analysis/src/endpoints/tests/dot.rs
@@ -14,7 +14,7 @@ async fn render_dot(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let sbom = sbom.id;
 
     // Ensure child has an ancestor that includes it
-    let uri = format!("/api/v2/analysis/sbom/{sbom}/render.dot");
+    let uri = format!("/api/v3/analysis/sbom/{sbom}/render.dot");
     let request: Request = TestRequest::get().uri(&uri).to_request();
     let response: String = String::from_utf8(app.call_and_read_body(request).await.into())?;
     log::debug!("{response}");
@@ -57,7 +57,7 @@ async fn render_unsupported_ext(ctx: &TrustifyContext) -> Result<(), anyhow::Err
     let sbom = sbom.id;
 
     // Ensure child has an ancestor that includes it
-    let uri = format!("/api/v2/analysis/sbom/{sbom}/render.foo");
+    let uri = format!("/api/v3/analysis/sbom/{sbom}/render.foo");
     let request: Request = TestRequest::get().uri(&uri).to_request();
     let response = app.call_service(request).await;
 

--- a/modules/analysis/src/endpoints/tests/mod.rs
+++ b/modules/analysis/src/endpoints/tests/mod.rs
@@ -184,7 +184,7 @@ async fn test_status_endpoint(ctx: &TrustifyContext) -> Result<(), anyhow::Error
         })
         .await?;
 
-    let uri = "/api/v2/analysis/status";
+    let uri = "/api/v3/analysis/status";
     let request: Request = TestRequest::get().uri(uri).to_request();
     let response: Value = app.call_and_read_body_json(request).await;
 
@@ -194,7 +194,7 @@ async fn test_status_endpoint(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     // ingest duplicate sbom which has different date
     ctx.ingest_documents(["spdx/simple-dup.json"]).await?;
 
-    let uri = "/api/v2/analysis/status";
+    let uri = "/api/v3/analysis/status";
     let request: Request = TestRequest::get().uri(uri).to_request();
     let response: Value = app.call_and_read_body_json(request).await;
 

--- a/modules/analysis/src/endpoints/tests/req.rs
+++ b/modules/analysis/src/endpoints/tests/req.rs
@@ -64,7 +64,7 @@ impl<C: CallService> ReqExt for C {
             false => "",
         };
 
-        const BASE: &str = "/api/v2/analysis/";
+        const BASE: &str = "/api/v3/analysis/";
 
         let mut uri = match loc {
             What::None => {

--- a/modules/analysis/src/endpoints/tests/spdx.rs
+++ b/modules/analysis/src/endpoints/tests/spdx.rs
@@ -249,7 +249,7 @@ async fn spdx_only_contains_relationships(ctx: &TrustifyContext) -> Result<(), a
     let purl = "pkg:rpm/redhat/rubygem-google-cloud-compute@0.5.0-1.el8sat?arch=src";
 
     let uri = format!(
-        "/api/v2/analysis/component/{}?descendants=10&relationships=contains",
+        "/api/v3/analysis/component/{}?descendants=10&relationships=contains",
         urlencoding::encode(purl)
     );
     let request: Request = TestRequest::get().uri(&uri).to_request();

--- a/modules/fundamental/README.md
+++ b/modules/fundamental/README.md
@@ -5,13 +5,13 @@
 By PURL:
 
 ```bash
-http localhost:8080/api/v2/sbom/by-purl purl==pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1
+http localhost:8080/api/v3/sbom/by-purl purl==pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1
 ```
 
 By package ID (as returned by other APIs):
 
 ```bash
-http localhost:8080/api/v2/sbom/by-purl id==6cfff15d-ee06-4cb7-be37-a835aed2af82
+http localhost:8080/api/v3/sbom/by-purl id==6cfff15d-ee06-4cb7-be37-a835aed2af82
 ```
 
 ## List SBOMs
@@ -30,7 +30,7 @@ to point to an SBOM/advisory in the form of `urn:uuid:<id>`.
 ### Get labels
 
 ```bash
-http localhost:8080/api/v2/sbom/$ID | jq .labels
+http localhost:8080/api/v3/sbom/$ID | jq .labels
 ```
 
 ### Mutate labels
@@ -38,7 +38,7 @@ http localhost:8080/api/v2/sbom/$ID | jq .labels
 Replace all labels:
 
 ```bash
-http PUT localhost:8080/api/v2/sbom/$ID/label foo=bar bar=baz baz= 
+http PUT localhost:8080/api/v3/sbom/$ID/label foo=bar bar=baz baz= 
 ```
 
 This will replace all existing labels with the following labels:
@@ -52,7 +52,7 @@ This will replace all existing labels with the following labels:
 Update (patch) labels:
 
 ```bash
-http PATCH localhost:8080/api/v2/sbom/$ID/label foo=bar bar=
+http PATCH localhost:8080/api/v3/sbom/$ID/label foo=bar bar=
 ```
 
 This will set `foo` to `bar` and remove the label `bar`.

--- a/modules/fundamental/src/advisory/endpoints/label.rs
+++ b/modules/fundamental/src/advisory/endpoints/label.rs
@@ -38,7 +38,7 @@ mod default {
         (status = 200, description = "List all unique key/value labels from all Advisories", body = Vec<Value>),
     ),
 )]
-#[get("/v2/advisory-labels")]
+#[get("/v3/advisory-labels")]
 /// List all unique key/value labels from all Advisories
 pub async fn all(
     db: web::Data<Database>,
@@ -67,7 +67,7 @@ pub async fn all(
         (status = 404, description = "The advisory could not be found"),
     ),
 )]
-#[put("/v2/advisory/{id}/label")]
+#[put("/v3/advisory/{id}/label")]
 pub async fn set(
     advisory: web::Data<AdvisoryService>,
     db: web::Data<Database>,
@@ -99,7 +99,7 @@ pub async fn set(
         (status = 404, description = "The advisory could not be found"),
     ),
 )]
-#[patch("/v2/advisory/{id}/label")]
+#[patch("/v3/advisory/{id}/label")]
 pub async fn update(
     advisory: web::Data<AdvisoryService>,
     id: web::Path<Id>,

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -144,7 +144,7 @@ pub async fn get(
         (status = 404, description = "The advisory could not be found"),
     ),
 )]
-#[delete("/v2/advisory/{key}")]
+#[delete("/v3/advisory/{key}")]
 /// Delete an advisory
 pub async fn delete(
     i: web::Data<IngestorService>,
@@ -201,7 +201,7 @@ const fn default_format() -> Format {
         (status = 400, description = "The file could not be parsed as an advisory"),
     )
 )]
-#[post("/v2/advisory")]
+#[post("/v3/advisory")]
 /// Upload a new advisory
 pub async fn upload(
     service: web::Data<IngestorService>,
@@ -248,7 +248,7 @@ pub async fn upload(
         (status = 404, description = "The document could not be found"),
     )
 )]
-#[get("/v2/advisory/{key}/download")]
+#[get("/v3/advisory/{key}/download")]
 /// Download an advisory document
 pub async fn download(
     db: web::Data<Database>,

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -410,7 +410,7 @@ async fn upload_default_csaf_format(ctx: &TrustifyContext) -> Result<(), anyhow:
 
     let payload = document_bytes("csaf/cve-2023-33201.json").await?;
 
-    let uri = "/api/v2/advisory";
+    let uri = "/api/v3/advisory";
     let request = TestRequest::post()
         .uri(uri)
         .set_payload(payload)
@@ -448,7 +448,7 @@ async fn upload_default_csaf_format_multiple(ctx: &TrustifyContext) -> Result<()
         "csaf/rhsa-2024-2705.json",
     ];
 
-    let uri = "/api/v2/advisory";
+    let uri = "/api/v3/advisory";
 
     for file in files {
         let payload = document_bytes(file).await?;
@@ -471,7 +471,7 @@ async fn upload_osv_format(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
     let payload = document_bytes("osv/RUSTSEC-2021-0079.json").await?;
 
-    let uri = "/api/v2/advisory";
+    let uri = "/api/v3/advisory";
     let request = TestRequest::post()
         .uri(uri)
         .set_payload(payload)
@@ -489,7 +489,7 @@ async fn upload_cve_format(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
     let payload = document_bytes("mitre/CVE-2024-27088.json").await?;
 
-    let uri = "/api/v2/advisory";
+    let uri = "/api/v3/advisory";
     let request = TestRequest::post()
         .uri(uri)
         .set_payload(payload)
@@ -506,7 +506,7 @@ async fn upload_cve_format(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn upload_unknown_format(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/advisory";
+    let uri = "/api/v3/advisory";
     let request = TestRequest::post().uri(uri).to_request();
 
     let response = app.call_service(request).await;
@@ -527,7 +527,7 @@ async fn upload_with_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
     let app = caller(ctx).await?;
     let payload = document_bytes("csaf/cve-2023-33201.json").await?;
 
-    let uri = "/api/v2/advisory?labels.foo=bar&labels.bar=baz";
+    let uri = "/api/v3/advisory?labels.foo=bar&labels.bar=baz";
     let request = TestRequest::post()
         .uri(uri)
         .set_payload(payload)
@@ -569,7 +569,7 @@ async fn download_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let digest: String = Sha256::digest(document_bytes(DOC).await?).encode_hex();
     let app = caller(ctx).await?;
     ctx.ingest_document(DOC).await?;
-    let uri = format!("/api/v2/advisory/sha256:{digest}/download");
+    let uri = format!("/api/v3/advisory/sha256:{digest}/download");
     let request = TestRequest::get().uri(&uri).to_request();
     let doc: Value = app.call_and_read_body_json(request).await;
     assert_eq!(doc["document"]["tracking"]["id"], "CVE-2023-33201");
@@ -583,7 +583,7 @@ async fn download_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn download_advisory_by_id(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
     let result = ctx.ingest_document(DOC).await?;
-    let uri = format!("/api/v2/advisory/urn:uuid:{}/download", result.id);
+    let uri = format!("/api/v3/advisory/urn:uuid:{}/download", result.id);
     let request = TestRequest::get().uri(&uri).to_request();
     let doc: Value = app.call_and_read_body_json(request).await;
     assert_eq!(doc["document"]["tracking"]["id"], "CVE-2023-33201");
@@ -628,7 +628,7 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let response = app
         .call_service(
             TestRequest::delete()
-                .uri(&format!("/api/v2/advisory/urn:uuid:{}", doc.id))
+                .uri(&format!("/api/v3/advisory/urn:uuid:{}", doc.id))
                 .to_request(),
         )
         .await;
@@ -651,7 +651,7 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let response = app
         .call_service(
             TestRequest::delete()
-                .uri(&format!("/api/v2/advisory/urn:uuid:{}", doc.id))
+                .uri(&format!("/api/v3/advisory/urn:uuid:{}", doc.id))
                 .to_request(),
         )
         .await;
@@ -747,7 +747,7 @@ async fn test_label(
         .id
         .to_string();
 
-    let mut uri = format!("/api/v2/advisory-labels?filter_text={}", encode(query));
+    let mut uri = format!("/api/v3/advisory-labels?filter_text={}", encode(query));
 
     if let Some(limit) = limit.into() {
         uri.push_str(&format!("&limit={limit}"));

--- a/modules/fundamental/src/common/test.rs
+++ b/modules/fundamental/src/common/test.rs
@@ -47,7 +47,7 @@ impl FromCreateResponse for anyhow::Result<GroupResponse> {
 
         assert_eq!(
             location,
-            format!("/api/v2/group/sbom/{id}").as_str(),
+            format!("/api/v3/group/sbom/{id}").as_str(),
             "must return a relative URL to the group"
         );
 
@@ -124,7 +124,7 @@ impl Create {
         let response = app
             .call_service(
                 TestRequest::post()
-                    .uri("/api/v2/group/sbom")
+                    .uri("/api/v3/group/sbom")
                     .set_json(request_body)
                     .to_request(),
             )
@@ -163,7 +163,7 @@ pub async fn read_assignments(
     let response = app
         .call_service(
             TestRequest::get()
-                .uri(&format!("/api/v2/group/sbom-assignment/{}", sbom_id))
+                .uri(&format!("/api/v3/group/sbom-assignment/{}", sbom_id))
                 .to_request(),
         )
         .await;
@@ -227,7 +227,7 @@ impl UpdateAssignments {
         let initial_etag = self.etag.clone();
 
         let request = TestRequest::put()
-            .uri(&format!("/api/v2/group/sbom-assignment/{}", &self.sbom_id))
+            .uri(&format!("/api/v3/group/sbom-assignment/{}", &self.sbom_id))
             .set_json(&self.group_ids);
 
         let request = match self.etag {

--- a/modules/fundamental/src/license/endpoints/mod.rs
+++ b/modules/fundamental/src/license/endpoints/mod.rs
@@ -44,7 +44,7 @@ struct LicenseQuery {
         (status = 200, description = "Matching licenses", body = PaginatedResults<LicenseText>),
     ),
 )]
-#[get("/v2/license")]
+#[get("/v3/license")]
 pub async fn list_licenses(
     service: web::Data<LicenseService>,
     db: web::Data<Database>,

--- a/modules/fundamental/src/license/endpoints/spdx.rs
+++ b/modules/fundamental/src/license/endpoints/spdx.rs
@@ -18,7 +18,7 @@ use trustify_common::{
         (status = 200, description = "Matching licenses", body = PaginatedResults<SpdxLicenseSummary>),
     ),
 )]
-#[get("/v2/license/spdx/license")]
+#[get("/v3/license/spdx/license")]
 /// List SPDX licenses
 pub async fn list_spdx_licenses(
     state: web::Data<LicenseService>,
@@ -37,7 +37,7 @@ pub async fn list_spdx_licenses(
         (status = 200, description = "SPDX license details", body = SpdxLicenseDetails),
     ),
 )]
-#[get("/v2/license/spdx/license/{id}")]
+#[get("/v3/license/spdx/license/{id}")]
 /// Get SPDX license details
 pub async fn get_spdx_license(
     state: web::Data<LicenseService>,

--- a/modules/fundamental/src/license/endpoints/test.rs
+++ b/modules/fundamental/src/license/endpoints/test.rs
@@ -12,7 +12,7 @@ use trustify_test_context::{TrustifyContext, call::CallService};
 async fn list_spdx_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/license/spdx/license?total=true";
+    let uri = "/api/v3/license/spdx/license?total=true";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -28,12 +28,12 @@ async fn list_spdx_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
 async fn get_spdx_license(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/license/spdx/license/GLWTPL";
+    let uri = "/api/v3/license/spdx/license/GLWTPL";
     let request = TestRequest::get().uri(uri).to_request();
     let response: SpdxLicenseDetails = app.call_and_read_body_json(request).await;
     assert_eq!(response.summary.id, "GLWTPL");
 
-    let uri = "/api/v2/license/spdx/license/GlwtPL";
+    let uri = "/api/v3/license/spdx/license/GlwtPL";
     let request = TestRequest::get().uri(uri).to_request();
     let response: SpdxLicenseDetails = app.call_and_read_body_json(request).await;
     assert_eq!(response.summary.id, "GLWTPL");
@@ -46,7 +46,7 @@ async fn get_spdx_license(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn list_licenses_no_data(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/license?total=true";
+    let uri = "/api/v3/license?total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
@@ -66,7 +66,7 @@ async fn list_licenses_with_spdx_sbom(ctx: &TrustifyContext) -> Result<(), anyho
     ctx.ingest_document("spdx/OCP-TOOLS-4.11-RHEL-8.json")
         .await?;
 
-    let uri = "/api/v2/license?sort=license:asc&total=true";
+    let uri = "/api/v3/license?sort=license:asc&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
@@ -103,7 +103,7 @@ async fn list_licenses_no_license_ref(ctx: &TrustifyContext) -> Result<(), anyho
     ctx.ingest_document("spdx/OCP-TOOLS-4.11-RHEL-8.json")
         .await?;
 
-    let uri = "/api/v2/license?sort=license:asc&limit=733&total=true";
+    let uri = "/api/v3/license?sort=license:asc&limit=733&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
@@ -138,7 +138,7 @@ async fn list_licenses_with_cyclonedx_sbom(ctx: &TrustifyContext) -> Result<(), 
     ctx.ingest_document("zookeeper-3.9.2-cyclonedx.json")
         .await?;
 
-    let uri = "/api/v2/license?sort=license:asc&total=true";
+    let uri = "/api/v3/license?sort=license:asc&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
@@ -169,7 +169,7 @@ async fn list_licenses_with_mixed_sboms(ctx: &TrustifyContext) -> Result<(), any
     ])
     .await?;
 
-    let uri = "/api/v2/license?sort=license:asc&total=true";
+    let uri = "/api/v3/license?sort=license:asc&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
@@ -206,35 +206,35 @@ async fn list_licenses_with_search_filter(ctx: &TrustifyContext) -> Result<(), a
     .await?;
 
     // Test search filter for "ASL" (Apache Software License)
-    let uri = "/api/v2/license?q=license~ASL&total=true";
+    let uri = "/api/v3/license?q=license~ASL&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
     assert_eq!(response.total, Some(4));
 
     // Test full text search filter for "ASL" (Apache Software License)
-    let uri = "/api/v2/license?q=ASL&total=true";
+    let uri = "/api/v3/license?q=ASL&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
     assert_eq!(response.total, Some(4));
 
     // Test case-insensitive search filter for "asl"
-    let uri = "/api/v2/license?q=asl&total=true";
+    let uri = "/api/v3/license?q=asl&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
     assert_eq!(response.total, Some(4));
 
     // Test case-insensitive search filter for "AsL"
-    let uri = "/api/v2/license?q=AsL&total=true";
+    let uri = "/api/v3/license?q=AsL&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
     assert_eq!(response.total, Some(4));
 
     // Test for non-existent license
-    let uri = "/api/v2/license?q=NonExistentLicense&total=true";
+    let uri = "/api/v3/license?q=NonExistentLicense&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
@@ -242,7 +242,7 @@ async fn list_licenses_with_search_filter(ctx: &TrustifyContext) -> Result<(), a
     assert_eq!(0, response.items.len());
 
     // Test search filter for "ASL" (Apache Software License) and sorting (default asc)
-    let uri = "/api/v2/license?q=license~ASL&sort=license&total=true";
+    let uri = "/api/v3/license?q=license~ASL&sort=license&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
@@ -254,7 +254,7 @@ async fn list_licenses_with_search_filter(ctx: &TrustifyContext) -> Result<(), a
     assert_eq!(license_names, sorted_licenses);
 
     // Test full text search filter for "ASL" (Apache Software License) and sorting desc
-    let uri = "/api/v2/license?q=ASL&sort=license:desc&total=true";
+    let uri = "/api/v3/license?q=ASL&sort=license:desc&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
@@ -275,7 +275,7 @@ async fn list_licenses_with_pagination(ctx: &TrustifyContext) -> Result<(), anyh
     let app = caller(ctx).await?;
 
     // Test pagination - first page
-    let uri = "/api/v2/license?limit=5&offset=0&total=true";
+    let uri = "/api/v3/license?limit=5&offset=0&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
@@ -290,7 +290,7 @@ async fn list_licenses_with_pagination(ctx: &TrustifyContext) -> Result<(), anyh
 
     // Test pagination - second page (if there are enough items)
     if total_licenses > 5 {
-        let uri = "/api/v2/license?limit=5&offset=5&total=true";
+        let uri = "/api/v3/license?limit=5&offset=5&total=true";
         let request = TestRequest::get().uri(uri).to_request();
         let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
@@ -305,7 +305,7 @@ async fn list_licenses_with_pagination(ctx: &TrustifyContext) -> Result<(), anyh
 
     // Test pagination with offset beyond available items
     let uri = format!(
-        "/api/v2/license?limit=5&offset={}&total=true",
+        "/api/v3/license?limit=5&offset={}&total=true",
         total_licenses + 10
     );
     let request = TestRequest::get().uri(&uri).to_request();
@@ -329,7 +329,7 @@ async fn list_licenses_no_partial_license_ref_match(
     // LicenseRef-GPL ("GPL License") vs LicenseRef-GPLv2 ("GPLv2 License")
     ctx.ingest_document("spdx/license-ref-overlap.json").await?;
 
-    let uri = "/api/v2/license?limit=1000";
+    let uri = "/api/v3/license?limit=1000";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
@@ -393,7 +393,7 @@ async fn list_licenses_sorting(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     ctx.ingest_document("spdx/OCP-TOOLS-4.11-RHEL-8.json")
         .await?;
 
-    let uri = "/api/v2/license?sort=license:asc&limit=733&total=true";
+    let uri = "/api/v3/license?sort=license:asc&limit=733&total=true";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
 
@@ -406,7 +406,7 @@ async fn list_licenses_sorting(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     sorted_licenses.sort();
     assert_eq!(license_names, sorted_licenses);
 
-    let uri = "/api/v2/license?sort=license:desc&limit=733";
+    let uri = "/api/v3/license?sort=license:desc&limit=733";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseText> = app.call_and_read_body_json(request).await;
     let license_names: Vec<String> = response.items.iter().map(|l| l.license.clone()).collect();

--- a/modules/fundamental/src/organization/endpoints/mod.rs
+++ b/modules/fundamental/src/organization/endpoints/mod.rs
@@ -40,7 +40,7 @@ pub fn configure(
         (status = 200, description = "Matching organizations", body = OrganizationSummary),
     ),
 )]
-#[get("/v2/organization")]
+#[get("/v3/organization")]
 /// List organizations
 pub async fn all(
     state: web::Data<OrganizationService>,
@@ -64,7 +64,7 @@ pub async fn all(
         (status = 404, description = "The organization could not be found"),
     ),
 )]
-#[get("/v2/organization/{id}")]
+#[get("/v3/organization/{id}")]
 /// Retrieve organization details
 pub async fn get(
     state: web::Data<OrganizationService>,

--- a/modules/fundamental/src/organization/endpoints/test.rs
+++ b/modules/fundamental/src/organization/endpoints/test.rs
@@ -51,7 +51,7 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let uri = "/api/v2/organization?sort=name";
+    let uri = "/api/v3/organization?sort=name";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -117,7 +117,7 @@ async fn one_organization(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let first_org = &orgs.items[0];
     let org_id = first_org.head.id;
 
-    let uri = format!("/api/v2/organization/{org_id}");
+    let uri = format!("/api/v3/organization/{org_id}");
 
     let request = TestRequest::get().uri(&uri).to_request();
 

--- a/modules/fundamental/src/product/endpoints/mod.rs
+++ b/modules/fundamental/src/product/endpoints/mod.rs
@@ -43,7 +43,7 @@ pub fn configure(
         (status = 200, description = "Matching products", body = PaginatedResults<ProductSummary>),
     ),
 )]
-#[get("/v2/product")]
+#[get("/v3/product")]
 pub async fn all(
     state: web::Data<ProductService>,
     db: web::Data<Database>,
@@ -66,7 +66,7 @@ pub async fn all(
         (status = 404, description = "The product could not be found"),
     ),
 )]
-#[get("/v2/product/{id}")]
+#[get("/v3/product/{id}")]
 pub async fn get(
     state: web::Data<ProductService>,
     db: web::Data<Database>,
@@ -93,7 +93,7 @@ pub async fn get(
         (status = 404, description = "The product could not be found"),
     ),
 )]
-#[delete("/v2/product/{id}")]
+#[delete("/v3/product/{id}")]
 pub async fn delete(
     state: web::Data<ProductService>,
     db: web::Data<Database>,

--- a/modules/fundamental/src/product/endpoints/test.rs
+++ b/modules/fundamental/src/product/endpoints/test.rs
@@ -38,7 +38,7 @@ async fn all_products(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let uri = "/api/v2/product?sort=name";
+    let uri = "/api/v3/product?sort=name";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -88,7 +88,7 @@ async fn one_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let first_product = &products.items[0];
     let product_id = first_product.head.id;
 
-    let uri = format!("/api/v2/product/{product_id}");
+    let uri = format!("/api/v3/product/{product_id}");
 
     let request = TestRequest::get().uri(&uri).to_request();
 
@@ -135,7 +135,7 @@ async fn delete_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let first_product = &products.items[0];
     let product_id = first_product.head.id;
 
-    let uri = format!("/api/v2/product/{product_id}");
+    let uri = format!("/api/v3/product/{product_id}");
 
     let request = TestRequest::delete().uri(&uri).to_request();
 

--- a/modules/fundamental/src/purl/endpoints/base.rs
+++ b/modules/fundamental/src/purl/endpoints/base.rs
@@ -27,7 +27,7 @@ use trustify_common::{
         (status = 200, description = "Details for the versionless base PURL", body = BasePurlDetails),
     ),
 )]
-#[get("/v2/purl/base/{key}")]
+#[get("/v3/purl/base/{key}")]
 /// Retrieve details about a base versionless pURL
 pub async fn get_base_purl(
     service: web::Data<PurlService>,
@@ -56,7 +56,7 @@ pub async fn get_base_purl(
         (status = 200, description = "All relevant matching versionless base PURL", body = PaginatedResults<BasePurlSummary>),
     ),
 )]
-#[get("/v2/purl/base")]
+#[get("/v3/purl/base")]
 /// List base versionless pURLs
 pub async fn all_base_purls(
     service: web::Data<PurlService>,

--- a/modules/fundamental/src/purl/endpoints/mod.rs
+++ b/modules/fundamental/src/purl/endpoints/mod.rs
@@ -81,7 +81,7 @@ pub async fn get(
         (status = 200, description = "All relevant matching qualified PURLs", body = PaginatedResults<PurlSummary>),
     ),
 )]
-#[get("/v2/purl")]
+#[get("/v3/purl")]
 /// List fully-qualified pURLs
 pub async fn all(
     service: web::Data<PurlService>,
@@ -102,7 +102,7 @@ pub async fn all(
         (status = 200, description = "Get recommendations and remediations for provided purls", body = RecommendResponse)
     )
 )]
-#[post("/v2/purl/recommend")]
+#[post("/v3/purl/recommend")]
 pub async fn recommend(
     purl_service: web::Data<PurlService>,
     db: web::Data<Database>,

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 async fn recommend(app: &impl CallService, purls: &[&str]) -> Value {
     app.call_and_read_body_json(
         TestRequest::post()
-            .uri("/api/v2/purl/recommend")
+            .uri("/api/v3/purl/recommend")
             .set_json(json!({ "purls": purls }))
             .to_request(),
     )
@@ -85,13 +85,13 @@ async fn base_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/purl/base?q=log4j";
+    let uri = "/api/v3/purl/base?q=log4j";
     let request = TestRequest::get().uri(uri).to_request();
     let log4j: PaginatedResults<BasePurlSummary> = app.call_and_read_body_json(request).await;
 
     assert_eq!(1, log4j.items.len());
 
-    let uri = format!("/api/v2/purl/base/{}", log4j.items[0].head.uuid);
+    let uri = format!("/api/v3/purl/base/{}", log4j.items[0].head.uuid);
     let request = TestRequest::get().uri(&uri).to_request();
     let response: BasePurlDetails = app.call_and_read_body_json(request).await;
     assert_eq!(log4j.items[0].head.uuid, response.head.uuid);
@@ -105,7 +105,7 @@ async fn qualified_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/purl?q=log4j";
+    let uri = "/api/v3/purl?q=log4j";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
 
@@ -120,7 +120,7 @@ async fn qualified_packages_filtering(ctx: &TrustifyContext) -> Result<(), anyho
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = format!("/api/v2/purl?q={}", encode("type=maven"));
+    let uri = format!("/api/v3/purl?q={}", encode("type=maven"));
     let request = TestRequest::get().uri(&uri).to_request();
     let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
     assert_eq!(3, response.items.len());
@@ -131,7 +131,7 @@ async fn qualified_packages_filtering(ctx: &TrustifyContext) -> Result<(), anyho
             &ctx.db,
         )
         .await?;
-    let uri = format!("/api/v2/purl?q={}", encode("type=rpm&arch=i386"));
+    let uri = format!("/api/v3/purl?q={}", encode("type=rpm&arch=i386"));
     let request = TestRequest::get().uri(&uri).to_request();
     let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
     assert_eq!(1, response.items.len());
@@ -151,7 +151,7 @@ async fn package_with_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
 
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/purl?q=hyper";
+    let uri = "/api/v3/purl?q=hyper";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
 
@@ -202,7 +202,7 @@ async fn purl_component_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Err
         .id;
     let query = async |query| {
         let app = caller(ctx).await.unwrap();
-        let uri = format!("/api/v2/purl?q={}", urlencoding::encode(query));
+        let uri = format!("/api/v3/purl?q={}", urlencoding::encode(query));
         let request = TestRequest::get().uri(&uri).to_request();
         let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
         tracing::debug!(test = "", "{response:#?}");
@@ -242,7 +242,7 @@ async fn purl_filter_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
 
     let query = async |query| {
         let app = caller(ctx).await.unwrap();
-        let uri = format!("/api/v2/purl?q={}&sort=purl:qualifiers:type", encode(query));
+        let uri = format!("/api/v3/purl?q={}&sort=purl:qualifiers:type", encode(query));
         let request = TestRequest::get().uri(&uri).to_request();
         let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
         tracing::debug!(test = "", "{response:#?}");
@@ -273,7 +273,7 @@ async fn test_purl_license_details(ctx: &TrustifyContext) -> Result<(), anyhow::
     ctx.ingest_documents(["spdx/OCP-TOOLS-4.11-RHEL-8.json"])
         .await?;
 
-    let uri = "/api/v2/purl?q=graphite2";
+    let uri = "/api/v3/purl?q=graphite2";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
 

--- a/modules/fundamental/src/sbom/endpoints/label.rs
+++ b/modules/fundamental/src/sbom/endpoints/label.rs
@@ -39,7 +39,7 @@ mod default {
         (status = 200, description = "List all unique key/value labels from all SBOMs", body = Vec<Value>),
     ),
 )]
-#[get("/v2/sbom-labels")]
+#[get("/v3/sbom-labels")]
 /// List all unique key/value labels from all SBOMs
 pub async fn all(
     db: web::Data<Database>,
@@ -68,7 +68,7 @@ pub async fn all(
         (status = 404, description = "The SBOM could not be found"),
     ),
 )]
-#[patch("/v2/sbom/{id}/label")]
+#[patch("/v3/sbom/{id}/label")]
 pub async fn update(
     sbom: web::Data<SbomService>,
     id: web::Path<Id>,
@@ -99,7 +99,7 @@ pub async fn update(
         (status = 404, description = "The SBOM could not be found"),
     ),
 )]
-#[put("/v2/sbom/{id}/label")]
+#[put("/v3/sbom/{id}/label")]
 pub async fn set(
     sbom: web::Data<SbomService>,
     db: web::Data<Database>,

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -102,7 +102,7 @@ const CONTENT_TYPE_GZIP: &str = "application/gzip";
         (status = 400, description = "Invalid UUID format."),
     ),
 )]
-#[get("/v2/sbom/{id}/all-license-ids")]
+#[get("/v3/sbom/{id}/all-license-ids")]
 pub async fn get_unique_licenses(
     fetcher: web::Data<LicenseService>,
     db: web::Data<Database>,
@@ -129,7 +129,7 @@ pub async fn get_unique_licenses(
         (status = 404, description = "The document could not be found"),
     ),
 )]
-#[get("/v2/sbom/{id}/license-export")]
+#[get("/v3/sbom/{id}/license-export")]
 pub async fn get_license_export(
     fetcher: web::Data<LicenseService>,
     db: web::Data<Database>,
@@ -275,7 +275,7 @@ mod v3 {
         (status = 200, description = "Matching SBOMs", body = PaginatedResults<SbomSummary>),
     ),
 )]
-#[get("/v2/sbom/by-package")]
+#[get("/v3/sbom/by-package")]
 pub async fn all_related(
     sbom: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -309,7 +309,7 @@ pub async fn all_related(
         (status = 200, description = "Number of matching SBOMs per package", body = Vec<i64>),
     ),
 )]
-#[get("/v2/sbom/count-by-package")]
+#[get("/v3/sbom/count-by-package")]
 pub async fn count_related(
     sbom: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -339,7 +339,7 @@ pub async fn count_related(
         (status = 404, description = "The SBOM could not be found"),
     ),
 )]
-#[get("/v2/sbom/{id}")]
+#[get("/v3/sbom/{id}")]
 pub async fn get(
     fetcher: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -399,7 +399,7 @@ all!(GetSbomAdvisories -> ReadSbom, ReadAdvisory);
         (status = 404, description = "The SBOM could not be found"),
     ),
 )]
-#[delete("/v2/sbom/{id}")]
+#[delete("/v3/sbom/{id}")]
 pub async fn delete(
     i: web::Data<IngestorService>,
     service: web::Data<SbomService>,
@@ -441,7 +441,7 @@ pub async fn delete(
         (status = 404, description = "The SBOM could not be found"),
     ),
 )]
-#[get("/v2/sbom/{id}/packages")]
+#[get("/v3/sbom/{id}/packages")]
 pub async fn packages(
     fetch: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -478,7 +478,7 @@ pub async fn packages(
         (status = 200, description = "AI Models", body = PaginatedResults<SbomModel>),
     ),
 )]
-#[get("/v2/sbom/{id}/models")]
+#[get("/v3/sbom/{id}/models")]
 pub async fn models(
     fetch: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -508,7 +508,7 @@ pub async fn models(
         (status = 200, description = "AI Models", body = PaginatedResults<SbomModel>),
     ),
 )]
-#[get("/v2/sbom/models")]
+#[get("/v3/sbom/models")]
 pub async fn all_models(
     fetch: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -552,7 +552,7 @@ struct RelatedQuery {
         (status = 404, description = "The SBOM could not be found"),
     ),
 )]
-#[get("/v2/sbom/{id}/related")]
+#[get("/v3/sbom/{id}/related")]
 pub async fn related(
     fetch: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -630,7 +630,7 @@ const fn default_format() -> Format {
         (status = 400, description = "One or more group IDs are invalid or do not exist"),
     )
 )]
-#[post("/v2/sbom")]
+#[post("/v3/sbom")]
 #[allow(clippy::too_many_arguments)]
 /// Upload a new SBOM
 pub async fn upload(
@@ -689,7 +689,7 @@ pub async fn upload(
         (status = 404, description = "The document could not be found"),
     )
 )]
-#[get("/v2/sbom/{key}/download")]
+#[get("/v3/sbom/{key}/download")]
 pub async fn download(
     ingestor: web::Data<IngestorService>,
     db: web::Data<Database>,

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -186,7 +186,7 @@ mod v2 {
             GroupFilterQuery,
         ),
         responses(
-            (status = 200, description = "Matching SBOMs", body = PaginatedResults<SbomSummary>),
+            (status = 200, description = "Matching SBOMs", body = PaginatedResults<SbomSummary<SbomPackage>>),
         ),
     )]
     #[get("/v2/sbom")]
@@ -230,7 +230,7 @@ mod v3 {
             GroupFilterQuery,
         ),
         responses(
-            (status = 200, description = "Matching SBOMs", body = PaginatedResults<SbomPackageSummary>),
+            (status = 200, description = "Matching SBOMs", body = PaginatedResults<SbomSummary<SbomPackageSummary>>),
         ),
     )]
     #[get("/v3/sbom")]

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -32,7 +32,7 @@ async fn fetch_unique_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
         .id
         .to_string();
 
-    let uri = format!("/api/v2/sbom/urn:uuid:{id}/all-license-ids");
+    let uri = format!("/api/v3/sbom/urn:uuid:{id}/all-license-ids");
     let req = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(req).await;
     let expected_result = json!([
@@ -366,7 +366,7 @@ async fn fetch_unique_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
         .id
         .to_string();
 
-    let uri = format!("/api/v2/sbom/urn:uuid:{id}/all-license-ids");
+    let uri = format!("/api/v3/sbom/urn:uuid:{id}/all-license-ids");
     let req = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(req).await;
     let expected_result = json!([
@@ -431,13 +431,13 @@ async fn fetch_unique_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     assert!(expected_result.contains_subset(response.clone()));
 
     // properly formatted but not existent Id
-    let req = TestRequest::get().uri("/api/v2/sbom/sha256:e5c850b67868563002801668950832278f8093308b3a3c57931f591442ed3160/all-license-ids").to_request();
+    let req = TestRequest::get().uri("/api/v3/sbom/sha256:e5c850b67868563002801668950832278f8093308b3a3c57931f591442ed3160/all-license-ids").to_request();
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::NOT_FOUND, response.status());
 
     // badly formatted Id
     let req = TestRequest::get()
-        .uri("/api/v2/sbom/sha123:1234/all-license-ids")
+        .uri("/api/v3/sbom/sha123:1234/all-license-ids")
         .to_request();
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::BAD_REQUEST, response.status());
@@ -450,7 +450,7 @@ async fn fetch_unique_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
         .await?
         .id
         .to_string();
-    let uri = format!("/api/v2/sbom/urn:uuid:{id}/all-license-ids");
+    let uri = format!("/api/v3/sbom/urn:uuid:{id}/all-license-ids");
     let req = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(req).await;
     let expected_result = json!([
@@ -588,7 +588,7 @@ async fn get_packages_sbom_by_query(ctx: &TrustifyContext) -> Result<(), anyhow:
 
     async fn query_value(app: &impl CallService, id: &str, q: &str) -> Value {
         let uri = format!(
-            "/api/v2/sbom/urn:uuid:{id}/packages?total=true&q={}",
+            "/api/v3/sbom/urn:uuid:{id}/packages?total=true&q={}",
             urlencoding::encode(q)
         );
         let req = TestRequest::get().uri(&uri).to_request();
@@ -984,7 +984,7 @@ async fn license_export(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .id
         .to_string();
 
-    let uri = format!("/api/v2/sbom/urn:uuid:{id}/license-export");
+    let uri = format!("/api/v3/sbom/urn:uuid:{id}/license-export");
     let req = TestRequest::get().uri(&uri).to_request();
     let response = app.call_service(req).await;
 
@@ -1012,7 +1012,7 @@ async fn upload(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let app = caller(ctx).await?;
 
     let request = TestRequest::post()
-        .uri("/api/v2/sbom")
+        .uri("/api/v3/sbom")
         .set_payload(document_bytes("quarkus-bom-2.13.8.Final-redhat-00004.json").await?)
         .to_request();
 
@@ -1073,7 +1073,7 @@ async fn upload_with_groups(
     let ids = create_groups(&app, build_groups(&group_paths)).await?;
 
     let query = resolve_group_refs(&ids, groups);
-    let uri = format!("/api/v2/sbom?{query}");
+    let uri = format!("/api/v3/sbom?{query}");
     let request = TestRequest::post()
         .uri(&uri)
         .set_payload(document_bytes("quarkus-bom-2.13.8.Final-redhat-00004.json").await?)
@@ -1101,7 +1101,7 @@ async fn get_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await?
         .id
         .to_string();
-    let uri = format!("/api/v2/sbom/urn:uuid:{id}");
+    let uri = format!("/api/v3/sbom/urn:uuid:{id}");
     let req = TestRequest::get().uri(&uri).to_request();
     let sbom: Value = app.call_and_read_body_json(req).await;
     log::debug!("{sbom:#?}");
@@ -1125,7 +1125,7 @@ async fn filter_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     async fn query(app: &impl CallService, id: &str, q: &str) -> PaginatedResults<SbomPackage> {
         let uri = format!(
-            "/api/v2/sbom/urn:uuid:{id}/packages?total=true&q={}",
+            "/api/v3/sbom/urn:uuid:{id}/packages?total=true&q={}",
             encode(q)
         );
         let req = TestRequest::get().uri(&uri).to_request();
@@ -1213,7 +1213,7 @@ async fn delete_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let response = app
         .call_service(
             TestRequest::delete()
-                .uri(&format!("/api/v2/sbom/urn:uuid:{}", result.id.clone()))
+                .uri(&format!("/api/v3/sbom/urn:uuid:{}", result.id.clone()))
                 .to_request(),
         )
         .await;
@@ -1226,7 +1226,7 @@ async fn delete_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let response = app
         .call_service(
             TestRequest::delete()
-                .uri(&format!("/api/v2/sbom/urn:uuid:{}", result.id.clone()))
+                .uri(&format!("/api/v3/sbom/urn:uuid:{}", result.id.clone()))
                 .to_request(),
         )
         .await;
@@ -1248,7 +1248,7 @@ async fn download_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let id = result.id.to_string();
 
     let req = TestRequest::get()
-        .uri(&format!("/api/v2/sbom/urn:uuid:{id}"))
+        .uri(&format!("/api/v3/sbom/urn:uuid:{id}"))
         .to_request();
 
     let sbom = app.call_and_read_body_json::<SbomSummary>(req).await;
@@ -1261,7 +1261,7 @@ async fn download_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // Verify we can download by all hashes
     for hash in hashes {
         let req = TestRequest::get()
-            .uri(&format!("/api/v2/sbom/{hash}/download"))
+            .uri(&format!("/api/v3/sbom/{hash}/download"))
             .to_request();
         let body = app.call_and_read_body(req).await;
         assert_eq!(bytes, body);
@@ -1269,7 +1269,7 @@ async fn download_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // Verify we can download by uuid
     let req = TestRequest::get()
-        .uri(&format!("/api/v2/sbom/urn:uuid:{id}/download"))
+        .uri(&format!("/api/v3/sbom/urn:uuid:{id}/download"))
         .to_request();
     let body = app.call_and_read_body(req).await;
     assert_eq!(bytes, body);
@@ -1378,7 +1378,7 @@ async fn get_advisories_with_deprecated_filtering(
 async fn query_sboms_by_ingested_time(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     async fn query(app: &impl CallService, q: &str) -> Value {
         let uri = format!(
-            "/api/v2/sbom?total=true&q={}&sort={}",
+            "/api/v3/sbom?total=true&q={}&sort={}",
             urlencoding::encode(q),
             urlencoding::encode("ingested:desc")
         );
@@ -1416,7 +1416,7 @@ async fn query_sboms_by_ingested_time(ctx: &TrustifyContext) -> Result<(), anyho
 async fn query_sboms_by_label(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let query = async |total, q| {
         let app = caller(ctx).await.unwrap();
-        let uri = format!("/api/v2/sbom?total=true&q={}", encode(q));
+        let uri = format!("/api/v3/sbom?total=true&q={}", encode(q));
         let req = TestRequest::get().uri(&uri).to_request();
         let response: Value = app.call_and_read_body_json(req).await;
         assert_eq!(total, response["total"], "for {q}");
@@ -1489,7 +1489,7 @@ async fn query_sboms_by_package(ctx: &TrustifyContext) -> Result<(), anyhow::Err
     let query = async |purl, sort| {
         let app = caller(ctx).await.unwrap();
         let uri = format!(
-            "/api/v2/sbom/by-package?total=true&purl={}&sort={}",
+            "/api/v3/sbom/by-package?total=true&purl={}&sort={}",
             encode(purl),
             encode(sort)
         );
@@ -1530,7 +1530,7 @@ async fn query_sboms_by_array_values(ctx: &TrustifyContext) -> Result<(), anyhow
 
     let query = async |expected_count, q| {
         let app = caller(ctx).await.unwrap();
-        let uri = format!("/api/v2/sbom?total=true&q={}", encode(q));
+        let uri = format!("/api/v3/sbom?total=true&q={}", encode(q));
         let req = TestRequest::get().uri(&uri).to_request();
         let response: Value = app.call_and_read_body_json(req).await;
         tracing::debug!(test = "", "{response:#?}");
@@ -1565,7 +1565,7 @@ async fn test_label(
         .id
         .to_string();
 
-    let mut uri = format!("/api/v2/sbom-labels?filter_text={}", encode(query));
+    let mut uri = format!("/api/v3/sbom-labels?filter_text={}", encode(query));
 
     if let Some(limit) = limit.into() {
         uri.push_str(&format!("&limit={limit}"));
@@ -1646,7 +1646,7 @@ async fn get_cbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // First upload it via the normal SBOM endpoint
     let request = TestRequest::post()
-        .uri("/api/v2/sbom")
+        .uri("/api/v3/sbom")
         .set_payload(document_bytes("cyclonedx/cryptographic/keycloak-cbom.json").await?)
         .to_request();
     let response = app.call_service(request).await;
@@ -1655,7 +1655,7 @@ async fn get_cbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // Now fetch the AIBOM we just uploaded by its id
     let id = result.id.to_string();
-    let uri = format!("/api/v2/sbom/{id}");
+    let uri = format!("/api/v3/sbom/{id}");
 
     let req = TestRequest::get().uri(&uri).to_request();
     let sbom: Value = app.call_and_read_body_json(req).await;
@@ -1672,7 +1672,7 @@ async fn get_cbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(labels["kind"], "cbom");
     assert_eq!(labels["type"], "cyclonedx");
 
-    let uri = format!("/api/v2/sbom/{id}/packages?total=true");
+    let uri = format!("/api/v3/sbom/{id}/packages?total=true");
     let req = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(req).await;
     log::info!("{:#}", json!(response));
@@ -1691,7 +1691,7 @@ async fn get_aibom_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
 
     // First upload it via the normal SBOM endpoint
     let request = TestRequest::post()
-        .uri("/api/v2/sbom")
+        .uri("/api/v3/sbom")
         .set_payload(
             document_bytes("cyclonedx/ai/ibm-granite_granite-docling-258M_aibom.json").await?,
         )
@@ -1702,7 +1702,7 @@ async fn get_aibom_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
 
     // Now fetch the AIBOM we just uploaded by its id
     let id = result.id.to_string();
-    let uri = format!("/api/v2/sbom/{id}");
+    let uri = format!("/api/v3/sbom/{id}");
     let req = TestRequest::get().uri(&uri).to_request();
     let sbom: Value = app.call_and_read_body_json(req).await;
     log::debug!("{sbom:#?}");
@@ -1714,7 +1714,7 @@ async fn get_aibom_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
     assert_eq!(labels["kind"], "aibom");
     assert_eq!(labels["type"], "cyclonedx");
 
-    let uri = format!("/api/v2/sbom/{id}/packages?total=true");
+    let uri = format!("/api/v3/sbom/{id}/packages?total=true");
     let req = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(req).await;
     log::info!("{:#}", json!(response));
@@ -1753,7 +1753,7 @@ async fn get_aibom_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
     assert!(expected_result.contains_subset(response.clone()));
 
     let uri = format!(
-        "/api/v2/sbom/by-package?purl={}",
+        "/api/v3/sbom/by-package?purl={}",
         encode("pkg:generic/ibm-granite%2Fgranite-docling-258M@1.0")
     );
     let req = TestRequest::get().uri(&uri).to_request();
@@ -1853,7 +1853,7 @@ async fn query_aibom_models(
         .id
         .to_string();
 
-    let uri = format!("/api/v2/sbom/{id}/models?total=true&q={}", encode(q));
+    let uri = format!("/api/v3/sbom/{id}/models?total=true&q={}", encode(q));
     let req = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(req).await;
 
@@ -1896,9 +1896,9 @@ async fn query_all_aibom_models(
     .await?;
 
     let uri = if let Some(q) = q {
-        format!("/api/v2/sbom/models?total=true&q={}", encode(q))
+        format!("/api/v3/sbom/models?total=true&q={}", encode(q))
     } else {
-        "/api/v2/sbom/models?total=true".into()
+        "/api/v3/sbom/models?total=true".into()
     };
     let req = TestRequest::get().uri(&uri).to_request();
     let app = caller(ctx).await?;
@@ -1964,7 +1964,7 @@ async fn filter_sboms_by_group(
         .await?;
 
     let query = resolve_group_refs(&ids, groups);
-    let uri = format!("/api/v2/sbom?total=true&{query}");
+    let uri = format!("/api/v3/sbom?total=true&{query}");
     log::info!("URI: {uri}");
     let req = TestRequest::get().uri(&uri).to_request();
 
@@ -1994,20 +1994,20 @@ async fn packages_by_hash(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // Fetch summary to get hashes
     let req = TestRequest::get()
-        .uri(&format!("/api/v2/sbom/urn:uuid:{id}"))
+        .uri(&format!("/api/v3/sbom/urn:uuid:{id}"))
         .to_request();
     let sbom: Value = app.call_and_read_body_json(req).await;
     let sha256 = sbom["sha256"].as_str().unwrap();
 
     // Fetch packages by UUID
     let req = TestRequest::get()
-        .uri(&format!("/api/v2/sbom/urn:uuid:{id}/packages?total=true"))
+        .uri(&format!("/api/v3/sbom/urn:uuid:{id}/packages?total=true"))
         .to_request();
     let by_uuid: Value = app.call_and_read_body_json(req).await;
 
     // Fetch packages by SHA-256
     let req = TestRequest::get()
-        .uri(&format!("/api/v2/sbom/{sha256}/packages?total=true"))
+        .uri(&format!("/api/v3/sbom/{sha256}/packages?total=true"))
         .to_request();
     let by_hash: Value = app.call_and_read_body_json(req).await;
 
@@ -2017,21 +2017,21 @@ async fn packages_by_hash(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // Non-existent hash -> 404
     let req = TestRequest::get()
-        .uri("/api/v2/sbom/sha256:0000000000000000000000000000000000000000000000000000000000000000/packages")
+        .uri("/api/v3/sbom/sha256:0000000000000000000000000000000000000000000000000000000000000000/packages")
         .to_request();
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::NOT_FOUND, response.status());
 
     // Invalid identifier (no prefix) -> 400
     let req = TestRequest::get()
-        .uri("/api/v2/sbom/not-an-id/packages")
+        .uri("/api/v3/sbom/not-an-id/packages")
         .to_request();
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::BAD_REQUEST, response.status());
 
     // Unsupported prefix -> 400
     let req = TestRequest::get()
-        .uri("/api/v2/sbom/sha123:abcd/packages")
+        .uri("/api/v3/sbom/sha123:abcd/packages")
         .to_request();
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::BAD_REQUEST, response.status());
@@ -2050,20 +2050,20 @@ async fn related_by_hash(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // Fetch summary to get hashes
     let req = TestRequest::get()
-        .uri(&format!("/api/v2/sbom/urn:uuid:{id}"))
+        .uri(&format!("/api/v3/sbom/urn:uuid:{id}"))
         .to_request();
     let sbom: Value = app.call_and_read_body_json(req).await;
     let sha256 = sbom["sha256"].as_str().unwrap();
 
     // Fetch related by UUID
     let req = TestRequest::get()
-        .uri(&format!("/api/v2/sbom/urn:uuid:{id}/related"))
+        .uri(&format!("/api/v3/sbom/urn:uuid:{id}/related"))
         .to_request();
     let by_uuid: Value = app.call_and_read_body_json(req).await;
 
     // Fetch related by SHA-256
     let req = TestRequest::get()
-        .uri(&format!("/api/v2/sbom/{sha256}/related"))
+        .uri(&format!("/api/v3/sbom/{sha256}/related"))
         .to_request();
     let by_hash: Value = app.call_and_read_body_json(req).await;
 
@@ -2072,21 +2072,21 @@ async fn related_by_hash(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // Non-existent hash -> 404
     let req = TestRequest::get()
-        .uri("/api/v2/sbom/sha256:0000000000000000000000000000000000000000000000000000000000000000/related")
+        .uri("/api/v3/sbom/sha256:0000000000000000000000000000000000000000000000000000000000000000/related")
         .to_request();
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::NOT_FOUND, response.status());
 
     // Invalid identifier (no prefix) -> 400
     let req = TestRequest::get()
-        .uri("/api/v2/sbom/not-an-id/related")
+        .uri("/api/v3/sbom/not-an-id/related")
         .to_request();
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::BAD_REQUEST, response.status());
 
     // Unsupported prefix -> 400
     let req = TestRequest::get()
-        .uri("/api/v2/sbom/sha123:abcd/related")
+        .uri("/api/v3/sbom/sha123:abcd/related")
         .to_request();
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::BAD_REQUEST, response.status());

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1777,7 +1777,7 @@ async fn get_aibom_models(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .id
         .to_string();
 
-    let uri = format!("/api/v2/sbom/{id}/models?total=true&counts=true");
+    let uri = format!("/api/v3/sbom/{id}/models?total=true&counts=true");
     let req = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(req).await;
     log::info!("response:\n{:#}", json!(response));

--- a/modules/fundamental/src/sbom_group/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom_group/endpoints/mod.rs
@@ -64,7 +64,7 @@ pub fn configure(
         (status = 403, description = "The user authenticated, but not authorized for this operation"),
    )
 )]
-#[get("/v2/group/sbom")]
+#[get("/v3/group/sbom")]
 /// List SBOM groups
 async fn list(
     service: web::Data<SbomGroupService>,
@@ -104,7 +104,7 @@ struct CreateResponse {
         (status = 409, description = "The name of the group is not unique within the parent"),
     )
 )]
-#[post("/v2/group/sbom")]
+#[post("/v3/group/sbom")]
 /// Create a new SBOM group
 async fn create(
     req: HttpRequest,
@@ -143,7 +143,7 @@ async fn create(
         (status = 412, description = "The requested revision is not the current revision of the group"),
     )
 )]
-#[delete("/v2/group/sbom/{id}")]
+#[delete("/v3/group/sbom/{id}")]
 /// Delete an SBOM group
 async fn delete(
     service: web::Data<SbomGroupService>,
@@ -179,7 +179,7 @@ async fn delete(
         (status = 412, description = "The requested revision is not the current revision of the group"),
     )
 )]
-#[put("/v2/group/sbom/{id}")]
+#[put("/v3/group/sbom/{id}")]
 /// Update an SBOM group
 async fn update(
     service: web::Data<SbomGroupService>,
@@ -217,7 +217,7 @@ async fn update(
         (status = 403, description = "The user authenticated, but not authorized for this operation"),
     )
 )]
-#[get("/v2/group/sbom/{id}")]
+#[get("/v3/group/sbom/{id}")]
 /// Read the SBOM group information
 async fn read(
     service: web::Data<SbomGroupService>,
@@ -250,7 +250,7 @@ async fn read(
         (status = 404, description = "The SBOM was not found"),
     )
 )]
-#[get("/v2/group/sbom-assignment/{id}")]
+#[get("/v3/group/sbom-assignment/{id}")]
 /// Get SBOM group assignments
 async fn read_assignments(
     service: web::Data<SbomGroupService>,
@@ -285,7 +285,7 @@ async fn read_assignments(
         (status = 412, description = "The requested revision is not the current revision"),
     )
 )]
-#[put("/v2/group/sbom-assignment/{id}")]
+#[put("/v3/group/sbom-assignment/{id}")]
 /// Update SBOM group assignments
 async fn update_assignments(
     service: web::Data<SbomGroupService>,
@@ -318,7 +318,7 @@ async fn update_assignments(
         (status = 403, description = "The user authenticated, but not authorized for this operation"),
     )
 )]
-#[put("/v2/group/sbom-assignment")]
+#[put("/v3/group/sbom-assignment")]
 /// Bulk update SBOM group assignments
 async fn bulk_update_assignments(
     service: web::Data<SbomGroupService>,

--- a/modules/fundamental/src/sbom_group/endpoints/test/assignment.rs
+++ b/modules/fundamental/src/sbom_group/endpoints/test/assignment.rs
@@ -80,7 +80,7 @@ async fn sbom_group_assignments_not_found(ctx: &TrustifyContext) -> anyhow::Resu
     let response = app
         .call_service(
             TestRequest::get()
-                .uri("/api/v2/group/sbom-assignment/00000000-0000-0000-0000-000000000000")
+                .uri("/api/v3/group/sbom-assignment/00000000-0000-0000-0000-000000000000")
                 .to_request(),
         )
         .await;
@@ -194,7 +194,7 @@ async fn call_assign(
 ) -> StatusCode {
     app.call_service(
         TestRequest::put()
-            .uri(&format!("/api/v2/group/sbom-assignment/{sbom_id}"))
+            .uri(&format!("/api/v3/group/sbom-assignment/{sbom_id}"))
             .set_json(body)
             .to_request(),
     )
@@ -205,7 +205,7 @@ async fn call_assign(
 async fn call_bulk_assign(app: &impl CallService, body: impl serde::Serialize) -> StatusCode {
     app.call_service(
         TestRequest::put()
-            .uri("/api/v2/group/sbom-assignment")
+            .uri("/api/v3/group/sbom-assignment")
             .set_json(body)
             .to_request(),
     )

--- a/modules/fundamental/src/sbom_group/endpoints/test/create.rs
+++ b/modules/fundamental/src/sbom_group/endpoints/test/create.rs
@@ -81,7 +81,7 @@ async fn create_and_delete_group(
     let group: GroupResponse = Create::new("test_group_for_deletion").execute(&app).await?;
 
     // Delete the group
-    let delete_request = TestRequest::delete().uri(&format!("/api/v2/group/sbom/{}", group.id));
+    let delete_request = TestRequest::delete().uri(&format!("/api/v3/group/sbom/{}", group.id));
     let delete_request = add_if_match(delete_request, if_match_type, &group.etag);
 
     let delete_response = app.call_service(delete_request.to_request()).await;
@@ -91,7 +91,7 @@ async fn create_and_delete_group(
     let get_response = app
         .call_service(
             TestRequest::get()
-                .uri(&format!("/api/v2/group/sbom/{}", group.id))
+                .uri(&format!("/api/v3/group/sbom/{}", group.id))
                 .to_request(),
         )
         .await;

--- a/modules/fundamental/src/sbom_group/endpoints/test/delete.rs
+++ b/modules/fundamental/src/sbom_group/endpoints/test/delete.rs
@@ -23,7 +23,7 @@ async fn delete_nonexistent_group(ctx: &TrustifyContext) -> Result<(), anyhow::E
     let delete_response = app
         .call_service(
             TestRequest::delete()
-                .uri(&format!("/api/v2/group/sbom/{}", nonexistent_id))
+                .uri(&format!("/api/v3/group/sbom/{}", nonexistent_id))
                 .insert_header((http::header::IF_MATCH, "*"))
                 .to_request(),
         )
@@ -59,7 +59,7 @@ async fn delete_group_with_children(ctx: &TrustifyContext) -> Result<(), anyhow:
     let delete_response = app
         .call_service(
             TestRequest::delete()
-                .uri(&format!("/api/v2/group/sbom/{}", parent.id))
+                .uri(&format!("/api/v3/group/sbom/{}", parent.id))
                 .insert_header((http::header::IF_MATCH, "*"))
                 .to_request(),
         )

--- a/modules/fundamental/src/sbom_group/endpoints/test/list.rs
+++ b/modules/fundamental/src/sbom_group/endpoints/test/list.rs
@@ -285,7 +285,7 @@ async fn run_list_test(
     expected_referenced: Option<Vec<&'static [&'static str]>>,
 ) -> anyhow::Result<()> {
     let mut uri = format!(
-        "/api/v2/group/sbom?total=true&q={}&",
+        "/api/v3/group/sbom?total=true&q={}&",
         urlencoding::encode(q)
     );
     if options.totals {

--- a/modules/fundamental/src/sbom_group/endpoints/test/mod.rs
+++ b/modules/fundamental/src/sbom_group/endpoints/test/mod.rs
@@ -76,7 +76,7 @@ impl Update {
         }
 
         let request = TestRequest::put()
-            .uri(&format!("/api/v2/group/sbom/{}", &self.id))
+            .uri(&format!("/api/v3/group/sbom/{}", &self.id))
             .set_json(update_body);
 
         let request = add_if_match(request, self.if_match_type, &self.etag);
@@ -96,7 +96,7 @@ async fn get_group_helper(
     let response = app
         .call_service(
             TestRequest::get()
-                .uri(&format!("/api/v2/group/sbom/{}", id))
+                .uri(&format!("/api/v3/group/sbom/{}", id))
                 .to_request(),
         )
         .await;

--- a/modules/fundamental/src/test/label.rs
+++ b/modules/fundamental/src/test/label.rs
@@ -24,7 +24,7 @@ impl Api {
                 urlencoding::encode(&id.to_string())
             ),
             Self::Sbom => format!(
-                "/api/v2/sbom/urn:uuid:{}",
+                "/api/v3/sbom/urn:uuid:{}",
                 urlencoding::encode(&id.to_string())
             ),
         }
@@ -35,11 +35,11 @@ impl Api {
         let suffix = suffix.unwrap_or("");
         match self {
             Self::Advisory => format!(
-                "/api/v2/advisory/urn:uuid:{}{suffix}",
+                "/api/v3/advisory/urn:uuid:{}{suffix}",
                 urlencoding::encode(&id.to_string())
             ),
             Self::Sbom => format!(
-                "/api/v2/sbom/urn:uuid:{}{suffix}",
+                "/api/v3/sbom/urn:uuid:{}{suffix}",
                 urlencoding::encode(&id.to_string())
             ),
         }

--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -123,7 +123,7 @@ pub async fn get(
 }
 
 #[utoipa::path(
-  operation_id = "analyze",
+  operation_id = "v2/analyze",
   tag = "vulnerability",
   request_body = AnalysisRequest,
   responses(
@@ -131,6 +131,7 @@ pub async fn get(
   ),
 )]
 #[post("/v2/vulnerability/analyze")]
+#[deprecated = "Use the v3 version of this API"]
 /// Analyze the provided purls for the known vulnerabilities
 pub async fn analyze(
     service: web::Data<VulnerabilityService>,

--- a/modules/fundamental/src/weakness/endpoints/mod.rs
+++ b/modules/fundamental/src/weakness/endpoints/mod.rs
@@ -30,7 +30,7 @@ pub fn configure(
         (status = 200, description = "Matching weaknesses", body = PaginatedResults<LicenseSummary>),
     ),
 )]
-#[get("/v2/weakness")]
+#[get("/v3/weakness")]
 /// List weaknesses
 pub async fn list_weaknesses(
     state: web::Data<WeaknessService>,
@@ -49,7 +49,7 @@ pub async fn list_weaknesses(
         (status = 404, description = "The weakness could not be found"),
     ),
 )]
-#[get("/v2/weakness/{id}")]
+#[get("/v3/weakness/{id}")]
 /// Retrieve weakness details
 pub async fn get_weakness(
     state: web::Data<WeaknessService>,

--- a/modules/fundamental/src/weakness/endpoints/test.rs
+++ b/modules/fundamental/src/weakness/endpoints/test.rs
@@ -21,7 +21,7 @@ async fn list_weaknesses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/weakness?total=true";
+    let uri = "/api/v3/weakness?total=true";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -45,7 +45,7 @@ async fn query_weaknesses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/weakness?q=struts&total=true";
+    let uri = "/api/v3/weakness?q=struts&total=true";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -69,7 +69,7 @@ async fn get_weakness(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let app = caller(ctx).await?;
 
-    let uri = "/api/v2/weakness/CWE-1004";
+    let uri = "/api/v3/weakness/CWE-1004";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -92,7 +92,7 @@ async fn get_weakness(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(1, child_of.len());
     assert!(child_of.contains(&"CWE-732".to_string()));
 
-    let uri = "/api/v2/weakness/CWE-FOO";
+    let uri = "/api/v3/weakness/CWE-FOO";
     let request = TestRequest::get().uri(uri).to_request();
     let response = app.call_service(request).await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);

--- a/modules/fundamental/tests/analysis.rs
+++ b/modules/fundamental/tests/analysis.rs
@@ -12,7 +12,7 @@ include!("../src/test/common.rs");
 
 async fn assert_status(app: &impl CallService, sboms: usize, graphs: usize) {
     let request: Request = TestRequest::get()
-        .uri("/api/v2/analysis/status")
+        .uri("/api/v3/analysis/status")
         .to_request();
     let response: Value = app.call_and_read_body_json(request).await;
 
@@ -27,7 +27,7 @@ async fn upload_lazy_load(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let app = caller_with(ctx, Config::default(), PaginationCache::for_test()).await?;
 
     let request = TestRequest::post()
-        .uri("/api/v2/sbom")
+        .uri("/api/v3/sbom")
         .set_payload(document_bytes_raw("spdx/simple.json").await?)
         .to_request();
 
@@ -41,7 +41,7 @@ async fn upload_lazy_load(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // now perform a query
 
     let uri = format!(
-        "/api/v2/analysis/component/{}?ancestors=10",
+        "/api/v3/analysis/component/{}?ancestors=10",
         urlencoding::encode("pkg:rpm/redhat/A@0.0.0?arch=src")
     );
     let request: Request = TestRequest::get().uri(&uri).to_request();

--- a/modules/fundamental/tests/decompress.rs
+++ b/modules/fundamental/tests/decompress.rs
@@ -18,7 +18,7 @@ async fn assert(
 ) -> anyhow::Result<()> {
     let app = caller(ctx).await?;
 
-    let request = TestRequest::post().uri("/api/v2/sbom");
+    let request = TestRequest::post().uri("/api/v3/sbom");
 
     let request = match content_type.into() {
         Some(ct) => request.append_header((http::header::CONTENT_TYPE, ct)),

--- a/modules/fundamental/tests/limit.rs
+++ b/modules/fundamental/tests/limit.rs
@@ -22,7 +22,7 @@ async fn upload_bomb_sbom(ctx: &TrustifyContext) -> anyhow::Result<()> {
     .await?;
 
     let request = TestRequest::post()
-        .uri("/api/v2/sbom")
+        .uri("/api/v3/sbom")
         .set_payload(document_bytes_raw("bomb.bz2").await?)
         .to_request();
 
@@ -47,7 +47,7 @@ async fn upload_bomb_advisory(ctx: &TrustifyContext) -> anyhow::Result<()> {
     .await?;
 
     let request = TestRequest::post()
-        .uri("/api/v2/advisory")
+        .uri("/api/v3/advisory")
         .set_payload(document_bytes_raw("bomb.bz2").await?)
         .to_request();
 

--- a/modules/fundamental/tests/sbom/cyclonedx/corner_cases.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/corner_cases.rs
@@ -28,7 +28,7 @@ async fn ingest_broken_refs_api(ctx: &TrustifyContext) -> Result<(), anyhow::Err
     let app = caller(ctx).await?;
 
     let request = TestRequest::post()
-        .uri("/api/v2/sbom")
+        .uri("/api/v3/sbom")
         .set_payload(document_bytes("cyclonedx/broken-refs.json").await?)
         .to_request();
 

--- a/modules/fundamental/tests/sbom/spdx/corner_cases.rs
+++ b/modules/fundamental/tests/sbom/spdx/corner_cases.rs
@@ -311,7 +311,7 @@ async fn ingest_broken_refs_api(ctx: &TrustifyContext) -> Result<(), anyhow::Err
     let app = caller(ctx).await?;
 
     let request = TestRequest::post()
-        .uri("/api/v2/sbom")
+        .uri("/api/v3/sbom")
         .set_payload(document_bytes("spdx/broken-refs.json").await?)
         .to_request();
 

--- a/modules/importer/README.md
+++ b/modules/importer/README.md
@@ -24,13 +24,13 @@ trustd importer --help
 ### Create a new CSAF importer
 
 ```shell
-http POST localhost:8080/api/v2/importer/redhat-csaf csaf[source]=https://redhat.com/.well-known/csaf/provider-metadata.json csaf[disabled]:=false csaf[onlyPatterns][]="^cve-2023-" csaf[period]=30s csaf[v3Signatures]:=true
+http POST localhost:8080/api/v3/importer/redhat-csaf csaf[source]=https://redhat.com/.well-known/csaf/provider-metadata.json csaf[disabled]:=false csaf[onlyPatterns][]="^cve-2023-" csaf[period]=30s csaf[v3Signatures]:=true
 ```
 
 ### Create a new OSV importer
 
 ```shell
-http POST localhost:8080/api/v2/importer/osv-r osv[source]=https://github.com/RConsortium/r-advisory-database osv[path]=vulns osv[disabled]:=false osv[period]=30s
+http POST localhost:8080/api/v3/importer/osv-r osv[source]=https://github.com/RConsortium/r-advisory-database osv[path]=vulns osv[disabled]:=false osv[period]=30s
 ```
 
 ### Create a new SBOM importer
@@ -38,68 +38,68 @@ http POST localhost:8080/api/v2/importer/osv-r osv[source]=https://github.com/RC
 Quarkus & RHEL 9 data:
 
 ```shell
-http POST localhost:8080/api/v2/importer/redhat-sbom sbom[source]=https://security.access.redhat.com/data/sbom/v1/ sbom[keys][]=https://security.access.redhat.com/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4 sbom[disabled]:=false sbom[onlyPatterns][]=quarkus sbom[onlyPatterns][]=rhel-9 sbom[period]=30s sbom[v3Signatures]:=true
+http POST localhost:8080/api/v3/importer/redhat-sbom sbom[source]=https://security.access.redhat.com/data/sbom/v1/ sbom[keys][]=https://security.access.redhat.com/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4 sbom[disabled]:=false sbom[onlyPatterns][]=quarkus sbom[onlyPatterns][]=rhel-9 sbom[period]=30s sbom[v3Signatures]:=true
 ```
 
 ### Get all importers
 
 ```shell
-http GET localhost:8080/api/v2/importer
+http GET localhost:8080/api/v3/importer
 ```
 
 ### Get a specific importer
 
 ```shell
-http GET localhost:8080/api/v2/importer/redhat-csaf
-http GET localhost:8080/api/v2/importer/redhat-sbom
+http GET localhost:8080/api/v3/importer/redhat-csaf
+http GET localhost:8080/api/v3/importer/redhat-sbom
 ```
 
 ### Get reports
 
 ```shell
-http GET localhost:8080/api/v2/importer/redhat-csaf/report
-http GET localhost:8080/api/v2/importer/redhat-sbom/report
+http GET localhost:8080/api/v3/importer/redhat-csaf/report
+http GET localhost:8080/api/v3/importer/redhat-sbom/report
 ```
 
 ### Update an importer configuration
 
 ```shell
-http PUT localhost:8080/api/v2/importer/redhat-csaf csaf[source]=https://redhat.com/.well-known/csaf/provider-metadata.json csaf[disabled]:=false csaf[period]=30s csaf[v3Signatures]:=true csaf[fetchRetries]:=50
+http PUT localhost:8080/api/v3/importer/redhat-csaf csaf[source]=https://redhat.com/.well-known/csaf/provider-metadata.json csaf[disabled]:=false csaf[period]=30s csaf[v3Signatures]:=true csaf[fetchRetries]:=50
 ```
 
 Or, updating the existing configuration (requires `jq`). To preview the changes:
 
 ```shell
-http GET localhost:8080/api/v2/importer/redhat-csaf/report | jq .configuration | jq .csaf.fetchRetries=50
+http GET localhost:8080/api/v3/importer/redhat-csaf/report | jq .configuration | jq .csaf.fetchRetries=50
 ```
 
 To execute:
 
 ```shell
-http GET localhost:8080/api/v2/importer/redhat-csaf | jq .configuration | jq .csaf.fetchRetries=50 | http PUT localhost:8080/api/v2/importer/redhat-csaf
+http GET localhost:8080/api/v3/importer/redhat-csaf | jq .configuration | jq .csaf.fetchRetries=50 | http PUT localhost:8080/api/v3/importer/redhat-csaf
 ```
 
 ### Patch an importer configuration
 
 ```shell
-http PATCH localhost:8080/api/v2/importer/redhat-csaf "Content-Type:application/merge-patch+json" csaf[fetchRetries]:=50
+http PATCH localhost:8080/api/v3/importer/redhat-csaf "Content-Type:application/merge-patch+json" csaf[fetchRetries]:=50
 ```
 
 ### Delete an importer
 
 ```shell
-http DELETE localhost:8080/api/v2/importer/redhat-csaf
-http DELETE localhost:8080/api/v2/importer/redhat-sbom
+http DELETE localhost:8080/api/v3/importer/redhat-csaf
+http DELETE localhost:8080/api/v3/importer/redhat-sbom
 ```
 
 ### Set the enabled state of an importer
 
 ```shell
-echo true | http PUT localhost:8080/api/v2/importer/redhat-sbom/enabled
+echo true | http PUT localhost:8080/api/v3/importer/redhat-sbom/enabled
 ```
 
 ### Force an importer run
 
 ```shell
-http PUT localhost:8080/api/v2/importer/redhat-sbom/force
+http PUT localhost:8080/api/v3/importer/redhat-sbom/force
 ```

--- a/modules/importer/src/endpoints.rs
+++ b/modules/importer/src/endpoints.rs
@@ -41,7 +41,7 @@ pub fn configure(
         (status = 200, description = "List importer configurations", body = [Importer])
     )
 )]
-#[get("/v2/importer")]
+#[get("/v3/importer")]
 /// List importer configurations
 async fn list(
     service: web::Data<ImporterService>,
@@ -62,7 +62,7 @@ async fn list(
         (status = 409, description = "An importer with that name already exists")
     )
 )]
-#[post("/v2/importer/{name}")]
+#[post("/v3/importer/{name}")]
 /// Create a new importer configuration
 async fn create(
     service: web::Data<ImporterService>,
@@ -90,7 +90,7 @@ async fn create(
         (status = 404, description = "The importer could not be found")
     )
 )]
-#[get("/v2/importer/{name}")]
+#[get("/v3/importer/{name}")]
 /// Get an importer configuration
 async fn read(
     service: web::Data<ImporterService>,
@@ -121,7 +121,7 @@ async fn read(
         (status = 412, description = "The provided if-match header did not match the stored revision"),
     )
 )]
-#[put("/v2/importer/{name}")]
+#[put("/v3/importer/{name}")]
 /// Update an existing importer configuration
 async fn update(
     service: web::Data<ImporterService>,
@@ -159,7 +159,7 @@ async fn update(
         (status = 412, description = "The provided if-match header did not match the stored revision"),
     )
 )]
-#[patch("/v2/importer/{name}", guard = "guards::json_merge")]
+#[patch("/v3/importer/{name}", guard = "guards::json_merge")]
 /// Update an existing importer configuration
 async fn patch_json_merge(
     service: web::Data<ImporterService>,
@@ -198,7 +198,7 @@ async fn patch_json_merge(
         (status = 412, description = "The provided if-match header did not match the stored revision"),
     )
 )]
-#[put("/v2/importer/{name}/enabled")]
+#[put("/v3/importer/{name}/enabled")]
 /// Update an existing importer configuration
 async fn set_enabled(
     service: web::Data<ImporterService>,
@@ -236,7 +236,7 @@ async fn set_enabled(
         (status = 412, description = "The provided if-match header did not match the stored revision"),
     )
 )]
-#[post("/v2/importer/{name}/force")]
+#[post("/v3/importer/{name}/force")]
 /// Force an importer to run as soon as possible
 async fn force(
     service: web::Data<ImporterService>,
@@ -265,7 +265,7 @@ async fn force(
         (status = 201, description = "Delete the importer configuration"),
     )
 )]
-#[delete("/v2/importer/{name}")]
+#[delete("/v3/importer/{name}")]
 /// Delete an importer configuration
 async fn delete(
     service: web::Data<ImporterService>,
@@ -292,7 +292,7 @@ async fn delete(
         (status = 200, description = "Retrieved importer reports", body = PaginatedResults<ImporterReport>),
     )
 )]
-#[get("/v2/importer/{name}/report")]
+#[get("/v3/importer/{name}/report")]
 /// Get reports for an importer
 async fn get_reports(
     service: web::Data<ImporterService>,

--- a/modules/importer/src/test.rs
+++ b/modules/importer/src/test.rs
@@ -81,7 +81,7 @@ async fn default(ctx: TrustifyContext) {
     // create one
 
     let req = actix::TestRequest::post()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .set_json(mock_configuration("bar"))
         .to_request();
 
@@ -91,7 +91,7 @@ async fn default(ctx: TrustifyContext) {
     // now list all
 
     let req = actix::TestRequest::get()
-        .uri("/api/v2/importer")
+        .uri("/api/v3/importer")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -119,7 +119,7 @@ async fn default(ctx: TrustifyContext) {
     // update it
 
     let req = actix::TestRequest::put()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .set_json(mock_configuration("baz"))
         .to_request();
 
@@ -129,7 +129,7 @@ async fn default(ctx: TrustifyContext) {
     // get it
 
     let req = actix::TestRequest::get()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -141,7 +141,7 @@ async fn default(ctx: TrustifyContext) {
     // delete it
 
     let req = actix::TestRequest::delete()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -150,7 +150,7 @@ async fn default(ctx: TrustifyContext) {
     // get none
 
     let req = actix::TestRequest::get()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -165,7 +165,7 @@ async fn oplock(ctx: TrustifyContext) {
     // create one
 
     let req = actix::TestRequest::post()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .set_json(mock_configuration("bar"))
         .to_request();
 
@@ -175,7 +175,7 @@ async fn oplock(ctx: TrustifyContext) {
     // update it (no lock)
 
     let req = actix::TestRequest::put()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .set_json(mock_configuration("baz"))
         .to_request();
 
@@ -185,7 +185,7 @@ async fn oplock(ctx: TrustifyContext) {
     // get it
 
     let req = actix::TestRequest::get()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -201,7 +201,7 @@ async fn oplock(ctx: TrustifyContext) {
     // update it (with lock)
 
     let req = actix::TestRequest::put()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .set_json(mock_configuration("buz"))
         .append_header((header::IF_MATCH, etag.clone()))
         .to_request();
@@ -212,7 +212,7 @@ async fn oplock(ctx: TrustifyContext) {
     // get it
 
     let req = actix::TestRequest::get()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -224,7 +224,7 @@ async fn oplock(ctx: TrustifyContext) {
     // update it (with broken lock)
 
     let req = actix::TestRequest::put()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .set_json(mock_configuration("boz"))
         .append_header((header::IF_MATCH, etag.clone()))
         .to_request();
@@ -235,7 +235,7 @@ async fn oplock(ctx: TrustifyContext) {
     // update it (with wrong name)
 
     let req = actix::TestRequest::put()
-        .uri("/api/v2/importer/foo2")
+        .uri("/api/v3/importer/foo2")
         .set_json(mock_configuration("boz"))
         .append_header((header::IF_MATCH, etag.clone()))
         .to_request();
@@ -246,7 +246,7 @@ async fn oplock(ctx: TrustifyContext) {
     // get it (must not change)
 
     let req = actix::TestRequest::get()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -264,7 +264,7 @@ async fn oplock(ctx: TrustifyContext) {
     // delete it (wrong lock)
 
     let req = actix::TestRequest::delete()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .append_header((header::IF_MATCH, old_etag.clone()))
         .to_request();
 
@@ -274,7 +274,7 @@ async fn oplock(ctx: TrustifyContext) {
     // get it (must still be there)
 
     let req = actix::TestRequest::get()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -286,7 +286,7 @@ async fn oplock(ctx: TrustifyContext) {
     // delete it (correct lock)
 
     let req = actix::TestRequest::delete()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .append_header((header::IF_MATCH, etag.clone()))
         .to_request();
 
@@ -296,7 +296,7 @@ async fn oplock(ctx: TrustifyContext) {
     // get none
 
     let req = actix::TestRequest::get()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -311,7 +311,7 @@ async fn patch(ctx: TrustifyContext) {
     // create one
 
     let req = actix::TestRequest::post()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .set_json(mock_configuration("bar"))
         .to_request();
 
@@ -321,7 +321,7 @@ async fn patch(ctx: TrustifyContext) {
     // get it
 
     let req = actix::TestRequest::get()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -333,7 +333,7 @@ async fn patch(ctx: TrustifyContext) {
     // patch it
 
     let req = actix::TestRequest::patch()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .set_json(json!({
             "sbom": {
                 "source": "baz",
@@ -348,7 +348,7 @@ async fn patch(ctx: TrustifyContext) {
     // get it (again)
 
     let req = actix::TestRequest::get()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -360,7 +360,7 @@ async fn patch(ctx: TrustifyContext) {
     // delete it
 
     let req = actix::TestRequest::delete()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -369,7 +369,7 @@ async fn patch(ctx: TrustifyContext) {
     // try again
 
     let req = actix::TestRequest::patch()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .set_json(json!({
             "sbom": {
                 "source": "bar",
@@ -389,7 +389,7 @@ async fn read_only(ctx: &mut ReadOnly<TrustifyContext>) {
     // list all
 
     let req = actix::TestRequest::get()
-        .uri("/api/v2/importer")
+        .uri("/api/v3/importer")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -401,7 +401,7 @@ async fn read_only(ctx: &mut ReadOnly<TrustifyContext>) {
     // try to create one, must fail
 
     let req = actix::TestRequest::post()
-        .uri("/api/v2/importer/foo")
+        .uri("/api/v3/importer/foo")
         .set_json(mock_configuration("bar"))
         .to_request();
 

--- a/modules/ingestor/README.md
+++ b/modules/ingestor/README.md
@@ -3,11 +3,11 @@
 ## Upload an SBOM
 
 ```shell
-cat file.sbom | http POST localhost:8080/api/v2/sbom location==cli
+cat file.sbom | http POST localhost:8080/api/v3/sbom location==cli
 ```
 
 ## Upload a dataset
 
 ```shell
-http POST localhost:8080/api/v2/dataset @file-to-upload
+http POST localhost:8080/api/v3/dataset @file-to-upload
 ```

--- a/modules/ingestor/src/endpoints.rs
+++ b/modules/ingestor/src/endpoints.rs
@@ -53,7 +53,7 @@ struct UploadParams {
         (status = 400, description = "The file could not be parsed as an dataset"),
     )
 )]
-#[post("/v2/dataset")]
+#[post("/v3/dataset")]
 /// Upload a new dataset
 pub async fn upload_dataset(
     service: web::Data<IngestorService>,

--- a/modules/ingestor/tests/limit.rs
+++ b/modules/ingestor/tests/limit.rs
@@ -30,7 +30,7 @@ async fn upload_bomb_dataset(ctx: &TrustifyContext) -> anyhow::Result<()> {
     dataset.finish()?;
 
     let request = TestRequest::post()
-        .uri("/api/v2/dataset")
+        .uri("/api/v3/dataset")
         .set_payload(data)
         .to_request();
 

--- a/modules/ui/src/endpoints.rs
+++ b/modules/ui/src/endpoints.rs
@@ -95,7 +95,7 @@ mod default {
         )
     )
 )]
-#[post("/v2/ui/extract-sbom-purls")]
+#[post("/v3/ui/extract-sbom-purls")]
 /// Extract PURLs from an SBOM provided in the request
 async fn extract_sbom_purls(
     web::Query(ExtractSbomPurls { format }): web::Query<ExtractSbomPurls>,

--- a/modules/ui/tests/extract.rs
+++ b/modules/ui/tests/extract.rs
@@ -70,7 +70,7 @@ async fn assert_extract_fn(
 
     let bytes = document_bytes_raw(file).await?;
 
-    let mut uri = "/api/v2/ui/extract-sbom-purls?".to_string();
+    let mut uri = "/api/v3/ui/extract-sbom-purls?".to_string();
 
     if let Some(format) = format.into() {
         uri = format!("{uri}format={format}")

--- a/modules/user/src/endpoints.rs
+++ b/modules/user/src/endpoints.rs
@@ -33,7 +33,7 @@ pub fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfig, db: 
         (status = 404, description = "The user preference key could not be found"),
     )
 )]
-#[get("/v2/userPreference/{key}")]
+#[get("/v3/userPreference/{key}")]
 /// Get user preferences
 async fn get(
     service: web::Data<UserPreferenceService>,
@@ -67,7 +67,7 @@ async fn get(
         (status = 412, description = "The provided If-Match revision did not match the actual revision")
     )
 )]
-#[put("/v2/userPreference/{key}")]
+#[put("/v3/userPreference/{key}")]
 /// Set user preferences
 async fn set(
     service: web::Data<UserPreferenceService>,
@@ -106,7 +106,7 @@ async fn set(
         (status = 412, description = "The provided If-Match revision did not match the actual revision")
     )
 )]
-#[delete("/v2/userPreference/{key}")]
+#[delete("/v3/userPreference/{key}")]
 /// Delete user preferences
 async fn delete(
     service: web::Data<UserPreferenceService>,

--- a/modules/user/src/test.rs
+++ b/modules/user/src/test.rs
@@ -147,7 +147,7 @@ async fn wrong_rev(ctx: TrustifyContext) {
     // create one
 
     let req = actix::TestRequest::put()
-        .uri("/api/v2/userPreference/foo")
+        .uri("/api/v3/userPreference/foo")
         .set_json(json!({"a": 1}))
         .to_request()
         .test_auth("user-a");
@@ -158,7 +158,7 @@ async fn wrong_rev(ctx: TrustifyContext) {
     // try to update the wrong one
 
     let req = actix::TestRequest::put()
-        .uri("/api/v2/userPreference/foo")
+        .uri("/api/v3/userPreference/foo")
         .append_header((header::IF_MATCH, r#""a""#))
         .set_json(json!({"a": 2}))
         .to_request()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27,7 +27,249 @@ paths:
                     type: boolean
                   version:
                     type: string
-  /api/v2/advisory:
+  /api/v2/sbom:
+    get:
+      tags:
+      - sbom
+      summary: List SBOMs
+      operationId: v2/listSboms
+      parameters:
+      - name: q
+        in: query
+        description: |
+          EBNF grammar for the _q_ parameter:
+          ```text
+              q = ( values | filter ) { '&' q }
+              values = value { '|', values }
+              filter = field, operator, values
+              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
+              value = (* any text but escape special characters with '\' *)
+              field = (* must match an entity attribute name *)
+          ```
+          Any values in a _q_ will result in a case-insensitive "full
+          text search", effectively producing an OR clause of LIKE
+          clauses for every string-ish field in the resource being
+          queried.
+
+          Examples:
+          - `foo` - any field containing 'foo'
+          - `foo|bar` - any field containing either 'foo' OR 'bar'
+          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
+
+          A _filter_ may also be used to constrain the results. The
+          filter's field name must correspond to one of the resource's
+          attributes. If it doesn't, an error will be returned
+          containing a list of the valid fields for that resource.
+
+          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
+          to find resources on which a particular field isn't set. For
+          example, `name=%00` and `name!=%00` yield the WHERE clauses,
+          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
+
+          Examples:
+          - `name=foo` - entity's _name_ matches 'foo' exactly
+          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
+          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
+          - `name=` - entity's _name_ is the empty string, ''
+          - `name=%00` - entity's _name_ isn't set
+          - `published>3 days ago` - date values can be "human time"
+
+          Multiple full text searches and/or filters should be
+          '&'-delimited -- they are logically AND'd together.
+
+          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
+
+          Fields corresponding to JSON objects in the database may use a
+          ':' to delimit the column name and the object key,
+          e.g. `purl:qualifiers:type=pom`
+
+          Any operator or special character, e.g. '|', '&', within a
+          value should be escaped by prefixing it with a backslash.
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        description: |
+          EBNF grammar for the _sort_ parameter:
+          ```text
+              sort = field [ ':', order ] { ',' sort }
+              order = ( "asc" | "desc" )
+              field = (* must match the name of entity's attributes *)
+          ```
+          The optional _order_ should be one of "asc" or "desc". If
+          omitted, the order defaults to "asc".
+
+          Each _field_ name must correspond to one of the columns of the
+          table holding the entities being queried. Those corresponding
+          to JSON objects in the database may use a ':' to delimit the
+          column name and the object key,
+          e.g. `purl:qualifiers:type:desc`
+        required: false
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: |-
+          The first item to return, skipping all that come before it.
+
+          NOTE: The order of items is defined by the API being called.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: limit
+        in: query
+        description: |-
+          The maximum number of entries to return.
+
+          Zero means: return no items (the total count is still computed if requested).
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
+      - name: group
+        in: query
+        description: |-
+          Filter by group IDs. Only SBOMs assigned to any of the provided groups will be returned.
+          Can be specified multiple times. Malformed IDs are silently ignored.
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        '200':
+          description: Matching SBOMs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResults_SbomSummary'
+      deprecated: true
+  /api/v2/vulnerability/analyze:
+    post:
+      tags:
+      - vulnerability
+      summary: Analyze the provided purls for the known vulnerabilities
+      operationId: v2/analyze
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnalysisRequest'
+        required: true
+      responses:
+        '200':
+          description: Analyze the provided purls to search for known vulnerabilities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnalysisResponse'
+      deprecated: true
+  /api/v3/advisory:
+    get:
+      tags:
+      - advisory
+      summary: List advisories
+      operationId: listAdvisories
+      parameters:
+      - name: q
+        in: query
+        description: |
+          Query for advisories defined using the following EBNF grammar (ISO/IEC 14977):
+          ```text
+          (* Query Grammar - EBNF Compliant *)
+          query = ( values | filter ) , { "&" , query } ;
+          values = value , { "|" , value } ;
+          filter = field , operator , values ;
+          operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<" ;
+          field = ("id" | "identifier" | "version" | "document_id" | "deprecated" | "issuer_id" | "published" | "modified" | "withdrawn" | "title" | "ingested" | "label")
+          value = { value_char } ;
+          value_char = escaped_char | normal_char ;
+          escaped_char = "\" , special_char ;
+          normal_char = ? any character except '&', '|', '=', '!', '~', '>', '<', '\' ? ;
+          special_char = "&" | "|" | "=" | "!" | "~" | ">" | "<" | "\" ;
+          ```
+          Examples:
+          - Simple filter: title=example
+          - Multiple values filter: title=foo|bar|baz
+          - Complex filter: modified>2024-01-01
+          - Combined query: title=foo&average_severity=high
+          - Escaped characters: title=foo\\&bar
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        description: |-
+          EBNF grammar for the _sort_ parameter:
+          ```text
+              sort = field [ ':', order ] { ',' sort }
+              order = ( "asc" | "desc" )
+              field = ("id" | "identifier" | "version" | "document_id" | "deprecated" | "issuer_id" | "published" | "modified" | "withdrawn" | "title" | "ingested" | "label")
+          ```
+          The optional _order_ should be one of "asc" or "desc". If
+          omitted, the order defaults to "asc".
+
+          Each _field_ name must correspond to one of the columns of the
+          table holding the entities being queried. Those corresponding
+          to JSON objects in the database may use a ':' to delimit the
+          column name and the object key,
+          e.g. `purl:qualifiers:type:desc`
+        required: false
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: |-
+          The first item to return, skipping all that come before it.
+
+          NOTE: The order of items is defined by the API being called.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: limit
+        in: query
+        description: |-
+          The maximum number of entries to return.
+
+          Zero means: return no items (the total count is still computed if requested).
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
+      - name: deprecated
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - Ignore
+          - Consider
+      responses:
+        '200':
+          description: Matching vulnerabilities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResults_AdvisorySummary'
     post:
       tags:
       - advisory
@@ -81,7 +323,7 @@ paths:
           description: Upload a file
         '400':
           description: The file could not be parsed as an advisory
-  /api/v2/advisory-labels:
+  /api/v3/advisory-labels:
     get:
       tags:
       - advisory
@@ -108,7 +350,7 @@ paths:
               schema:
                 type: array
                 items: {}
-  /api/v2/advisory/{id}/label:
+  /api/v3/advisory/{id}/label:
     put:
       tags:
       - advisory
@@ -155,7 +397,27 @@ paths:
           description: Modified the labels of the advisory
         '404':
           description: The advisory could not be found
-  /api/v2/advisory/{key}:
+  /api/v3/advisory/{key}:
+    get:
+      tags:
+      - advisory
+      summary: Get an advisory
+      operationId: getAdvisory
+      parameters:
+      - name: key
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: Matching advisory
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvisoryDetails'
+        '404':
+          description: The advisory could not be found
     delete:
       tags:
       - advisory
@@ -176,7 +438,7 @@ paths:
                 $ref: '#/components/schemas/AdvisoryDetails'
         '404':
           description: The advisory could not be found
-  /api/v2/advisory/{key}/download:
+  /api/v3/advisory/{key}/download:
     get:
       tags:
       - advisory
@@ -199,7 +461,7 @@ paths:
                 format: binary
         '404':
           description: The document could not be found
-  /api/v2/analysis/component:
+  /api/v3/analysis/component:
     get:
       tags:
       - analysis
@@ -351,7 +613,7 @@ paths:
           description: The user did not provide valid authentication credentials
         '403':
           description: The user lacks the required permission
-  /api/v2/analysis/component/{key}:
+  /api/v3/analysis/component/{key}:
     get:
       tags:
       - analysis
@@ -435,7 +697,7 @@ paths:
           description: The user did not provide valid authentication credentials
         '403':
           description: The user lacks the required permission
-  /api/v2/analysis/latest/component:
+  /api/v3/analysis/latest/component:
     get:
       tags:
       - analysis
@@ -587,7 +849,7 @@ paths:
           description: The user did not provide valid authentication credentials
         '403':
           description: The user lacks the required permission
-  /api/v2/analysis/latest/component/{key}:
+  /api/v3/analysis/latest/component/{key}:
     get:
       tags:
       - analysis
@@ -671,7 +933,7 @@ paths:
           description: The user did not provide valid authentication credentials
         '403':
           description: The user lacks the required permission
-  /api/v2/analysis/sbom/{sbom}/render.{ext}:
+  /api/v3/analysis/sbom/{sbom}/render.{ext}:
     get:
       tags:
       - analysis
@@ -707,7 +969,7 @@ paths:
           description: The SBOM could not be found
         '415':
           description: Unsupported rendering format
-  /api/v2/analysis/status:
+  /api/v3/analysis/status:
     get:
       tags:
       - analysis
@@ -730,7 +992,7 @@ paths:
           description: The user did not provide valid authentication credentials
         '403':
           description: The user lacks the required permission
-  /api/v2/dataset:
+  /api/v3/dataset:
     post:
       tags:
       - dataset
@@ -758,7 +1020,7 @@ paths:
           description: Uploaded the dataset
         '400':
           description: The file could not be parsed as an dataset
-  /api/v2/group/sbom:
+  /api/v3/group/sbom:
     get:
       tags:
       - sbomGroup
@@ -927,7 +1189,7 @@ paths:
           description: The user authenticated, but not authorized for this operation
         '409':
           description: The name of the group is not unique within the parent
-  /api/v2/group/sbom-assignment:
+  /api/v3/group/sbom-assignment:
     put:
       tags:
       - sbomGroup
@@ -948,7 +1210,7 @@ paths:
           description: The user was not authenticated
         '403':
           description: The user authenticated, but not authorized for this operation
-  /api/v2/group/sbom-assignment/{id}:
+  /api/v3/group/sbom-assignment/{id}:
     get:
       tags:
       - sbomGroup
@@ -1011,7 +1273,7 @@ paths:
           description: The user authenticated, but not authorized for this operation
         '412':
           description: The requested revision is not the current revision
-  /api/v2/group/sbom/{id}:
+  /api/v3/group/sbom/{id}:
     get:
       tags:
       - sbomGroup
@@ -1120,7 +1382,7 @@ paths:
           description: The group has child groups and cannot be deleted
         '412':
           description: The requested revision is not the current revision of the group
-  /api/v2/importer:
+  /api/v3/importer:
     get:
       tags:
       - importer
@@ -1135,7 +1397,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Importer'
-  /api/v2/importer/{name}:
+  /api/v3/importer/{name}:
     get:
       tags:
       - importer
@@ -1273,7 +1535,7 @@ paths:
           description: The importer could not be found
         '412':
           description: The provided if-match header did not match the stored revision
-  /api/v2/importer/{name}/enabled:
+  /api/v3/importer/{name}/enabled:
     put:
       tags:
       - importer
@@ -1307,7 +1569,7 @@ paths:
           description: The importer could not be found
         '412':
           description: The provided if-match header did not match the stored revision
-  /api/v2/importer/{name}/force:
+  /api/v3/importer/{name}/force:
     post:
       tags:
       - importer
@@ -1341,7 +1603,7 @@ paths:
           description: The importer could not be found
         '412':
           description: The provided if-match header did not match the stored revision
-  /api/v2/importer/{name}/report:
+  /api/v3/importer/{name}/report:
     get:
       tags:
       - importer
@@ -1462,7 +1724,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_ImporterReport'
-  /api/v2/license:
+  /api/v3/license:
     get:
       tags:
       - license
@@ -1550,7 +1812,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_LicenseText'
-  /api/v2/license/spdx/license:
+  /api/v3/license/spdx/license:
     get:
       tags:
       - spdx license
@@ -1666,7 +1928,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_SpdxLicenseSummary'
-  /api/v2/license/spdx/license/{id}:
+  /api/v3/license/spdx/license/{id}:
     get:
       tags:
       - spdx license
@@ -1685,7 +1947,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SpdxLicenseDetails'
-  /api/v2/organization:
+  /api/v3/organization:
     get:
       tags:
       - organization
@@ -1801,7 +2063,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OrganizationSummary'
-  /api/v2/organization/{id}:
+  /api/v3/organization/{id}:
     get:
       tags:
       - organization
@@ -1824,7 +2086,7 @@ paths:
                 $ref: '#/components/schemas/OrganizationDetails'
         '404':
           description: The organization could not be found
-  /api/v2/product:
+  /api/v3/product:
     get:
       tags:
       - product
@@ -1939,7 +2201,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_ProductSummary'
-  /api/v2/product/{id}:
+  /api/v3/product/{id}:
     get:
       tags:
       - product
@@ -1982,7 +2244,7 @@ paths:
                 $ref: '#/components/schemas/ProductDetails'
         '404':
           description: The product could not be found
-  /api/v2/purl:
+  /api/v3/purl:
     get:
       tags:
       - purl
@@ -2098,7 +2360,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_PurlSummary'
-  /api/v2/purl/base:
+  /api/v3/purl/base:
     get:
       tags:
       - purl
@@ -2214,7 +2476,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_BasePurlSummary'
-  /api/v2/purl/base/{key}:
+  /api/v3/purl/base/{key}:
     get:
       tags:
       - purl
@@ -2234,7 +2496,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasePurlDetails'
-  /api/v2/purl/recommend:
+  /api/v3/purl/recommend:
     post:
       tags:
       - purl
@@ -2252,1488 +2514,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RecommendResponse'
-  /api/v2/sbom:
-    get:
-      tags:
-      - sbom
-      summary: List SBOMs
-      operationId: v2/listSboms
-      parameters:
-      - name: q
-        in: query
-        description: |
-          EBNF grammar for the _q_ parameter:
-          ```text
-              q = ( values | filter ) { '&' q }
-              values = value { '|', values }
-              filter = field, operator, values
-              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
-              value = (* any text but escape special characters with '\' *)
-              field = (* must match an entity attribute name *)
-          ```
-          Any values in a _q_ will result in a case-insensitive "full
-          text search", effectively producing an OR clause of LIKE
-          clauses for every string-ish field in the resource being
-          queried.
-
-          Examples:
-          - `foo` - any field containing 'foo'
-          - `foo|bar` - any field containing either 'foo' OR 'bar'
-          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
-
-          A _filter_ may also be used to constrain the results. The
-          filter's field name must correspond to one of the resource's
-          attributes. If it doesn't, an error will be returned
-          containing a list of the valid fields for that resource.
-
-          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
-          to find resources on which a particular field isn't set. For
-          example, `name=%00` and `name!=%00` yield the WHERE clauses,
-          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
-
-          Examples:
-          - `name=foo` - entity's _name_ matches 'foo' exactly
-          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
-          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
-          - `name=` - entity's _name_ is the empty string, ''
-          - `name=%00` - entity's _name_ isn't set
-          - `published>3 days ago` - date values can be "human time"
-
-          Multiple full text searches and/or filters should be
-          '&'-delimited -- they are logically AND'd together.
-
-          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
-
-          Fields corresponding to JSON objects in the database may use a
-          ':' to delimit the column name and the object key,
-          e.g. `purl:qualifiers:type=pom`
-
-          Any operator or special character, e.g. '|', '&', within a
-          value should be escaped by prefixing it with a backslash.
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        description: |
-          EBNF grammar for the _sort_ parameter:
-          ```text
-              sort = field [ ':', order ] { ',' sort }
-              order = ( "asc" | "desc" )
-              field = (* must match the name of entity's attributes *)
-          ```
-          The optional _order_ should be one of "asc" or "desc". If
-          omitted, the order defaults to "asc".
-
-          Each _field_ name must correspond to one of the columns of the
-          table holding the entities being queried. Those corresponding
-          to JSON objects in the database may use a ':' to delimit the
-          column name and the object key,
-          e.g. `purl:qualifiers:type:desc`
-        required: false
-        schema:
-          type: string
-      - name: offset
-        in: query
-        description: |-
-          The first item to return, skipping all that come before it.
-
-          NOTE: The order of items is defined by the API being called.
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: limit
-        in: query
-        description: |-
-          The maximum number of entries to return.
-
-          Zero means: return no items (the total count is still computed if requested).
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: total
-        in: query
-        description: Whether to compute and return the total count of matching items.
-        required: false
-        schema:
-          type: boolean
-      - name: group
-        in: query
-        description: |-
-          Filter by group IDs. Only SBOMs assigned to any of the provided groups will be returned.
-          Can be specified multiple times. Malformed IDs are silently ignored.
-        required: false
-        schema:
-          type: array
-          items:
-            type: string
-      responses:
-        '200':
-          description: Matching SBOMs
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedResults_SbomSummary'
-      deprecated: true
-    post:
-      tags:
-      - sbom
-      summary: Upload a new SBOM
-      operationId: uploadSbom
-      parameters:
-      - name: labels
-        in: path
-        description: |-
-          Optional labels.
-
-          Only use keys with a prefix of `labels.`
-        required: true
-        schema:
-          $ref: '#/components/schemas/Labels'
-      - name: format
-        in: path
-        description: The format of the uploaded document.
-        required: true
-        schema:
-          type: string
-          enum:
-          - osv
-          - csaf
-          - cve
-          - spdx
-          - cyclonedx
-          - clearlydefinedcuration
-          - clearlydefined
-          - cwecatalog
-          - advisory
-          - sbom
-          - unknown
-      - name: cache
-        in: path
-        description: Await loading the document into the analysis graph cache
-        required: true
-        schema:
-          type: string
-          enum:
-          - skip
-          - queue
-          - wait
-      - name: group
-        in: path
-        description: |-
-          Optional group IDs to assign the SBOM to after ingestion.
-
-          If one or more group IDs are invalid, the upload will fail with 400 Bad Request
-          and the SBOM will not be ingested.
-        required: true
-        schema:
-          type: array
-          items:
-            type: string
-      requestBody:
-        content:
-          application/octet-stream:
-            schema:
-              type: array
-              items:
-                type: integer
-                format: int32
-                minimum: 0
-        required: true
-      responses:
-        '201':
-          description: Upload an SBOM
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IngestResult'
-        '400':
-          description: One or more group IDs are invalid or do not exist
-  /api/v2/sbom-labels:
-    get:
-      tags:
-      - sbom
-      summary: List all unique key/value labels from all SBOMs
-      operationId: listSbomLabels
-      parameters:
-      - name: filter_text
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      responses:
-        '200':
-          description: List all unique key/value labels from all SBOMs
-          content:
-            application/json:
-              schema:
-                type: array
-                items: {}
-  /api/v2/sbom/by-package:
-    get:
-      tags:
-      - sbom
-      summary: Find all SBOMs containing the provided package.
-      description: |-
-        The package can be provided either via a PURL or using the ID of a package as returned by
-        other APIs, but not both.
-      operationId: listRelatedSboms
-      parameters:
-      - name: q
-        in: query
-        description: |
-          EBNF grammar for the _q_ parameter:
-          ```text
-              q = ( values | filter ) { '&' q }
-              values = value { '|', values }
-              filter = field, operator, values
-              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
-              value = (* any text but escape special characters with '\' *)
-              field = (* must match an entity attribute name *)
-          ```
-          Any values in a _q_ will result in a case-insensitive "full
-          text search", effectively producing an OR clause of LIKE
-          clauses for every string-ish field in the resource being
-          queried.
-
-          Examples:
-          - `foo` - any field containing 'foo'
-          - `foo|bar` - any field containing either 'foo' OR 'bar'
-          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
-
-          A _filter_ may also be used to constrain the results. The
-          filter's field name must correspond to one of the resource's
-          attributes. If it doesn't, an error will be returned
-          containing a list of the valid fields for that resource.
-
-          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
-          to find resources on which a particular field isn't set. For
-          example, `name=%00` and `name!=%00` yield the WHERE clauses,
-          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
-
-          Examples:
-          - `name=foo` - entity's _name_ matches 'foo' exactly
-          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
-          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
-          - `name=` - entity's _name_ is the empty string, ''
-          - `name=%00` - entity's _name_ isn't set
-          - `published>3 days ago` - date values can be "human time"
-
-          Multiple full text searches and/or filters should be
-          '&'-delimited -- they are logically AND'd together.
-
-          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
-
-          Fields corresponding to JSON objects in the database may use a
-          ':' to delimit the column name and the object key,
-          e.g. `purl:qualifiers:type=pom`
-
-          Any operator or special character, e.g. '|', '&', within a
-          value should be escaped by prefixing it with a backslash.
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        description: |
-          EBNF grammar for the _sort_ parameter:
-          ```text
-              sort = field [ ':', order ] { ',' sort }
-              order = ( "asc" | "desc" )
-              field = (* must match the name of entity's attributes *)
-          ```
-          The optional _order_ should be one of "asc" or "desc". If
-          omitted, the order defaults to "asc".
-
-          Each _field_ name must correspond to one of the columns of the
-          table holding the entities being queried. Those corresponding
-          to JSON objects in the database may use a ':' to delimit the
-          column name and the object key,
-          e.g. `purl:qualifiers:type:desc`
-        required: false
-        schema:
-          type: string
-      - name: offset
-        in: query
-        description: |-
-          The first item to return, skipping all that come before it.
-
-          NOTE: The order of items is defined by the API being called.
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: limit
-        in: query
-        description: |-
-          The maximum number of entries to return.
-
-          Zero means: return no items (the total count is still computed if requested).
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: total
-        in: query
-        description: Whether to compute and return the total count of matching items.
-        required: false
-        schema:
-          type: boolean
-      - name: purl
-        in: query
-        description: Find by PURL
-        required: false
-        schema:
-          oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/Purl'
-      - name: cpe
-        in: query
-        description: Find by CPE
-        required: false
-        schema:
-          oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/Cpe'
-      responses:
-        '200':
-          description: Matching SBOMs
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedResults_SbomSummary'
-  /api/v2/sbom/count-by-package:
-    get:
-      tags:
-      - sbom
-      summary: Count all SBOMs containing the provided packages.
-      description: |-
-        The packages can be provided either via a PURL or using the ID of a package as returned by
-        other APIs, but not both.
-      operationId: countRelatedSboms
-      parameters:
-      - name: purl
-        in: path
-        description: Find by PURL
-        required: true
-        schema:
-          oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/Purl'
-      - name: cpe
-        in: path
-        description: Find by CPE
-        required: true
-        schema:
-          oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/Cpe'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/ExternalReferenceQuery'
-        required: true
-      responses:
-        '200':
-          description: Number of matching SBOMs per package
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: integer
-                  format: int64
-  /api/v2/sbom/models:
-    get:
-      tags:
-      - sbom
-      summary: Search for all AI models
-      operationId: listAllModels
-      parameters:
-      - name: q
-        in: query
-        description: |
-          EBNF grammar for the _q_ parameter:
-          ```text
-              q = ( values | filter ) { '&' q }
-              values = value { '|', values }
-              filter = field, operator, values
-              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
-              value = (* any text but escape special characters with '\' *)
-              field = (* must match an entity attribute name *)
-          ```
-          Any values in a _q_ will result in a case-insensitive "full
-          text search", effectively producing an OR clause of LIKE
-          clauses for every string-ish field in the resource being
-          queried.
-
-          Examples:
-          - `foo` - any field containing 'foo'
-          - `foo|bar` - any field containing either 'foo' OR 'bar'
-          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
-
-          A _filter_ may also be used to constrain the results. The
-          filter's field name must correspond to one of the resource's
-          attributes. If it doesn't, an error will be returned
-          containing a list of the valid fields for that resource.
-
-          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
-          to find resources on which a particular field isn't set. For
-          example, `name=%00` and `name!=%00` yield the WHERE clauses,
-          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
-
-          Examples:
-          - `name=foo` - entity's _name_ matches 'foo' exactly
-          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
-          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
-          - `name=` - entity's _name_ is the empty string, ''
-          - `name=%00` - entity's _name_ isn't set
-          - `published>3 days ago` - date values can be "human time"
-
-          Multiple full text searches and/or filters should be
-          '&'-delimited -- they are logically AND'd together.
-
-          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
-
-          Fields corresponding to JSON objects in the database may use a
-          ':' to delimit the column name and the object key,
-          e.g. `purl:qualifiers:type=pom`
-
-          Any operator or special character, e.g. '|', '&', within a
-          value should be escaped by prefixing it with a backslash.
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        description: |
-          EBNF grammar for the _sort_ parameter:
-          ```text
-              sort = field [ ':', order ] { ',' sort }
-              order = ( "asc" | "desc" )
-              field = (* must match the name of entity's attributes *)
-          ```
-          The optional _order_ should be one of "asc" or "desc". If
-          omitted, the order defaults to "asc".
-
-          Each _field_ name must correspond to one of the columns of the
-          table holding the entities being queried. Those corresponding
-          to JSON objects in the database may use a ':' to delimit the
-          column name and the object key,
-          e.g. `purl:qualifiers:type:desc`
-        required: false
-        schema:
-          type: string
-      - name: offset
-        in: query
-        description: |-
-          The first item to return, skipping all that come before it.
-
-          NOTE: The order of items is defined by the API being called.
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: limit
-        in: query
-        description: |-
-          The maximum number of entries to return.
-
-          Zero means: return no items (the total count is still computed if requested).
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: total
-        in: query
-        description: Whether to compute and return the total count of matching items.
-        required: false
-        schema:
-          type: boolean
-      - name: counts
-        in: query
-        description: Include SBOM counts for each model
-        required: false
-        schema:
-          type: boolean
-      responses:
-        '200':
-          description: AI Models
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedResults_SbomModel'
-  /api/v2/sbom/{id}:
-    get:
-      tags:
-      - sbom
-      summary: Get information about an SBOM
-      operationId: getSbom
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
-      responses:
-        '200':
-          description: Matching SBOM
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SbomSummary'
-        '404':
-          description: The SBOM could not be found
-    delete:
-      tags:
-      - sbom
-      summary: Delete an SBOM
-      operationId: deleteSbom
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
-      responses:
-        '204':
-          description: Matching SBOM as deleted
-        '404':
-          description: The SBOM could not be found
-  /api/v2/sbom/{id}/all-license-ids:
-    get:
-      tags:
-      - sbom
-      operationId: listAllLicenseIds
-      parameters:
-      - name: id
-        in: path
-        description: ID of the SBOM to get the license IDs for
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: fetch all unique license id and license info id
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/LicenseRefMapping'
-        '400':
-          description: Invalid UUID format.
-  /api/v2/sbom/{id}/label:
-    put:
-      tags:
-      - sbom
-      summary: Replace the labels of an SBOM
-      operationId: updateSbomLabels
-      parameters:
-      - name: id
-        in: path
-        description: Digest/hash of the document, prefixed by hash type, such as 'sha256:<hash>' or 'urn:uuid:<uuid>'
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Labels'
-        required: true
-      responses:
-        '204':
-          description: Replaced the labels of the SBOM
-        '404':
-          description: The SBOM could not be found
-    patch:
-      tags:
-      - sbom
-      summary: Modify existing labels of an SBOM
-      operationId: patchSbomLabels
-      parameters:
-      - name: id
-        in: path
-        description: Digest/hash of the document, prefixed by hash type, such as 'sha256:<hash>' or 'urn:uuid:<uuid>'
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Update'
-        required: true
-      responses:
-        '204':
-          description: Modified the labels of the SBOM
-        '404':
-          description: The SBOM could not be found
-  /api/v2/sbom/{id}/license-export:
-    get:
-      tags:
-      - sbom
-      operationId: getLicenseExport
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: license gzip files
-          content:
-            application/gzip:
-              schema:
-                type: array
-                items:
-                  type: integer
-                  format: int32
-                  minimum: 0
-        '404':
-          description: The document could not be found
-  /api/v2/sbom/{id}/models:
-    get:
-      tags:
-      - sbom
-      summary: Search for AI models associated with an SBOM
-      operationId: listModels
-      parameters:
-      - name: id
-        in: path
-        description: ID of the SBOM to get models for
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: q
-        in: query
-        description: |
-          EBNF grammar for the _q_ parameter:
-          ```text
-              q = ( values | filter ) { '&' q }
-              values = value { '|', values }
-              filter = field, operator, values
-              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
-              value = (* any text but escape special characters with '\' *)
-              field = (* must match an entity attribute name *)
-          ```
-          Any values in a _q_ will result in a case-insensitive "full
-          text search", effectively producing an OR clause of LIKE
-          clauses for every string-ish field in the resource being
-          queried.
-
-          Examples:
-          - `foo` - any field containing 'foo'
-          - `foo|bar` - any field containing either 'foo' OR 'bar'
-          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
-
-          A _filter_ may also be used to constrain the results. The
-          filter's field name must correspond to one of the resource's
-          attributes. If it doesn't, an error will be returned
-          containing a list of the valid fields for that resource.
-
-          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
-          to find resources on which a particular field isn't set. For
-          example, `name=%00` and `name!=%00` yield the WHERE clauses,
-          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
-
-          Examples:
-          - `name=foo` - entity's _name_ matches 'foo' exactly
-          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
-          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
-          - `name=` - entity's _name_ is the empty string, ''
-          - `name=%00` - entity's _name_ isn't set
-          - `published>3 days ago` - date values can be "human time"
-
-          Multiple full text searches and/or filters should be
-          '&'-delimited -- they are logically AND'd together.
-
-          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
-
-          Fields corresponding to JSON objects in the database may use a
-          ':' to delimit the column name and the object key,
-          e.g. `purl:qualifiers:type=pom`
-
-          Any operator or special character, e.g. '|', '&', within a
-          value should be escaped by prefixing it with a backslash.
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        description: |
-          EBNF grammar for the _sort_ parameter:
-          ```text
-              sort = field [ ':', order ] { ',' sort }
-              order = ( "asc" | "desc" )
-              field = (* must match the name of entity's attributes *)
-          ```
-          The optional _order_ should be one of "asc" or "desc". If
-          omitted, the order defaults to "asc".
-
-          Each _field_ name must correspond to one of the columns of the
-          table holding the entities being queried. Those corresponding
-          to JSON objects in the database may use a ':' to delimit the
-          column name and the object key,
-          e.g. `purl:qualifiers:type:desc`
-        required: false
-        schema:
-          type: string
-      - name: offset
-        in: query
-        description: |-
-          The first item to return, skipping all that come before it.
-
-          NOTE: The order of items is defined by the API being called.
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: limit
-        in: query
-        description: |-
-          The maximum number of entries to return.
-
-          Zero means: return no items (the total count is still computed if requested).
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: total
-        in: query
-        description: Whether to compute and return the total count of matching items.
-        required: false
-        schema:
-          type: boolean
-      - name: counts
-        in: query
-        description: Include SBOM counts for each model
-        required: false
-        schema:
-          type: boolean
-      responses:
-        '200':
-          description: AI Models
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedResults_SbomModel'
-  /api/v2/sbom/{id}/packages:
-    get:
-      tags:
-      - sbom
-      summary: Search for packages of an SBOM
-      operationId: listPackages
-      parameters:
-      - name: id
-        in: path
-        description: ID of the SBOM to get packages for
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
-      - name: q
-        in: query
-        description: |
-          EBNF grammar for the _q_ parameter:
-          ```text
-              q = ( values | filter ) { '&' q }
-              values = value { '|', values }
-              filter = field, operator, values
-              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
-              value = (* any text but escape special characters with '\' *)
-              field = (* must match an entity attribute name *)
-          ```
-          Any values in a _q_ will result in a case-insensitive "full
-          text search", effectively producing an OR clause of LIKE
-          clauses for every string-ish field in the resource being
-          queried.
-
-          Examples:
-          - `foo` - any field containing 'foo'
-          - `foo|bar` - any field containing either 'foo' OR 'bar'
-          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
-
-          A _filter_ may also be used to constrain the results. The
-          filter's field name must correspond to one of the resource's
-          attributes. If it doesn't, an error will be returned
-          containing a list of the valid fields for that resource.
-
-          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
-          to find resources on which a particular field isn't set. For
-          example, `name=%00` and `name!=%00` yield the WHERE clauses,
-          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
-
-          Examples:
-          - `name=foo` - entity's _name_ matches 'foo' exactly
-          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
-          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
-          - `name=` - entity's _name_ is the empty string, ''
-          - `name=%00` - entity's _name_ isn't set
-          - `published>3 days ago` - date values can be "human time"
-
-          Multiple full text searches and/or filters should be
-          '&'-delimited -- they are logically AND'd together.
-
-          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
-
-          Fields corresponding to JSON objects in the database may use a
-          ':' to delimit the column name and the object key,
-          e.g. `purl:qualifiers:type=pom`
-
-          Any operator or special character, e.g. '|', '&', within a
-          value should be escaped by prefixing it with a backslash.
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        description: |
-          EBNF grammar for the _sort_ parameter:
-          ```text
-              sort = field [ ':', order ] { ',' sort }
-              order = ( "asc" | "desc" )
-              field = (* must match the name of entity's attributes *)
-          ```
-          The optional _order_ should be one of "asc" or "desc". If
-          omitted, the order defaults to "asc".
-
-          Each _field_ name must correspond to one of the columns of the
-          table holding the entities being queried. Those corresponding
-          to JSON objects in the database may use a ':' to delimit the
-          column name and the object key,
-          e.g. `purl:qualifiers:type:desc`
-        required: false
-        schema:
-          type: string
-      - name: offset
-        in: query
-        description: |-
-          The first item to return, skipping all that come before it.
-
-          NOTE: The order of items is defined by the API being called.
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: limit
-        in: query
-        description: |-
-          The maximum number of entries to return.
-
-          Zero means: return no items (the total count is still computed if requested).
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: total
-        in: query
-        description: Whether to compute and return the total count of matching items.
-        required: false
-        schema:
-          type: boolean
-      responses:
-        '200':
-          description: Packages
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedResults_SbomPackage'
-        '404':
-          description: The SBOM could not be found
-  /api/v2/sbom/{id}/related:
-    get:
-      tags:
-      - sbom
-      summary: Search for related packages in an SBOM
-      operationId: listRelatedPackages
-      parameters:
-      - name: id
-        in: path
-        description: ID of SBOM to search packages in
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
-      - name: reference
-        in: query
-        description: The Package to use as reference
-        required: false
-        schema:
-          type:
-          - string
-          - 'null'
-      - name: which
-        in: query
-        description: Which side the reference should be on
-        required: false
-        schema:
-          type: string
-          enum:
-          - left
-          - right
-      - name: relationship
-        in: query
-        description: Optional relationship filter
-        required: false
-        schema:
-          oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/Relationship'
-      - name: q
-        in: query
-        description: |
-          EBNF grammar for the _q_ parameter:
-          ```text
-              q = ( values | filter ) { '&' q }
-              values = value { '|', values }
-              filter = field, operator, values
-              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
-              value = (* any text but escape special characters with '\' *)
-              field = (* must match an entity attribute name *)
-          ```
-          Any values in a _q_ will result in a case-insensitive "full
-          text search", effectively producing an OR clause of LIKE
-          clauses for every string-ish field in the resource being
-          queried.
-
-          Examples:
-          - `foo` - any field containing 'foo'
-          - `foo|bar` - any field containing either 'foo' OR 'bar'
-          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
-
-          A _filter_ may also be used to constrain the results. The
-          filter's field name must correspond to one of the resource's
-          attributes. If it doesn't, an error will be returned
-          containing a list of the valid fields for that resource.
-
-          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
-          to find resources on which a particular field isn't set. For
-          example, `name=%00` and `name!=%00` yield the WHERE clauses,
-          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
-
-          Examples:
-          - `name=foo` - entity's _name_ matches 'foo' exactly
-          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
-          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
-          - `name=` - entity's _name_ is the empty string, ''
-          - `name=%00` - entity's _name_ isn't set
-          - `published>3 days ago` - date values can be "human time"
-
-          Multiple full text searches and/or filters should be
-          '&'-delimited -- they are logically AND'd together.
-
-          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
-
-          Fields corresponding to JSON objects in the database may use a
-          ':' to delimit the column name and the object key,
-          e.g. `purl:qualifiers:type=pom`
-
-          Any operator or special character, e.g. '|', '&', within a
-          value should be escaped by prefixing it with a backslash.
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        description: |
-          EBNF grammar for the _sort_ parameter:
-          ```text
-              sort = field [ ':', order ] { ',' sort }
-              order = ( "asc" | "desc" )
-              field = (* must match the name of entity's attributes *)
-          ```
-          The optional _order_ should be one of "asc" or "desc". If
-          omitted, the order defaults to "asc".
-
-          Each _field_ name must correspond to one of the columns of the
-          table holding the entities being queried. Those corresponding
-          to JSON objects in the database may use a ':' to delimit the
-          column name and the object key,
-          e.g. `purl:qualifiers:type:desc`
-        required: false
-        schema:
-          type: string
-      - name: offset
-        in: query
-        description: |-
-          The first item to return, skipping all that come before it.
-
-          NOTE: The order of items is defined by the API being called.
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: limit
-        in: query
-        description: |-
-          The maximum number of entries to return.
-
-          Zero means: return no items (the total count is still computed if requested).
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: total
-        in: query
-        description: Whether to compute and return the total count of matching items.
-        required: false
-        schema:
-          type: boolean
-      responses:
-        '200':
-          description: Packages
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedResults_SbomPackageRelation_SbomPackage'
-        '404':
-          description: The SBOM could not be found
-  /api/v2/sbom/{key}/download:
-    get:
-      tags:
-      - sbom
-      summary: Download an SBOM
-      operationId: downloadSbom
-      parameters:
-      - name: key
-        in: path
-        description: Identifier of the SBOM, either `urn:uuid:<uuid>` or a digest e.g. `sha256:<hex>`
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
-      responses:
-        '200':
-          description: Download a an SBOM
-          content:
-            application/json:
-              schema:
-                type: string
-                format: binary
-        '404':
-          description: The document could not be found
-  /api/v2/ui/extract-sbom-purls:
-    post:
-      tags:
-      - ui
-      summary: Extract PURLs from an SBOM provided in the request
-      operationId: extractSbomPurls
-      parameters:
-      - name: format
-        in: query
-        description: An SBOM format to expect, or [`Format::SBOM`] and [`Format::Unknown`] to auto-detect.
-        required: false
-        schema:
-          $ref: '#/components/schemas/Format'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-              format: binary
-        required: true
-      responses:
-        '200':
-          description: Information extracted from the SBOM
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ExtractResult'
-        '400':
-          description: Bad request data, like an unsupported format or invalid data
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorInformation'
-  /api/v2/userPreference/{key}:
-    get:
-      tags:
-      - userPreferences
-      summary: Get user preferences
-      operationId: getUserPreferences
-      parameters:
-      - name: key
-        in: path
-        description: The key to the user preferences
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: User preference stored under this key
-          headers:
-            etag:
-              schema:
-                type: string
-              description: Revision ID
-          content:
-            application/json:
-              schema: {}
-        '404':
-          description: The user preference key could not be found
-    put:
-      tags:
-      - userPreferences
-      summary: Set user preferences
-      operationId: setUserPreferences
-      parameters:
-      - name: key
-        in: path
-        description: The key to the user preferences
-        required: true
-        schema:
-          type: string
-      - name: if-match
-        in: header
-        description: The revision to update
-        required: false
-        schema:
-          type:
-          - string
-          - 'null'
-      requestBody:
-        content:
-          application/json:
-            schema: {}
-        required: true
-      responses:
-        '200':
-          description: User preference stored under this key
-          headers:
-            etag:
-              schema:
-                type: string
-              description: Revision ID
-        '412':
-          description: The provided If-Match revision did not match the actual revision
-    delete:
-      tags:
-      - userPreferences
-      summary: Delete user preferences
-      operationId: deleteUserPreferences
-      parameters:
-      - name: key
-        in: path
-        description: The key to the user preferences
-        required: true
-        schema:
-          type: string
-      - name: if-match
-        in: header
-        description: The revision to delete
-        required: false
-        schema:
-          type:
-          - string
-          - 'null'
-      requestBody:
-        content:
-          application/json:
-            schema: {}
-        required: true
-      responses:
-        '201':
-          description: User preferences are deleted
-        '412':
-          description: The provided If-Match revision did not match the actual revision
-  /api/v2/vulnerability/analyze:
-    post:
-      tags:
-      - vulnerability
-      summary: Analyze the provided purls for the known vulnerabilities
-      operationId: analyze
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AnalysisRequest'
-        required: true
-      responses:
-        '200':
-          description: Analyze the provided purls to search for known vulnerabilities
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AnalysisResponse'
-  /api/v2/weakness:
-    get:
-      tags:
-      - weakness
-      summary: List weaknesses
-      operationId: listWeaknesses
-      parameters:
-      - name: q
-        in: query
-        description: |
-          EBNF grammar for the _q_ parameter:
-          ```text
-              q = ( values | filter ) { '&' q }
-              values = value { '|', values }
-              filter = field, operator, values
-              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
-              value = (* any text but escape special characters with '\' *)
-              field = (* must match an entity attribute name *)
-          ```
-          Any values in a _q_ will result in a case-insensitive "full
-          text search", effectively producing an OR clause of LIKE
-          clauses for every string-ish field in the resource being
-          queried.
-
-          Examples:
-          - `foo` - any field containing 'foo'
-          - `foo|bar` - any field containing either 'foo' OR 'bar'
-          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
-
-          A _filter_ may also be used to constrain the results. The
-          filter's field name must correspond to one of the resource's
-          attributes. If it doesn't, an error will be returned
-          containing a list of the valid fields for that resource.
-
-          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
-          to find resources on which a particular field isn't set. For
-          example, `name=%00` and `name!=%00` yield the WHERE clauses,
-          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
-
-          Examples:
-          - `name=foo` - entity's _name_ matches 'foo' exactly
-          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
-          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
-          - `name=` - entity's _name_ is the empty string, ''
-          - `name=%00` - entity's _name_ isn't set
-          - `published>3 days ago` - date values can be "human time"
-
-          Multiple full text searches and/or filters should be
-          '&'-delimited -- they are logically AND'd together.
-
-          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
-
-          Fields corresponding to JSON objects in the database may use a
-          ':' to delimit the column name and the object key,
-          e.g. `purl:qualifiers:type=pom`
-
-          Any operator or special character, e.g. '|', '&', within a
-          value should be escaped by prefixing it with a backslash.
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        description: |
-          EBNF grammar for the _sort_ parameter:
-          ```text
-              sort = field [ ':', order ] { ',' sort }
-              order = ( "asc" | "desc" )
-              field = (* must match the name of entity's attributes *)
-          ```
-          The optional _order_ should be one of "asc" or "desc". If
-          omitted, the order defaults to "asc".
-
-          Each _field_ name must correspond to one of the columns of the
-          table holding the entities being queried. Those corresponding
-          to JSON objects in the database may use a ':' to delimit the
-          column name and the object key,
-          e.g. `purl:qualifiers:type:desc`
-        required: false
-        schema:
-          type: string
-      - name: offset
-        in: query
-        description: |-
-          The first item to return, skipping all that come before it.
-
-          NOTE: The order of items is defined by the API being called.
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: limit
-        in: query
-        description: |-
-          The maximum number of entries to return.
-
-          Zero means: return no items (the total count is still computed if requested).
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: total
-        in: query
-        description: Whether to compute and return the total count of matching items.
-        required: false
-        schema:
-          type: boolean
-      responses:
-        '200':
-          description: Matching weaknesses
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedResults_LicenseSummary'
-  /api/v2/weakness/{id}:
-    get:
-      tags:
-      - weakness
-      summary: Retrieve weakness details
-      operationId: getWeakness
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: The weakness
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LicenseSummary'
-        '404':
-          description: The weakness could not be found
-  /api/v3/advisory:
-    get:
-      tags:
-      - advisory
-      summary: List advisories
-      operationId: listAdvisories
-      parameters:
-      - name: q
-        in: query
-        description: |
-          Query for advisories defined using the following EBNF grammar (ISO/IEC 14977):
-          ```text
-          (* Query Grammar - EBNF Compliant *)
-          query = ( values | filter ) , { "&" , query } ;
-          values = value , { "|" , value } ;
-          filter = field , operator , values ;
-          operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<" ;
-          field = ("id" | "identifier" | "version" | "document_id" | "deprecated" | "issuer_id" | "published" | "modified" | "withdrawn" | "title" | "ingested" | "label")
-          value = { value_char } ;
-          value_char = escaped_char | normal_char ;
-          escaped_char = "\" , special_char ;
-          normal_char = ? any character except '&', '|', '=', '!', '~', '>', '<', '\' ? ;
-          special_char = "&" | "|" | "=" | "!" | "~" | ">" | "<" | "\" ;
-          ```
-          Examples:
-          - Simple filter: title=example
-          - Multiple values filter: title=foo|bar|baz
-          - Complex filter: modified>2024-01-01
-          - Combined query: title=foo&average_severity=high
-          - Escaped characters: title=foo\\&bar
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        description: |-
-          EBNF grammar for the _sort_ parameter:
-          ```text
-              sort = field [ ':', order ] { ',' sort }
-              order = ( "asc" | "desc" )
-              field = ("id" | "identifier" | "version" | "document_id" | "deprecated" | "issuer_id" | "published" | "modified" | "withdrawn" | "title" | "ingested" | "label")
-          ```
-          The optional _order_ should be one of "asc" or "desc". If
-          omitted, the order defaults to "asc".
-
-          Each _field_ name must correspond to one of the columns of the
-          table holding the entities being queried. Those corresponding
-          to JSON objects in the database may use a ':' to delimit the
-          column name and the object key,
-          e.g. `purl:qualifiers:type:desc`
-        required: false
-        schema:
-          type: string
-      - name: offset
-        in: query
-        description: |-
-          The first item to return, skipping all that come before it.
-
-          NOTE: The order of items is defined by the API being called.
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: limit
-        in: query
-        description: |-
-          The maximum number of entries to return.
-
-          Zero means: return no items (the total count is still computed if requested).
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: total
-        in: query
-        description: Whether to compute and return the total count of matching items.
-        required: false
-        schema:
-          type: boolean
-      - name: deprecated
-        in: query
-        required: false
-        schema:
-          type: string
-          enum:
-          - Ignore
-          - Consider
-      responses:
-        '200':
-          description: Matching vulnerabilities
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedResults_AdvisorySummary'
-  /api/v3/advisory/{key}:
-    get:
-      tags:
-      - advisory
-      summary: Get an advisory
-      operationId: getAdvisory
-      parameters:
-      - name: key
-        in: path
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
-      responses:
-        '200':
-          description: Matching advisory
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AdvisoryDetails'
-        '404':
-          description: The advisory could not be found
   /api/v3/purl/{key}:
     get:
       tags:
@@ -3888,6 +2668,445 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_SbomPackageSummary'
+    post:
+      tags:
+      - sbom
+      summary: Upload a new SBOM
+      operationId: uploadSbom
+      parameters:
+      - name: labels
+        in: path
+        description: |-
+          Optional labels.
+
+          Only use keys with a prefix of `labels.`
+        required: true
+        schema:
+          $ref: '#/components/schemas/Labels'
+      - name: format
+        in: path
+        description: The format of the uploaded document.
+        required: true
+        schema:
+          type: string
+          enum:
+          - osv
+          - csaf
+          - cve
+          - spdx
+          - cyclonedx
+          - clearlydefinedcuration
+          - clearlydefined
+          - cwecatalog
+          - advisory
+          - sbom
+          - unknown
+      - name: cache
+        in: path
+        description: Await loading the document into the analysis graph cache
+        required: true
+        schema:
+          type: string
+          enum:
+          - skip
+          - queue
+          - wait
+      - name: group
+        in: path
+        description: |-
+          Optional group IDs to assign the SBOM to after ingestion.
+
+          If one or more group IDs are invalid, the upload will fail with 400 Bad Request
+          and the SBOM will not be ingested.
+        required: true
+        schema:
+          type: array
+          items:
+            type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: int32
+                minimum: 0
+        required: true
+      responses:
+        '201':
+          description: Upload an SBOM
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IngestResult'
+        '400':
+          description: One or more group IDs are invalid or do not exist
+  /api/v3/sbom-labels:
+    get:
+      tags:
+      - sbom
+      summary: List all unique key/value labels from all SBOMs
+      operationId: listSbomLabels
+      parameters:
+      - name: filter_text
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      responses:
+        '200':
+          description: List all unique key/value labels from all SBOMs
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {}
+  /api/v3/sbom/by-package:
+    get:
+      tags:
+      - sbom
+      summary: Find all SBOMs containing the provided package.
+      description: |-
+        The package can be provided either via a PURL or using the ID of a package as returned by
+        other APIs, but not both.
+      operationId: listRelatedSboms
+      parameters:
+      - name: q
+        in: query
+        description: |
+          EBNF grammar for the _q_ parameter:
+          ```text
+              q = ( values | filter ) { '&' q }
+              values = value { '|', values }
+              filter = field, operator, values
+              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
+              value = (* any text but escape special characters with '\' *)
+              field = (* must match an entity attribute name *)
+          ```
+          Any values in a _q_ will result in a case-insensitive "full
+          text search", effectively producing an OR clause of LIKE
+          clauses for every string-ish field in the resource being
+          queried.
+
+          Examples:
+          - `foo` - any field containing 'foo'
+          - `foo|bar` - any field containing either 'foo' OR 'bar'
+          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
+
+          A _filter_ may also be used to constrain the results. The
+          filter's field name must correspond to one of the resource's
+          attributes. If it doesn't, an error will be returned
+          containing a list of the valid fields for that resource.
+
+          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
+          to find resources on which a particular field isn't set. For
+          example, `name=%00` and `name!=%00` yield the WHERE clauses,
+          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
+
+          Examples:
+          - `name=foo` - entity's _name_ matches 'foo' exactly
+          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
+          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
+          - `name=` - entity's _name_ is the empty string, ''
+          - `name=%00` - entity's _name_ isn't set
+          - `published>3 days ago` - date values can be "human time"
+
+          Multiple full text searches and/or filters should be
+          '&'-delimited -- they are logically AND'd together.
+
+          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
+
+          Fields corresponding to JSON objects in the database may use a
+          ':' to delimit the column name and the object key,
+          e.g. `purl:qualifiers:type=pom`
+
+          Any operator or special character, e.g. '|', '&', within a
+          value should be escaped by prefixing it with a backslash.
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        description: |
+          EBNF grammar for the _sort_ parameter:
+          ```text
+              sort = field [ ':', order ] { ',' sort }
+              order = ( "asc" | "desc" )
+              field = (* must match the name of entity's attributes *)
+          ```
+          The optional _order_ should be one of "asc" or "desc". If
+          omitted, the order defaults to "asc".
+
+          Each _field_ name must correspond to one of the columns of the
+          table holding the entities being queried. Those corresponding
+          to JSON objects in the database may use a ':' to delimit the
+          column name and the object key,
+          e.g. `purl:qualifiers:type:desc`
+        required: false
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: |-
+          The first item to return, skipping all that come before it.
+
+          NOTE: The order of items is defined by the API being called.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: limit
+        in: query
+        description: |-
+          The maximum number of entries to return.
+
+          Zero means: return no items (the total count is still computed if requested).
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
+      - name: purl
+        in: query
+        description: Find by PURL
+        required: false
+        schema:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/Purl'
+      - name: cpe
+        in: query
+        description: Find by CPE
+        required: false
+        schema:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/Cpe'
+      responses:
+        '200':
+          description: Matching SBOMs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResults_SbomSummary'
+  /api/v3/sbom/count-by-package:
+    get:
+      tags:
+      - sbom
+      summary: Count all SBOMs containing the provided packages.
+      description: |-
+        The packages can be provided either via a PURL or using the ID of a package as returned by
+        other APIs, but not both.
+      operationId: countRelatedSboms
+      parameters:
+      - name: purl
+        in: path
+        description: Find by PURL
+        required: true
+        schema:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/Purl'
+      - name: cpe
+        in: path
+        description: Find by CPE
+        required: true
+        schema:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/Cpe'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/ExternalReferenceQuery'
+        required: true
+      responses:
+        '200':
+          description: Number of matching SBOMs per package
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+  /api/v3/sbom/models:
+    get:
+      tags:
+      - sbom
+      summary: Search for all AI models
+      operationId: listAllModels
+      parameters:
+      - name: q
+        in: query
+        description: |
+          EBNF grammar for the _q_ parameter:
+          ```text
+              q = ( values | filter ) { '&' q }
+              values = value { '|', values }
+              filter = field, operator, values
+              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
+              value = (* any text but escape special characters with '\' *)
+              field = (* must match an entity attribute name *)
+          ```
+          Any values in a _q_ will result in a case-insensitive "full
+          text search", effectively producing an OR clause of LIKE
+          clauses for every string-ish field in the resource being
+          queried.
+
+          Examples:
+          - `foo` - any field containing 'foo'
+          - `foo|bar` - any field containing either 'foo' OR 'bar'
+          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
+
+          A _filter_ may also be used to constrain the results. The
+          filter's field name must correspond to one of the resource's
+          attributes. If it doesn't, an error will be returned
+          containing a list of the valid fields for that resource.
+
+          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
+          to find resources on which a particular field isn't set. For
+          example, `name=%00` and `name!=%00` yield the WHERE clauses,
+          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
+
+          Examples:
+          - `name=foo` - entity's _name_ matches 'foo' exactly
+          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
+          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
+          - `name=` - entity's _name_ is the empty string, ''
+          - `name=%00` - entity's _name_ isn't set
+          - `published>3 days ago` - date values can be "human time"
+
+          Multiple full text searches and/or filters should be
+          '&'-delimited -- they are logically AND'd together.
+
+          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
+
+          Fields corresponding to JSON objects in the database may use a
+          ':' to delimit the column name and the object key,
+          e.g. `purl:qualifiers:type=pom`
+
+          Any operator or special character, e.g. '|', '&', within a
+          value should be escaped by prefixing it with a backslash.
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        description: |
+          EBNF grammar for the _sort_ parameter:
+          ```text
+              sort = field [ ':', order ] { ',' sort }
+              order = ( "asc" | "desc" )
+              field = (* must match the name of entity's attributes *)
+          ```
+          The optional _order_ should be one of "asc" or "desc". If
+          omitted, the order defaults to "asc".
+
+          Each _field_ name must correspond to one of the columns of the
+          table holding the entities being queried. Those corresponding
+          to JSON objects in the database may use a ':' to delimit the
+          column name and the object key,
+          e.g. `purl:qualifiers:type:desc`
+        required: false
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: |-
+          The first item to return, skipping all that come before it.
+
+          NOTE: The order of items is defined by the API being called.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: limit
+        in: query
+        description: |-
+          The maximum number of entries to return.
+
+          Zero means: return no items (the total count is still computed if requested).
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
+      - name: counts
+        in: query
+        description: Include SBOM counts for each model
+        required: false
+        schema:
+          type: boolean
+      responses:
+        '200':
+          description: AI Models
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResults_SbomModel'
+  /api/v3/sbom/{id}:
+    get:
+      tags:
+      - sbom
+      summary: Get information about an SBOM
+      operationId: getSbom
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: Matching SBOM
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SbomSummary'
+        '404':
+          description: The SBOM could not be found
+    delete:
+      tags:
+      - sbom
+      summary: Delete an SBOM
+      operationId: deleteSbom
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/Id'
+      responses:
+        '204':
+          description: Matching SBOM as deleted
+        '404':
+          description: The SBOM could not be found
   /api/v3/sbom/{id}/advisory:
     get:
       tags:
@@ -3911,6 +3130,649 @@ paths:
                   $ref: '#/components/schemas/SbomAdvisory'
         '404':
           description: The SBOM could not be found
+  /api/v3/sbom/{id}/all-license-ids:
+    get:
+      tags:
+      - sbom
+      operationId: listAllLicenseIds
+      parameters:
+      - name: id
+        in: path
+        description: ID of the SBOM to get the license IDs for
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: fetch all unique license id and license info id
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LicenseRefMapping'
+        '400':
+          description: Invalid UUID format.
+  /api/v3/sbom/{id}/label:
+    put:
+      tags:
+      - sbom
+      summary: Replace the labels of an SBOM
+      operationId: updateSbomLabels
+      parameters:
+      - name: id
+        in: path
+        description: Digest/hash of the document, prefixed by hash type, such as 'sha256:<hash>' or 'urn:uuid:<uuid>'
+        required: true
+        schema:
+          $ref: '#/components/schemas/Id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Labels'
+        required: true
+      responses:
+        '204':
+          description: Replaced the labels of the SBOM
+        '404':
+          description: The SBOM could not be found
+    patch:
+      tags:
+      - sbom
+      summary: Modify existing labels of an SBOM
+      operationId: patchSbomLabels
+      parameters:
+      - name: id
+        in: path
+        description: Digest/hash of the document, prefixed by hash type, such as 'sha256:<hash>' or 'urn:uuid:<uuid>'
+        required: true
+        schema:
+          $ref: '#/components/schemas/Id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Update'
+        required: true
+      responses:
+        '204':
+          description: Modified the labels of the SBOM
+        '404':
+          description: The SBOM could not be found
+  /api/v3/sbom/{id}/license-export:
+    get:
+      tags:
+      - sbom
+      operationId: getLicenseExport
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: license gzip files
+          content:
+            application/gzip:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: int32
+                  minimum: 0
+        '404':
+          description: The document could not be found
+  /api/v3/sbom/{id}/models:
+    get:
+      tags:
+      - sbom
+      summary: Search for AI models associated with an SBOM
+      operationId: listModels
+      parameters:
+      - name: id
+        in: path
+        description: ID of the SBOM to get models for
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: q
+        in: query
+        description: |
+          EBNF grammar for the _q_ parameter:
+          ```text
+              q = ( values | filter ) { '&' q }
+              values = value { '|', values }
+              filter = field, operator, values
+              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
+              value = (* any text but escape special characters with '\' *)
+              field = (* must match an entity attribute name *)
+          ```
+          Any values in a _q_ will result in a case-insensitive "full
+          text search", effectively producing an OR clause of LIKE
+          clauses for every string-ish field in the resource being
+          queried.
+
+          Examples:
+          - `foo` - any field containing 'foo'
+          - `foo|bar` - any field containing either 'foo' OR 'bar'
+          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
+
+          A _filter_ may also be used to constrain the results. The
+          filter's field name must correspond to one of the resource's
+          attributes. If it doesn't, an error will be returned
+          containing a list of the valid fields for that resource.
+
+          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
+          to find resources on which a particular field isn't set. For
+          example, `name=%00` and `name!=%00` yield the WHERE clauses,
+          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
+
+          Examples:
+          - `name=foo` - entity's _name_ matches 'foo' exactly
+          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
+          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
+          - `name=` - entity's _name_ is the empty string, ''
+          - `name=%00` - entity's _name_ isn't set
+          - `published>3 days ago` - date values can be "human time"
+
+          Multiple full text searches and/or filters should be
+          '&'-delimited -- they are logically AND'd together.
+
+          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
+
+          Fields corresponding to JSON objects in the database may use a
+          ':' to delimit the column name and the object key,
+          e.g. `purl:qualifiers:type=pom`
+
+          Any operator or special character, e.g. '|', '&', within a
+          value should be escaped by prefixing it with a backslash.
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        description: |
+          EBNF grammar for the _sort_ parameter:
+          ```text
+              sort = field [ ':', order ] { ',' sort }
+              order = ( "asc" | "desc" )
+              field = (* must match the name of entity's attributes *)
+          ```
+          The optional _order_ should be one of "asc" or "desc". If
+          omitted, the order defaults to "asc".
+
+          Each _field_ name must correspond to one of the columns of the
+          table holding the entities being queried. Those corresponding
+          to JSON objects in the database may use a ':' to delimit the
+          column name and the object key,
+          e.g. `purl:qualifiers:type:desc`
+        required: false
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: |-
+          The first item to return, skipping all that come before it.
+
+          NOTE: The order of items is defined by the API being called.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: limit
+        in: query
+        description: |-
+          The maximum number of entries to return.
+
+          Zero means: return no items (the total count is still computed if requested).
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
+      - name: counts
+        in: query
+        description: Include SBOM counts for each model
+        required: false
+        schema:
+          type: boolean
+      responses:
+        '200':
+          description: AI Models
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResults_SbomModel'
+  /api/v3/sbom/{id}/packages:
+    get:
+      tags:
+      - sbom
+      summary: Search for packages of an SBOM
+      operationId: listPackages
+      parameters:
+      - name: id
+        in: path
+        description: ID of the SBOM to get packages for
+        required: true
+        schema:
+          $ref: '#/components/schemas/Id'
+      - name: q
+        in: query
+        description: |
+          EBNF grammar for the _q_ parameter:
+          ```text
+              q = ( values | filter ) { '&' q }
+              values = value { '|', values }
+              filter = field, operator, values
+              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
+              value = (* any text but escape special characters with '\' *)
+              field = (* must match an entity attribute name *)
+          ```
+          Any values in a _q_ will result in a case-insensitive "full
+          text search", effectively producing an OR clause of LIKE
+          clauses for every string-ish field in the resource being
+          queried.
+
+          Examples:
+          - `foo` - any field containing 'foo'
+          - `foo|bar` - any field containing either 'foo' OR 'bar'
+          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
+
+          A _filter_ may also be used to constrain the results. The
+          filter's field name must correspond to one of the resource's
+          attributes. If it doesn't, an error will be returned
+          containing a list of the valid fields for that resource.
+
+          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
+          to find resources on which a particular field isn't set. For
+          example, `name=%00` and `name!=%00` yield the WHERE clauses,
+          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
+
+          Examples:
+          - `name=foo` - entity's _name_ matches 'foo' exactly
+          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
+          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
+          - `name=` - entity's _name_ is the empty string, ''
+          - `name=%00` - entity's _name_ isn't set
+          - `published>3 days ago` - date values can be "human time"
+
+          Multiple full text searches and/or filters should be
+          '&'-delimited -- they are logically AND'd together.
+
+          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
+
+          Fields corresponding to JSON objects in the database may use a
+          ':' to delimit the column name and the object key,
+          e.g. `purl:qualifiers:type=pom`
+
+          Any operator or special character, e.g. '|', '&', within a
+          value should be escaped by prefixing it with a backslash.
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        description: |
+          EBNF grammar for the _sort_ parameter:
+          ```text
+              sort = field [ ':', order ] { ',' sort }
+              order = ( "asc" | "desc" )
+              field = (* must match the name of entity's attributes *)
+          ```
+          The optional _order_ should be one of "asc" or "desc". If
+          omitted, the order defaults to "asc".
+
+          Each _field_ name must correspond to one of the columns of the
+          table holding the entities being queried. Those corresponding
+          to JSON objects in the database may use a ':' to delimit the
+          column name and the object key,
+          e.g. `purl:qualifiers:type:desc`
+        required: false
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: |-
+          The first item to return, skipping all that come before it.
+
+          NOTE: The order of items is defined by the API being called.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: limit
+        in: query
+        description: |-
+          The maximum number of entries to return.
+
+          Zero means: return no items (the total count is still computed if requested).
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
+      responses:
+        '200':
+          description: Packages
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResults_SbomPackage'
+        '404':
+          description: The SBOM could not be found
+  /api/v3/sbom/{id}/related:
+    get:
+      tags:
+      - sbom
+      summary: Search for related packages in an SBOM
+      operationId: listRelatedPackages
+      parameters:
+      - name: id
+        in: path
+        description: ID of SBOM to search packages in
+        required: true
+        schema:
+          $ref: '#/components/schemas/Id'
+      - name: reference
+        in: query
+        description: The Package to use as reference
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      - name: which
+        in: query
+        description: Which side the reference should be on
+        required: false
+        schema:
+          type: string
+          enum:
+          - left
+          - right
+      - name: relationship
+        in: query
+        description: Optional relationship filter
+        required: false
+        schema:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/Relationship'
+      - name: q
+        in: query
+        description: |
+          EBNF grammar for the _q_ parameter:
+          ```text
+              q = ( values | filter ) { '&' q }
+              values = value { '|', values }
+              filter = field, operator, values
+              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
+              value = (* any text but escape special characters with '\' *)
+              field = (* must match an entity attribute name *)
+          ```
+          Any values in a _q_ will result in a case-insensitive "full
+          text search", effectively producing an OR clause of LIKE
+          clauses for every string-ish field in the resource being
+          queried.
+
+          Examples:
+          - `foo` - any field containing 'foo'
+          - `foo|bar` - any field containing either 'foo' OR 'bar'
+          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
+
+          A _filter_ may also be used to constrain the results. The
+          filter's field name must correspond to one of the resource's
+          attributes. If it doesn't, an error will be returned
+          containing a list of the valid fields for that resource.
+
+          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
+          to find resources on which a particular field isn't set. For
+          example, `name=%00` and `name!=%00` yield the WHERE clauses,
+          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
+
+          Examples:
+          - `name=foo` - entity's _name_ matches 'foo' exactly
+          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
+          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
+          - `name=` - entity's _name_ is the empty string, ''
+          - `name=%00` - entity's _name_ isn't set
+          - `published>3 days ago` - date values can be "human time"
+
+          Multiple full text searches and/or filters should be
+          '&'-delimited -- they are logically AND'd together.
+
+          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
+
+          Fields corresponding to JSON objects in the database may use a
+          ':' to delimit the column name and the object key,
+          e.g. `purl:qualifiers:type=pom`
+
+          Any operator or special character, e.g. '|', '&', within a
+          value should be escaped by prefixing it with a backslash.
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        description: |
+          EBNF grammar for the _sort_ parameter:
+          ```text
+              sort = field [ ':', order ] { ',' sort }
+              order = ( "asc" | "desc" )
+              field = (* must match the name of entity's attributes *)
+          ```
+          The optional _order_ should be one of "asc" or "desc". If
+          omitted, the order defaults to "asc".
+
+          Each _field_ name must correspond to one of the columns of the
+          table holding the entities being queried. Those corresponding
+          to JSON objects in the database may use a ':' to delimit the
+          column name and the object key,
+          e.g. `purl:qualifiers:type:desc`
+        required: false
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: |-
+          The first item to return, skipping all that come before it.
+
+          NOTE: The order of items is defined by the API being called.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: limit
+        in: query
+        description: |-
+          The maximum number of entries to return.
+
+          Zero means: return no items (the total count is still computed if requested).
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
+      responses:
+        '200':
+          description: Packages
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResults_SbomPackageRelation_SbomPackage'
+        '404':
+          description: The SBOM could not be found
+  /api/v3/sbom/{key}/download:
+    get:
+      tags:
+      - sbom
+      summary: Download an SBOM
+      operationId: downloadSbom
+      parameters:
+      - name: key
+        in: path
+        description: Identifier of the SBOM, either `urn:uuid:<uuid>` or a digest e.g. `sha256:<hex>`
+        required: true
+        schema:
+          $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: Download a an SBOM
+          content:
+            application/json:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: The document could not be found
+  /api/v3/ui/extract-sbom-purls:
+    post:
+      tags:
+      - ui
+      summary: Extract PURLs from an SBOM provided in the request
+      operationId: extractSbomPurls
+      parameters:
+      - name: format
+        in: query
+        description: An SBOM format to expect, or [`Format::SBOM`] and [`Format::Unknown`] to auto-detect.
+        required: false
+        schema:
+          $ref: '#/components/schemas/Format'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '200':
+          description: Information extracted from the SBOM
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExtractResult'
+        '400':
+          description: Bad request data, like an unsupported format or invalid data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInformation'
+  /api/v3/userPreference/{key}:
+    get:
+      tags:
+      - userPreferences
+      summary: Get user preferences
+      operationId: getUserPreferences
+      parameters:
+      - name: key
+        in: path
+        description: The key to the user preferences
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: User preference stored under this key
+          headers:
+            etag:
+              schema:
+                type: string
+              description: Revision ID
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: The user preference key could not be found
+    put:
+      tags:
+      - userPreferences
+      summary: Set user preferences
+      operationId: setUserPreferences
+      parameters:
+      - name: key
+        in: path
+        description: The key to the user preferences
+        required: true
+        schema:
+          type: string
+      - name: if-match
+        in: header
+        description: The revision to update
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+        required: true
+      responses:
+        '200':
+          description: User preference stored under this key
+          headers:
+            etag:
+              schema:
+                type: string
+              description: Revision ID
+        '412':
+          description: The provided If-Match revision did not match the actual revision
+    delete:
+      tags:
+      - userPreferences
+      summary: Delete user preferences
+      operationId: deleteUserPreferences
+      parameters:
+      - name: key
+        in: path
+        description: The key to the user preferences
+        required: true
+        schema:
+          type: string
+      - name: if-match
+        in: header
+        description: The revision to delete
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+        required: true
+      responses:
+        '201':
+          description: User preferences are deleted
+        '412':
+          description: The provided If-Match revision did not match the actual revision
   /api/v3/vulnerability:
     get:
       tags:
@@ -4045,6 +3907,143 @@ paths:
                 $ref: '#/components/schemas/VulnerabilityDetails'
         '404':
           description: The vulnerability could not be found
+  /api/v3/weakness:
+    get:
+      tags:
+      - weakness
+      summary: List weaknesses
+      operationId: listWeaknesses
+      parameters:
+      - name: q
+        in: query
+        description: |
+          EBNF grammar for the _q_ parameter:
+          ```text
+              q = ( values | filter ) { '&' q }
+              values = value { '|', values }
+              filter = field, operator, values
+              operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<"
+              value = (* any text but escape special characters with '\' *)
+              field = (* must match an entity attribute name *)
+          ```
+          Any values in a _q_ will result in a case-insensitive "full
+          text search", effectively producing an OR clause of LIKE
+          clauses for every string-ish field in the resource being
+          queried.
+
+          Examples:
+          - `foo` - any field containing 'foo'
+          - `foo|bar` - any field containing either 'foo' OR 'bar'
+          - `foo&bar` - some field contains 'foo' AND some field contains 'bar'
+
+          A _filter_ may also be used to constrain the results. The
+          filter's field name must correspond to one of the resource's
+          attributes. If it doesn't, an error will be returned
+          containing a list of the valid fields for that resource.
+
+          An ASCII value of `NUL`, percent-encoded as `%00`, may be used
+          to find resources on which a particular field isn't set. For
+          example, `name=%00` and `name!=%00` yield the WHERE clauses,
+          'NAME IS NULL' and 'NAME IS NOT NULL', respectively.
+
+          Examples:
+          - `name=foo` - entity's _name_ matches 'foo' exactly
+          - `name~foo` - entity's _name_ contains 'foo', case-insensitive
+          - `name~foo|bar` - entity's _name_ contains either 'foo' OR 'bar', case-insensitive
+          - `name=` - entity's _name_ is the empty string, ''
+          - `name=%00` - entity's _name_ isn't set
+          - `published>3 days ago` - date values can be "human time"
+
+          Multiple full text searches and/or filters should be
+          '&'-delimited -- they are logically AND'd together.
+
+          - `red hat|fedora&labels:type=cve|osv&published>last wednesday 17:00`
+
+          Fields corresponding to JSON objects in the database may use a
+          ':' to delimit the column name and the object key,
+          e.g. `purl:qualifiers:type=pom`
+
+          Any operator or special character, e.g. '|', '&', within a
+          value should be escaped by prefixing it with a backslash.
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        description: |
+          EBNF grammar for the _sort_ parameter:
+          ```text
+              sort = field [ ':', order ] { ',' sort }
+              order = ( "asc" | "desc" )
+              field = (* must match the name of entity's attributes *)
+          ```
+          The optional _order_ should be one of "asc" or "desc". If
+          omitted, the order defaults to "asc".
+
+          Each _field_ name must correspond to one of the columns of the
+          table holding the entities being queried. Those corresponding
+          to JSON objects in the database may use a ':' to delimit the
+          column name and the object key,
+          e.g. `purl:qualifiers:type:desc`
+        required: false
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: |-
+          The first item to return, skipping all that come before it.
+
+          NOTE: The order of items is defined by the API being called.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: limit
+        in: query
+        description: |-
+          The maximum number of entries to return.
+
+          Zero means: return no items (the total count is still computed if requested).
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: total
+        in: query
+        description: Whether to compute and return the total count of matching items.
+        required: false
+        schema:
+          type: boolean
+      responses:
+        '200':
+          description: Matching weaknesses
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResults_LicenseSummary'
+  /api/v3/weakness/{id}:
+    get:
+      tags:
+      - weakness
+      summary: Retrieve weakness details
+      operationId: getWeakness
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: The weakness
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LicenseSummary'
+        '404':
+          description: The weakness could not be found
 components:
   schemas:
     AdvisoryDetails:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -152,7 +152,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedResults_SbomSummary'
+                $ref: '#/components/schemas/PaginatedResults_SbomSummary_SbomPackage'
       deprecated: true
   /api/v2/vulnerability/analyze:
     post:
@@ -2667,7 +2667,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedResults_SbomPackageSummary'
+                $ref: '#/components/schemas/PaginatedResults_SbomSummary_SbomPackageSummary'
     post:
       tags:
       - sbom
@@ -5513,41 +5513,6 @@ components:
           - 'null'
           format: int64
           minimum: 0
-    PaginatedResults_SbomPackageSummary:
-      type: object
-      required:
-      - items
-      properties:
-        items:
-          type: array
-          items:
-            type: object
-            required:
-            - id
-            - name
-            properties:
-              group:
-                type:
-                - string
-                - 'null'
-                description: An optional group/namespace for an SBOM package
-              id:
-                type: string
-                description: The SBOM internal ID of a package
-              name:
-                type: string
-                description: The name of the package in the SBOM
-              version:
-                type:
-                - string
-                - 'null'
-                description: An optional version for an SBOM package
-        total:
-          type:
-          - integer
-          - 'null'
-          format: int64
-          minimum: 0
     PaginatedResults_SbomSummary:
       type: object
       required:
@@ -5567,6 +5532,126 @@ components:
                   type: array
                   items:
                     $ref: '#/components/schemas/SbomPackage'
+        total:
+          type:
+          - integer
+          - 'null'
+          format: int64
+          minimum: 0
+    PaginatedResults_SbomSummary_SbomPackage:
+      type: object
+      required:
+      - items
+      properties:
+        items:
+          type: array
+          items:
+            allOf:
+            - $ref: '#/components/schemas/SbomHead'
+            - $ref: '#/components/schemas/SourceDocument'
+            - type: object
+              required:
+              - described_by
+              properties:
+                described_by:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - id
+                    - name
+                    - purl
+                    - cpe
+                    - licenses
+                    - licenses_ref_mapping
+                    properties:
+                      cpe:
+                        type: array
+                        items:
+                          type: string
+                        description: CPEs identifying the package
+                      group:
+                        type:
+                        - string
+                        - 'null'
+                        description: An optional group/namespace for an SBOM package
+                      id:
+                        type: string
+                        description: The SBOM internal ID of a package
+                      licenses:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/LicenseInfo'
+                        description: License info
+                      licenses_ref_mapping:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/LicenseRefMapping'
+                        description: |-
+                          LicenseRef mappings
+
+                          **Deprecated**: Licenses are now pre-expanded at ingestion time via `expanded_license` /
+                          `sbom_license_expanded` tables. This field is always empty and will be removed in a future
+                          release.
+                        deprecated: true
+                      name:
+                        type: string
+                        description: The name of the package in the SBOM
+                      purl:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/PurlSummary'
+                        description: PURLs identifying the package
+                      version:
+                        type:
+                        - string
+                        - 'null'
+                        description: An optional version for an SBOM package
+        total:
+          type:
+          - integer
+          - 'null'
+          format: int64
+          minimum: 0
+    PaginatedResults_SbomSummary_SbomPackageSummary:
+      type: object
+      required:
+      - items
+      properties:
+        items:
+          type: array
+          items:
+            allOf:
+            - $ref: '#/components/schemas/SbomHead'
+            - $ref: '#/components/schemas/SourceDocument'
+            - type: object
+              required:
+              - described_by
+              properties:
+                described_by:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - id
+                    - name
+                    properties:
+                      group:
+                        type:
+                        - string
+                        - 'null'
+                        description: An optional group/namespace for an SBOM package
+                      id:
+                        type: string
+                        description: The SBOM internal ID of a package
+                      name:
+                        type: string
+                        description: The name of the package in the SBOM
+                      version:
+                        type:
+                        - string
+                        - 'null'
+                        description: An optional version for an SBOM package
         total:
           type:
           - integer

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -597,33 +597,33 @@ mod test {
     #[case::ro_put(
         true,
         Method::PUT,
-        "/api/v2/importer/foo",
+        "/api/v3/importer/foo",
         StatusCode::SERVICE_UNAVAILABLE
     )]
     // read-only mode rejects PATCH
     #[case::ro_patch(
         true,
         Method::PATCH,
-        "/api/v2/importer/foo",
+        "/api/v3/importer/foo",
         StatusCode::SERVICE_UNAVAILABLE
     )]
     // read-only mode rejects DELETE
     #[case::ro_delete(
         true,
         Method::DELETE,
-        "/api/v2/importer/foo",
+        "/api/v3/importer/foo",
         StatusCode::SERVICE_UNAVAILABLE
     )]
     // normal mode allows GET
     #[case::rw_get(false, Method::GET, "/api/v3/advisory", StatusCode::OK)]
     // normal mode lets POST through to handler
-    #[case::rw_post(false, Method::POST, "/api/v3/advisory", StatusCode::NOT_FOUND)]
+    #[case::rw_post(false, Method::POST, "/api/v3/advisory", StatusCode::BAD_REQUEST)]
     // normal mode lets PUT through to handler
-    #[case::rw_put(false, Method::PUT, "/api/v2/importer/foo", StatusCode::BAD_REQUEST)]
+    #[case::rw_put(false, Method::PUT, "/api/v3/importer/foo", StatusCode::BAD_REQUEST)]
     // normal mode lets PATCH through to handler
-    #[case::rw_patch(false, Method::PATCH, "/api/v2/importer/foo", StatusCode::NOT_FOUND)]
+    #[case::rw_patch(false, Method::PATCH, "/api/v3/importer/foo", StatusCode::NOT_FOUND)]
     // normal mode lets DELETE through to handler
-    #[case::rw_delete(false, Method::DELETE, "/api/v2/importer/foo", StatusCode::NO_CONTENT)]
+    #[case::rw_delete(false, Method::DELETE, "/api/v3/importer/foo", StatusCode::NO_CONTENT)]
     #[test_log::test(actix_web::test)]
     async fn read_only_guards_mutations(
         ctx: &TrustifyContext,


### PR DESCRIPTION
See: https://redhat.atlassian.net/browse/TC-4296

## Summary by Sourcery

Migrate REST API surface from v2 to v3 endpoints and update OpenAPI spec, handlers, CLI paths, and tests accordingly.

Enhancements:
- Add new v3-only endpoints and parameters for advisories, SBOMs, vulnerabilities, weaknesses, purls, licenses, organizations, products, importers, user preferences, datasets, analysis, and UI helpers, including refined query grammars and response schemas.
- Deprecate remaining v2 analysis and vulnerability endpoints while preserving backward compatibility where needed.