### PR TITLE
perf(analysis): batch CPE resolution pipeline to fix latest/component

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 [dependencies]
 actix-web = { workspace = true }
 anyhow = { workspace = true }
-async-compression = { workspace = true, features = ["gzip", "lzma"] }
+async-compression = { workspace = true, features = ["gzip", "lzma", "tokio"] }
 bytes = { workspace = true }
 bytesize = { workspace = true, features = ["serde"] }
 chrono = { workspace = true }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -58,6 +58,7 @@ mod m0002160_fix_ref_fk;
 mod m0002170_drop_cvss_tables;
 mod m0002180_advisory_fk_indexes;
 mod m0002190_vulnerability_base_score_advisory;
+mod m0002200_checksum_node_sbom_index;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -132,6 +133,7 @@ impl MigratorExt for Migrator {
             .normal(m0002170_drop_cvss_tables::Migration)
             .normal(m0002180_advisory_fk_indexes::Migration)
             .normal(m0002190_vulnerability_base_score_advisory::Migration)
+            .normal(m0002200_checksum_node_sbom_index::Migration)
     }
 }
 

--- a/migration/src/m0002200_checksum_node_sbom_index.rs
+++ b/migration/src/m0002200_checksum_node_sbom_index.rs
@@ -1,0 +1,50 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(SbomNodeChecksum::Table)
+                    .name(Indexes::SbomNodeChecksumNodeSbomIdx.to_string())
+                    .col(SbomNodeChecksum::NodeId)
+                    .col(SbomNodeChecksum::SbomId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(SbomNodeChecksum::Table)
+                    .name(Indexes::SbomNodeChecksumNodeSbomIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Indexes {
+    SbomNodeChecksumNodeSbomIdx,
+}
+
+#[derive(DeriveIden)]
+enum SbomNodeChecksum {
+    Table,
+    NodeId,
+    SbomId,
+}

--- a/modules/analysis/src/service/load/rank.rs
+++ b/modules/analysis/src/service/load/rank.rs
@@ -1,11 +1,13 @@
 use crate::{
     Error,
-    service::{ResolvedSbom, resolve_rh_external_sbom_ancestors},
+    service::{
+        ResolvedSbom, resolve_rh_external_sbom_ancestors,
+        resolve_rh_external_sbom_ancestors_batch,
+    },
 };
-use async_recursion::async_recursion;
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DbErr, EntityTrait, FromQueryResult, QueryFilter, QuerySelect,
-    RelationTrait, Select, prelude::DateTimeWithTimeZone,
+    ColumnTrait, ConnectionTrait, DatabaseBackend, DbErr, EntityTrait, FromQueryResult, QueryFilter,
+    QuerySelect, RelationTrait, Select, Statement, prelude::DateTimeWithTimeZone,
 };
 use sea_query::JoinType;
 use std::collections::{HashMap, HashSet};
@@ -40,6 +42,15 @@ pub struct RankedSbom {
     pub rank: Option<usize>,
 }
 
+/// Helper for deserializing recursive CTE results into `package_relates_to_package::Model`.
+#[derive(Debug, Clone, FromQueryResult)]
+struct AncestorRow {
+    sbom_id: Uuid,
+    left_node_id: String,
+    relationship: Relationship,
+    right_node_id: String,
+}
+
 /// prepare a select statement, returning [`Row`]s.
 pub fn select() -> Select<sbom_node::Entity> {
     sbom_node::Entity::find()
@@ -52,26 +63,9 @@ pub fn select() -> Select<sbom_node::Entity> {
         .left_join(sbom::Entity)
 }
 
-/// Recursively resolves external SBOM references to build a complete dependency graph across multiple SBOM files.
-///
-/// This function performs a **Depth-First Search (DFS)** starting from a specific node in a specific SBOM.
-/// It looks for "external references" (pointers to other SBOMs), resolves them, and then recursively
-/// traverses up the tree of the referenced SBOMs to find further ancestors.
-///
-/// # Arguments
-///
-/// * `sbom_id` - The UUID of the current SBOM being inspected.
-/// * `node_id` - The node ID within the current SBOM to search for external ancestors.
-/// * `connection` - The database connection.
-/// * `visited` - A `HashSet` used to track visited SBOM UUIDs and prevent infinite recursion in cyclic graphs.
-///
-/// # Returns
-///
-/// Returns a `Result` containing:
-/// * `Vec<ResolvedSbom>`: A flattened list of all resolved external SBOM ancestors found recursively.
-/// * `Error`: If a database error occurs.
-#[async_recursion]
-#[instrument(skip(connection, visited), fields(visisted_len=visited.len()), err(level=tracing::Level::INFO))]
+/// Resolves external SBOM references starting from a single node.
+/// Delegates to [`find_external_refs_bfs`] for the actual traversal.
+#[instrument(skip(connection, visited), fields(visited_len=visited.len()), err(level = tracing::Level::INFO))]
 async fn find_external_refs<C>(
     sbom_id: Uuid,
     node_id: String,
@@ -81,33 +75,61 @@ async fn find_external_refs<C>(
 where
     C: ConnectionTrait + Send,
 {
-    if !visited.insert((sbom_id, node_id.clone())) {
-        log::debug!("cycle detected for SBOM {sbom_id} / {node_id}, skipping recursion");
-        return Ok(vec![]);
-    }
+    find_external_refs_bfs(vec![(sbom_id, node_id)], connection, visited).await
+}
 
-    let mut all_resolved_sboms = vec![];
+/// Resolves external SBOM references using iterative BFS with batch queries per level.
+///
+/// Accepts multiple starting `(sbom_id, node_id)` pairs as the initial frontier.
+/// Each BFS level does 3 queries (batch external resolution + batch ancestor CTE),
+/// regardless of how many nodes are in the frontier.
+#[instrument(skip_all, err(level = tracing::Level::INFO))]
+async fn find_external_refs_bfs<C>(
+    initial_frontier: Vec<(Uuid, String)>,
+    connection: &C,
+    visited: &mut HashSet<(Uuid, String)>,
+) -> Result<Vec<ResolvedSbom>, Error>
+where
+    C: ConnectionTrait + Send,
+{
+    let mut all_resolved = Vec::new();
+    let mut frontier = initial_frontier;
 
-    // execute query and handle the result safely ONCE.
-    // usage: resolve_rh_external_sbom_ancestors likely returns Result<Vec<...>, Error>
-    let direct_ancestors = resolve_rh_external_sbom_ancestors(sbom_id, node_id, connection).await?;
-
-    for ancestor in direct_ancestors {
-        let top_package_of_sbom =
-            find_node_ancestors(ancestor.sbom_id, ancestor.node_id.clone(), connection).await?;
-
-        for package in top_package_of_sbom {
-            let deep_ancestors =
-                find_external_refs(package.sbom_id, package.left_node_id, connection, visited)
-                    .await?;
-
-            all_resolved_sboms.extend(deep_ancestors);
+    while !frontier.is_empty() {
+        frontier.retain(|(sbom_id, node_id)| visited.insert((*sbom_id, node_id.clone())));
+        if frontier.is_empty() {
+            break;
         }
 
-        all_resolved_sboms.push(ancestor);
+        let resolved_map =
+            resolve_rh_external_sbom_ancestors_batch(&frontier, connection).await?;
+
+        let mut ancestor_inputs = Vec::new();
+        for ancestors in resolved_map.values() {
+            for ancestor in ancestors {
+                all_resolved.push(ancestor.clone());
+                ancestor_inputs.push((ancestor.sbom_id, ancestor.node_id.clone()));
+            }
+        }
+
+        if ancestor_inputs.is_empty() {
+            break;
+        }
+
+        let ancestor_chains =
+            find_node_ancestors_batch(&ancestor_inputs, connection).await?;
+
+        let mut next_frontier = Vec::new();
+        for chain in ancestor_chains.values() {
+            for rel in chain {
+                next_frontier.push((rel.sbom_id, rel.left_node_id.clone()));
+            }
+        }
+
+        frontier = next_frontier;
     }
 
-    Ok(all_resolved_sboms)
+    Ok(all_resolved)
 }
 
 /// Retrieves the distinct list of CPE (Common Platform Enumeration) UUIDs associated with a specific SBOM,
@@ -151,74 +173,197 @@ async fn describing_cpes(
         .await?)
 }
 
-/// Retrieves lineage (ancestors) of a specific node within an SBOM graph as represented
-/// in sql data (NOT in memory graph).
+/// Batch version of [`describing_cpes`] — fetches CPE UUIDs for multiple SBOMs in a single query.
+#[instrument(skip_all, err(level = tracing::Level::INFO))]
+async fn describing_cpes_batch(
+    connection: &(impl ConnectionTrait + Send),
+    sbom_ids: &[Uuid],
+) -> Result<HashMap<Uuid, Vec<Uuid>>, Error> {
+    if sbom_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows = sbom_node_cpe_ref::Entity::find()
+        .distinct()
+        .select_only()
+        .column(sbom_node_cpe_ref::Column::SbomId)
+        .column(sbom_node_cpe_ref::Column::CpeId)
+        .filter(sbom_node_cpe_ref::Column::SbomId.is_in(sbom_ids.to_vec()))
+        .join(JoinType::Join, sbom_node_cpe_ref::Relation::Sbom.def())
+        .join(
+            JoinType::Join,
+            sbom::Relation::PackageRelatesToPackages.def(),
+        )
+        .filter(package_relates_to_package::Column::Relationship.eq(Relationship::Describes))
+        .into_tuple::<(Uuid, Uuid)>()
+        .all(connection)
+        .await?;
+
+    let mut result: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
+    for (sbom_id, cpe_id) in rows {
+        result.entry(sbom_id).or_default().push(cpe_id);
+    }
+
+    Ok(result)
+}
+
+/// Retrieves lineage (ancestors) of a specific node within an SBOM graph using a
+/// recursive CTE instead of iterative per-level queries.
 ///
-/// This function performs an iterative upstream traversal starting from the `start_node_id`.
-/// It walks the `package_relates_to_package` table from Child to Parent until it reaches
-/// a root node (no further parents) or hits a hard-coded recursion depth limit.
+/// Walks the `package_relates_to_package` table from Child to Parent until it reaches
+/// a root node (no further parents). Cycle detection via a visited-node array in the CTE.
 ///
-/// # Arguments
+/// # Single Path Traversal
 ///
-/// * `sbom_id` - The unique identifier of the SBOM to scope the search within.
-/// * `start_node_id` - The identifier of the child node to begin the traversal from.
-/// * `connection` - The database connection used to execute the queries.
-///
-/// # Returns
-///
-/// Returns a `Result` containing:
-/// * `Vec<package_relates_to_package::Model>`: A vector of relationship entities ordered
-///   from the immediate parent up to the root ancestor.
-/// * `DbErr`: If a database error occurs during traversal.
-///
-/// # Behavior & Limitations
-///
-/// * **Single Path Traversal**: If a node has multiple parents (DAG structure), this function
-///   currently selects *a single random* parent returned by the database and ignores others.
-/// * **Cycle Protection**: Records visited nodes of the SBOM to prevent infinite loops in
-///   cyclic graphs (e.g., A -> B -> A).
-#[instrument(skip(connection), err(level=tracing::Level::INFO))]
+/// If a node has multiple parents (DAG), one parent per level is selected (via `LIMIT 1`
+/// in the lateral join).
+#[instrument(skip(connection), err(level = tracing::Level::INFO))]
 pub async fn find_node_ancestors<C: ConnectionTrait>(
     sbom_id: Uuid,
     start_node_id: String,
     connection: &C,
 ) -> Result<Vec<package_relates_to_package::Model>, DbErr> {
-    let mut ancestors = Vec::new();
-    let mut current_child_id = start_node_id;
+    // AncestorOf = 9 (integer value from DeriveActiveEnum)
+    const ANCESTOR_OF: i32 = 9;
 
-    // guard to prevent infinite loops (e.g. cycles A->B->A)
-    let mut visited = HashSet::new();
+    let sql = r#"
+WITH RECURSIVE ancestors AS (
+    SELECT sbom_id, left_node_id, relationship, right_node_id,
+           ARRAY[$2::text] AS visited
+    FROM (
+        SELECT * FROM package_relates_to_package
+        WHERE sbom_id = $1 AND right_node_id = $2 AND relationship != $3
+        LIMIT 1
+    ) anchor
+    UNION ALL
+    SELECT p.sbom_id, p.left_node_id, p.relationship, p.right_node_id,
+           a.visited || a.left_node_id::text
+    FROM ancestors a
+    JOIN LATERAL (
+        SELECT * FROM package_relates_to_package
+        WHERE sbom_id = a.sbom_id AND right_node_id = a.left_node_id
+          AND relationship != $3
+        LIMIT 1
+    ) p ON true
+    WHERE NOT (a.left_node_id = ANY(a.visited))
+)
+SELECT sbom_id, left_node_id, relationship::int4, right_node_id FROM ancestors
+"#;
 
-    loop {
-        if !visited.insert(current_child_id.clone()) {
-            log::warn!("recursion detected (node: {current_child_id}, sbom: {sbom_id})",);
-            break;
-        }
+    let stmt = Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        sql,
+        [sbom_id.into(), start_node_id.into(), ANCESTOR_OF.into()],
+    );
 
-        // Find relationship where current node is the CHILD (Right Side).
-        // The LEFT side is the parent/container node.
-        let parents = package_relates_to_package::Entity::find()
-            .filter(package_relates_to_package::Column::SbomId.eq(sbom_id))
-            .filter(package_relates_to_package::Column::RightNodeId.eq(&current_child_id))
-            // We are interested in retrieving information (ex. CPE) from top level sbom
-            // so we filter out the 'tippity top' upstream node which use AncestorOf
-            // relationship type.
-            .filter(package_relates_to_package::Column::Relationship.ne(Relationship::AncestorOf))
-            .all(connection)
-            .await?;
+    let rows = AncestorRow::find_by_statement(stmt).all(connection).await?;
 
-        // no parents found
-        if parents.is_empty() {
-            break;
-        }
+        let ancestors = rows
+        .into_iter()
+        .map(|r| package_relates_to_package::Model {
+            sbom_id: r.sbom_id,
+            left_node_id: r.left_node_id,
+            relationship: r.relationship,
+            right_node_id: r.right_node_id,
+        })
+        .collect::<Vec<_>>();
 
-        let parent_rel = &parents[0];
-        ancestors.push(parent_rel.clone());
-        current_child_id = parent_rel.left_node_id.clone();
+    tracing::debug!("Found {} ancestors for node", ancestors.len());
+    Ok(ancestors)
+}
+
+/// Batch version of [`find_node_ancestors`] — runs a single recursive CTE for all
+/// `(sbom_id, node_id)` pairs, returning ancestor chains grouped by input pair.
+#[instrument(skip_all, err(level = tracing::Level::INFO))]
+async fn find_node_ancestors_batch<C: ConnectionTrait>(
+    inputs: &[(Uuid, String)],
+    connection: &C,
+) -> Result<HashMap<(Uuid, String), Vec<package_relates_to_package::Model>>, DbErr> {
+    if inputs.is_empty() {
+        return Ok(HashMap::new());
     }
 
-    log::debug!("Found {} ancestors for node", ancestors.len());
-    Ok(ancestors)
+    const ANCESTOR_OF: i32 = 9;
+
+    let mut sql_parts = Vec::with_capacity(inputs.len());
+    let mut params: Vec<sea_orm::Value> = Vec::with_capacity(inputs.len() * 2 + 1);
+
+    for (i, (sbom_id, node_id)) in inputs.iter().enumerate() {
+        let idx = i * 2;
+        sql_parts.push(format!("(${}::uuid, ${}::text)", idx + 1, idx + 2));
+        params.push((*sbom_id).into());
+        params.push(node_id.clone().into());
+    }
+
+    let ancestor_of_param_idx = params.len() + 1;
+    params.push(ANCESTOR_OF.into());
+
+    let values_clause = sql_parts.join(", ");
+    let sql = format!(
+        r#"
+WITH RECURSIVE
+input_nodes(root_sbom_id, root_node_id) AS (VALUES {values_clause}),
+ancestors AS (
+    SELECT i.root_sbom_id, i.root_node_id,
+           p.sbom_id, p.left_node_id, p.relationship, p.right_node_id,
+           ARRAY[i.root_node_id::text] AS visited
+    FROM input_nodes i
+    JOIN LATERAL (
+        SELECT * FROM package_relates_to_package
+        WHERE sbom_id = i.root_sbom_id AND right_node_id = i.root_node_id
+          AND relationship != ${ancestor_of_param_idx}
+        LIMIT 1
+    ) p ON true
+    UNION ALL
+    SELECT a.root_sbom_id, a.root_node_id,
+           p.sbom_id, p.left_node_id, p.relationship, p.right_node_id,
+           a.visited || a.left_node_id::text
+    FROM ancestors a
+    JOIN LATERAL (
+        SELECT * FROM package_relates_to_package
+        WHERE sbom_id = a.sbom_id AND right_node_id = a.left_node_id
+          AND relationship != ${ancestor_of_param_idx}
+        LIMIT 1
+    ) p ON true
+    WHERE NOT (a.left_node_id = ANY(a.visited))
+)
+SELECT root_sbom_id, root_node_id,
+       sbom_id, left_node_id, relationship::int4, right_node_id
+FROM ancestors
+"#
+    );
+
+    let stmt = Statement::from_sql_and_values(DatabaseBackend::Postgres, &sql, params);
+
+    #[derive(Debug, FromQueryResult)]
+    struct BatchAncestorRow {
+        root_sbom_id: Uuid,
+        root_node_id: String,
+        sbom_id: Uuid,
+        left_node_id: String,
+        relationship: Relationship,
+        right_node_id: String,
+    }
+
+    let rows = BatchAncestorRow::find_by_statement(stmt)
+        .all(connection)
+        .await?;
+
+    let mut result: HashMap<(Uuid, String), Vec<package_relates_to_package::Model>> =
+        HashMap::new();
+    for r in rows {
+        result
+            .entry((r.root_sbom_id, r.root_node_id))
+            .or_default()
+            .push(package_relates_to_package::Model {
+                sbom_id: r.sbom_id,
+                left_node_id: r.left_node_id,
+                relationship: r.relationship,
+                right_node_id: r.right_node_id,
+            });
+    }
+
+    Ok(result)
 }
 
 /// Resolve CPEs for matched SBOMs.
@@ -340,27 +485,28 @@ async fn resolve_ancestor_external_sboms(
     }
 }
 
-/// Expands a list of External SBOMs into RankedSboms by fetching their CPEs.
-#[instrument(skip(external_sboms, connection), err(level=tracing::Level::INFO))]
+/// Expands a list of External SBOMs into RankedSboms by fetching their CPEs in batch.
+#[instrument(skip(external_sboms, connection), err(level = tracing::Level::INFO))]
 async fn enrich_external_sboms(
     matched: &Row,
     external_sboms: Vec<ResolvedSbom>,
     connection: &(impl ConnectionTrait + Send),
 ) -> Result<Vec<RankedSbom>, Error> {
+    let sbom_ids: Vec<Uuid> = external_sboms.iter().map(|e| e.sbom_id).collect();
+    let cpes_map = describing_cpes_batch(connection, &sbom_ids).await?;
+
     let mut results = Vec::new();
-
     for external_sbom in external_sboms {
-        let cpes = describing_cpes(connection, external_sbom.sbom_id).await?;
-        log::debug!("Cpes: {:?}", cpes);
-
-        results.extend(cpes.into_iter().map(|cpe_id| RankedSbom {
-            matched_sbom_id: matched.sbom_id,
-            matched_name: matched.name.clone(),
-            top_ancestor_sbom: external_sbom.sbom_id,
-            cpe_id,
-            sbom_date: matched.published,
-            rank: None,
-        }));
+        if let Some(cpes) = cpes_map.get(&external_sbom.sbom_id) {
+            results.extend(cpes.iter().map(|&cpe_id| RankedSbom {
+                matched_sbom_id: matched.sbom_id,
+                matched_name: matched.name.clone(),
+                top_ancestor_sbom: external_sbom.sbom_id,
+                cpe_id,
+                sbom_date: matched.published,
+                rank: None,
+            }));
+        }
     }
 
     Ok(results)
@@ -658,6 +804,97 @@ mod test {
                 },
             ]
         );
+
+        Ok(())
+    }
+
+    /// Verify that [`find_node_ancestors_batch`] produces the same results as calling
+    /// [`find_node_ancestors`] individually for each input.
+    #[test_context(TrustifyContext)]
+    #[test_log::test(actix_web::test)]
+    async fn find_node_ancestors_batch_matches_individual(
+        ctx: &TrustifyContext,
+    ) -> Result<(), anyhow::Error> {
+        let [id] = ctx
+            .ingest_documents(["cyclonedx/loop.json"])
+            .await?
+            .into_uuid();
+
+        // Given: individual calls for nodes C and A
+        let individual_c = super::find_node_ancestors(id, "C".into(), &ctx.db).await?;
+        let individual_a = super::find_node_ancestors(id, "A".into(), &ctx.db).await?;
+
+        // When: batch call with both inputs
+        let batch_result = super::find_node_ancestors_batch(
+            &[(id, "C".into()), (id, "A".into())],
+            &ctx.db,
+        )
+        .await?;
+
+        // Then: batch results match individual calls
+        let to_pairs = |rels: &[package_relates_to_package::Model]| -> Vec<(String, String)> {
+            rels.iter()
+                .map(|r| (r.left_node_id.clone(), r.right_node_id.clone()))
+                .collect()
+        };
+
+        assert_eq!(
+            to_pairs(batch_result.get(&(id, "C".into())).unwrap_or(&vec![])),
+            to_pairs(&individual_c),
+        );
+        assert_eq!(
+            to_pairs(batch_result.get(&(id, "A".into())).unwrap_or(&vec![])),
+            to_pairs(&individual_a),
+        );
+
+        Ok(())
+    }
+
+    /// Verify that [`resolve_rh_external_sbom_ancestors_batch`] produces the same results
+    /// as calling [`resolve_rh_external_sbom_ancestors`] individually for each input.
+    #[test_context(TrustifyContext)]
+    #[test_log::test(actix_web::test)]
+    async fn resolve_rh_external_sbom_ancestors_batch_matches_individual(
+        ctx: &TrustifyContext,
+    ) -> Result<(), anyhow::Error> {
+        let [id_a, id_b] = ctx
+            .ingest_documents(["spdx/cycle/ext-a.json", "spdx/cycle/ext-b.json"])
+            .await?
+            .into_uuid();
+
+        // Given: individual calls
+        let mut individual_a =
+            resolve_rh_external_sbom_ancestors(id_a, "SPDXRef-Root-A".into(), &ctx.db).await?;
+        let mut individual_b =
+            resolve_rh_external_sbom_ancestors(id_b, "SPDXRef-Root-B".into(), &ctx.db).await?;
+
+        // When: batch call with both inputs
+        let batch_result = resolve_rh_external_sbom_ancestors_batch(
+            &[
+                (id_a, "SPDXRef-Root-A".into()),
+                (id_b, "SPDXRef-Root-B".into()),
+            ],
+            &ctx.db,
+        )
+        .await?;
+
+        // Then: batch results match individual calls (sort for deterministic comparison)
+        let mut batch_a = batch_result
+            .get(&(id_a, "SPDXRef-Root-A".into()))
+            .cloned()
+            .unwrap_or_default();
+        let mut batch_b = batch_result
+            .get(&(id_b, "SPDXRef-Root-B".into()))
+            .cloned()
+            .unwrap_or_default();
+
+        batch_a.sort();
+        batch_b.sort();
+        individual_a.sort();
+        individual_b.sort();
+
+        assert_eq!(batch_a, individual_a);
+        assert_eq!(batch_b, individual_b);
 
         Ok(())
     }

--- a/modules/analysis/src/service/load/rank.rs
+++ b/modules/analysis/src/service/load/rank.rs
@@ -1,13 +1,12 @@
 use crate::{
     Error,
     service::{
-        ResolvedSbom, resolve_rh_external_sbom_ancestors,
-        resolve_rh_external_sbom_ancestors_batch,
+        ResolvedSbom, resolve_rh_external_sbom_ancestors, resolve_rh_external_sbom_ancestors_batch,
     },
 };
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DatabaseBackend, DbErr, EntityTrait, FromQueryResult, QueryFilter,
-    QuerySelect, RelationTrait, Select, Statement, prelude::DateTimeWithTimeZone,
+    ColumnTrait, ConnectionTrait, DatabaseBackend, DbErr, EntityTrait, FromQueryResult,
+    QueryFilter, QuerySelect, RelationTrait, Select, Statement, prelude::DateTimeWithTimeZone,
 };
 use sea_query::JoinType;
 use std::collections::{HashMap, HashSet};
@@ -101,8 +100,7 @@ where
             break;
         }
 
