### PR TITLE
Search recursion problems with Rust 1.94.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.94.1"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Search recursion issues with Rust 1.94.1