### PR TITLE
fix: improve database health check error reporting and correctness

### DIFF
--- a/common/infrastructure/src/health/checks/local.rs
+++ b/common/infrastructure/src/health/checks/local.rs
@@ -42,6 +42,7 @@ impl<T> Local<T> {
         Fut: Future<Output = ()> + 'static,
     {
         let state = Arc::new(AtomicBool::new(false));
+        let error: Cow<'static, str> = error.into();
 
         let rt = Builder::new_current_thread()
             .enable_all()
@@ -50,6 +51,7 @@ impl<T> Local<T> {
 
         {
             let state = state.clone();
+            let error = error.clone();
             std::thread::spawn(move || {
                 let local = LocalSet::new();
                 {
@@ -59,7 +61,9 @@ impl<T> Local<T> {
 
                 rt.block_on(local);
 
-                log::info!("check future returned");
+                log::warn!(
+                    "health check future returned, will report failure from now on: {error}"
+                );
 
                 // if the check loop ends, the check defaults to false
                 state.store(false, Ordering::Release);
@@ -67,7 +71,7 @@ impl<T> Local<T> {
         }
 
         Ok(Local {
-            error: error.into(),
+            error,
             state,
             _handle: (),
         })

--- a/common/infrastructure/src/infra.rs
+++ b/common/infrastructure/src/infra.rs
@@ -138,7 +138,10 @@ impl Infrastructure {
     ) -> anyhow::Result<Pin<Box<dyn Future<Output = anyhow::Result<()>>>>> {
         if !self.config.infrastructure_enabled {
             log::info!("Infrastructure endpoint is disabled");
+            // Keep self.health alive so that registered health checks (e.g. database)
+            // are not dropped while the server is still running.
             return Ok(Box::pin(async move {
+                let _health = self.health;
                 loop {
                     tokio::time::sleep(tokio::time::Duration::from_secs(3600)).await
                 }

--- a/server/src/profile/mod.rs
+++ b/server/src/profile/mod.rs
@@ -16,7 +16,7 @@ pub fn spawn_db_check(db: Database) -> anyhow::Result<impl Check> {
                     async move { db.ping().await.is_ok() },
                 )
                 .await
-                .is_ok()
+                .unwrap_or(false)
             }
         }
     })


### PR DESCRIPTION
Log at warn level when the health check future exits so operators can detect a degraded state. Also fix the timeout result handling: the outer .is_ok() discarded the inner ping result, causing a fast database failure to be reported as healthy.

## Summary by Sourcery

Improve health check reporting for local checks and database connectivity failures.

Bug Fixes:
- Correct database health check result handling so that timeouts and fast failures are reported as unhealthy instead of healthy.

Enhancements:
- Log a warning when the local health check future terminates and default subsequent health status to failure with the associated error message.