### PR TITLE
build: don't exclude download, it's required

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -8,7 +8,6 @@
 /.idea
 /.claude
 /docs/book
-/download
 /vendor
 **/node_modules
 **/.terraform

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8524,7 +8524,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-auth"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-common"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8610,7 +8610,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-cvss"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "serde",
  "test-log",
@@ -8620,7 +8620,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-db"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8637,7 +8637,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-entity"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8663,7 +8663,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-infrastructure"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "actix-cors",
  "actix-tls",
@@ -8699,7 +8699,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-migration"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "sea-orm-migration",
@@ -8716,7 +8716,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-analysis"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8765,7 +8765,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-fundamental"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8842,7 +8842,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-graphql"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8865,7 +8865,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-importer"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8923,7 +8923,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ingestor"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8977,7 +8977,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-storage"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -9009,7 +9009,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ui"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "actix-web",
  "actix-web-static-files",
@@ -9031,7 +9031,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-user"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9053,14 +9053,14 @@ dependencies = [
 
 [[package]]
 name = "trustify-query"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "utoipa",
 ]
 
 [[package]]
 name = "trustify-query-derive"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -9068,7 +9068,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-server"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -9112,7 +9112,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-test-context"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9155,7 +9155,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-trustd"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -10196,7 +10196,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.14"
+version = "0.4.15"
 edition = "2024"
 publish = false
 license = "Apache-2.0"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache License, Version 2.0
     identifier: Apache-2.0
-  version: 0.4.14
+  version: 0.4.15
 paths:
   /.well-known/trustify:
     get:


### PR DESCRIPTION
This only changes the release process part, not actual code.

Claude added an exclude for `/download`, I missed that, and we need it. That's why the last parts of the release build fail.

## Summary by Sourcery

Update project metadata and container ignore configuration for the new release.

Build:
- Adjust container ignore configuration to ensure required download assets are included in release builds.

Chores:
- Bump workspace and API specification versions from 0.4.14 to 0.4.15.