### PR TITLE
ci: free ~5GB disk space

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,6 +91,28 @@ jobs:
           sudo rm -Rf ${RUBY_PATH}
           sudo rm -Rf ${SWIFT_PATH}
           sudo rm -Rf ${GRADLE_HOME}
+
+          sudo rm -rf /usr/share/miniconda
+          sudo rm -rf /opt/hostedtoolcache/Python
+          sudo rm -rf /opt/hostedtoolcache/Ruby
+          sudo rm -rf /opt/hostedtoolcache/Java
+          sudo rm -rf /opt/hostedtoolcache/PyPy
+          sudo rm -rf /opt/hostedtoolcache/sbt
+          sudo rm -rf /opt/hostedtoolcache/stack
+          sudo rm -rf /opt/hostedtoolcache/lein
+          sudo rm -rf /opt/pipx
+          sudo rm -rf /var/lib/mysql
+          sudo rm -rf /var/lib/redis
+          sudo rm -rf /var/lib/snapd
+          sudo rm -rf /var/cache/apt
+          sudo rm -rf /usr/local/aws-cli
+          sudo rm -rf /usr/local/aws-sam-cli
+          sudo rm -rf /usr/local/share/terraform
+          sudo rm -rf /usr/local/share/helm
+          sudo rm -rf /usr/local/share/kubectl
+          sudo rm -rf /usr/local/share/pip-cache
+          sudo rm -rf /usr/share/man
+          sudo rm -rf /usr/share/doc
       - run: df -h
 
       - uses: actions/checkout@v5


### PR DESCRIPTION
reason:

<img width="1143" height="586" alt="2026-06-02_14-38" src="https://github.com/user-attachments/assets/ec04c563-38f6-4216-83b5-8986d4f17bd2" />


**Test in a personal repo:** https://github.com/helio-frota/ci-space

Before:

<img width="674" height="265" alt="before" src="https://github.com/user-attachments/assets/4738e03d-1df7-4da0-9ece-ef8862795e19" />

After:

<img width="546" height="149" alt="after" src="https://github.com/user-attachments/assets/82b0ca8f-5cb3-4518-a69e-9a937084b731" />

## Summary by Sourcery

CI:
- Extend the CI cleanup step to delete unused preinstalled SDKs, package managers, caches, and service data directories to reclaim several gigabytes of disk space on GitHub-hosted runners.