### PR TITLE
[ADR] Policy management

### DIFF
--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -181,11 +181,11 @@ This distinction ensures that clients using optimistic concurrency (`IfMatch`) r
 ## Trustify API Endpoints
 
 ```
-POST   /api/v2/policy          # Create a new policy reference
-GET    /api/v2/policy          # List policy references
-GET    /api/v2/policy/{id}     # Get a single policy reference
-PUT    /api/v2/policy/{id}     # Update a policy reference
-DELETE /api/v2/policy/{id}     # Delete a policy reference
+POST   /api/v3/policy          # Create a new policy reference
+GET    /api/v3/policy          # List policy references
+GET    /api/v3/policy/{id}     # Get a single policy reference
+PUT    /api/v3/policy/{id}     # Update a policy reference
+DELETE /api/v3/policy/{id}     # Delete a policy reference
 ```
 
 ### Permissions
@@ -212,13 +212,13 @@ Endpoint permission requirements:
 
 | Endpoint                     | Permission      |
 | ---------------------------- | --------------- |
-| `POST /api/v2/policy`        | `create.policy` |
-| `GET /api/v2/policy`         | `read.policy`   |
-| `GET /api/v2/policy/{id}`    | `read.policy`   |
-| `PUT /api/v2/policy/{id}`    | `update.policy` |
-| `DELETE /api/v2/policy/{id}` | `delete.policy` |
+| `POST /api/v3/policy`        | `create.policy` |
+| `GET /api/v3/policy`         | `read.policy`   |
+| `GET /api/v3/policy/{id}`    | `read.policy`   |
+| `PUT /api/v3/policy/{id}`    | `update.policy` |
+| `DELETE /api/v3/policy/{id}` | `delete.policy` |
 
-### POST `/api/v2/policy`
+### POST `/api/v3/policy`
 
 Create a new policy reference.
 
@@ -239,7 +239,7 @@ Create a new policy reference.
   And:
 
   ```
-  Location: /api/v2/policy/<id>
+  Location: /api/v3/policy/<id>
   ```
 
 - 400 - if the request could not be understood
@@ -247,7 +247,7 @@ Create a new policy reference.
 - 403 - if the user was authenticated but not authorized
 - 409 - if a policy with the same name already exists
 
-### GET `/api/v2/policy`
+### GET `/api/v3/policy`
 
 List policy references, optionally filtered.
 
@@ -281,7 +281,7 @@ The following `q` parameters are supported:
 - 401 - if the user was not authenticated
 - 403 - if the user was authenticated but not authorized
 
-### GET `/api/v2/policy/{id}`
+### GET `/api/v3/policy/{id}`
 
 Get a single policy reference by ID.
 
@@ -304,7 +304,7 @@ Get a single policy reference by ID.
 - 403 - if the user was authenticated but not authorized
 - 404 - if the policy was not found or the user doesn't have permission to read this policy
 
-### PUT `/api/v2/policy/{id}`
+### PUT `/api/v3/policy/{id}`
 
 Update an existing policy reference.
 
@@ -326,7 +326,7 @@ Update an existing policy reference.
 - 409 - if a policy with the same name already exists
 - 412 - if the `IfMatch` header was present, but its value didn't match the stored revision
 
