### PR TITLE
fix: redact database password from tracing span output

### DIFF
--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -105,7 +105,7 @@ pub struct Database {
 }
 
 impl Database {
-    #[instrument(err(level=tracing::Level::INFO))]
+    #[instrument(skip(database), fields(database = ?crate::redact::HideString(database, &database.password.0)), err(level=tracing::Level::INFO))]
     pub async fn new(database: &crate::config::Database) -> Result<Self, anyhow::Error> {
         let url = database.to_url();
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -13,6 +13,7 @@ pub mod middleware;
 pub mod model;
 pub mod package;
 pub mod purl;
+pub mod redact;
 pub mod requested_field;
 pub mod reqwest;
 pub mod sbom;

--- a/common/src/redact.rs
+++ b/common/src/redact.rs
@@ -1,0 +1,52 @@
+use std::fmt;
+
+pub struct HideString<'a, T: fmt::Debug>(pub &'a T, pub &'a str);
+
+impl<T: fmt::Debug> fmt::Debug for HideString<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.1.is_empty() {
+            return self.0.fmt(f);
+        }
+        let debug_output = format!("{:?}", self.0);
+        write!(f, "{}", debug_output.replace(self.1, "***"))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::rstest;
+
+    #[derive(Debug)]
+    struct Config {
+        #[allow(dead_code)]
+        url: reqwest::Url,
+        #[allow(dead_code)]
+        password: String,
+    }
+
+    #[rstest]
+    #[case::string_url(
+        "postgres://user:secret@host/db",
+        "secret",
+        r#""postgres://user:***@host/db""#
+    )]
+    #[case::no_match("no sensitive data here", "secret", r#""no sensitive data here""#)]
+    #[case::empty_hide_string("hello", "", r#""hello""#)]
+    fn redacts_from_string(#[case] value: &str, #[case] hide: &str, #[case] expected: &str) {
+        assert_eq!(format!("{:?}", HideString(&value, hide)), expected);
+    }
+
+    #[test]
+    fn redacts_password_from_parsed_url() {
+        let config = Config {
+            url: reqwest::Url::parse("postgres://user:secret@host/db").unwrap(),
+            password: "secret".into(),
+        };
+        let output = format!("{:?}", HideString(&config, &config.password));
+        assert_eq!(
+            output,
+            r#"Config { url: Url { scheme: "postgres", cannot_be_a_base: false, username: "user", password: Some("***"), host: Some(Domain("host")), port: None, path: "/db", query: None, fragment: None }, password: "***" }"#
+        );
+    }
+}


### PR DESCRIPTION
Add HideString newtype that wraps a Debug value and replaces all occurrences of a given string with "***" in the Debug output. Use it in the #[instrument] on Database::new to prevent the password from leaking through the url field in tracing spans.

## Summary by Sourcery

Redact sensitive database passwords from tracing spans when constructing a Database instance.

Enhancements:
- Introduce a generic HideString debug wrapper that masks a specified substring as "***" in Debug output.
- Apply the HideString wrapper to the database configuration in Database::new tracing instrumentation to prevent password leakage.
- Expose the new redact module from the common crate for reuse across the codebase.

Tests:
- Add unit and rstest-based tests verifying HideString redacts sensitive values in strings and structured types like URLs.