### PR TITLE
test: add a test to ensure loop references don't cause a problem

### DIFF
--- a/etc/test-data/spdx/cycle/ext-a.json
+++ b/etc/test-data/spdx/cycle/ext-a.json
@@ -1,0 +1,53 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
+  "name": "cycle-alpha",
+  "documentNamespace": "uri:cycle-ext-a",
+  "creationInfo": {
+    "created": "2024-01-01T00:00:00Z",
+    "creators": ["Tool: test"]
+  },
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Root-A",
+      "name": "Root-A",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "supplier": "Organization: Red Hat",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "aaaa111122223333444455556666777788889999aaaabbbbccccddddeeeeffff"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Leaf-A",
+      "name": "Leaf-A",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "supplier": "Organization: Red Hat",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bbbb111122223333444455556666777788889999aaaabbbbccccddddeeeeffff"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-Root-A",
+      "relationshipType": "DESCRIBES"
+    },
+    {
+      "spdxElementId": "SPDXRef-Leaf-A",
+      "relatedSpdxElement": "SPDXRef-Root-A",
+      "relationshipType": "CONTAINED_BY"
+    }
+  ]
+}

--- a/etc/test-data/spdx/cycle/ext-b.json
+++ b/etc/test-data/spdx/cycle/ext-b.json
@@ -1,0 +1,53 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
+  "name": "cycle-beta",
+  "documentNamespace": "uri:cycle-ext-b",
+  "creationInfo": {
+    "created": "2024-01-01T00:00:00Z",
+    "creators": ["Tool: test"]
+  },
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Root-B",
+      "name": "Root-B",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "supplier": "Organization: Red Hat",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bbbb111122223333444455556666777788889999aaaabbbbccccddddeeeeffff"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Leaf-B",
+      "name": "Leaf-B",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "supplier": "Organization: Red Hat",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "aaaa111122223333444455556666777788889999aaaabbbbccccddddeeeeffff"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-Root-B",
+      "relationshipType": "DESCRIBES"
+    },
+    {
+      "spdxElementId": "SPDXRef-Leaf-B",
+      "relatedSpdxElement": "SPDXRef-Root-B",
+      "relationshipType": "CONTAINED_BY"
+    }
+  ]
+}

--- a/modules/analysis/src/service/load/rank.rs
+++ b/modules/analysis/src/service/load/rank.rs
@@ -472,7 +472,9 @@ mod test {
     use chrono::{TimeZone, Utc};
     use futures::{StreamExt, TryStreamExt, stream};
     use rstest::rstest;
+    use std::time::Duration;
     use test_context::test_context;
+    use tokio::time::timeout;
     use trustify_entity::cpe;
     use trustify_test_context::{IngestionResult, TrustifyContext};
 
@@ -614,5 +616,49 @@ mod test {
         items.sort_by_key(key);
         expected.sort_by_key(key);
         assert_eq!(items, expected);
+    }
+
+    /// Ensure that [`find_external_refs`] terminates when two SBOMs reference each other
+    /// cyclically via shared package checksums.
+    #[test_context(TrustifyContext)]
+    #[test_log::test(actix_web::test)]
+    async fn find_external_refs_cycle(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+        let [id_a, _id_b] = ctx
+            .ingest_documents(["spdx/cycle/ext-a.json", "spdx/cycle/ext-b.json"])
+            .await?
+            .into_uuid();
+
+        let mut visited = HashSet::new();
+
+        // no native test timeout in Rust, using tokio's timeout as a deadlock guard
+
+        let mut result = timeout(
+            Duration::from_secs(10),
+            find_external_refs(id_a, "SPDXRef-Root-A".into(), &ctx.db, &mut visited),
+        )
+        .await
+        .expect("find_external_refs should not loop infinitely")?;
+
+        log::info!("resolved external SBOMs: {result:?}");
+
+        // assert
+
+        result.sort();
+
+        assert_eq!(
+            result,
+            vec![
+                ResolvedSbom {
+                    sbom_id: id_a,
+                    node_id: "SPDXRef-Leaf-A".into(),
+                },
+                ResolvedSbom {
+                    sbom_id: _id_b,
+                    node_id: "SPDXRef-Leaf-B".into(),
+                },
+            ]
+        );
+
+        Ok(())
     }
 }

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -90,7 +90,7 @@ pub struct AnalysisService {
     concurrency: usize,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct ResolvedSbom {
     // The ID of the SBOM the node was found in
     pub sbom_id: Uuid,


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Add an async test that ingests cyclically referencing SPDX SBOMs and verifies `find_external_refs` completes within a bounded time using a timeout guard.