### PR TITLE
perf(analysis): paginate before hydration to fix component search timeout

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 [dependencies]
 actix-web = { workspace = true }
 anyhow = { workspace = true }
-async-compression = { workspace = true, features = ["gzip", "lzma"] }
+async-compression = { workspace = true, features = ["gzip", "lzma", "tokio"] }
 bytes = { workspace = true }
 bytesize = { workspace = true, features = ["serde"] }
 chrono = { workspace = true }

--- a/modules/analysis/src/endpoints/tests/mod.rs
+++ b/modules/analysis/src/endpoints/tests/mod.rs
@@ -172,9 +172,7 @@ async fn test_quarkus_retrieve_analysis_endpoint(
 /// Verify pagination through the HTTP endpoint returns correct total and limited items.
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn test_pagination_through_endpoint(
-    ctx: &TrustifyContext,
-) -> Result<(), anyhow::Error> {
+async fn test_pagination_through_endpoint(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
     ctx.ingest_documents([
         "spdx/quarkus-bom-3.2.11.Final-redhat-00001.json",

--- a/modules/analysis/src/endpoints/tests/mod.rs
+++ b/modules/analysis/src/endpoints/tests/mod.rs
@@ -169,6 +169,53 @@ async fn test_quarkus_retrieve_analysis_endpoint(
     Ok(())
 }
 
+/// Verify pagination through the HTTP endpoint returns correct total and limited items.
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn test_pagination_through_endpoint(
+    ctx: &TrustifyContext,
+) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    ctx.ingest_documents([
+        "spdx/quarkus-bom-3.2.11.Final-redhat-00001.json",
+        "spdx/quarkus-bom-3.2.12.Final-redhat-00002.json",
+    ])
+    .await?;
+
+    // When: request with limit=1, offset=0, total=true
+    let page1: Value = app
+        .req(Req {
+            what: What::Q("spymemcached"),
+            limit: Some(1),
+            offset: Some(0),
+            total: true,
+            ..Req::default()
+        })
+        .await?;
+
+    assert_eq!(page1["total"], 2);
+    assert_eq!(page1["items"].as_array().map(|a| a.len()), Some(1));
+
+    // When: request page 2
+    let page2: Value = app
+        .req(Req {
+            what: What::Q("spymemcached"),
+            limit: Some(1),
+            offset: Some(1),
+            total: true,
+            ..Req::default()
+        })
+        .await?;
+
+    assert_eq!(page2["total"], 2);
+    assert_eq!(page2["items"].as_array().map(|a| a.len()), Some(1));
+
+    // Then: pages contain different items
+    assert_ne!(page1["items"][0]["sbom_id"], page2["items"][0]["sbom_id"]);
+
+    Ok(())
+}
+
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn test_status_endpoint(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {

--- a/modules/analysis/src/service/load/mod.rs
+++ b/modules/analysis/src/service/load/mod.rs
@@ -22,7 +22,7 @@ use sea_orm::{
 use sea_query::{JoinType, SelectStatement};
 use serde_json::Value;
 use std::{
-    collections::{HashMap, HashSet, hash_map::Entry},
+    collections::{BTreeSet, HashMap, HashSet, hash_map::Entry},
     fmt::Debug,
     str::FromStr,
     sync::Arc,
@@ -403,13 +403,11 @@ impl InnerService {
         log::debug!("ranked sboms: {:?}", ranked_sboms);
 
         // retrieve only ranked_sboms with rank = 1, sorted for deterministic pagination
-        let mut latest_ids: Vec<_> = ranked_sboms
+        let latest_ids: BTreeSet<_> = ranked_sboms
             .into_iter()
             .filter(|item| item.rank == Some(1))
             .map(|item| item.matched_sbom_id)
             .collect();
-        latest_ids.sort();
-        latest_ids.dedup();
 
         tracing::debug!("latest sboms: {:?}", latest_ids);
 

--- a/modules/analysis/src/service/load/mod.rs
+++ b/modules/analysis/src/service/load/mod.rs
@@ -17,7 +17,7 @@ use opentelemetry::KeyValue;
 use petgraph::{Graph, prelude::NodeIndex};
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DatabaseBackend, DbErr, EntityOrSelect, EntityTrait,
-    FromQueryResult, QueryFilter, QuerySelect, QueryTrait, RelationTrait, Statement,
+    FromQueryResult, QueryFilter, QueryOrder, QuerySelect, QueryTrait, RelationTrait, Statement,
 };
 use sea_query::{JoinType, SelectStatement};
 use serde_json::Value;
@@ -402,14 +402,16 @@ impl InnerService {
         apply_rank(&mut ranked_sboms);
         log::debug!("ranked sboms: {:?}", ranked_sboms);
 
-        // retrieve only ranked_sboms with rank = 1
-        let latest_ids: HashSet<_> = ranked_sboms
+        // retrieve only ranked_sboms with rank = 1, sorted for deterministic pagination
+        let mut latest_ids: Vec<_> = ranked_sboms
             .into_iter()
             .filter(|item| item.rank == Some(1))
             .map(|item| item.matched_sbom_id)
             .collect();
+        latest_ids.sort();
+        latest_ids.dedup();
 
-        log::debug!("latest sboms: {:?}", latest_ids);
+        tracing::debug!("latest sboms: {:?}", latest_ids);
 
         self.load_graphs(connection, latest_ids).await
     }
@@ -422,6 +424,7 @@ impl InnerService {
     ) -> Result<Vec<(Uuid, Arc<PackageGraph>)>, Error> {
         let distinct_sbom_ids = sbom::Entity::find()
             .filter(sbom::Column::SbomId.in_subquery(subquery))
+            .order_by_asc(sbom::Column::SbomId)
             .select()
             .all(connection)
             .await?

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -492,6 +492,176 @@ impl AnalysisService {
             .await
     }
 
+    /// Count nodes matching the query across all graphs, without hydrating them.
+    fn count_matching_nodes(query: &GraphQuery, graphs: &[(Uuid, Arc<PackageGraph>)]) -> u64 {
+        graphs
+            .iter()
+            .map(|(_, graph)| {
+                graph
+                    .node_indices()
+                    .filter(|&i| Self::filter(graph, query, i))
+                    .count() as u64
+            })
+            .sum()
+    }
+
+    /// Collect nodes from the graph, applying pagination at the index level.
+    ///
+    /// Flattens matching nodes across ALL graphs into a single sequence, sorts
+    /// by `(sbom_id, node_id)` for deterministic ordering, then applies skip/take
+    /// globally. Only the paged subset runs through the expensive `create` closure.
+    #[instrument(skip(self, create, graphs))]
+    async fn collect_graph_paged<'a, 'g, F, Fut>(
+        &self,
+        query: impl Into<GraphQuery<'a>> + Debug,
+        graphs: &'g [(Uuid, Arc<PackageGraph>)],
+        concurrency: usize,
+        offset: usize,
+        limit: usize,
+        create: F,
+    ) -> Result<Vec<Node>, Error>
+    where
+        F: Fn(&'g Graph<graph::Node, Relationship>, NodeIndex, &'g graph::Node) -> Fut + Clone,
+        Fut: Future<Output = Result<Node, Error>>,
+    {
+        let query = query.into();
+
+        let mut matching: Vec<_> = graphs
+            .iter()
+            .flat_map(|(_, graph)| {
+                graph
+                    .node_indices()
+                    .filter(|&i| Self::filter(graph, &query, i))
+                    .filter_map(|i| graph.node_weight(i).map(|w| (graph.as_ref(), i, w)))
+            })
+            .collect();
+
+        matching.sort_by(|a, b| {
+            a.2.sbom_id
+                .cmp(&b.2.sbom_id)
+                .then_with(|| a.2.node_id.cmp(&b.2.node_id))
+        });
+
+        let matching: Vec<_> = matching.into_iter().skip(offset).take(limit).collect();
+
+        stream::iter(matching)
+            .map(|(graph, node_index, package_node)| {
+                let create = create.clone();
+                create(graph, node_index, package_node)
+            })
+            .buffer_unordered(concurrency)
+            .try_collect::<Vec<_>>()
+            .await
+    }
+
+    /// Run graph query with pagination applied before hydration.
+    #[instrument(skip(self, connection, graphs))]
+    async fn run_graph_query_paged<'a, C: ConnectionTrait>(
+        &self,
+        query: impl Into<GraphQuery<'a>> + Debug,
+        options: QueryOptions,
+        graphs: &[(Uuid, Arc<PackageGraph>)],
+        paginated: impl Pagination,
+        connection: &C,
+    ) -> Result<PaginatedResults<Node>, Error> {
+        let query = query.into();
+        let relationships = options.relationships;
+        tracing::debug!(?relationships, "relations");
+
+        let total = if paginated.total() {
+            Some(Self::count_matching_nodes(&query, graphs))
+        } else {
+            None
+        };
+
+        let limit = paginated.limit() as usize;
+        let offset = paginated.offset() as usize;
+
+        if limit == 0 {
+            return Ok(PaginatedResults {
+                items: vec![],
+                total,
+            });
+        }
+
+        if total.is_some_and(|t| offset as u64 >= t) {
+            return Ok(PaginatedResults {
+                items: vec![],
+                total,
+            });
+        }
+
+        let loader = &GraphLoader::new(self.clone());
+
+        let items = self
+            .collect_graph_paged(
+                query,
+                graphs,
+                self.concurrency,
+                offset,
+                limit,
+                |graph, node_index, node| {
+                    let graph_cache = self.inner.graph_cache.clone();
+                    let relationships = relationships.clone();
+                    async move {
+                        tracing::trace!(
+                            "Discovered node - sbom: {}, node: {}",
+                            node.sbom_id,
+                            node.node_id
+                        );
+
+                        let ancestors = Collector::new(
+                            &graph_cache,
+                            graphs,
+                            node.sbom_id,
+                            graph,
+                            node_index,
+                            Direction::Incoming,
+                            options.ancestors,
+                            &relationships,
+                            connection,
+                            self.concurrency,
+                            loader,
+                        )
+                        .collect();
+
+                        let descendants = Collector::new(
+                            &graph_cache,
+                            graphs,
+                            node.sbom_id,
+                            graph,
+                            node_index,
+                            Direction::Outgoing,
+                            options.descendants,
+                            &relationships,
+                            connection,
+                            self.concurrency,
+                            loader,
+                        )
+                        .collect();
+
+                        let (ancestors, descendants) = futures::join!(ancestors, descendants);
+                        let ancestors = ancestors?;
+                        let descendants = descendants?;
+
+                        let mut warnings = ancestors.1;
+                        warnings.extend(descendants.1);
+
+                        Ok(Node {
+                            base: node.into(),
+                            relationship: None,
+                            ancestors: ancestors.0,
+                            descendants: descendants.0,
+                            warnings,
+                        })
+                    }
+                },
+            )
+            .await?;
+
+        Ok(PaginatedResults { items, total })
+    }
+
     #[instrument(skip(self, connection, graphs))]
     pub async fn run_graph_query<'a, C: ConnectionTrait>(
         &self,
@@ -592,11 +762,8 @@ impl AnalysisService {
         let options = options.into();
 
         let graphs = self.load_graphs(connection, distinct_sbom_ids).await?;
-        let components = self
-            .run_graph_query(query, options, &graphs, connection)
-            .await?;
-
-        Ok(paginated.paginate_array(&components))
+        self.run_graph_query_paged(query, options, &graphs, paginated, connection)
+            .await
     }
 
     /// locate components, retrieve dependency information
@@ -613,11 +780,8 @@ impl AnalysisService {
 
         let graphs = self.load_graphs_query(connection, query).await?;
 
-        let components = self
-            .run_graph_query(query, options, &graphs, connection)
-            .await?;
-
-        Ok(paginated.paginate_array(&components))
+        self.run_graph_query_paged(query, options, &graphs, paginated, connection)
+            .await
     }
 
     pub(crate) async fn load_graphs_query(
@@ -639,19 +803,15 @@ impl AnalysisService {
         let query = query.into();
         let options = options.into();
 
-        // load only latest graphs
         let graphs = self
             .inner
             .load_latest_graphs_query(connection, query)
             .await?;
 
-        log::debug!("graph sbom count: {:?}", graphs.len());
+        tracing::debug!("graph sbom count: {:?}", graphs.len());
 
-        let components = self
-            .run_graph_query(query, options, &graphs, connection)
-            .await?;
-
-        Ok(paginated.paginate_array(&components))
+        self.run_graph_query_paged(query, options, &graphs, paginated, connection)
+            .await
     }
 
     /// check if a node in the graph matches the provided query

--- a/modules/analysis/src/service/test/mod.rs
+++ b/modules/analysis/src/service/test/mod.rs
@@ -863,3 +863,178 @@ async fn resolve_sbom_cdx_rh_variant_external_node_sbom(
 
     Ok(())
 }
+
+/// Verify that pagination limits the number of hydrated nodes.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn test_pagination_limits_hydration(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    ctx.ingest_documents([
+        "spdx/quarkus-bom-3.2.11.Final-redhat-00001.json",
+        "spdx/quarkus-bom-3.2.12.Final-redhat-00002.json",
+    ])
+    .await?;
+
+    let service = AnalysisService::new(AnalysisConfig::default(), ReadOnly::new(ctx.db.clone()));
+
+    // When: request with limit=1 and total=true
+    let result = service
+        .retrieve(
+            &Query::q("spymemcached"),
+            QueryOptions::ancestors(),
+            Paginated {
+                offset: 0,
+                limit: 1,
+                total: true,
+            },
+            &ctx.db,
+        )
+        .await?;
+
+    // Then: only 1 item returned but total reflects all matches
+    assert_eq!(result.items.len(), 1);
+    assert_eq!(result.total, Some(2));
+
+    Ok(())
+}
+
+/// Verify that offset produces different results from different pages.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn test_pagination_offset(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    ctx.ingest_documents([
+        "spdx/quarkus-bom-3.2.11.Final-redhat-00001.json",
+        "spdx/quarkus-bom-3.2.12.Final-redhat-00002.json",
+    ])
+    .await?;
+
+    let service = AnalysisService::new(AnalysisConfig::default(), ReadOnly::new(ctx.db.clone()));
+
+    // Given: page 1 (offset=0, limit=1)
+    let page1 = service
+        .retrieve(
+            &Query::q("spymemcached"),
+            QueryOptions::ancestors(),
+            Paginated {
+                offset: 0,
+                limit: 1,
+                total: false,
+            },
+            &ctx.db,
+        )
+        .await?;
+
+    // Given: page 2 (offset=1, limit=1)
+    let page2 = service
+        .retrieve(
+            &Query::q("spymemcached"),
+            QueryOptions::ancestors(),
+            Paginated {
+                offset: 1,
+                limit: 1,
+                total: false,
+            },
+            &ctx.db,
+        )
+        .await?;
+
+    // Then: both pages have 1 item each
+    assert_eq!(page1.items.len(), 1);
+    assert_eq!(page2.items.len(), 1);
+
+    // Then: the items are different (from different SBOMs)
+    assert_ne!(&page1.items[0].base.sbom_id, &page2.items[0].base.sbom_id);
+
+    // Given: combined page (offset=0, limit=2)
+    let combined = service
+        .retrieve(
+            &Query::q("spymemcached"),
+            QueryOptions::ancestors(),
+            Paginated {
+                offset: 0,
+                limit: 2,
+                total: true,
+            },
+            &ctx.db,
+        )
+        .await?;
+
+    // Then: union of page1 + page2 matches the combined result
+    assert_eq!(combined.items.len(), 2);
+    assert_eq!(combined.total, Some(2));
+
+    Ok(())
+}
+
+/// Verify that pagination correctly spans across multiple SBOM graph boundaries.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn test_pagination_cross_graph(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    ctx.ingest_documents([
+        "spdx/quarkus-bom-3.2.11.Final-redhat-00001.json",
+        "spdx/quarkus-bom-3.2.12.Final-redhat-00002.json",
+    ])
+    .await?;
+
+    let service = AnalysisService::new(AnalysisConfig::default(), ReadOnly::new(ctx.db.clone()));
+
+    // Given: a query that matches nodes across both SBOMs
+    let all = service
+        .retrieve(
+            &Query::q("spymemcached"),
+            QueryOptions::default(),
+            Paginated {
+                offset: 0,
+                limit: 100,
+                total: true,
+            },
+            &ctx.db,
+        )
+        .await?;
+
+    let total = all.total.unwrap_or(0) as usize;
+    assert!(total >= 2, "need at least 2 matches across SBOMs");
+
+    // When: paginate through all results one at a time
+    let mut collected_sbom_ids = Vec::new();
+    for i in 0..total {
+        let page = service
+            .retrieve(
+                &Query::q("spymemcached"),
+                QueryOptions::default(),
+                Paginated {
+                    offset: i as u64,
+                    limit: 1,
+                    total: false,
+                },
+                &ctx.db,
+            )
+            .await?;
+
+        assert_eq!(page.items.len(), 1, "page at offset {i} should have 1 item");
+        collected_sbom_ids.push(page.items[0].base.sbom_id.clone());
+    }
+
+    // Then: all items are accounted for (no duplicates, no gaps)
+    assert_eq!(collected_sbom_ids.len(), total);
+    let unique: std::collections::HashSet<_> = collected_sbom_ids.iter().collect();
+    assert_eq!(unique.len(), total, "no duplicate items across pages");
+
+    // Then: offset beyond total returns empty
+    let beyond = service
+        .retrieve(
+            &Query::q("spymemcached"),
+            QueryOptions::default(),
+            Paginated {
+                offset: total as u64,
+                limit: 1,
+                total: true,
+            },
+            &ctx.db,
+        )
+        .await?;
+
+    assert!(beyond.items.is_empty());
+    assert_eq!(beyond.total, Some(total as u64));
+
+    Ok(())
+}


