### PR TITLE
chore: create a clone of the /v2/purl/recommend endpoint

### DIFF
--- a/modules/fundamental/src/purl/endpoints/mod.rs
+++ b/modules/fundamental/src/purl/endpoints/mod.rs
@@ -23,6 +23,9 @@ use trustify_common::{
 
 mod base;
 
+#[cfg(test)]
+mod test;
+
 pub fn configure(
     config: &mut utoipa_actix_web::service_config::ServiceConfig,
     db: Database,
@@ -35,7 +38,8 @@ pub fn configure(
         .app_data(web::Data::new(purl_service))
         .service(base::get_base_purl)
         .service(base::all_base_purls)
-        .service(recommend) // Must be before `get` to avoid {key} matching "recommend"
+        .service(v2::recommend) // Must be before `get` to avoid {key} matching "recommend"
+        .service(v3::recommend) // Must be before `get` to avoid {key} matching "recommend"
         .service(all)
         .service(get);
 }
@@ -94,28 +98,58 @@ pub async fn all(
     Ok(HttpResponse::Ok().json(service.purls(search, paginated, &tx).await?))
 }
 
-#[utoipa::path(
-    operation_id = "recommend",
-    tag = "purl",
-    request_body = RecommendRequest,
-    responses(
-        (status = 200, description = "Get recommendations and remediations for provided purls", body = RecommendResponse)
-    )
-)]
-#[post("/v3/purl/recommend")]
-pub async fn recommend(
-    purl_service: web::Data<PurlService>,
-    db: web::Data<Database>,
-    request: web::Json<RecommendRequest>,
-    _: Require<ReadAdvisory>,
-) -> actix_web::Result<impl Responder> {
-    let tx = db.begin_read().await?;
-    let recommendations = purl_service.recommend_purls(&request.purls, &tx).await?;
+mod v2 {
+    #![allow(deprecated)]
+    use super::*;
 
-    let response = RecommendResponse { recommendations };
+    #[utoipa::path(
+        operation_id = "v2/recommend",
+        tag = "purl",
+        request_body = RecommendRequest,
+        responses(
+            (status = 200, description = "Get recommendations and remediations for provided purls", body = RecommendResponse)
+        )
+    )]
+    #[post("/v2/purl/recommend")]
+    #[deprecated = "Use the v3 version of this API"]
+    pub async fn recommend(
+        purl_service: web::Data<PurlService>,
+        db: web::Data<Database>,
+        request: web::Json<RecommendRequest>,
+        _: Require<ReadAdvisory>,
+    ) -> actix_web::Result<impl Responder> {
+        let tx = db.begin_read().await?;
+        let recommendations = purl_service.recommend_purls(&request.purls, &tx).await?;
 
-    Ok(HttpResponse::Ok().json(response))
+        let response = RecommendResponse { recommendations };
+
+        Ok(HttpResponse::Ok().json(response))
+    }
 }
 
-#[cfg(test)]
-mod test;
+mod v3 {
+    use super::*;
+
+    #[utoipa::path(
+        operation_id = "recommend",
+        tag = "purl",
+        request_body = RecommendRequest,
+        responses(
+            (status = 200, description = "Get recommendations and remediations for provided purls", body = RecommendResponse)
+        )
+    )]
+    #[post("/v3/purl/recommend")]
+    pub async fn recommend(
+        purl_service: web::Data<PurlService>,
+        db: web::Data<Database>,
+        request: web::Json<RecommendRequest>,
+        _: Require<ReadAdvisory>,
+    ) -> actix_web::Result<impl Responder> {
+        let tx = db.begin_read().await?;
+        let recommendations = purl_service.recommend_purls(&request.purls, &tx).await?;
+
+        let response = RecommendResponse { recommendations };
+
+        Ok(HttpResponse::Ok().json(response))
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27,6 +27,25 @@ paths:
                     type: boolean
                   version:
                     type: string
+  /api/v2/purl/recommend:
+    post:
+      tags:
+      - purl
+      operationId: v2/recommend
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecommendRequest'
+        required: true
+      responses:
+        '200':
+          description: Get recommendations and remediations for provided purls
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecommendResponse'
+      deprecated: true
   /api/v2/sbom:
     get:
       tags:


### PR DESCRIPTION
The /v2/purl/recommend endpoint gets cloned in order to make it easier for DA to migrate.

## Summary by Sourcery

Clone the existing purl recommendation API into a versioned v2 endpoint while preserving v3 as the primary implementation.

New Features:
- Introduce a versioned /api/v2/purl/recommend endpoint that mirrors the existing purl recommendation behavior.

Enhancements:
- Split the purl recommendation handler into separate v2 (deprecated) and v3 modules and register both routes in the purl endpoint configuration.

Documentation:
- Update the OpenAPI specification to document the new deprecated /api/v2/purl/recommend endpoint.