### PR TITLE
ci: enable CI workflows for feature branch PRs

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -13,6 +13,7 @@ on:
       - 'etc/**'
     branches:
       - "main"
+      - "feature/**"
 
 concurrency:
   group: benchmark-${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - release/**
+      - feature/**
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -13,6 +13,7 @@ on:
       - 'etc/**'
     branches:
       - main
+      - feature/**
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- Add `feature/**` to the `pull_request` branch filters of **ci**, **benchmark**, and **codecov** workflows
- PRs targeting feature branches now receive the same CI treatment as PRs targeting `main`
- Only `pull_request` triggers updated — `push` triggers unchanged to avoid overriding baselines

## Context

The feature branch workflow ([TC-4418](https://redhat.atlassian.net/browse/TC-4418)) creates PRs against feature branches instead of main. However, CI didn't run on those PRs because workflows only triggered on `main` and `release/**`.

Per [Jens's feedback](https://redhat.atlassian.net/browse/TC-4517), the following are intentionally **not** changed:
- **openapi.yaml** — UI shouldn't update from a temporary branch
- **rita-*.yaml** — `pull_request_target` security concern (unprotected branches could manipulate bot config)
- **benchmark/codecov `push`** — would override baselines
- Release/deploy/backport workflows — not relevant for feature branches

Resolves: [TC-4517](https://redhat.atlassian.net/browse/TC-4517)

## Test plan

- [ ] Open a test PR targeting a `feature/**` branch and verify ci, benchmark, and codecov workflows trigger
- [ ] Verify pushing directly to a `feature/**` branch does NOT trigger benchmark or codecov
- [ ] Verify PRs targeting `main` still trigger all workflows as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4418]: https://redhat.atlassian.net/browse/TC-4418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-4517]: https://redhat.atlassian.net/browse/TC-4517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enable CI, benchmark, and code coverage workflows for pull requests targeting feature branches.

Build:
- Trigger benchmark.yaml and codecov.yaml workflows on pull requests into feature/** branches alongside main.

CI:
- Run ci.yaml workflow for pull requests into feature/** branches in addition to main and release/**.