### PR TITLE
fix: enable comma-separated values for MIGRATION_DATA_SKIP env var

### DIFF
--- a/migration/src/data/migration.rs
+++ b/migration/src/data/migration.rs
@@ -8,6 +8,7 @@ use sea_orm::{DatabaseConnection, DbErr};
 use sea_orm_migration::{MigrationName, MigrationTrait, SchemaManager};
 use std::{ffi::OsString, ops::Deref, sync::LazyLock};
 use tokio::task_local;
+use tracing::log;
 use trustify_module_storage::{config::StorageConfig, service::dispatch::DispatchBackend};
 
 /// A migration which also processes data.
@@ -102,6 +103,7 @@ impl<'c> SchemaDataManager<'c> {
         storage: &'c DispatchBackend,
         options: &'c Options,
     ) -> Self {
+        log::info!("Options: {options:#?}");
         Self {
             manager,
             db,

--- a/migration/src/data/mod.rs
+++ b/migration/src/data/mod.rs
@@ -63,7 +63,12 @@ pub struct Options {
     pub skip_all: bool,
 
     /// Skip the provided list of data migrations
-    #[arg(long, env = "MIGRATION_DATA_SKIP", conflicts_with = "skip_all")]
+    #[arg(
+        long,
+        env = "MIGRATION_DATA_SKIP",
+        conflicts_with = "skip_all",
+        value_delimiter = ','
+    )]
     pub skip: Vec<String>,
 }
 


### PR DESCRIPTION
Add `value_delimiter` so clap splits the env var on commas, and log the resolved options at startup for easier debugging.

## Summary by Sourcery

Allow configuration of skipped data migrations via comma-separated MIGRATION_DATA_SKIP values and log resolved migration options at startup for easier debugging.

Enhancements:
- Support comma-separated values in the MIGRATION_DATA_SKIP environment variable for selecting data migrations to skip.
- Log the effective data migration options during schema data manager initialization to aid troubleshooting.