### PR TITLE
Search recursion problems with Rust 1.93.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.93.1"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump the Rust toolchain channel from 1.91.1 to 1.93.1 in rust-toolchain.toml.