### PR TITLE
Fix trustify-ui branch 0.5.z

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9016,7 +9016,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/guacsec/trustify-ui.git?branch=release%2F0.5.z#209058dea920d0dbf29a7aa20d27018d44317b64"
+source = "git+https://github.com/guacsec/trustify-ui.git?branch=publish%2Frelease%2F0.5.z#05be2658d98d6096dfdbdfa60cc187324c81c2df"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9632,7 +9632,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ trustify-query = {path = "query" }
 trustify-query-derive = {path = "query/query-derive" }
 trustify-server = { path = "server", default-features = false }
 trustify-test-context = { path = "test-context" }
-trustify-ui = { git = "https://github.com/guacsec/trustify-ui.git", branch = "release/0.5.z" }
+trustify-ui = { git = "https://github.com/guacsec/trustify-ui.git", branch = "publish/release/0.5.z" }
 
 # These dependencies are active during both the build time and the run time. So they are normal dependencies
 # as well as build-dependencies. However, we can't control feature flags for build dependencies the way we do


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update trustify-ui git dependency to use the publish/release/0.5.z branch in Cargo.toml.