### PR TITLE
docs: fix method for "force run"

### DIFF
--- a/modules/importer/README.md
+++ b/modules/importer/README.md
@@ -101,5 +101,5 @@ echo true | http PUT localhost:8080/api/v3/importer/redhat-sbom/enabled
 ### Force an importer run
 
 ```shell
-http PUT localhost:8080/api/v3/importer/redhat-sbom/force
+http POST localhost:8080/api/v3/importer/redhat-sbom/force
 ```


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct the documented HTTP method for the importer 'force run' endpoint from PUT to POST.