### PR TITLE
ci: skip tests for markdown-only changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,6 +95,12 @@ jobs:
 
       - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            non_md_changes:
+              - '!**/*.md'
 
       - name: Cache Theseus Postgresql Installation
         uses: actions/cache@v5
@@ -115,6 +121,7 @@ jobs:
           sudo chmod a+rwx /mnt/trustify
 
       - name: Test
+        if: steps.filter.outputs.non_md_changes == 'true'
         run: cargo test --all-features
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" # for embedded postgresql


### PR DESCRIPTION
tested here https://github.com/helio-frota/ci-space/actions

## Summary by Sourcery

Skip running Rust test job when a pull request only changes Markdown files by adding a path-based filter to the CI workflow.

CI:
- Add a paths-filter step to detect non-Markdown changes in the CI workflow.
- Guard the Rust test step so it runs only when changes include non-Markdown files.

## Summary by Sourcery

Optimize CI test execution based on file change types.

CI:
- Add a paths-filter step to detect whether a pull request includes non-Markdown file changes.
- Conditionally run the Rust test step only when non-Markdown files are modified in a pull request.