### PR TITLE
fix!: make all DELETE endpoints idempotent

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -142,6 +142,19 @@ Any files modified by steps 1–2 (e.g., `openapi.yaml`, JSON schema files) must
 - Every endpoint has a `#[utoipa::path(...)]` attribute for OpenAPI documentation with `tag`, `operation_id`, `params`, and `responses`
 - Route attributes use Actix macros: `#[get("/v3/...")]`, `#[post("/v3/...")]`, `#[delete("/v3/...")]`
 
+### DELETE Idempotency
+
+All DELETE endpoints return `204 No Content` regardless of whether the resource existed.
+Deleting a non-existent resource is a successful no-op, not a 404 error. This makes
+DELETE operations idempotent — callers do not need to check existence before deleting,
+and concurrent or repeated deletes are safe.
+
+**Exception — `If-Match` revision checks:** When a DELETE request includes an `If-Match`
+header, the server validates the provided revision against the current resource state.
+If the revisions do not match (including when the resource does not exist but a specific
+revision was provided), the server returns `412 Precondition Failed`. When `If-Match: *`
+is used (or the header is omitted), the idempotent 204 behavior applies.
+
 ## Entity Model Patterns
 
 - Entities use `#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]` with `#[sea_orm(table_name = "...")]`

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -141,8 +141,7 @@ pub async fn get(
         ("key" = Id, Path),
     ),
     responses(
-        (status = 200, description = "Matching advisory", body = AdvisoryDetails),
-        (status = 404, description = "The advisory could not be found"),
+        (status = 204, description = "The advisory was deleted or did not exist"),
     ),
 )]
 #[delete("/v3/advisory/{key}")]
@@ -157,19 +156,15 @@ pub async fn delete(
     let tx = db.begin().await?;
 
     let id = Id::from_str(&key)?;
-    match service.fetch_advisory(id, &tx).await? {
-        Some(v) => match service.delete_advisory(v.head.uuid, &tx).await? {
-            false => Ok(HttpResponse::NotFound().finish()),
-            true => {
-                tx.commit().await?;
-                if let Err(e) = delete_doc(&v.source_document, i.storage()).await {
-                    log::warn!("Ignoring {e}");
-                }
-                Ok(HttpResponse::Ok().json(v))
-            }
-        },
-        None => Ok(HttpResponse::NotFound().finish()),
+    if let Some(v) = service.fetch_advisory(id, &tx).await?
+        && service.delete_advisory(v.head.uuid, &tx).await?
+    {
+        tx.commit().await?;
+        if let Err(e) = delete_doc(&v.source_document, i.storage()).await {
+            log::error!("Ignoring {e}");
+        }
     }
+    Ok(HttpResponse::NoContent().finish())
 }
 
 #[derive(IntoParams, Clone, Debug, PartialEq, Eq, serde::Deserialize)]

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -634,7 +634,7 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await;
 
     log::debug!("Code: {}", response.status());
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
     assert!(storage.retrieve(key).await?.is_none());
 
     // check that the document is gone
@@ -647,7 +647,7 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await;
     assert_eq!(advisory_list.total, Some(0));
 
-    // second delete should fail
+    // Deleting again should be idempotent (204, not 404).
     let response = app
         .call_service(
             TestRequest::delete()
@@ -657,7 +657,29 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await;
 
     log::debug!("Code: {}", response.status());
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(response.into_body().try_into_bytes().unwrap().is_empty());
+
+    Ok(())
+}
+
+/// Deleting an advisory that was never created should return 204.
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn delete_nonexistent_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    let id = uuid::Uuid::new_v4();
+
+    let response = app
+        .call_service(
+            TestRequest::delete()
+                .uri(&format!("/api/v3/advisory/urn:uuid:{id}"))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(response.into_body().try_into_bytes().unwrap().is_empty());
 
     Ok(())
 }

--- a/modules/fundamental/src/product/endpoints/mod.rs
+++ b/modules/fundamental/src/product/endpoints/mod.rs
@@ -90,8 +90,7 @@ pub async fn get(
         ("id", Path, description = "Opaque ID of the product")
     ),
     responses(
-        (status = 200, description = "Matching product", body = ProductDetails),
-        (status = 404, description = "The product could not be found"),
+        (status = 204, description = "The product was deleted or did not exist"),
     ),
 )]
 #[delete("/v3/product/{id}")]
@@ -102,19 +101,7 @@ pub async fn delete(
     _: Require<DeleteMetadata>,
 ) -> Result<impl Responder, Error> {
     let tx = db.begin().await?;
-
-    match state.fetch_product(*id, &tx).await? {
-        Some(v) => {
-            let rows_affected = state.delete_product(v.head.id, &tx).await?;
-            match rows_affected {
-                0 => Ok(HttpResponse::NotFound().finish()),
-                1 => {
-                    tx.commit().await?;
-                    Ok(HttpResponse::Ok().json(v))
-                }
-                _ => Err(Error::Internal("Unexpected number of rows affected".into())),
-            }
-        }
-        None => Ok(HttpResponse::NotFound().finish()),
-    }
+    state.delete_product(*id, &tx).await?;
+    tx.commit().await?;
+    Ok(HttpResponse::NoContent().finish())
 }

--- a/modules/fundamental/src/product/endpoints/test.rs
+++ b/modules/fundamental/src/product/endpoints/test.rs
@@ -1,6 +1,6 @@
 use crate::test::caller;
 use actix_http::StatusCode;
