### PR TITLE
docs: document migration reversibility requirement in CONVENTIONS.md

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -159,6 +159,7 @@ Any files modified by steps 1–2 (e.g., `openapi.yaml`, JSON schema files) must
 - Column additions use `add_column_if_not_exists()`
 - Drop operations use `.if_exists()`
 - Raw SQL loaded via `include_str!("migration_dir/up.sql")`
+- Migrations must implement `down()` for reversibility — the `test_migrations` CI test verifies this by running `refresh()` (down + up) on every migration
 - Data migrations are separate from schema migrations, run via `trustd db data <names>`
 
 ## Rust Idioms
@@ -926,7 +927,8 @@ idempotency guards, raw SQL loading, data migration separation). Additional conv
 
 - **Numbering**: increment by 10 (e.g., `m0002190` → `m0002200`) to leave room for
   insertions.
-- **Reversibility**: implement both `up()` and `down()`.
+- **Reversibility**: implement both `up()` and `down()`. The `test_migrations` CI test
+  runs `refresh()` (down + up) on every migration to enforce this.
 - **Schema vs. data**: schema migrations registered with `.normal()`; data backfills
   registered with `.data()`. Prefer no data in schema migrations — separate schema changes
   from data changes.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -159,7 +159,7 @@ Any files modified by steps 1–2 (e.g., `openapi.yaml`, JSON schema files) must
 - Column additions use `add_column_if_not_exists()`
 - Drop operations use `.if_exists()`
 - Raw SQL loaded via `include_str!("migration_dir/up.sql")`
-- Migrations must implement `down()` for reversibility — the `test_migrations` CI test verifies this by running `refresh()` (down + up) on every migration
+- Migrations must implement `down()` for reversibility — the migration module tests verify this (e.g., by running `refresh()`, which executes down + up on every migration)
 - Data migrations are separate from schema migrations, run via `trustd db data <names>`
 
 ## Rust Idioms
@@ -927,8 +927,7 @@ idempotency guards, raw SQL loading, data migration separation). Additional conv
 
 - **Numbering**: increment by 10 (e.g., `m0002190` → `m0002200`) to leave room for
   insertions.
-- **Reversibility**: implement both `up()` and `down()`. The `test_migrations` CI test
-  runs `refresh()` (down + up) on every migration to enforce this.
+- **Reversibility**: implement both `up()` and `down()`.
 - **Schema vs. data**: schema migrations registered with `.normal()`; data backfills
   registered with `.data()`. Prefer no data in schema migrations — separate schema changes
   from data changes.


### PR DESCRIPTION
## Summary

- Add explicit convention that migrations must implement `down()` for reversibility
- Reference migration module tests that enforce reversibility (e.g., by running `refresh()` = down + up)
- Broadened test reference from `test_migrations` to all migration module tests per reviewer feedback
- Removed redundant reversibility expansion in Migrations sub-section per reviewer feedback

Implements [TC-4512](https://redhat.atlassian.net/browse/TC-4512)
Implements [TC-4710](https://redhat.atlassian.net/browse/TC-4710)
Implements [TC-4711](https://redhat.atlassian.net/browse/TC-4711)

## Test plan

- [ ] Verify CONVENTIONS.md renders correctly on GitHub
- [ ] Confirm Migration Patterns section references migration module tests generally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4512]: https://redhat.atlassian.net/browse/TC-4512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-4710]: https://redhat.atlassian.net/browse/TC-4710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-4711]: https://redhat.atlassian.net/browse/TC-4711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