### PR TITLE
Add `DELETE /api/v3/sbom` endpoint for batch SBOMs deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8645,6 +8645,7 @@ dependencies = [
  "csv",
  "cve",
  "flate2",
+ "futures",
  "futures-util",
  "hex",
  "humantime",

--- a/cli/src/api/client.rs
+++ b/cli/src/api/client.rs
@@ -2,6 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use indicatif::style::TemplateError;
 use reqwest::{Client, RequestBuilder, StatusCode};
+use serde::Serialize;
 use thiserror::Error;
 use tokio::{sync::RwLock, time::sleep};
 
@@ -157,6 +158,21 @@ impl ApiClient {
         self.execute_with_retry(|| async {
             let url = self.url(path);
             let request = self.client.delete(&url);
+            let response = self.authorize(request).await.send().await?;
+            self.handle_response(response).await
+        })
+        .await
+    }
+
+    /// Perform a DELETE request with JSON and retry logic
+    pub async fn delete_with_json<T: Serialize + ?Sized>(
+        &self,
+        path: &str,
+        json: &T,
+    ) -> Result<String, ApiError> {
+        self.execute_with_retry(|| async {
+            let url = self.url(path);
+            let request = self.client.delete(&url).json(json);
             let response = self.authorize(request).await.send().await?;
             self.handle_response(response).await
         })

--- a/cli/src/api/sbom.rs
+++ b/cli/src/api/sbom.rs
@@ -15,8 +15,8 @@ use tokio::sync::Mutex;
 
 use super::client::{ApiClient, ApiError};
 use crate::common::{
-    DeleteEntry, DeleteResult, ListParams, PruneParams, build_prune_query, delete_entries,
-    new_delete_result,
+    DeleteEntry, DeleteResult, DeletedResult, FailedResult, ListParams, PruneParams,
+    build_prune_query, delete_entries, new_delete_result,
 };
 
 const SBOM_PATH: &str = "/v3/sbom";
@@ -300,6 +300,11 @@ pub async fn delete(client: &ApiClient, id: &str) -> Result<(), ApiError> {
     Ok(())
 }
 
+/// Delete multiple SBOMs by their IDs in one batch
+pub async fn delete_many(client: &ApiClient, ids: &Vec<String>) -> Result<String, ApiError> {
+    client.delete_with_json(SBOM_PATH, ids).await
+}
+
 /// Delete all SBOMs by listing and deleting each one
 pub async fn delete_by_query(
     client: &ApiClient,
@@ -398,8 +403,37 @@ pub async fn prune(client: &ApiClient, params: &PruneParams) -> Result<DeleteRes
         return Ok(new_delete_result(total));
     }
 
+    let ids = entries.iter().map(|x| x.id.clone()).collect();
+    let mut deleted = vec![];
+    let mut failed = vec![];
+
     // Perform the actual deletion
-    delete_list(client, entries, params.concurrency).await
+    match delete_many(client, &ids).await {
+        Ok(_) => deleted.extend(entries.iter().map(|x| DeletedResult {
+            id: x.id.clone(),
+            identifier: x.identifier.clone(),
+        })),
+        Err(e) => failed.extend(entries.iter().map(|x| FailedResult {
+            id: x.id.clone(),
+            identifier: x.identifier.clone(),
+            error: e.to_string(),
+        })),
+    }
+
+    let deleted_total = deleted.len() as u32;
+    let skipped = vec![];
+    let skipped_total = 0;
+    let failed_total = failed.len() as u32;
+
+    Ok(DeleteResult {
+        deleted,
+        deleted_total,
+        skipped,
+        skipped_total,
+        failed,
+        failed_total,
+        total,
+    })
 }
 
 /// Read delete entries from a file

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -62,6 +62,7 @@ csaf = { workspace = true }
 csv = { workspace = true }
 cve = { workspace = true }
 flate2 = { workspace = true }
+futures = { workspace = true }
 hex = { workspace = true }
 humantime = { workspace = true }
 jsonpath-rust = { workspace = true }

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use crate::{
     Error,
-    common::{LicenseRefMapping, service::delete_doc},
+    common::LicenseRefMapping,
     license::{
         get_sanitize_filename,
         service::{LicenseService, license_export::LicenseExporter},
@@ -23,7 +23,6 @@ use crate::{
         service::{SbomService, sbom::FetchOptions},
     },
     sbom_group::service::SbomGroupService,
-    source_document::model::SourceDocument,
 };
 use actix_web::{HttpResponse, Responder, delete, get, http::header, post, web};
 use config::Config;
@@ -47,7 +46,7 @@ use trustify_module_ingestor::{
     model::IngestResult,
     service::{Cache, Format, IngestorService},
 };
-use trustify_module_storage::service::StorageBackend;
+use trustify_module_storage::service::{StorageBackend, StorageKey};
 
 #[derive(Clone, Debug, PartialEq, Eq, Default, serde::Deserialize, IntoParams)]
 pub struct ModelGetParams {
@@ -78,6 +77,7 @@ pub fn configure(
         .service(get)
         .service(get_sbom_advisories)
         .service(delete)
+        .service(delete_many)
         .service(packages)
         .service(models)
         .service(related)
@@ -388,6 +388,20 @@ pub async fn get_sbom_advisories(
 
 all!(GetSbomAdvisories -> ReadSbom, ReadAdvisory);
 
+async fn delete_blobs<T: StorageBackend>(digests: &[String], storage: &T) {
+    if let Err(e) = storage
+        .delete_many(
+            &digests
+                .iter()
+                .map(|k| StorageKey::from_sha256(k))
+                .collect::<Vec<_>>(),
+        )
+        .await
+    {
+        log::error!("Failed to remove SBOMs from the storage: {e:#?}");
+    }
+}
+
 /// Delete an SBOM
 #[utoipa::path(
     tag = "sbom",
@@ -410,16 +424,51 @@ pub async fn delete(
     let tx = db.begin().await?;
 
     let id = Id::from_str(&id)?;
-    if let Some((v, _, source_document)) = service.fetch_sbom(id, &tx).await?
-        && service.delete_sbom(v.sbom_id, &tx).await?
+    if let Some((v, _, _)) = service.fetch_sbom(id, &tx).await?
+        && let digests = service.delete_sboms(vec![v.sbom_id], &tx).await?
+        && !digests.is_empty()
     {
         tx.commit().await?;
-        if let Err(e) =
-            delete_doc(&SourceDocument::from_entity(&source_document), i.storage()).await
-        {
-            log::warn!("Ignoring {e}");
-        }
+        delete_blobs(&digests, i.storage()).await;
     }
+    Ok(HttpResponse::NoContent().finish())
+}
+
+/// Delete multiple SBOMs
+#[utoipa::path(
+    tag = "sbom",
+    operation_id = "deleteSboms",
+    request_body(
+        content = Vec<String>,
+        description = "List of ids of SBOMs to be deleted",
+        content_type = "application/json",
+    ),
+    responses(
+        (status = 204, description = "Requested SBOMs were deleted or did not exist"),
+    ),
+)]
+#[delete("/v3/sbom")]
+pub async fn delete_many(
+    i: web::Data<IngestorService>,
+    service: web::Data<SbomService>,
+    db: web::Data<db::ReadWrite>,
+    web::Json(body): web::Json<Vec<String>>,
+    _: Require<DeleteSbom>,
+) -> actix_web::Result<impl Responder, Error> {
+    let tx = db.begin().await?;
+
+    let ids = body
+        .into_iter()
+        .filter_map(|x| Uuid::try_parse(&x).ok())
+        .collect();
+
+    let digests = service.delete_sboms(ids, &tx).await?;
+
+    if !digests.is_empty() {
+        tx.commit().await?;
+        delete_blobs(&digests, i.storage()).await;
+    }
+
     Ok(HttpResponse::NoContent().finish())
 }
 

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -3,15 +3,18 @@ use crate::{
         Group, GroupRef, UpdateAssignments, create_groups, locate_id, read_assignments,
         resolve_group_refs,
     },
+    purl::model::summary::purl::PurlSummary,
     sbom::model::{SbomPackage, SbomSummary},
     test::{caller, label::Api},
 };
 use actix_http::StatusCode;
 use actix_web::{
     body::MessageBody,
+    dev::ServiceResponse,
     test::{TestRequest, read_body},
 };
 use flate2::bufread::GzDecoder;
+use futures::future::join_all;
 use rstest::rstest;
 use serde_json::{Value, json};
 use std::{collections::HashMap, io::Read, str::FromStr};
@@ -21,9 +24,10 @@ use trustify_common::{id::Id, model::PaginatedResults};
 use trustify_module_ingestor::{model::IngestResult, service::Format};
 use trustify_module_storage::service::{StorageBackend, StorageKey};
 use trustify_test_context::{
-    TrustifyContext, call::CallService, document_bytes, subset::ContainsSubset,
+    IngestionResult, TrustifyContext, call::CallService, document_bytes, subset::ContainsSubset,
 };
 use urlencoding::encode;
+use uuid::Uuid;
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
@@ -1237,6 +1241,133 @@ async fn delete_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     log::debug!("Code: {}", response.status());
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
     assert!(response.into_body().try_into_bytes().unwrap().is_empty());
+
+    Ok(())
+}
+
+/// Test deleting sboms in a batch
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn delete_sboms(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    const TASKS: usize = 20;
+    let app = caller(ctx).await?;
+    let storage = &ctx.storage;
+    let [_, id1, id2, id3] = ctx
+        .ingest_documents([
+            // this advisory refers to many packages in both the Quarkus SBOMs
+            "csaf/rhsa-2024-2705.json",
+            "spdx/quarkus-bom-3.2.11.Final-redhat-00001.json",
+            "spdx/quarkus-bom-3.2.12.Final-redhat-00002.json",
+            // this SBOM is totally unrelated with the previous documents
+            "ubi9-9.2-755.1697625012.json",
+        ])
+        .await?
+        .into_uuid();
+
+    async fn get_storage_key(
+        app: &impl CallService,
+        id: &Uuid,
+    ) -> Result<StorageKey, anyhow::Error> {
+        let uri = format!("/api/v3/sbom/urn:uuid:{id}");
+        let req = TestRequest::get().uri(&uri).to_request();
+        let sbom = app.call_and_read_body_json::<SbomSummary>(req).await;
+
+        Ok(sbom.source_document.try_into()?)
+    }
+
+    let key1 = get_storage_key(&app, &id1).await?;
+    assert!(storage.retrieve(key1.clone()).await?.is_some());
+    let key2 = get_storage_key(&app, &id2).await?;
+    assert!(storage.retrieve(key2.clone()).await?.is_some());
+    let key3 = get_storage_key(&app, &id3).await?;
+    assert!(storage.retrieve(key3.clone()).await?.is_some());
+
+    async fn count_purls(app: &impl CallService) -> Option<u64> {
+        let req = TestRequest::get()
+            .uri("/api/v3/purl?total=true")
+            .to_request();
+
+        app.call_and_read_body_json::<PaginatedResults<PurlSummary>>(req)
+            .await
+            .total
+    }
+
+    async fn delete<const N: usize>(app: &impl CallService, ids: [&Uuid; N]) -> ServiceResponse {
+        let req = TestRequest::delete()
+            .uri("/api/v3/sbom")
+            .set_json(ids.into_iter().map(|x| Id::Uuid(*x)).collect::<Vec<_>>())
+            .to_request();
+
+        app.call_service(req).await
+    }
+
+    async fn delete_concurrently<const N: usize>(
+        app: &impl CallService,
+        ids: [&Uuid; N],
+        count: usize,
+    ) -> Vec<ServiceResponse> {
+        let mut tasks = vec![];
+
+        for _ in 0..count {
+            let req = TestRequest::delete()
+                .uri("/api/v3/sbom")
+                .set_json(ids.into_iter().map(|x| Id::Uuid(*x)).collect::<Vec<_>>())
+                .to_request();
+            let app_ref = &app;
+
+            tasks.push(async move { app_ref.call_service(req).await });
+        }
+        join_all(tasks).await
+    }
+
+    assert_eq!(count_purls(&app).await, Some(2087));
+
+    // Delete with no input provided
+    let response = delete(&app, []).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(response.into_body().try_into_bytes().unwrap().is_empty());
+    // - no purl should be GC'ed (garbage collected)
+    assert_eq!(count_purls(&app).await, Some(2087));
+    // - check the storage
+    assert!(storage.retrieve(key1.clone()).await?.is_some());
+    assert!(storage.retrieve(key2.clone()).await?.is_some());
+    assert!(storage.retrieve(key3.clone()).await?.is_some());
+
+    // Delete quarkus #1
+    let response = delete(&app, [&id1]).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(response.into_body().try_into_bytes().unwrap().is_empty());
+    // - 4 purls should be GC'ed
+    assert_eq!(count_purls(&app).await, Some(2083));
+    // - check the storage
+    assert!(storage.retrieve(key1.clone()).await?.is_none());
+    assert!(storage.retrieve(key2.clone()).await?.is_some());
+    assert!(storage.retrieve(key3.clone()).await?.is_some());
+
+    // Delete ubi9 and quarkus #1 again, do it concurrently
+    let responses = delete_concurrently(&app, [&id1, &id3], TASKS).await;
+    assert_eq!(responses.len(), TASKS);
+    for response in responses {
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert!(response.into_body().try_into_bytes().unwrap().is_empty());
+    }
+    // - 610 purls should be GC'ed
+    assert_eq!(count_purls(&app).await, Some(1473));
+    // - check the storage
+    assert!(storage.retrieve(key1.clone()).await?.is_none());
+    assert!(storage.retrieve(key2.clone()).await?.is_some());
+    assert!(storage.retrieve(key3.clone()).await?.is_none());
+
+    // Delete quarkus #2, and ubi9 and quarkus #1 again
+    let response = delete(&app, [&id2, &id1, &id3]).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(response.into_body().try_into_bytes().unwrap().is_empty());
+    // - 1 purl should be GC'ed
+    assert_eq!(count_purls(&app).await, Some(1472));
+    // - check the storage
+    assert!(storage.retrieve(key1.clone()).await?.is_none());
+    assert!(storage.retrieve(key2.clone()).await?.is_none());
+    assert!(storage.retrieve(key3.clone()).await?.is_none());
 
     Ok(())
 }

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -17,7 +17,7 @@ use sea_orm::{
 use sea_query::{ColumnType, Expr, JoinType, UnionType, extension::postgres::PgExpr};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::{collections::HashMap, fmt::Debug, sync::Arc, vec::Vec};
 use tracing::{Instrument, info_span, instrument};
 use trustify_common::{
     cpe::Cpe,
@@ -114,80 +114,81 @@ impl SbomService {
         })
     }
 
-    /// delete one sbom
+    /// delete multiple sboms
     #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
-    pub async fn delete_sbom<C: ConnectionTrait>(
+    pub async fn delete_sboms<C: ConnectionTrait>(
         &self,
-        id: Uuid,
+        ids: Vec<Uuid>,
         connection: &C,
-    ) -> Result<bool, Error> {
+    ) -> Result<Vec<String>, Error> {
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+
         // IMPORTANT: Capture qualified_purl IDs before CASCADE deletion.
-        // After SBOM deletion, CASCADE removes sbom_node_purl_ref entries,
+        // After SBOMs deletion, CASCADE removes sbom_node_purl_ref entries,
         // then GC uses the captured IDs to clean up orphaned PURLs.
         let qualified_purl_ids: Vec<Uuid> = sbom_node_purl_ref::Entity::find()
             .select_only()
             .column(sbom_node_purl_ref::Column::QualifiedPurlId)
-            .filter(sbom_node_purl_ref::Column::SbomId.eq(id))
+            .filter(sbom_node_purl_ref::Column::SbomId.is_in(ids.clone()))
             .into_tuple()
             .all(connection)
             .await?;
 
         log::debug!(
-            "Captured {} qualified_purl IDs from SBOM {} for cleanup",
+            "Captured {} qualified_purl IDs from SBOMs {:?} for cleanup",
             qualified_purl_ids.len(),
-            id
+            ids
         );
 
-        // Delete the SBOM - CASCADE will properly delete sbom_package and sbom_node_purl_ref
+        // Delete SBOMs - CASCADE will properly delete sbom_package and sbom_node_purl_ref
         let stmt = Statement::from_sql_and_values(
             connection.get_database_backend(),
-            r#"DELETE FROM sbom WHERE sbom_id=$1 RETURNING source_document_id"#,
-            [id.into()],
+            r#"DELETE FROM sbom WHERE sbom_id = ANY($1) RETURNING source_document_id"#,
+            vec![ids.clone().into()],
         );
 
         let result = connection.query_all(stmt).await?;
-        if result.len() > 1 {
-            return Err(Error::Data(format!("Too many rows deleted for {id}")));
-        }
 
-        for row in &result {
-            let source_document = row.try_get_by_index::<Option<Uuid>>(0)?;
-            if let Some(doc) = source_document {
-                source_document::Entity::delete_by_id(doc)
-                    .exec(connection)
-                    .await?;
-            }
-        }
+        let source_document_ids: Vec<_> = result
+            .iter()
+            .map(|r| r.try_get_by_index::<Uuid>(0))
+            .collect::<Result<_, _>>()?;
+
+        let digests = match source_document_ids.is_empty() {
+            true => vec![],
+            false => source_document::Entity::delete_many()
+                .filter(source_document::Column::Id.is_in(source_document_ids))
+                .exec_with_returning(connection)
+                .await?
+                .iter()
+                .map(|x| x.sha256.clone())
+                .collect(),
+        };
 
         // Cleanup orphaned PURLs if deletion succeeded and we had PURLs to check
-        if !qualified_purl_ids.is_empty() && result.len() == 1 {
-            // Build array parameter for the GC query
-            let array_param = sea_query::Value::Array(
-                sea_query::ArrayType::Uuid,
-                Some(Box::new(
-                    qualified_purl_ids
-                        .iter()
-                        .map(|&id| sea_query::Value::Uuid(Some(Box::new(id))))
-                        .collect(),
-                )),
-            );
-
+        if !qualified_purl_ids.is_empty() {
             let gc_stmt = Statement::from_sql_and_values(
                 connection.get_database_backend(),
                 // it looks much more readable in an SQL file
                 include_str!("gc_purls_after_sbom_deletion.sql"),
-                vec![array_param],
+                vec![qualified_purl_ids.into()],
             );
 
-            let gc_result = connection.execute(gc_stmt).await?;
+            let gc_result = connection
+                .execute(gc_stmt)
+                .instrument(info_span!("delete_sboms::gc"))
+                .await?;
             log::debug!(
-                "Cleaned up {} orphaned purl records after SBOM {} deletion",
+                "Cleaned up {} orphaned purl records after SBOMs {:?} deletion",
                 gc_result.rows_affected(),
-                id
+                ids,
             );
         }
 
-        Ok(result.len() == 1)
+        // Return a list of keys of blobs to be removed from the storage
+        Ok(digests)
     }
 
     /// fetch all SBOMs
@@ -1334,8 +1335,20 @@ mod test {
 
         let service = SbomService::new(PaginationCache::for_test());
 
-        assert!(service.delete_sbom(sbom_v1.sbom.sbom_id, &ctx.db).await?);
-        assert!(!service.delete_sbom(sbom_v1.sbom.sbom_id, &ctx.db).await?);
+        assert!(
+            // A digest is expected
+            !service
+                .delete_sboms(vec![sbom_v1.sbom.sbom_id], &ctx.db)
+                .await?
+                .is_empty()
+        );
+        assert!(
+            // No SBOM, no digest
+            service
+                .delete_sboms(vec![sbom_v1.sbom.sbom_id], &ctx.db)
+                .await?
+                .is_empty()
+        );
 
         Ok(())
     }

--- a/modules/fundamental/src/sbom/service/test.rs
+++ b/modules/fundamental/src/sbom/service/test.rs
@@ -547,7 +547,13 @@ async fn delete_sbom_orphaned_purl_test(ctx: &TrustifyContext) -> Result<(), any
     let tx = ctx.db.begin().await?;
     let sbom_service = SbomService::new(PaginationCache::for_test());
     // delete the UBI SBOM
-    assert!(sbom_service.delete_sbom(ubi9_sbom.id.parse()?, &tx).await?);
+    assert!(
+        // Digest is expected
+        !sbom_service
+            .delete_sboms(vec![ubi9_sbom.id.parse()?], &tx)
+            .await?
+            .is_empty()
+    );
     tx.commit().await?;
 
     // it should not leave behind orphaned purls
@@ -558,9 +564,11 @@ async fn delete_sbom_orphaned_purl_test(ctx: &TrustifyContext) -> Result<(), any
     // delete the quarkus sbom....
     let tx = ctx.db.begin().await?;
     assert!(
-        sbom_service
-            .delete_sbom(quarkus_sbom.id.parse()?, &tx)
+        // Digest is expected
+        !sbom_service
+            .delete_sboms(vec![quarkus_sbom.id.parse()?], &tx)
             .await?
+            .is_empty(),
     );
     tx.commit().await?;
 
@@ -620,7 +628,8 @@ async fn delete_sbom_preserves_advisory_referenced_packages(
     let sbom_uuid = results[1].id.parse().expect("SBOM should have a UUID");
     let tx = ctx.db.begin().await?;
     assert!(
-        service.delete_sbom(sbom_uuid, &tx).await?,
+        // Digest is expected
+        !service.delete_sboms(vec![sbom_uuid], &tx).await?.is_empty(),
         "SBOM should be deleted"
     );
     tx.commit().await?;
@@ -659,7 +668,8 @@ async fn delete_sbom_preserves_advisory_referenced_packages(
     let sbom_uuid = results[2].id.parse().expect("SBOM should have a UUID");
     let tx = ctx.db.begin().await?;
     assert!(
-        service.delete_sbom(sbom_uuid, &tx).await?,
+        // Digest is expected
+        !service.delete_sboms(vec![sbom_uuid], &tx).await?.is_empty(),
         "SBOM should be deleted"
     );
     tx.commit().await?;
@@ -682,7 +692,11 @@ async fn delete_sbom_preserves_advisory_referenced_packages(
     let ubi_sbom_uuid = results[3].id.parse().expect("SBOM should have a UUID");
     let tx = ctx.db.begin().await?;
     assert!(
-        service.delete_sbom(ubi_sbom_uuid, &tx).await?,
+        // Digest is expected
+        !service
+            .delete_sboms(vec![ubi_sbom_uuid], &tx)
+            .await?
+            .is_empty(),
         "SBOM should be deleted"
     );
     tx.commit().await?;

--- a/modules/storage/src/service/mod.rs
+++ b/modules/storage/src/service/mod.rs
@@ -13,6 +13,7 @@ use crate::service::fs::FileSystemBackend;
 use bytes::Bytes;
 use futures::Stream;
 use hex::ToHex;
+use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::future::Future;
 use tokio::io::AsyncRead;
@@ -27,8 +28,28 @@ pub enum StoreError<B: Debug> {
     Backend(#[source] B),
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum DeleteManyError<E> {
+    /// The whole operation failed
+    #[error("{0}")]
+    Generic(E),
+    /// Individual delete errors
+    #[error("individual delete errors: {0}")]
+    Individual(HashMap<StorageKey, E>),
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct StorageKey(String);
+
+impl StorageKey {
+    /// Create a storage key from the digest.
+    ///
+    /// The digest must be SHA256 (without "sha256:" prefix) and user must
+    /// ensure this (for simplicity we omitted checks here).
+    pub fn from_sha256(digest: &str) -> Self {
+        Self(digest.into())
+    }
+}
 
 impl Display for StorageKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -112,4 +133,29 @@ pub trait StorageBackend {
     /// (i.e., return `Ok(())`) and not result in an error. This ensures consistent
     /// behavior across all backends.
     fn delete(&self, key: StorageKey) -> impl Future<Output = Result<(), Self::Error>>;
+
+    /// Batch variant of `delete`, with the same requirements.
+    fn delete_many(
+        &self,
+        keys: &[StorageKey],
+    ) -> impl Future<Output = Result<(), DeleteManyError<Self::Error>>> {
+        async move {
+            // Default implementation: delete blobs one by one (can be overridden in
+            // implementations for particular backends).
+            let mut whats_wrong = HashMap::new();
+
+            for key in keys {
+                // Do not stop on the first error---instead, accumulate all errors
+                // into one and return it when we are done (we do not want one faulty
+                // request to stop the entire deletion process)
+                if let Err(e) = self.delete(key.clone()).await {
+                    whats_wrong.insert(key.clone(), e);
+                }
+            }
+            match whats_wrong.is_empty() {
+                true => Ok(()),
+                false => Err(DeleteManyError::Individual(whats_wrong)),
+            }
+        }
+    }
 }

--- a/modules/storage/src/service/s3.rs
+++ b/modules/storage/src/service/s3.rs
@@ -1,8 +1,8 @@
 use crate::{
     config::S3Config,
     service::{
-        StorageBackend, StorageKey, StorageResult, StoreError, compression::Compression,
-        temp::TempFile,
+        DeleteManyError, StorageBackend, StorageKey, StorageResult, StoreError,
+        compression::Compression, temp::TempFile,
     },
 };
 use anyhow::{Context, anyhow, bail};
@@ -15,6 +15,7 @@ use aws_sdk_s3::{
     },
     operation::get_object::GetObjectError,
     primitives::FsBuilder,
+    types::{Delete, ObjectIdentifier},
 };
 use aws_smithy_http_client::tls::{Provider, TlsContext, TrustStore, rustls_provider::CryptoMode};
 use aws_smithy_types::endpoint::Endpoint;
@@ -214,6 +215,38 @@ impl StorageBackend for S3Backend {
             Ok(_) => Ok(()),
             Err(err) => Err(Error::S3(err.into())),
         }
+    }
+
+    async fn delete_many(&self, keys: &[StorageKey]) -> Result<(), DeleteManyError<Self::Error>> {
+        if keys.is_empty() {
+            return Ok(());
+        }
+
+        // From official AWS S3 SDK examples
+        //
+        // Push into a mut vector to use `?` early return errors while building object keys.
+        let mut delete_object_ids: Vec<ObjectIdentifier> = vec![];
+        for StorageKey(key) in keys {
+            let obj_id = ObjectIdentifier::builder()
+                .key(key)
+                .build()
+                .map_err(|err| DeleteManyError::Generic(Error::S3(err.into())))?;
+            delete_object_ids.push(obj_id);
+        }
+
+        self.client
+            .delete_objects()
+            .bucket(&self.bucket)
+            .delete(
+                Delete::builder()
+                    .set_objects(Some(delete_object_ids))
+                    .build()
+                    .map_err(|err| DeleteManyError::Generic(Error::S3(err.into())))?,
+            )
+            .send()
+            .await
+            .map_err(|err| DeleteManyError::Generic(Error::S3(err.into())))?;
+        Ok(())
     }
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2749,6 +2749,23 @@ paths:
                 $ref: '#/components/schemas/IngestResult'
         '400':
           description: One or more group IDs are invalid or do not exist
+    delete:
+      tags:
+      - sbom
+      summary: Delete multiple SBOMs
+      operationId: deleteSboms
+      requestBody:
+        description: List of ids of SBOMs to be deleted
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+        required: true
+      responses:
+        '204':
+          description: Requested SBOMs were deleted or did not exist
   /api/v3/sbom-labels:
     get:
       tags:


### PR DESCRIPTION
Supports [Batch/Bulk operations conventions](https://github.com/guacsec/trustify/blob/main/CONVENTIONS.md#missing-batchbulk-operations).

Related Jiras: TC-4003, TC-3934

## Summary by Sourcery

Introduce server-side SBOM pruning APIs and CLI integration for bulk deletion with preview support.

New Features:
- Add /api/v3/sbom/prune GET and DELETE endpoints to list and prune SBOMs based on existing query filters with pagination-like parameters.
- Expose SBOM prune context and states (fetched, deleted, skipped, failed) via new API schemas and models, including storage keys for follow-up cleanup.
- Extend the CLI to call the new prune endpoints, supporting dry-run and actual prune operations while mapping results into existing delete reporting.

Enhancements:
- Refactor SBOM deletion logic to support bulk deletion, including coordinated cleanup of related entities and storage artifacts, and reuse this path for single-SBOM delete.
- Augment storage service keys and related types with serialization and OpenAPI schema support for use over the API.
- Document the SBOM pruning API design and behavior in a new ADR.

Build:
- Update Cargo.toml dependencies to wire fundamental and storage modules into the CLI and enable schema/serde support.

Documentation:
- Add an ADR describing the SBOM prune API endpoints, usage, logging, safety features, and future scheduling plans.