### PR DESCRIPTION
Split graph node processing into three phases:
1. Count matching nodes across cached graphs (cheap in-memory filter)
2. Apply offset/limit to the globally-flattened node index iterator
3. Run expensive Collector hydration only for the paged subset

This reduces per-request work from ~39,280 Collector runs to ~25 (the default page limit), a ~1,500x improvement.

Also:
- Add deterministic graph ordering via ORDER BY sbom_id in load_graphs_subquery and sorted/deduped Vec in load_latest_graphs_query
- Migrate log::debug to tracing::debug in retrieve_latest
- Fix missing tokio feature on async-compression in common crate
- Add 4 pagination tests: limits, offset, cross-graph, endpoint

Implements TC-4365


Assisted-by: Claude Code

## Summary by Sourcery

Apply pagination to graph node queries before expensive hydration to dramatically reduce per-request analysis workload and prevent timeouts.

New Features:
- Add paginated graph query execution that flattens nodes across graphs, applies global offset/limit, and hydrates only the selected subset.

Bug Fixes:
- Ensure async-compression is correctly configured with the tokio feature in the common crate to fix runtime issues.

Enhancements:
- Introduce deterministic graph and node ordering via sorted SBOM IDs and (sbom_id, node_id) sorting to make pagination stable across requests.
- Refactor analysis retrieval paths to reuse a shared paginated graph query helper instead of paginating in-memory results.
- Switch debug logging in graph loading to use tracing for consistency with the rest of the codebase.

Tests:
- Add service-level tests to verify pagination limits hydration, honors offsets, and spans results across multiple SBOM graphs without duplication.
- Add endpoint-level test to validate paginated HTTP responses return correct totals and distinct items across pages.