### PR TITLE
perf(db): add index on sbom_external_node(sbom_id, external_node_ref)

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -58,6 +58,7 @@ mod m0002160_fix_ref_fk;
 mod m0002170_drop_cvss_tables;
 mod m0002180_advisory_fk_indexes;
 mod m0002190_vulnerability_base_score_advisory;
+mod m0002200_sbom_external_node_ref_index;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -132,6 +133,7 @@ impl MigratorExt for Migrator {
             .normal(m0002170_drop_cvss_tables::Migration)
             .normal(m0002180_advisory_fk_indexes::Migration)
             .normal(m0002190_vulnerability_base_score_advisory::Migration)
+            .normal(m0002200_sbom_external_node_ref_index::Migration)
     }
 }
 

--- a/migration/src/m0002200_sbom_external_node_ref_index.rs
+++ b/migration/src/m0002200_sbom_external_node_ref_index.rs
@@ -1,0 +1,50 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(SbomExternalNode::Table)
+                    .name(Indexes::IdxSbomExternalNodeRef.to_string())
+                    .col(SbomExternalNode::SbomId)
+                    .col(SbomExternalNode::ExternalNodeRef)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(SbomExternalNode::Table)
+                    .name(Indexes::IdxSbomExternalNodeRef.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Indexes {
+    IdxSbomExternalNodeRef,
+}
+
+#[derive(DeriveIden)]
+enum SbomExternalNode {
+    Table,
+    SbomId,
+    ExternalNodeRef,
+}


### PR DESCRIPTION
Eliminates sequential scan during external node resolution. Verified: Seq Scan → Index Scan on hosted environment.

Implements TC-4750

Assisted-by: Claude Code

## Summary by Sourcery

Enhancements:
- Introduce a migration that adds a composite index on sbom_external_node(sbom_id, external_node_ref) to optimize query performance.