-### DELETE `/api/v2/policy/{id}`
+### DELETE `/api/v3/policy/{id}`
 
 Delete an existing policy reference.
 

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -36,7 +36,6 @@ Trustify stores only the identity and location of a policy (id, name, URL/ref, c
 - `description` (TEXT) — what this policy enforces
 - `policy_type` (ENUM) — `'Conforma'`
 - `configuration` (JSONB) — Conforma-specific configuration model shown below
-- `revision` (UUID) — used for conditional UPDATE (optimistic concurrency via `ETag`); stored as UUID in database and exposed as an opaque `ETag` header in GET responses
 
 **`policy.configuration` JSONB model:**
 
@@ -81,8 +80,6 @@ enum PolicyType {
 /// The policy reference information
 #[derive(Serialize, Deserialize)]
 struct Policy {
-    #[serde(with = "uuid::serde::urn")]
-    #[schema(value_type = String)]
     id: Uuid,
     name: String,
     description: String,

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -35,10 +35,12 @@ Trustify stores only the identity and location of a policy (id, name, URL/ref, c
 - `name` (VARCHAR, unique) — user-friendly label
 - `description` (TEXT) — what this policy enforces
 - `policy_type` (ENUM) — `'Conforma'`
-- `configuration` (JSONB) — see model below
+- `configuration` (JSONB) — Conforma-specific configuration model shown below
 - `revision` (UUID) — used for conditional UPDATE (optimistic concurrency via `ETag`); stored as UUID in database, exposed as opaque string in API responses
 
 **`policy.configuration` JSONB model:**
+
+This JSONB schema describes the configuration for `policy_type = Conforma`. Future validator backends may use a different configuration shape, so the field remains JSONB to allow backend-specific extensions.
 
 | Field                  | Type     | Required        | Description                                                                                                           |
 | ---------------------- | -------- | --------------- | --------------------------------------------------------------------------------------------------------------------- |

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -4,7 +4,7 @@ Date: 2026-06-02
 
 ## Status
 
-PROPOSED
+APPROVED
 
 ## Context
 

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -88,7 +88,7 @@ struct Policy {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     policy_type: PolicyType,
-    configuration: PolicyConfiguration,
+    configuration: PolicyImporter,
     /// Conditional updates compare this revision (also exposed as `ETag` on GET).
     /// Stored as UUID in database, serialized as String in API responses.
     revision: String,
@@ -103,7 +103,7 @@ struct PolicyRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     policy_type: PolicyType,
-    configuration: PolicyConfiguration,
+    configuration: PolicyImporter,
 }
 ```
 
@@ -128,19 +128,52 @@ struct PolicyAuth {
 
 ```rust
 /// Policy configuration (stored as JSONB)
-#[derive(Serialize, Deserialize)]
-struct PolicyConfiguration {
-    policy_ref: String,
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    ToSchema,
+    schemars::JsonSchema,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyImporter {
+    #[serde(flatten)]
+    pub common: CommonImporter,
+
+    /// Reference to the policy source, e.g. git://github.com/org/policy-repo?ref=main
+    pub policy_ref: String,
+
+    /// Credentials for private policy repositories
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    auth: Option<PolicyAuth>,
+    pub auth: Option<PolicyAuth>,
+
+    /// Sub-paths within the policy repository to evaluate
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    policy_paths: Vec<String>,
+    pub policy_paths: Vec<String>,
+
+    /// Rule codes to skip during validation
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    exclude: Vec<String>,
+    pub exclude: Vec<String>,
+
+    /// If non-empty, only these rule codes are evaluated
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    include: Vec<String>,
+    pub include: Vec<String>,
+
+    /// Per-policy override of the default execution timeout
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    timeout_seconds: Option<u32>,
+    pub timeout_seconds: Option<u32>,
+}
+```
+
+```rust
+/// extending modules/importer/src/model/mod.rs
+pub enum ImporterConfiguration {
+    // existing code
+    Policy(PolicyImporter),
 }
 ```
 
@@ -157,18 +190,16 @@ The trade-off:
 
 ### Type Safety
 
-The `configuration` field uses a strongly-typed `PolicyConfiguration` struct rather than raw `serde_json::Value`. This provides:
+The `configuration` field uses a strongly-typed `PolicyConfiguration` struct rather than raw `serde_json::Value`. Importer:
 
 - Compile-time validation of required fields (`policy_ref`)
 - Type safety for nested structures (e.g., `AuthType` enum)
 - Clear API contract in generated OpenAPI schemas
 - Prevention of malformed configurations at ingestion time
 
-The database still stores this as JSONB, but the API layer enforces the typed schema. If future validator backends require backend-specific fields not present in `PolicyConfiguration`, the struct can be extended with an optional `extensions: Option<serde_json::Value>` field rather than weakening the entire type.
+The database still stores this as JSONB, but the API layer enforces the typed schema. If future validator backends require backend-specific fields not present in `PolicyConfiguration`, the struct can be extended with an optional `extensions: Option<serde_json::Value>` field rather than weakeniImporter type.
 
 ### UPDATE and DELETE Semantics and Optimistic Concurrency
-
-Both UPDATE (PUT) and DELETE endpoints support optimistic concurrency control via the `IfMatch` header and follow consistent semantics:
 
 **UPDATE (PUT) Semantics:**
 

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -1,0 +1,332 @@
+# 00018. Policy Management
+
+Date: 2026-06-02
+
+## Status
+
+PROPOSED
+
+## Context
+
+Trustify provides SBOM storage, analysis, and vulnerability tracking but lacks automated policy enforcement. Organizations need to validate SBOMs against security and compliance policies (licensing, vulnerabilities, provenance) without relying on manual, inconsistent review processes.
+
+Policy management is the prerequisite step: Trustify must be able to store, retrieve, and manage policy references before any policy validation can be triggered. Policy references identify external policy sources (e.g. git repositories) that a validation engine (such as Conforma) fetches at runtime — Trustify does not store the policy content itself.
+
+This ADR covers policy management (CRUD) which provides the building block for future integration with the Conforma validation engine.
+
+### Requirements
+
+Users need the ability to:
+
+1. Define and manage multiple policy configurations
+2. Associate policies with validation backends (initially Conforma)
+
+## Decision
+
+Add a `policy` module to Trustify that stores references to external policies and exposes a CRUD API for managing them.
+
+Trustify stores only the identity and location of a policy (id, name, URL/ref, configuration). Policy content is not cached — the validation engine fetches it at runtime from the referenced source.
+
+### The Data Model
+
+**`policy`** — stores references to external policies, not the policies themselves
+
+- `id` (UUID, PK)
+- `name` (VARCHAR, unique) — user-friendly label
+- `description` (TEXT) — what this policy enforces
+- `policy_type` (ENUM) — `'Conforma'`
+- `configuration` (JSONB) — see model below
+- `revision` (UUID) — used for conditional UPDATE (optimistic concurrency via `ETag`)
+
+**`policy.configuration` JSONB model:**
+
+| Field                  | Type     | Required        | Description                                                                                           |
+| ---------------------- | -------- | --------------- | ----------------------------------------------------------------------------------------------------- |
+| `policy_ref`           | string   | yes             | Policy source URL, e.g. `"git://[URL]?ref=[BRANCH OR TAG]"`                                           |
+| `auth`                 | object   | no              | Credentials for private repos; sensitive values encrypted via `ring::aead` AES-256-GCM (never logged) |
+| `auth.type`            | string   | yes (if `auth`) | `"token"`, `"ssh_key"`, or `"none"`                                                                   |
+| `auth.token_encrypted` | string   | no              | AES-256-GCM encrypted bearer/PAT token, prefixed with encryption scheme                               |
+| `policy_paths`         | string[] | no              | Sub-paths within the repo to evaluate                                                                 |
+| `exclude`              | string[] | no              | Rule codes to skip during validation                                                                  |
+| `include`              | string[] | no              | If non-empty, only these rule codes are evaluated                                                     |
+| `timeout_seconds`      | integer  | no              | Per-policy override of the default execution timeout                                                  |
+
+`policy.configuration` example:
+
+```json
+{
+  "policy_ref": "git://github.com/org/policy-repo?ref=main",
+  "auth": {
+    "type": "token",
+    "token_encrypted": "AES-256-GCM:<base64-nonce>:<base64-ciphertext>"
+  },
+  "policy_paths": ["policy/lib", "policy/release"],
+  "exclude": ["hello_world.minimal_packages"],
+  "include": [],
+  "timeout_seconds": 300
+}
+```
+
+#### Data Model Implementation
+
+```rust
+enum ValidatorKind {
+    Null,
+    Conforma,
+}
+```
+
+```rust
+/// The policy reference information
+#[derive(Serialize, Deserialize)]
+struct Policy {
+    id: String,
+    name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    policy_type: ValidatorKind,
+    configuration: serde_json::Value,
+    /// Conditional updates compare this revision (also exposed as `ETag` on GET).
+    revision: Uuid,
+}
+```
+
+```rust
+/// Policy information that can be mutated
+#[derive(Serialize, Deserialize)]
+struct PolicyRequest {
+    name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    policy_type: ValidatorKind,
+    configuration: serde_json::Value,
+}
+```
+
+```rust
+/// Credentials for private policy repos (`policy.configuration.auth`)
+#[derive(Serialize, Deserialize)]
+struct PolicyAuth {
+    /// `"token"`, `"ssh_key"`, or `"none"`
+    #[serde(rename = "type")]
+    auth_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    token_encrypted: Option<String>,
+}
+```
+
+```rust
+/// Policy configuration (stored as JSONB)
+#[derive(Serialize, Deserialize)]
+struct PolicyConfiguration {
+    policy_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    auth: Option<PolicyAuth>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    policy_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    exclude: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    include: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timeout_seconds: Option<u32>,
+}
+```
+
+## Consequences
+
+### Policy Management
+
+Trustify stores only external references and does not cache policy content. When `policy.policy_type` is `"Conforma"`, the validation engine fetches the policy at validation time from the git source specified in `policy.configuration.policy_ref`.
+
+The trade-off:
+
+- Validation always uses the latest policy content from the referenced branch or tag, but network failures or policy repo outages will cause execution errors.
+- For private policy repositories, authentication credentials are stored in the `configuration` JSONB column and encrypted at rest using `ring::aead` (AES-256-GCM authenticated encryption); they are never logged The `ring` crate is already a direct dependency of the project (used for digest hashing), so no new dependency is required.
+
+## Trustify API Endpoints
+
+```
+POST   /api/v2/policy          # Create a new policy reference
+GET    /api/v2/policy          # List policy references
+GET    /api/v2/policy/{id}     # Get a single policy reference
+PUT    /api/v2/policy/{id}     # Update a policy reference
+DELETE /api/v2/policy/{id}     # Delete a policy reference
+```
+
+### Permissions
+
+The policy module introduces the following permissions, following the existing Trustify CRUD convention:
+
+| Permission      | Description                |
+| --------------- | -------------------------- |
+| `create.policy` | Create policy references   |
+| `read.policy`   | List/get policy references |
+| `update.policy` | Update policy references   |
+| `delete.policy` | Delete policy references   |
+
+These permissions map to the default OIDC scope groups:
+
+| Scope             | Permissions granted |
+| ----------------- | ------------------- |
+| `create:document` | `create.policy`     |
+| `read:document`   | `read.policy`       |
+| `update:document` | `update.policy`     |
+| `delete:document` | `delete.policy`     |
+
+Endpoint permission requirements:
+
+| Endpoint                     | Permission      |
+| ---------------------------- | --------------- |
+| `POST /api/v2/policy`        | `create.policy` |
+| `GET /api/v2/policy`         | `read.policy`   |
+| `GET /api/v2/policy/{id}`    | `read.policy`   |
+| `PUT /api/v2/policy/{id}`    | `update.policy` |
+| `DELETE /api/v2/policy/{id}` | `delete.policy` |
+
+### POST `/api/v2/policy`
+
+Create a new policy reference.
+
+#### Request
+
+| part | name | type            | description |
+| ---- | ---- | --------------- | ----------- |
+| body | -    | `PolicyRequest` |             |
+
+#### Response
+
+- 201 - the policy was created
+
+  ```yaml
+  id: <id> # ID of the created policy
+  ```
+
+  And:
+
+  ```
+  Location: /api/v2/policy/<id>
+  ```
+
+- 400 - if the request could not be understood
+- 401 - if the user was not authenticated
+- 403 - if the user was authenticated but not authorized
+- 409 - if a policy with the same name already exists
+
+### GET `/api/v2/policy`
+
+List policy references, optionally filtered.
+
+By default, the entries will be sorted by name ascending.
+
+#### Request
+
+| part  | name     | type       | description                                             |
+| ----- | -------- | ---------- | ------------------------------------------------------- |
+| query | `q`      | "q" string | "q style" query string                                  |
+| query | `limit`  | u64        | Maximum number of items to return                       |
+| query | `offset` | u64        | Initial items to skip before actually returning results |
+
+The following `q` parameters are supported:
+
+- `name`: Filters policies by their name.
+
+#### Response
+
+- 200 - if the user is allowed to read policies
+
+  ```rust
+  #[derive(Serialize, Deserialize)]
+  struct PaginatedPolicy {
+      total: u64,
+      items: Vec<Policy>,
+  }
+  ```
+
+- 401 - if the user was not authenticated
+- 403 - if the user was authenticated but not authorized
+
+### GET `/api/v2/policy/{id}`
+
+Get a single policy reference by ID.
+
+#### Request
+
+| part | name | type     | description             |
+| ---- | ---- | -------- | ----------------------- |
+| path | `id` | `String` | ID of the policy to get |
+
+#### Response
+
+- 200 - if the policy was found
+
+  | part    | name   | type     | description                        |
+  | ------- | ------ | -------- | ---------------------------------- |
+  | body    | -      | `Policy` | The policy information             |
+  | headers | `ETag` | string   | Value which indicates the revision |
+
+- 401 - if the user was not authenticated
+- 404 - if the policy was not found or the user doesn't have permission to read this policy
+
+### PUT `/api/v2/policy/{id}`
+
+Update an existing policy reference.
+
+#### Request
+
+| part   | name      | type             | description                    |
+| ------ | --------- | ---------------- | ------------------------------ |
+| path   | `id`      | `String`         | ID of the policy to update     |
+| header | `IfMatch` | `Option<String>` | ETag value, revision to update |
+| body   | -         | `PolicyRequest`  | The new content                |
+
+#### Response
+
+- 204 - the policy was updated
+- 400 - if the request could not be understood
+- 401 - if the user was not authenticated
+- 403 - if the user was authenticated but not authorized
+- 404 - if the policy was not found
+- 409 - if a policy with the same name already exists
+- 412 - if the `IfMatch` header was present, but its value didn't match the stored revision
+
+### DELETE `/api/v2/policy/{id}`
+
+Delete an existing policy reference.
+
+Deleting a policy will fail if there are validation results referencing it.
+
+#### Request
+
+| part   | name      | type             | description                    |
+| ------ | --------- | ---------------- | ------------------------------ |
+| path   | `id`      | `String`         | ID of the policy to delete     |
+| header | `IfMatch` | `Option<String>` | ETag value, revision to delete |
+
+#### Response
+
+- 204 - if the policy was successfully deleted
+- 204 - if the policy was already deleted
+- 400 - if the request could not be understood
+- 401 - if the user was not authenticated
+- 403 - if the user was authenticated but not authorized
+- 409 - if the policy has associated validation results
+- 412 - if the `IfMatch` header was present, but its value didn't match the stored revision
+
+## File Structure
+
+```
+modules/policy/
+├── Cargo.toml
+└── src/
+    ├── error.rs                # Error types
+    ├── lib.rs
+    ├── endpoints/
+    │   └── mod.rs              # REST endpoints
+    ├── model/
+    │   ├── mod.rs
+    │   └── policy.rs           # Policy API models
+    └── service/
+        ├── mod.rs
+        └── policy_manager.rs   # Policy configuration management
+```

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -166,9 +166,19 @@ The `configuration` field uses a strongly-typed `PolicyConfiguration` struct rat
 
 The database still stores this as JSONB, but the API layer enforces the typed schema. If future validator backends require backend-specific fields not present in `PolicyConfiguration`, the struct can be extended with an optional `extensions: Option<serde_json::Value>` field rather than weakening the entire type.
 
-### DELETE Semantics and Optimistic Concurrency
+### UPDATE and DELETE Semantics and Optimistic Concurrency
 
-The DELETE endpoint follows these semantics:
+Both UPDATE (PUT) and DELETE endpoints support optimistic concurrency control via the `IfMatch` header and follow consistent semantics:
+
+**UPDATE (PUT) Semantics:**
+
+- **Without `IfMatch`**: Unconditional update — always succeeds if resource exists and returns `204`
+- **With `IfMatch`**: Conditional update with optimistic concurrency control
+  - `204` if the resource exists and the ETag matches
+  - `404` if the resource doesn't exist (cannot validate the precondition)
+  - `412` if the resource exists but the ETag doesn't match
+
+**DELETE Semantics:**
 
 - **Without `IfMatch`**: Idempotent delete — returns `204` whether the resource exists or not
 - **With `IfMatch`**: Conditional delete with optimistic concurrency control
@@ -176,7 +186,10 @@ The DELETE endpoint follows these semantics:
   - `404` if the resource doesn't exist (cannot validate the precondition)
   - `412` if the resource exists but the ETag doesn't match
 
-This distinction ensures that clients using optimistic concurrency (`IfMatch`) receive explicit feedback when a resource has been deleted by another client, rather than silently succeeding. Clients not using `IfMatch` benefit from simple idempotent delete semantics.
+This distinction ensures that:
+
+- Clients using optimistic concurrency (`IfMatch`) receive explicit feedback when a resource has been modified or deleted by another client, rather than silently overwriting or succeeding
+- Clients not using `IfMatch` benefit from simple unconditional update semantics (PUT) and idempotent delete semantics (DELETE)
 
 ## Trustify API Endpoints
 

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -122,8 +122,7 @@ enum AuthType {
 struct PolicyAuth {
     #[serde(rename = "type")]
     auth_type: AuthType,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    token_encrypted: Option<String>,
+    token_encrypted: String,
 }
 ```
 

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -112,8 +112,7 @@ enum AuthType {
 /// Credentials for private policy repos (`policy.configuration.auth`)
 #[derive(Serialize, Deserialize)]
 struct PolicyAuth {
-    #[serde(rename = "type")]
-    auth_type: AuthType,
+    r#type: AuthType,
     token_encrypted: String,
 }
 ```

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -325,7 +325,7 @@ Get a single policy reference by ID.
 
 - 401 - if the user was not authenticated
 - 403 - if the user was authenticated but not authorized
-- 404 - if the policy was not found or the user doesn't have permission to read this policy
+- 404 - if the policy id doesn't match a policy UUID record or the user doesn't have permission to read this policy
 
 ### PUT `/api/v3/policy/{id}`
 
@@ -347,7 +347,7 @@ Update an existing policy reference.
 - 400 - if the request could not be understood
 - 401 - if the user was not authenticated
 - 403 - if the user was authenticated but not authorized
-- 404 - if the policy was not found
+- 404 - if the policy id doesn't match a policy UUID record
 - 409 - if a policy with the same name already exists
 - 412 - if the `IfMatch` header was present, but its value didn't match the stored revision
 
@@ -373,7 +373,7 @@ Deleting a policy will fail if there are validation results referencing it.
 - 400 - if the request could not be understood
 - 401 - if the user was not authenticated
 - 403 - if the user was authenticated but not authorized
-- 404 - if the policy was not found **and an `IfMatch` header was provided** (cannot validate precondition on missing resource)
+- 404 - if the policy id doesn't match a policy UUID record **and an `IfMatch` header was provided** (cannot validate precondition on missing resource)
 - 409 - if the policy has associated validation results
 - 412 - if the `IfMatch` header was present, but its value didn't match the stored revision
 

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -199,19 +199,11 @@ The policy module introduces the following permissions, following the existing T
 | `update.policy` | Update policy references   |
 | `delete.policy` | Delete policy references   |
 
-Endpoint permission requirements:
-
-| Endpoint                     | Permission      |
-| ---------------------------- | --------------- |
-| `POST /api/v3/policy`        | `create.policy` |
-| `GET /api/v3/policy`         | `read.policy`   |
-| `GET /api/v3/policy/{id}`    | `read.policy`   |
-| `PUT /api/v3/policy/{id}`    | `update.policy` |
-| `DELETE /api/v3/policy/{id}` | `delete.policy` |
-
 ### POST `/api/v3/policy`
 
 Create a new policy reference.
+
+**Permission required:** `create.policy`
 
 #### Request
 
@@ -243,6 +235,8 @@ Create a new policy reference.
 List policy references, optionally filtered.
 
 By default, the entries will be sorted by name ascending.
+
+**Permission required:** `read.policy`
 
 #### Request
 
@@ -276,6 +270,8 @@ The following `q` parameters are supported:
 
 Get a single policy reference by ID.
 
+**Permission required:** `read.policy`
+
 #### Request
 
 | part | name | type     | description             |
@@ -298,6 +294,8 @@ Get a single policy reference by ID.
 ### PUT `/api/v3/policy/{id}`
 
 Update an existing policy reference.
+
+**Permission required:** `update.policy`
 
 #### Request
 
@@ -322,6 +320,8 @@ Update an existing policy reference.
 Delete an existing policy reference.
 
 Deleting a policy will fail if there are validation results referencing it.
+
+**Permission required:** `delete.policy`
 
 #### Request
 

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -80,7 +80,7 @@ enum PolicyType {
 /// The policy reference information
 #[derive(Serialize, Deserialize)]
 struct Policy {
-    id: Uuid,
+    id: String,
     name: String,
     description: String,
     policy_type: PolicyType,

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -36,7 +36,7 @@ Trustify stores only the identity and location of a policy (id, name, URL/ref, c
 - `description` (TEXT) — what this policy enforces
 - `policy_type` (ENUM) — `'Conforma'`
 - `configuration` (JSONB) — Conforma-specific configuration model shown below
-- `revision` (UUID) — used for conditional UPDATE (optimistic concurrency via `ETag`); stored as UUID in database, exposed as opaque string in API responses
+- `revision` (UUID) — used for conditional UPDATE (optimistic concurrency via `ETag`); stored as UUID in database and exposed as an opaque `ETag` header in GET responses
 
 **`policy.configuration` JSONB model:**
 
@@ -85,12 +85,10 @@ struct Policy {
     #[schema(value_type = String)]
     id: Uuid,
     name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
+    description: String,
     policy_type: PolicyType,
     configuration: PolicyImporter,
-    /// Conditional updates compare this revision (also exposed as `ETag` on GET).
-    /// Stored as UUID in database, serialized as String in API responses.
+    /// Conditional updates compare this revision. Stored as UUID in database and exposed as an opaque `ETag` header on GET.
     revision: String,
 }
 ```
@@ -100,8 +98,7 @@ struct Policy {
 #[derive(Serialize, Deserialize)]
 struct PolicyRequest {
     name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
+    description: String,
     policy_type: PolicyType,
     configuration: PolicyImporter,
 }

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -199,15 +199,6 @@ The policy module introduces the following permissions, following the existing T
 | `update.policy` | Update policy references   |
 | `delete.policy` | Delete policy references   |
 
-These permissions map to the default OIDC scope groups:
-
-| Scope             | Permissions granted |
-| ----------------- | ------------------- |
-| `create:document` | `create.policy`     |
-| `read:document`   | `read.policy`       |
-| `update:document` | `update.policy`     |
-| `delete:document` | `delete.policy`     |
-
 Endpoint permission requirements:
 
 | Endpoint                     | Permission      |

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -40,16 +40,16 @@ Trustify stores only the identity and location of a policy (id, name, URL/ref, c
 
 **`policy.configuration` JSONB model:**
 
-| Field                  | Type     | Required        | Description                                                                                           |
-| ---------------------- | -------- | --------------- | ----------------------------------------------------------------------------------------------------- |
-| `policy_ref`           | string   | yes             | Policy source URL, e.g. `"git://[URL]?ref=[BRANCH OR TAG]"`                                           |
-| `auth`                 | object   | no              | Credentials for private repos; sensitive values encrypted via `ring::aead` AES-256-GCM (never logged) |
-| `auth.type`            | enum     | yes (if `auth`) | `AuthType` enum: `token`, `ssh_key`, or `none`                                                        |
-| `auth.token_encrypted` | string   | no              | AES-256-GCM encrypted bearer/PAT token, prefixed with encryption scheme                               |
-| `policy_paths`         | string[] | no              | Sub-paths within the repo to evaluate                                                                 |
-| `exclude`              | string[] | no              | Rule codes to skip during validation                                                                  |
-| `include`              | string[] | no              | If non-empty, only these rule codes are evaluated                                                     |
-| `timeout_seconds`      | integer  | no              | Per-policy override of the default execution timeout                                                  |
+| Field                  | Type     | Required        | Description                                                                                                           |
+| ---------------------- | -------- | --------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `policy_ref`           | string   | yes             | Policy source URL, e.g. `"git://[URL]?ref=[BRANCH OR TAG]"`                                                           |
+| `auth`                 | object   | no              | Credentials for private repos; encrypted by client before sending to Trustify (never logged or decrypted by Trustify) |
+| `auth.type`            | enum     | yes (if `auth`) | `AuthType` enum: `token`, `ssh_key`, or `none`                                                                        |
+| `auth.token_encrypted` | string   | no              | Encrypted bearer/PAT token (format defined by client); Trustify stores opaque, validation engine decrypts at use time |
+| `policy_paths`         | string[] | no              | Sub-paths within the repo to evaluate                                                                                 |
+| `exclude`              | string[] | no              | Rule codes to skip during validation                                                                                  |
+| `include`              | string[] | no              | If non-empty, only these rule codes are evaluated                                                                     |
+| `timeout_seconds`      | integer  | no              | Per-policy override of the default execution timeout                                                                  |
 
 `policy.configuration` example:
 
@@ -153,7 +153,7 @@ Trustify stores only external references and does not cache policy content. When
 The trade-off:
 
 - Validation always uses the latest policy content from the referenced branch or tag, but network failures or policy repo outages will cause execution errors.
-- For private policy repositories, authentication credentials are stored in the `configuration` JSONB column and encrypted at rest using `ring::aead` (AES-256-GCM authenticated encryption); they are never logged. The `ring` crate is already a direct dependency of the project (used for digest hashing), so no new dependency is required.
+- Authentication credentials (in `auth.token_encrypted`) are stored as opaque encrypted strings. The client encrypts credentials before sending to Trustify; Trustify never decrypts or accesses the encryption key. When the validation engine requests credentials from Trustify, it receives the encrypted blob and is responsible for decryption. This pass-through model keeps Trustify decoupled from the encryption/authentication scheme and eliminates the need for Trustify to manage encryption keys.
 
 ### Type Safety
 

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -73,7 +73,6 @@ This JSONB schema describes the configuration for `policy_type = Conforma`. Futu
 
 ```rust
 enum PolicyType {
-    Null,
     Conforma,
 }
 ```

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -36,7 +36,7 @@ Trustify stores only the identity and location of a policy (id, name, URL/ref, c
 - `description` (TEXT) — what this policy enforces
 - `policy_type` (ENUM) — `'Conforma'`
 - `configuration` (JSONB) — see model below
-- `revision` (UUID) — used for conditional UPDATE (optimistic concurrency via `ETag`)
+- `revision` (UUID) — used for conditional UPDATE (optimistic concurrency via `ETag`); stored as UUID in database, exposed as opaque string in API responses
 
 **`policy.configuration` JSONB model:**
 
@@ -44,7 +44,7 @@ Trustify stores only the identity and location of a policy (id, name, URL/ref, c
 | ---------------------- | -------- | --------------- | ----------------------------------------------------------------------------------------------------- |
 | `policy_ref`           | string   | yes             | Policy source URL, e.g. `"git://[URL]?ref=[BRANCH OR TAG]"`                                           |
 | `auth`                 | object   | no              | Credentials for private repos; sensitive values encrypted via `ring::aead` AES-256-GCM (never logged) |
-| `auth.type`            | string   | yes (if `auth`) | `"token"`, `"ssh_key"`, or `"none"`                                                                   |
+| `auth.type`            | enum     | yes (if `auth`) | `AuthType` enum: `token`, `ssh_key`, or `none`                                                        |
 | `auth.token_encrypted` | string   | no              | AES-256-GCM encrypted bearer/PAT token, prefixed with encryption scheme                               |
 | `policy_paths`         | string[] | no              | Sub-paths within the repo to evaluate                                                                 |
 | `exclude`              | string[] | no              | Rule codes to skip during validation                                                                  |
@@ -80,14 +80,17 @@ enum ValidatorKind {
 /// The policy reference information
 #[derive(Serialize, Deserialize)]
 struct Policy {
-    id: String,
+    #[serde(with = "uuid::serde::urn")]
+    #[schema(value_type = String)]
+    id: Uuid,
     name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     policy_type: ValidatorKind,
-    configuration: serde_json::Value,
+    configuration: PolicyConfiguration,
     /// Conditional updates compare this revision (also exposed as `ETag` on GET).
-    revision: Uuid,
+    /// Stored as UUID in database, serialized as String in API responses.
+    revision: String,
 }
 ```
 
@@ -99,17 +102,25 @@ struct PolicyRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     policy_type: ValidatorKind,
-    configuration: serde_json::Value,
+    configuration: PolicyConfiguration,
 }
 ```
 
 ```rust
+/// Authentication method for private policy repos
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum AuthType {
+    Token,
+    SshKey,
+    None,
+}
+
 /// Credentials for private policy repos (`policy.configuration.auth`)
 #[derive(Serialize, Deserialize)]
 struct PolicyAuth {
-    /// `"token"`, `"ssh_key"`, or `"none"`
     #[serde(rename = "type")]
-    auth_type: String,
+    auth_type: AuthType,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     token_encrypted: Option<String>,
 }
@@ -142,7 +153,30 @@ Trustify stores only external references and does not cache policy content. When
 The trade-off:
 
 - Validation always uses the latest policy content from the referenced branch or tag, but network failures or policy repo outages will cause execution errors.
-- For private policy repositories, authentication credentials are stored in the `configuration` JSONB column and encrypted at rest using `ring::aead` (AES-256-GCM authenticated encryption); they are never logged The `ring` crate is already a direct dependency of the project (used for digest hashing), so no new dependency is required.
+- For private policy repositories, authentication credentials are stored in the `configuration` JSONB column and encrypted at rest using `ring::aead` (AES-256-GCM authenticated encryption); they are never logged. The `ring` crate is already a direct dependency of the project (used for digest hashing), so no new dependency is required.
+
+### Type Safety
+
+The `configuration` field uses a strongly-typed `PolicyConfiguration` struct rather than raw `serde_json::Value`. This provides:
+
+- Compile-time validation of required fields (`policy_ref`)
+- Type safety for nested structures (e.g., `AuthType` enum)
+- Clear API contract in generated OpenAPI schemas
+- Prevention of malformed configurations at ingestion time
+
+The database still stores this as JSONB, but the API layer enforces the typed schema. If future validator backends require backend-specific fields not present in `PolicyConfiguration`, the struct can be extended with an optional `extensions: Option<serde_json::Value>` field rather than weakening the entire type.
+
+### DELETE Semantics and Optimistic Concurrency
+
+The DELETE endpoint follows these semantics:
+
+- **Without `IfMatch`**: Idempotent delete — returns `204` whether the resource exists or not
+- **With `IfMatch`**: Conditional delete with optimistic concurrency control
+  - `204` if the resource exists and the ETag matches
+  - `404` if the resource doesn't exist (cannot validate the precondition)
+  - `412` if the resource exists but the ETag doesn't match
+
+This distinction ensures that clients using optimistic concurrency (`IfMatch`) receive explicit feedback when a resource has been deleted by another client, rather than silently succeeding. Clients not using `IfMatch` benefit from simple idempotent delete semantics.
 
 ## Trustify API Endpoints
 
@@ -196,7 +230,7 @@ Create a new policy reference.
 
 #### Response
 
-- 201 - the policy was created
+- 201 - if the policy was successfully created
 
   ```yaml
   id: <id> # ID of the created policy
@@ -221,11 +255,12 @@ By default, the entries will be sorted by name ascending.
 
 #### Request
 
-| part  | name     | type       | description                                             |
-| ----- | -------- | ---------- | ------------------------------------------------------- |
-| query | `q`      | "q" string | "q style" query string                                  |
-| query | `limit`  | u64        | Maximum number of items to return                       |
-| query | `offset` | u64        | Initial items to skip before actually returning results |
+| part  | name     | type       | description                                                    |
+| ----- | -------- | ---------- | -------------------------------------------------------------- |
+| query | `q`      | "q" string | "q style" query string                                         |
+| query | `limit`  | u64        | Maximum number of items to return                              |
+| query | `offset` | u64        | Initial items to skip before actually returning results        |
+| query | `total`  | bool       | Whether to compute and return the total count (default: false) |
 
 The following `q` parameters are supported:
 
@@ -237,9 +272,9 @@ The following `q` parameters are supported:
 
   ```rust
   #[derive(Serialize, Deserialize)]
-  struct PaginatedPolicy {
-      total: u64,
+  struct PaginatedResults<Policy> {
       items: Vec<Policy>,
+      total: Option<u64>,
   }
   ```
 
@@ -266,6 +301,7 @@ Get a single policy reference by ID.
   | headers | `ETag` | string   | Value which indicates the revision |
 
 - 401 - if the user was not authenticated
+- 403 - if the user was authenticated but not authorized
 - 404 - if the policy was not found or the user doesn't have permission to read this policy
 
 ### PUT `/api/v2/policy/{id}`
@@ -282,7 +318,7 @@ Update an existing policy reference.
 
 #### Response
 
-- 204 - the policy was updated
+- 204 - if the policy was successfully updated
 - 400 - if the request could not be understood
 - 401 - if the user was not authenticated
 - 403 - if the user was authenticated but not authorized
@@ -306,10 +342,11 @@ Deleting a policy will fail if there are validation results referencing it.
 #### Response
 
 - 204 - if the policy was successfully deleted
-- 204 - if the policy was already deleted
+- 204 - if the policy was already deleted **and no `IfMatch` header was provided** (idempotent delete)
 - 400 - if the request could not be understood
 - 401 - if the user was not authenticated
 - 403 - if the user was authenticated but not authorized
+- 404 - if the policy was not found **and an `IfMatch` header was provided** (cannot validate precondition on missing resource)
 - 409 - if the policy has associated validation results
 - 412 - if the `IfMatch` header was present, but its value didn't match the stored revision
 

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -72,7 +72,7 @@ This JSONB schema describes the configuration for `policy_type = Conforma`. Futu
 #### Data Model Implementation
 
 ```rust
-enum ValidatorKind {
+enum PolicyType {
     Null,
     Conforma,
 }
@@ -88,7 +88,7 @@ struct Policy {
     name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
-    policy_type: ValidatorKind,
+    policy_type: PolicyType,
     configuration: PolicyConfiguration,
     /// Conditional updates compare this revision (also exposed as `ETag` on GET).
     /// Stored as UUID in database, serialized as String in API responses.
@@ -103,7 +103,7 @@ struct PolicyRequest {
     name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
-    policy_type: ValidatorKind,
+    policy_type: PolicyType,
     configuration: PolicyConfiguration,
 }
 ```

--- a/docs/adrs/00018-policy-management.md
+++ b/docs/adrs/00018-policy-management.md
@@ -88,8 +88,6 @@ struct Policy {
     description: String,
     policy_type: PolicyType,
     configuration: PolicyImporter,
-    /// Conditional updates compare this revision. Stored as UUID in database and exposed as an opaque `ETag` header on GET.
-    revision: String,
 }
 ```
 

--- a/docs/adrs/00020-policy-management.md
+++ b/docs/adrs/00020-policy-management.md
@@ -43,38 +43,32 @@ This JSONB schema describes the configuration for `policy_type = Conforma`. Futu
 
 | Field                  | Type     | Required        | Description                                                                                                           |
 | ---------------------- | -------- | --------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `policy_ref`           | string   | yes             | Policy source URL, e.g. `"git://[URL]?ref=[BRANCH OR TAG]"`                                                           |
+| `policyRef`            | string   | yes             | Policy source URL, e.g. `"git://[URL]?ref=[BRANCH OR TAG]"`                                                           |
 | `auth`                 | object   | no              | Credentials for private repos; encrypted by client before sending to Trustify (never logged or decrypted by Trustify) |
 | `auth.type`            | enum     | yes (if `auth`) | `AuthType` enum: `token`, `ssh_key`, or `none`                                                                        |
-| `auth.token_encrypted` | string   | no              | Encrypted bearer/PAT token (format defined by client); Trustify stores opaque, validation engine decrypts at use time |
-| `policy_paths`         | string[] | no              | Sub-paths within the repo to evaluate                                                                                 |
+| `auth.tokenEncrypted` | string   | no              | Encrypted bearer/PAT token (format defined by client); Trustify stores opaque, validation engine decrypts at use time |
+| `policyPaths`          | string[] | no              | Sub-paths within the repo to evaluate                                                                                 |
 | `exclude`              | string[] | no              | Rule codes to skip during validation                                                                                  |
 | `include`              | string[] | no              | If non-empty, only these rule codes are evaluated                                                                     |
-| `timeout_seconds`      | integer  | no              | Per-policy override of the default execution timeout                                                                  |
+| `timeoutSeconds`       | integer  | no              | Per-policy override of the default execution timeout                                                                  |
 
 `policy.configuration` example:
 
 ```json
 {
-  "policy_ref": "git://github.com/org/policy-repo?ref=main",
+  "policyRef": "git://github.com/org/policy-repo?ref=main",
   "auth": {
     "type": "token",
-    "token_encrypted": "AES-256-GCM:<base64-nonce>:<base64-ciphertext>"
+    "tokenEncrypted": "AES-256-GCM:<base64-nonce>:<base64-ciphertext>"
   },
-  "policy_paths": ["policy/lib", "policy/release"],
+  "policyPaths": ["policy/lib", "policy/release"],
   "exclude": ["hello_world.minimal_packages"],
   "include": [],
-  "timeout_seconds": 300
+  "timeoutSeconds": 300
 }
 ```
 
 #### Data Model Implementation
-
-```rust
-enum PolicyType {
-    Conforma,
-}
-```
 
 ```rust
 /// The policy reference information
@@ -83,19 +77,7 @@ struct Policy {
     id: String,
     name: String,
     description: String,
-    policy_type: PolicyType,
-    configuration: PolicyImporter,
-}
-```
-
-```rust
-/// Policy information that can be mutated
-#[derive(Serialize, Deserialize)]
-struct PolicyRequest {
-    name: String,
-    description: String,
-    policy_type: PolicyType,
-    configuration: PolicyImporter,
+    configuration: PolicyConfiguration,
 }
 ```
 
@@ -111,6 +93,7 @@ enum AuthType {
 
 /// Credentials for private policy repos (`policy.configuration.auth`)
 #[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct PolicyAuth {
     r#type: AuthType,
     token_encrypted: String,
@@ -131,7 +114,7 @@ struct PolicyAuth {
     schemars::JsonSchema,
 )]
 #[serde(rename_all = "camelCase")]
-pub struct PolicyImporter {
+pub struct PolicyConfiguration {
     #[serde(flatten)]
     pub common: CommonImporter,
 
@@ -164,7 +147,7 @@ pub struct PolicyImporter {
 /// extending modules/importer/src/model/mod.rs
 pub enum ImporterConfiguration {
     // existing code
-    Policy(PolicyImporter),
+    Policy(PolicyConfiguration),
 }
 ```
 
@@ -172,23 +155,23 @@ pub enum ImporterConfiguration {
 
 ### Policy Management
 
-Trustify stores only external references and does not cache policy content. When `policy.policy_type` is `"Conforma"`, the validation engine fetches the policy at validation time from the git source specified in `policy.configuration.policy_ref`.
+Trustify stores only external references and does not cache policy content. When `policy.policy_type` is "Conforma", the validation engine fetches the policy at validation time from the git source specified in `policy.configuration.policyRef`.
 
 The trade-off:
 
 - Validation always uses the latest policy content from the referenced branch or tag, but network failures or policy repo outages will cause execution errors.
-- Authentication credentials (in `auth.token_encrypted`) are stored as opaque encrypted strings. The client encrypts credentials before sending to Trustify; Trustify never decrypts or accesses the encryption key. When the validation engine requests credentials from Trustify, it receives the encrypted blob and is responsible for decryption. This pass-through model keeps Trustify decoupled from the encryption/authentication scheme and eliminates the need for Trustify to manage encryption keys.
+- Authentication credentials (in `auth.tokenEncrypted`) are stored as opaque encrypted strings. The client encrypts credentials before sending to Trustify; Trustify never decrypts or accesses the encryption key. When the validation engine requests credentials from Trustify, it receives the encrypted blob and is responsible for decryption. This pass-through model keeps Trustify decoupled from the encryption/authentication scheme and eliminates the need for Trustify to manage encryption keys.
 
 ### Type Safety
 
 The `configuration` field uses a strongly-typed `PolicyConfiguration` struct rather than raw `serde_json::Value`. Importer:
 
-- Compile-time validation of required fields (`policy_ref`)
+- Compile-time validation of required fields (`policyRef`)
 - Type safety for nested structures (e.g., `AuthType` enum)
 - Clear API contract in generated OpenAPI schemas
 - Prevention of malformed configurations at ingestion time
 
-The database still stores this as JSONB, but the API layer enforces the typed schema. If future validator backends require backend-specific fields not present in `PolicyConfiguration`, the struct can be extended with an optional `extensions: Option<serde_json::Value>` field rather than weakeniImporter type.
+The database still stores this as JSONB, but the API layer enforces the typed schema. If future validator backends require backend-specific fields not present in `PolicyConfiguration`, the type can be extended with an optional `extensions: Option<serde_json::Value>` field rather than weakeniImporter type.
 
 ### UPDATE and DELETE Semantics and Optimistic Concurrency
 
@@ -242,9 +225,9 @@ Create a new policy reference.
 
 #### Request
 
-| part | name | type            | description |
-| ---- | ---- | --------------- | ----------- |
-| body | -    | `PolicyRequest` |             |
+| part | name | type     | description |
+| ---- | ---- | -------- | ----------- |
+| body | -    | `Policy` |             |
 
 #### Response
 
@@ -338,7 +321,7 @@ Update an existing policy reference.
 | ------ | --------- | ---------------- | ------------------------------ |
 | path   | `id`      | `String`         | ID of the policy to update     |
 | header | `IfMatch` | `Option<String>` | ETag value, revision to update |
-| body   | -         | `PolicyRequest`  | The new content                |
+| body   | -         | `Policy`         | The new content                |
 
 #### Response
 


### PR DESCRIPTION
This ADR provides the description of the policy management.

The policies are defined outside of Trustify, initially in Git repositories (Github, Gitlab, etc) meanwhile we need to store some "meta-data" about a given policy, such as the link to the repo, what type of policy is used for (Conforma to start with), and some extra configuration when needed such as authentication details when relevant.

The policy management is the initial building block on the road towards SBOMs validation which will come when the first policy validation solution integration (Conforma API) with Trustify will be available which will permit to validate a SBOM against a specific policy and keep track of such result.

## Summary by Sourcery

Documentation:
- Add ADR describing the policy management data model, API endpoints, permissions, and file structure for integrating external policy references (e.g., Conforma-backed policies) into Trustify.