### PR TITLE
feat(ingestor): extract structured CycloneDX model card fields

### DIFF
--- a/etc/test-data/cyclonedx/ai/test_structured_model_card.json
+++ b/etc/test-data/cyclonedx/ai/test_structured_model_card.json
@@ -1,0 +1,180 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "authors": [
+        {
+          "name": "nvidia"
+        }
+      ],
+      "bom-ref": "pkg:huggingface/nvidia/canary-1b-v2@1.0",
+      "copyright": "NOASSERTION",
+      "description": "No description available",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://huggingface.co/nvidia/canary-1b-v2"
+        }
+      ],
+      "group": "nvidia",
+      "licenses": [
+        {
+          "license": {
+            "id": "unknown",
+            "url": "https://spdx.org/licenses/"
+          }
+        }
+      ],
+      "manufacturer": {
+        "name": "nvidia",
+        "url": [
+          "https://huggingface.co/nvidia"
+        ]
+      },
+      "modelCard": {
+        "modelParameters": {
+          "architectureFamily": "transformer",
+          "inputs": [
+            {
+              "format": "text"
+            }
+          ],
+          "modelArchitecture": "canary-1b-v2ForCausalLM",
+          "outputs": [
+            {
+              "format": "generated-text"
+            }
+          ],
+          "task": "text-generation",
+          "approach": {
+            "type": "supervised-learning"
+          }
+        },
+        "quantitativeAnalysis": {
+          "graphics": {}
+        },
+        "considerations": {
+          "technicalLimitations": [
+            "Limited to English text",
+            "Max 2048 tokens"
+          ]
+        }
+      },
+      "name": "canary-1b-v2",
+      "publisher": "nvidia",
+      "purl": "pkg:huggingface/nvidia/canary-1b-v2@1.0",
+      "supplier": {
+        "name": "nvidia",
+        "url": [
+          "https://huggingface.co/nvidia"
+        ]
+      },
+      "type": "machine-learning-model",
+      "version": "1.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "pkg:huggingface/nvidia/canary-1b-v2@1.0"
+      ],
+      "ref": "pkg:generic/nvidia%2Fcanary-1b-v2@1.0"
+    }
+  ],
+  "externalReferences": [
+    {
+      "type": "distribution",
+      "url": "https://huggingface.co/nvidia/canary-1b-v2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "pkg:generic/nvidia%2Fcanary-1b-v2@1.0",
+      "copyright": "NOASSERTION",
+      "description": "No description available",
+      "name": "canary-1b-v2",
+      "purl": "pkg:generic/nvidia%2Fcanary-1b-v2@1.0",
+      "type": "application",
+      "version": "1.0"
+    },
+    "properties": [
+      {
+        "name": "primaryPurpose",
+        "value": "automatic-speech-recognition"
+      },
+      {
+        "name": "suppliedBy",
+        "value": "nvidia"
+      },
+      {
+        "name": "typeOfModel",
+        "value": "transformer"
+      },
+      {
+        "name": "bomFormat",
+        "value": "CycloneDX"
+      },
+      {
+        "name": "specVersion",
+        "value": "1.6"
+      },
+      {
+        "name": "serialNumber",
+        "value": "urn:uuid:nvidia-canary-1b-v2"
+      },
+      {
+        "name": "version",
+        "value": "1.0.0"
+      },
+      {
+        "name": "primaryPurpose",
+        "value": "automatic-speech-recognition"
+      },
+      {
+        "name": "suppliedBy",
+        "value": "nvidia"
+      },
+      {
+        "name": "licenses",
+        "value": "cc-by-4.0"
+      },
+      {
+        "name": "limitation",
+        "value": "adhered to, & Mitigation                                                                    |  Transcripts and translations may be not 100% accurate"
+      },
+      {
+        "name": "safetyRiskAssessment",
+        "value": "</span>\n\nField                                               |  Response\n:---------------------------------------------------:|:----------------------------------\nModel Application(s)                               |  Speech to Text Transcription\nDescribe the life critical impact   |  None\nUse Case Restrictions                              | Abide by [CC-BY-4, </span>\n\nField                                                                                               |  Response\n:---------------------------------------------------------------------------------------------------|:---------------:\nParticipation considerations from adversely impacted groups [protected classes](https://www, |  If a word is not trained in the language model and not presented in vocabulary, the word is not likely to be recognized, & Security, and Privacy Subcards [here](https://developer, |  None\n\n## <span style=\"color:#b37800;\">Explainability:</span>\n\nField                                                                                                  |  Response\n:------------------------------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------:\nIntended Domain                                                                   |  Speech to Text Transcription and Translation\nModel Type                                                                                            |  Attention Encoder-Decoder\nIntended Users                                                                                        |  This model is intended for developers, researchers, academics, and industries building conversational based applications"
+      },
+      {
+        "name": "typeOfModel",
+        "value": "transformer"
+      },
+      {
+        "name": "downloadLocation",
+        "value": "https://huggingface.co/nvidia/canary-1b-v2/tree/main"
+      },
+      {
+        "name": "external_references",
+        "value": "[{\"type\": \"website\", \"url\": \"https://huggingface.co/nvidia/canary-1b-v2\", \"comment\": \"Model repository\"}, {\"type\": \"distribution\", \"url\": \"https://huggingface.co/nvidia/canary-1b-v2/tree/main\", \"comment\": \"Model files\"}]"
+      }
+    ],
+    "timestamp": "2025-09-26T10:07:22.695451Z",
+    "tools": {
+      "components": [
+        {
+          "bom-ref": "pkg:generic/aetheris-ai/aetheris-aibom-generator@1.0.0",
+          "manufacturer": {
+            "name": "Aetheris AI"
+          },
+          "name": "aetheris-aibom-generator",
+          "type": "application",
+          "version": "1.0"
+        }
+      ]
+    }
+  },
+  "serialNumber": "urn:uuid:test-structured-fields",
+  "specVersion": "1.6",
+  "version": 1
+}

