### PR TITLE
chore: aligning the instrumentation with standard

### DIFF
--- a/common/auth/src/authenticator/mod.rs
+++ b/common/auth/src/authenticator/mod.rs
@@ -121,7 +121,7 @@ impl Authenticator {
     }
 
     /// Validate a bearer token.
-    #[instrument(level = "debug", skip_all, fields(token = token.as_ref()), ret)]
+    #[instrument(level = "debug", skip_all, fields(token = token.as_ref()), err(level=tracing::Level::INFO))]
     pub async fn validate_token<S: AsRef<str>>(
         &self,
         token: S,

--- a/common/db/src/lib.rs
+++ b/common/db/src/lib.rs
@@ -14,7 +14,7 @@ use trustify_common::{config, db};
 pub struct Database<'a>(pub &'a db::Database);
 
 impl<'a> Database<'a> {
-    #[instrument(skip(self), err)]
+    #[instrument(skip(self), err(level=tracing::Level::INFO))]
     pub async fn migrate(&self) -> Result<(), anyhow::Error> {
         log::debug!("applying migrations");
         Migrator::up(self.0, None).await?;
@@ -23,7 +23,7 @@ impl<'a> Database<'a> {
         Ok(())
     }
 
-    #[instrument(skip(self), err)]
+    #[instrument(skip(self), err(level=tracing::Level::INFO))]
     pub async fn refresh(&self) -> Result<(), anyhow::Error> {
         log::warn!("refreshing database schema...");
         Migrator::refresh(self.0).await?;
@@ -33,7 +33,7 @@ impl<'a> Database<'a> {
     }
 
     /// Import a database from a provided DB dump.
-    #[instrument(err)]
+    #[instrument(err(level=tracing::Level::INFO))]
     pub async fn setup(database: &config::Database) -> Result<db::Database, anyhow::Error> {
         ensure!(
             database.url.is_none(),
@@ -71,7 +71,7 @@ impl<'a> Database<'a> {
         Ok(db)
     }
 
-    #[instrument(err)]
+    #[instrument(err(level=tracing::Level::INFO))]
     pub async fn bootstrap(database: &config::Database) -> Result<db::Database, anyhow::Error> {
         let db = Self::setup(database).await?;
 
@@ -81,7 +81,7 @@ impl<'a> Database<'a> {
     }
 
     /// Import a database from a provided DB dump.
-    #[instrument(skip(r), err)]
+    #[instrument(skip(r), err(level=tracing::Level::INFO))]
     pub async fn import<R>(
         database: &config::Database,
         mut r: R,

--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -79,7 +79,7 @@ pub struct Database {
 }
 
 impl Database {
-    #[instrument(err)]
+    #[instrument(err(level=tracing::Level::INFO))]
     pub async fn new(database: &crate::config::Database) -> Result<Self, anyhow::Error> {
         let url = database.to_url();
 
@@ -111,7 +111,7 @@ impl Database {
         Ok(Self { db, name })
     }
 
-    #[instrument(skip(self), err)]
+    #[instrument(skip(self), err(level=tracing::Level::INFO))]
     pub async fn close(self) -> anyhow::Result<()> {
         Ok(self.db.close().await?)
     }

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -34,7 +34,7 @@ impl AdvisoryService {
         Self { cache }
     }
 
-    #[instrument(skip(self, connection))]
+    #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
     pub async fn fetch_advisories<C: ConnectionTrait + Sync + Send>(
         &self,
         search: Query,

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -486,7 +486,7 @@ impl PurlService {
         })
     }
 
-    #[instrument(skip(self, connection), err)]
+    #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
     pub async fn recommend_purls<C: ConnectionTrait>(
         &self,
         purls: &[Purl],

--- a/modules/importer/src/runner/clearly_defined/mod.rs
+++ b/modules/importer/src/runner/clearly_defined/mod.rs
@@ -12,7 +12,7 @@ use trustify_module_ingestor::graph::Graph;
 use trustify_module_ingestor::service::IngestorService;
 
 impl super::ImportRunner {
-    #[instrument(skip(self), ret)]
+    #[instrument(skip(self), err(level=tracing::Level::INFO))]
     pub async fn run_once_clearly_defined(
         &self,
         context: impl RunContext + 'static,

--- a/modules/importer/src/runner/clearly_defined_curation/mod.rs
+++ b/modules/importer/src/runner/clearly_defined_curation/mod.rs
@@ -83,7 +83,7 @@ impl<C: RunContext> Callbacks<Vec<u8>> for Context<C> {
 }
 
 impl super::ImportRunner {
-    #[instrument(skip(self), ret)]
+    #[instrument(skip(self), err(level=tracing::Level::INFO))]
     pub async fn run_once_clearly_defined_curation(
         &self,
         context: impl RunContext + 'static,

--- a/modules/importer/src/runner/common/walker/git.rs
+++ b/modules/importer/src/runner/common/walker/git.rs
@@ -171,7 +171,7 @@ where
     }
 
     /// Run the walker
-    #[instrument(skip(self), ret)]
+    #[instrument(skip(self), err(level=tracing::Level::INFO))]
     pub async fn run(self) -> Result<Continuation, Error> {
         tokio::task::spawn_blocking(|| self.run_sync()).await?
     }

--- a/modules/importer/src/runner/cwe/mod.rs
+++ b/modules/importer/src/runner/cwe/mod.rs
@@ -13,7 +13,7 @@ use tracing::instrument;
 use trustify_module_ingestor::{graph::Graph, service::IngestorService};
 
 impl super::ImportRunner {
-    #[instrument(skip(self), ret)]
+    #[instrument(skip(self), err(level=tracing::Level::INFO))]
     pub async fn run_once_cwe_catalog(
         &self,
         context: impl RunContext + 'static,

--- a/modules/importer/src/runner/cwe/walker.rs
+++ b/modules/importer/src/runner/cwe/walker.rs
@@ -44,7 +44,7 @@ impl CweWalker {
     }
 
     /// Run the walker
-    #[instrument(skip(self), ret)]
+    #[instrument(skip(self), err(level=tracing::Level::INFO))]
     pub async fn run(self) -> Result<LastModified, Error> {
         let response = reqwest::get(&self.source).await?;
 

--- a/modules/importer/src/runner/quay/mod.rs
+++ b/modules/importer/src/runner/quay/mod.rs
@@ -14,7 +14,7 @@ use tracing::instrument;
 use trustify_module_ingestor::{graph::Graph, service::IngestorService};
 
 impl super::ImportRunner {
-    #[instrument(skip_all, ret)]
+    #[instrument(skip_all, err(level=tracing::Level::INFO))]
     pub async fn run_once_quay(
         &self,
         context: impl RunContext + 'static,

--- a/modules/importer/src/runner/quay/walker.rs
+++ b/modules/importer/src/runner/quay/walker.rs
@@ -73,7 +73,7 @@ impl<C: RunContext> QuayWalker<C> {
     }
 
     /// Run the walker
-    #[instrument(skip(self), ret)]
+    #[instrument(skip(self), err(level=tracing::Level::INFO))]
     pub async fn run(self) -> Result<LastModified, Error> {
         let progress = self.context.progress(format!(
             "Import SBOM attachments from: {}",

--- a/modules/importer/src/server/context.rs
+++ b/modules/importer/src/server/context.rs
@@ -94,6 +94,7 @@ impl CheckCancellation {
     }
 
     #[instrument(
+        skip(self),
         ret(level=Level::DEBUG),
         err(level=Level::INFO),
     )]

--- a/modules/importer/src/server/mod.rs
+++ b/modules/importer/src/server/mod.rs
@@ -73,7 +73,7 @@ struct Server {
 }
 
 impl Server {
-    #[instrument(skip_all, ret)]
+    #[instrument(skip_all, err(level=tracing::Level::INFO))]
     async fn run(self) -> anyhow::Result<()> {
         // The Heart struct spawns locally because the import fn isn't
         // Send, so we need a LocalSet

--- a/modules/ingestor/src/graph/product/mod.rs
+++ b/modules/ingestor/src/graph/product/mod.rs
@@ -228,7 +228,7 @@ impl Graph {
             .collect())
     }
 
-    #[instrument(skip(self, connection), err)]
+    #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
     pub async fn get_product_by_name<C: ConnectionTrait>(
         &self,
         name: impl Into<String> + Debug,
@@ -241,7 +241,7 @@ impl Graph {
             .map(|product| ProductContext::new(self, product)))
     }
 
-    #[instrument(skip(self, connection), err)]
+    #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
     pub async fn get_product_by_organization<C: ConnectionTrait>(
         &self,
         org: impl Into<String> + Debug,

--- a/modules/ingestor/src/graph/purl/mod.rs
+++ b/modules/ingestor/src/graph/purl/mod.rs
@@ -171,7 +171,7 @@ impl Graph {
         }
     }
 
-    #[instrument(skip(self, connection), err)]
+    #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
     pub async fn get_package_version_by_id<C: ConnectionTrait>(
         &self,
         id: Uuid,
@@ -215,7 +215,7 @@ impl Graph {
             .map(|package| PackageContext::new(self, package)))
     }
 
-    #[instrument(skip(self, connection), err)]
+    #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
     pub async fn get_package_by_id<C: ConnectionTrait>(
         &self,
         id: Uuid,

--- a/modules/ingestor/src/graph/sbom/clearly_defined.rs
+++ b/modules/ingestor/src/graph/sbom/clearly_defined.rs
@@ -7,7 +7,7 @@ use tracing::instrument;
 use trustify_common::purl::Purl;
 
 impl SbomContext {
-    #[instrument(skip(db, curation), err)]
+    #[instrument(skip(db, curation), err(level=tracing::Level::INFO))]
     pub async fn ingest_clearly_defined_curation<C: ConnectionTrait>(
         &self,
         curation: Curation,

--- a/modules/ingestor/src/graph/sbom/common/relationship.rs
+++ b/modules/ingestor/src/graph/sbom/common/relationship.rs
@@ -167,7 +167,7 @@ impl<ER: ExternalReferenceProcessor> RelationshipCreator<ER> {
     /// This expects a source of references to check against. If creating a fresh set of nodes and
     /// relationships, these sources would most likely be the creators (like [`super::PackageCreator`]).
     /// If nodes already exist in the database, those nodes would need to be extracted and provided.
-    #[instrument(skip_all, ret)]
+    #[instrument(skip_all, err(level=tracing::Level::INFO))]
     pub fn validate(&self, sources: References) -> Result<(), anyhow::Error> {
         let sources = sources.add_source(&self.externals);
 

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -188,7 +188,7 @@ impl<'g> CsafLoader<'g> {
         Ok(())
     }
 
-    #[instrument(skip_all, err)]
+    #[instrument(skip_all, err(level=tracing::Level::INFO))]
     async fn ingest_product_statuses<C: ConnectionTrait>(
         &self,
         csaf: &Csaf,

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -211,7 +211,7 @@ impl IngestorService {
         &self.storage
     }
 
-    #[instrument(skip_all, ret(level=tracing::Level::INFO))]
+    #[instrument(skip_all, err(level=tracing::Level::INFO))]
     pub async fn ingest(
         &self,
         bytes: &[u8],

--- a/modules/ingestor/src/service/sbom/clearly_defined.rs
+++ b/modules/ingestor/src/service/sbom/clearly_defined.rs
@@ -19,7 +19,7 @@ impl<'g> ClearlyDefinedLoader<'g> {
         Self { graph }
     }
 
-    #[instrument(skip(self, item, tx), ret(level=tracing::Level::INFO))]
+    #[instrument(skip(self, item, tx), err(level=tracing::Level::INFO))]
     pub async fn load(
         &self,
         labels: Labels,

--- a/modules/ingestor/src/service/weakness/mod.rs
+++ b/modules/ingestor/src/service/weakness/mod.rs
@@ -16,7 +16,7 @@ impl CweCatalogLoader {
         Self::default()
     }
 
-    #[instrument(skip(self, buffer, tx), ret)]
+    #[instrument(skip(self, buffer, tx), err(level=tracing::Level::INFO))]
     pub async fn load_bytes(
         &self,
         labels: Labels,
@@ -31,7 +31,7 @@ impl CweCatalogLoader {
         self.load(labels, &document, digests, tx).await
     }
 
-    #[instrument(skip(self, doc, tx), ret)]
+    #[instrument(skip(self, doc, tx), err(level=tracing::Level::INFO))]
     pub async fn load<'x>(
         &self,
         _labels: Labels,


### PR DESCRIPTION
* I asked Claude to read this section https://github.com/guacsec/trustify/blob/main/docs/design/log_tracing.md#instrumentation
* And to read all the rust code and it generated this: https://gist.github.com/helio-frota/57b033421fad29b00a5518deb401e361
* I removed `tests` from the generated markdown and applied the suggestions

Assisted-by: Claude Code

## Summary by Sourcery

Standardize tracing instrumentation across database, ingestor, importer, and service components to align with the project’s logging guidelines.

Enhancements:
- Set explicit INFO-level error logging on instrumented async functions and methods throughout the database, ingestor, importer, and service layers.
- Replace return-value-focused instrumentation with error-focused instrumentation where appropriate to emphasize error logging over return tracing.
- Adjust instrumentation attributes (such as skip lists) to better match the documented instrumentation standard.