-        let resolved_map =
-            resolve_rh_external_sbom_ancestors_batch(&frontier, connection).await?;
+        let resolved_map = resolve_rh_external_sbom_ancestors_batch(&frontier, connection).await?;
 
         let mut ancestor_inputs = Vec::new();
         for ancestors in resolved_map.values() {
@@ -116,8 +114,7 @@ where
             break;
         }
 
-        let ancestor_chains =
-            find_node_ancestors_batch(&ancestor_inputs, connection).await?;
+        let ancestor_chains = find_node_ancestors_batch(&ancestor_inputs, connection).await?;
 
         let mut next_frontier = Vec::new();
         for chain in ancestor_chains.values() {
@@ -258,7 +255,7 @@ SELECT sbom_id, left_node_id, relationship::int4, right_node_id FROM ancestors
 
     let rows = AncestorRow::find_by_statement(stmt).all(connection).await?;
 
-        let ancestors = rows
+    let ancestors = rows
         .into_iter()
         .map(|r| package_relates_to_package::Model {
             sbom_id: r.sbom_id,
@@ -825,11 +822,9 @@ mod test {
         let individual_a = super::find_node_ancestors(id, "A".into(), &ctx.db).await?;
 
         // When: batch call with both inputs
-        let batch_result = super::find_node_ancestors_batch(
-            &[(id, "C".into()), (id, "A".into())],
-            &ctx.db,
-        )
-        .await?;
+        let batch_result =
+            super::find_node_ancestors_batch(&[(id, "C".into()), (id, "A".into())], &ctx.db)
+                .await?;
 
         // Then: batch results match individual calls
         let to_pairs = |rels: &[package_relates_to_package::Model]| -> Vec<(String, String)> {

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -285,6 +285,77 @@ async fn resolve_rh_external_sbom_ancestors<C: ConnectionTrait>(
     )
 }
 
+/// Batch version of [`resolve_rh_external_sbom_ancestors`] — resolves external SBOM
+/// ancestors for multiple `(sbom_id, node_id)` pairs in two queries instead of 2N.
+#[instrument(skip_all, err(level = tracing::Level::INFO))]
+async fn resolve_rh_external_sbom_ancestors_batch<C: ConnectionTrait>(
+    inputs: &[(Uuid, String)],
+    connection: &C,
+) -> Result<HashMap<(Uuid, String), Vec<ResolvedSbom>>, Error> {
+    if inputs.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Query 1: Batch-fetch checksums for all input (sbom_id, node_id) pairs.
+    // SeaORM can't express multi-column IN, so use Condition::any() with compound filters.
+    let cond = inputs
+        .iter()
+        .fold(sea_orm::Condition::any(), |acc, (sid, nid)| {
+            acc.add(
+                sea_orm::Condition::all()
+                    .add(sbom_node_checksum::Column::SbomId.eq(*sid))
+                    .add(sbom_node_checksum::Column::NodeId.eq(nid.clone())),
+            )
+        });
+
+    let checksums = sbom_node_checksum::Entity::find()
+        .filter(cond)
+        .all(connection)
+        .await?;
+
+    if checksums.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Build a map: checksum_value → Vec<(input_sbom_id, input_node_id)>
+    let mut checksum_to_inputs: HashMap<String, Vec<(Uuid, String)>> = HashMap::new();
+    for c in &checksums {
+        checksum_to_inputs
+            .entry(c.value.clone())
+            .or_default()
+            .push((c.sbom_id, c.node_id.clone()));
+    }
+
+    let checksum_values: Vec<String> = checksum_to_inputs.keys().cloned().collect();
+
+    // Query 2: Find all nodes matching those checksum values
+    let matches = sbom_node_checksum::Entity::find()
+        .filter(sbom_node_checksum::Column::Value.is_in(checksum_values))
+        .all(connection)
+        .await?;
+
+    // Build result: for each matched node, find which input(s) it resolves,
+    // excluding matches where the SBOM is the same as the input SBOM.
+    let mut result: HashMap<(Uuid, String), Vec<ResolvedSbom>> = HashMap::new();
+    for m in matches {
+        if let Some(input_pairs) = checksum_to_inputs.get(&m.value) {
+            for (input_sbom_id, input_node_id) in input_pairs {
+                if m.sbom_id != *input_sbom_id {
+                    result
+                        .entry((*input_sbom_id, input_node_id.clone()))
+                        .or_default()
+                        .push(ResolvedSbom {
+                            sbom_id: m.sbom_id,
+                            node_id: m.node_id.clone(),
+                        });
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
 impl AnalysisService {
     /// Create a new analysis service instance with the configured cache size.
     ///


### PR DESCRIPTION
Replace sequential N+1 query patterns in the CPE resolution pipeline with batched operations:

- Replace iterative find_node_ancestors loop with a single recursive CTE (N queries per node → 1 query)
- Convert find_external_refs from recursive DFS to iterative BFS with batch queries per level (eliminates exponential query growth)
- Add batch versions: find_node_ancestors_batch, describing_cpes_batch, resolve_rh_external_sbom_ancestors_batch
- Update enrich_external_sboms to use batch CPE lookup (N queries → 1)
- Add composite index on sbom_node_checksum(node_id, sbom_id) to eliminate bitmap-AND on separate single-column indexes
- Fix missing tokio feature on async-compression in common crate

Implements TC-4364


Assisted-by: Claude Code

## Summary by Sourcery

Batch CPE resolution and ancestor traversal in the analysis pipeline to eliminate per-node N+1 queries and improve performance.

New Features:
- Introduce batched variants for node ancestor lookup, CPE description lookup, and external SBOM ancestor resolution, allowing multiple SBOM nodes to be processed in a single query pass.

Enhancements:
- Rewrite node ancestor traversal to use recursive SQL CTEs instead of iterative per-level queries, reducing query count and adding in-database cycle protection.
- Refactor external SBOM reference resolution from recursive DFS to iterative BFS with level-wise batch queries.
- Update external SBOM enrichment to use batched CPE lookups for all matched SBOMs in one step.
- Add regression tests to ensure batch APIs return the same results as the existing per-node implementations.

Build:
- Enable the "tokio" feature for the async-compression dependency in the common crate.

Tests:
- Add tests verifying equivalence between batched and individual ancestor resolution and external SBOM ancestor resolution APIs.