--- a/modules/ingestor/src/graph/sbom/common/machine_learning_model.rs
+++ b/modules/ingestor/src/graph/sbom/common/machine_learning_model.rs
@@ -17,13 +17,52 @@ pub struct ModelCard {
 
 impl From<&Component> for ModelCard {
     fn from(c: &Component) -> Self {
-        let properties = Value::from(c.model_card.as_ref().and_then(|card| {
-            card.properties.as_ref().map(|v| {
-                v.iter()
-                    .map(|p| (p.name.clone(), p.value.clone().into()))
-                    .collect::<Map<_, _>>()
-            })
-        }));
+        let properties = match c.model_card.as_ref() {
+            Some(card) => {
+                let mut map = Map::new();
+
+                if let Some(params) = &card.model_parameters {
+                    if let Some(task) = &params.task {
+                        map.insert(
+                            "primaryPurpose".to_string(),
+                            Value::String(task.clone()),
+                        );
+                    }
+                    if let Some(approach) = &params.approach
+                        && let Some(type_val) = &approach.type_
+                    {
+                        map.insert(
+                            "typeOfModel".to_string(),
+                            Value::String(type_val.clone()),
+                        );
+                    }
+                }
+
+                if let Some(considerations) = &card.considerations
+                    && let Some(limitations) = &considerations.technical_limitations
+                    && !limitations.is_empty()
+                {
+                    map.insert(
+                        "limitation".to_string(),
+                        Value::String(limitations.join("; ")),
+                    );
+                }
+
+                // Generic properties take precedence over structured fields
+                if let Some(props) = &card.properties {
+                    for p in props {
+                        map.insert(p.name.clone(), p.value.clone().into());
+                    }
+                }
+
+                if map.is_empty() {
+                    Value::Null
+                } else {
+                    Value::Object(map)
+                }
+            }
+            None => Value::Null,
+        };
         ModelCard { properties }
     }
 }

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -231,6 +231,170 @@ mod test {
         Ok(())
     }
 
+
+    #[test_context(TrustifyContext)]
+    #[test(tokio::test)]
+    async fn ingest_ai_cyclonedx_nvidia_properties(
+        ctx: &TrustifyContext,
+    ) -> Result<(), anyhow::Error> {
+        let graph = Graph::new();
+        let data = document_bytes("cyclonedx/ai/nvidia_canary-1b-v2_aibom.json").await?;
+
+        let ingestor = IngestorService::new(graph, ctx.storage.clone(), Default::default());
+
+        ctx.db
+            .transaction(async |tx| {
+                ingestor
+                    .ingest(
+                        &data,
+                        Format::CycloneDX,
+                        [("type", "cyclonedx"), ("kind", "aibom")],
+                        None,
+                        Cache::Skip,
+                        tx,
+                    )
+                    .await
+            })
+            .await?;
+
+        let models = sbom_ai::Entity::find().all(&ctx.db).await?;
+        assert_eq!(1, models.len());
+
+        let props = &models[0].properties;
+
+        // Generic properties take precedence over structured model_parameters.task
+        // modelParameters.task = "text-generation" but generic property primaryPurpose = "automatic-speech-recognition"
+        assert_eq!(
+            props.get("primaryPurpose").and_then(|v| v.as_str()),
+            Some("automatic-speech-recognition"),
+        );
+
+        // typeOfModel comes from generic properties (no structured approach.type_ in fixture)
+        assert_eq!(
+            props.get("typeOfModel").and_then(|v| v.as_str()),
+            Some("transformer"),
+        );
+
+        // limitation comes from generic properties (no structured considerations in fixture)
+        assert!(
+            props.get("limitation").and_then(|v| v.as_str()).is_some(),
+        );
+
+        // Other generic properties are also present
+        assert_eq!(
+            props.get("bomFormat").and_then(|v| v.as_str()),
+            Some("CycloneDX"),
+        );
+
+        Ok(())
+    }
+
+    #[test_context(TrustifyContext)]
+    #[test(tokio::test)]
+    async fn ingest_ai_cyclonedx_ibm_properties(
+        ctx: &TrustifyContext,
+    ) -> Result<(), anyhow::Error> {
+        let graph = Graph::new();
+        let data =
+            document_bytes("cyclonedx/ai/ibm-granite_granite-docling-258M_aibom.json").await?;
+
+        let ingestor = IngestorService::new(graph, ctx.storage.clone(), Default::default());
+
+        ctx.db
+            .transaction(async |tx| {
+                ingestor
+                    .ingest(
+                        &data,
+                        Format::CycloneDX,
+                        [("type", "cyclonedx"), ("kind", "aibom")],
+                        None,
+                        Cache::Skip,
+                        tx,
+                    )
+                    .await
+            })
+            .await?;
+
+        let models = sbom_ai::Entity::find().all(&ctx.db).await?;
+        assert_eq!(1, models.len());
+
+        let props = &models[0].properties;
+
+        // Generic property overrides structured model_parameters.task
+        // modelParameters.task = "text-generation" but generic property primaryPurpose = "image-text-to-text"
+        assert_eq!(
+            props.get("primaryPurpose").and_then(|v| v.as_str()),
+            Some("image-text-to-text"),
+        );
+
+        // typeOfModel from generic properties
+        assert_eq!(
+            props.get("typeOfModel").and_then(|v| v.as_str()),
+            Some("idefics3"),
+        );
+
+        // IBM fixture has no limitation property
+        assert!(props.get("limitation").is_none());
+
+        Ok(())
+    }
+
+
+    #[test_context(TrustifyContext)]
+    #[test(tokio::test)]
+    async fn ingest_ai_cyclonedx_structured_fields(
+        ctx: &TrustifyContext,
+    ) -> Result<(), anyhow::Error> {
+        let graph = Graph::new();
+        let data =
+            document_bytes("cyclonedx/ai/test_structured_model_card.json").await?;
+
+        let ingestor = IngestorService::new(graph, ctx.storage.clone(), Default::default());
+
+        ctx.db
+            .transaction(async |tx| {
+                ingestor
+                    .ingest(
+                        &data,
+                        Format::CycloneDX,
+                        [("type", "cyclonedx"), ("kind", "aibom")],
+                        None,
+                        Cache::Skip,
+                        tx,
+                    )
+                    .await
+            })
+            .await?;
+
+        let models = sbom_ai::Entity::find().all(&ctx.db).await?;
+        assert_eq!(1, models.len());
+
+        let props = &models[0].properties;
+
+        // Structured field: modelParameters.task → primaryPurpose
+        assert_eq!(
+            props.get("primaryPurpose").and_then(|v| v.as_str()),
+            Some("text-generation"),
+        );
+
+        // Structured field: modelParameters.approach.type → typeOfModel
+        assert_eq!(
+            props.get("typeOfModel").and_then(|v| v.as_str()),
+            Some("supervised-learning"),
+        );
+
+        // Structured field: considerations.technicalLimitations → limitation (joined)
+        assert_eq!(
+            props.get("limitation").and_then(|v| v.as_str()),
+            Some("Limited to English text; Max 2048 tokens"),
+        );
+
+        // No generic properties in this fixture, so no bomFormat etc.
+        assert!(props.get("bomFormat").is_none());
+
+        Ok(())
+    }
+
     #[test_context(TrustifyContext)]
     #[test(tokio::test)]
     async fn ingest_cryptographic_cyclonedx(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
## Summary

- Extracts structured CycloneDX model card fields into `sbom_ai.properties` as frontend-friendly keys:
  - `model_parameters.task` → `primaryPurpose`
  - `model_parameters.approach.type` → `typeOfModel`
  - `considerations.technical_limitations` → `limitation` (joined with "; ")
- Generic `model_card.properties` overlay on top, preserving precedence over structured fields
- Adds 3 new integration tests verifying field extraction, precedence rules, and per-fixture assertions

## Test plan

- [x] `cargo clippy -p trustify-module-ingestor` passes clean
- [x] `cargo test -p trustify-module-ingestor --lib -- ingest_ai` — all 5 AI tests pass
- [x] Nvidia fixture: verifies generic `primaryPurpose` overrides structured `task`
- [x] IBM fixture: verifies generic properties and absence of `limitation`
- [x] Structured fixture: verifies pure structured extraction (task, approach.type, technicalLimitations)

Implements [TC-4516](https://redhat.atlassian.net/browse/TC-4516)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4516]: https://redhat.atlassian.net/browse/TC-4516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Extract structured CycloneDX model card metadata into standardized AI SBOM properties and validate behavior with new integration tests.

New Features:
- Map CycloneDX model card structured fields into frontend-friendly sbom_ai.properties keys such as primaryPurpose, typeOfModel, and limitation.

Tests:
- Add AI CycloneDX integration tests covering Nvidia, IBM, and structured fixtures to verify field extraction, precedence of generic properties, and absence/presence of limitations.