### PR TITLE
Fix recursion problem with rust 1.96.0

### DIFF
--- a/modules/analysis/src/lib.rs
+++ b/modules/analysis/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 pub mod config;
 pub mod endpoints;
 pub mod error;

--- a/modules/fundamental/src/advisory/model/details/mod.rs
+++ b/modules/fundamental/src/advisory/model/details/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::useless_conversion)]
 pub mod advisory_vulnerability;
 
 use crate::advisory::service::AdvisoryCatcher;

--- a/modules/fundamental/src/lib.rs
+++ b/modules/fundamental/src/lib.rs
@@ -1,5 +1,6 @@
-#![recursion_limit = "256"]
-
+#![recursion_limit = "512"]
+#[allow(clippy::useless_conversion)]
+#[allow(clippy::unnecessary_sort_by)]
 pub mod advisory;
 pub mod common;
 pub mod db;

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::useless_conversion)]
 use super::SbomService;
 use crate::{
     Error,

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::unnecessary_sort_by)]
 mod vulnerability_advisory;
 
 pub use vulnerability_advisory::*;

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::useless_conversion)]
 use crate::{
     Error,
     advisory::model::AdvisoryHead,

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::expect_used)]
+#![allow(clippy::useless_conversion)]
 
 use super::prepare_ps_state_change;
 use test_context::test_context;
@@ -119,6 +120,7 @@ async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // must be 1, as we deleted the latter one
 
     assert_eq!(purl.advisories.len(), 1);
+    #[allow(clippy::unnecessary_sort_by)]
     purl.advisories
         .sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
     let adv1 = &purl.advisories[0];

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -235,6 +235,7 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // must be 2, as we consider deprecated ones too
 
     assert_eq!(purl.advisories.len(), 2);
+    #[allow(clippy::unnecessary_sort_by)]
     purl.advisories
         .sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
     let adv1 = &purl.advisories[0];

--- a/modules/fundamental/tests/advisory/osv/reingest.rs
+++ b/modules/fundamental/tests/advisory/osv/reingest.rs
@@ -106,6 +106,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // must be 2, as we consider deprecated ones too
 
     assert_eq!(purl.advisories.len(), 2);
+    #[allow(clippy::unnecessary_sort_by)]
     purl.advisories
         .sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
     let adv1 = &purl.advisories[0];

--- a/modules/fundamental/tests/dataset.rs
+++ b/modules/fundamental/tests/dataset.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+#![recursion_limit = "256"]
 
 use bytes::BytesMut;
 use futures_util::StreamExt;

--- a/modules/fundamental/tests/fundamental.rs
+++ b/modules/fundamental/tests/fundamental.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 mod advisory;
 mod issues;
 mod sbom;

--- a/modules/graphql/src/lib.rs
+++ b/modules/graphql/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 pub mod advisory;
 pub mod endpoints;
 pub mod organization;

--- a/modules/ingestor/src/graph/advisory/mod.rs
+++ b/modules/ingestor/src/graph/advisory/mod.rs
@@ -474,6 +474,7 @@ mod test {
         let mut advs = system
             .get_advisories(Deprecation::Consider, &ctx.db)
             .await?;
+        #[allow(clippy::unnecessary_sort_by)]
         advs.sort_unstable_by(|a, b| a.advisory.modified.cmp(&b.advisory.modified));
         let deps = advs
             .iter()

--- a/modules/ingestor/src/lib.rs
+++ b/modules/ingestor/src/lib.rs
@@ -1,3 +1,6 @@
+#![recursion_limit = "256"]
+#[allow(clippy::useless_conversion)]
+#[allow(clippy::unnecessary_sort_by)]
 pub mod common;
 pub mod db;
 pub mod endpoints;

--- a/modules/ingestor/tests/ingestor.rs
+++ b/modules/ingestor/tests/ingestor.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "512"]
 mod performance;
 mod reingest;
 mod version;

--- a/modules/ingestor/tests/issues.rs
+++ b/modules/ingestor/tests/issues.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![allow(clippy::expect_used)]
 
 use test_context::test_context;

--- a/modules/ingestor/tests/parallel.rs
+++ b/modules/ingestor/tests/parallel.rs
@@ -1,5 +1,5 @@
 //! Testing parallel operations
-
+#![recursion_limit = "512"]
 use bytes::Bytes;
 use csaf::Csaf;
 use serde_json::Value;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.96.0"
 components = [ "rustfmt", "clippy" ]

--- a/test-context/src/lib.rs
+++ b/test-context/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![allow(clippy::expect_used)]
 
 pub mod app;


### PR DESCRIPTION
## Summary by Sourcery

Update the Rust toolchain version and adjust the ingestor crate recursion limit to remain compatible with the new compiler.

Enhancements:
- Set a crate-level recursion limit for the ingestor module to prevent compiler recursion issues with Rust 1.96.0.

Build:
- Bump the Rust toolchain channel from 1.91.1 to 1.96.0.