-use actix_web::test::TestRequest;
+use actix_web::{body::MessageBody, test::TestRequest};
 use jsonpath_rust::JsonPath;
 use serde_json::{Value, json};
 use test_context::test_context;
@@ -141,7 +141,8 @@ async fn delete_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let response = app.call_service(request).await;
 
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(response.into_body().try_into_bytes().unwrap().is_empty());
 
     let products = service
         .fetch_products(
@@ -156,11 +157,13 @@ async fn delete_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     assert_eq!(Some(0), products.total);
 
+    // Deleting again should be idempotent (204, not 404).
     let request = TestRequest::delete().uri(&uri).to_request();
 
     let response = app.call_service(request).await;
 
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(response.into_body().try_into_bytes().unwrap().is_empty());
 
     Ok(())
 }

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -396,8 +396,7 @@ all!(GetSbomAdvisories -> ReadSbom, ReadAdvisory);
         ("id" = Id, Path),
     ),
     responses(
-        (status = 204, description = "Matching SBOM as deleted"),
-        (status = 404, description = "The SBOM could not be found"),
+        (status = 204, description = "The SBOM was deleted or did not exist"),
     ),
 )]
 #[delete("/v3/sbom/{id}")]
@@ -411,21 +410,17 @@ pub async fn delete(
     let tx = db.begin().await?;
 
     let id = Id::from_str(&id)?;
-    match service.fetch_sbom(id, &tx).await? {
-        Some((v, _, source_document)) => match service.delete_sbom(v.sbom_id, &tx).await? {
-            false => Ok(HttpResponse::NotFound().finish()),
-            true => {
-                tx.commit().await?;
-                if let Err(e) =
-                    delete_doc(&SourceDocument::from_entity(&source_document), i.storage()).await
-                {
-                    log::warn!("Ignoring {e}");
-                }
-                Ok(HttpResponse::NoContent().finish())
-            }
-        },
-        None => Ok(HttpResponse::NotFound().finish()),
+    if let Some((v, _, source_document)) = service.fetch_sbom(id, &tx).await?
+        && service.delete_sbom(v.sbom_id, &tx).await?
+    {
+        tx.commit().await?;
+        if let Err(e) =
+            delete_doc(&SourceDocument::from_entity(&source_document), i.storage()).await
+        {
+            log::warn!("Ignoring {e}");
+        }
     }
+    Ok(HttpResponse::NoContent().finish())
 }
 
 /// Search for packages of an SBOM

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -7,7 +7,10 @@ use crate::{
     test::{caller, label::Api},
 };
 use actix_http::StatusCode;
-use actix_web::test::{TestRequest, read_body};
+use actix_web::{
+    body::MessageBody,
+    test::{TestRequest, read_body},
+};
 use flate2::bufread::GzDecoder;
 use rstest::rstest;
 use serde_json::{Value, json};
@@ -1222,7 +1225,7 @@ async fn delete_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
     assert!(storage.retrieve(key).await?.is_none());
 
-    // If we try again, we should get a 404 since it was deleted.
+    // Deleting again should be idempotent (204, not 404).
     let response = app
         .call_service(
             TestRequest::delete()
@@ -1232,7 +1235,8 @@ async fn delete_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await;
 
     log::debug!("Code: {}", response.status());
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(response.into_body().try_into_bytes().unwrap().is_empty());
 
     Ok(())
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -449,14 +449,8 @@ paths:
         schema:
           $ref: '#/components/schemas/Id'
       responses:
-        '200':
-          description: Matching advisory
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AdvisoryDetails'
-        '404':
-          description: The advisory could not be found
+        '204':
+          description: The advisory was deleted or did not exist
   /api/v3/advisory/{key}/download:
     get:
       tags:
@@ -2255,14 +2249,8 @@ paths:
           type: string
           format: uuid
       responses:
-        '200':
-          description: Matching product
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProductDetails'
-        '404':
-          description: The product could not be found
+        '204':
+          description: The product was deleted or did not exist
   /api/v3/purl:
     get:
       tags:
@@ -3123,9 +3111,7 @@ paths:
           $ref: '#/components/schemas/Id'
       responses:
         '204':
-          description: Matching SBOM as deleted
-        '404':
-          description: The SBOM could not be found
+          description: The SBOM was deleted or did not exist
   /api/v3/sbom/{id}/advisory:
     get:
       tags:


### PR DESCRIPTION
Align DELETE behavior across product, sbom, and advisory endpoints to always return 204 No Content, making them idempotent. Previously some returned 404 on missing resources and 200 with a JSON body on success.

Document the DELETE idempotency convention in CONVENTIONS.md, including the If-Match revision check exception.

## Summary by Sourcery

Align DELETE behavior across advisory, product, and SBOM endpoints to be idempotent and consistently return 204 No Content without a response body, while updating documentation and tests accordingly.

Bug Fixes:
- Ensure deleting non-existent advisory, product, and SBOM resources returns 204 No Content instead of 404 or 200 with a body, making DELETE operations idempotent.

Enhancements:
- Simplify delete handlers for advisory, product, and SBOM endpoints to always respond with 204 No Content regardless of prior existence.

Documentation:
- Document the DELETE idempotency convention and its If-Match revision check exception in CONVENTIONS.md.

Tests:
- Update and extend advisory, product, and SBOM deletion tests to assert 204 No Content responses, empty bodies, and idempotent behavior on repeated or non-existent deletes.