### PR TITLE
fix: optimize expanded_license migration backfill

### DIFF
--- a/migration/src/m0002120_normalize_expanded_license/bench_expand.sql
+++ b/migration/src/m0002120_normalize_expanded_license/bench_expand.sql
@@ -1,0 +1,253 @@
+-- Benchmark: regexp_replace vs replace() for license expression expansion
+-- Run with: psql -f bench_expand.sql <database>
+--
+-- Creates temporary functions and test data, runs both implementations,
+-- verifies they produce identical results, and reports timings.
+
+-- Ensure the license_mapping type exists
+DO $$
+BEGIN
+    CREATE TYPE license_mapping AS (license_id TEXT, name TEXT);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+----------------------------------------------------------------------
+-- 1. Define both function variants under benchmark-specific names
+----------------------------------------------------------------------
+
+-- Old version: regex-based (dynamically compiled pattern per mapping)
+CREATE OR REPLACE FUNCTION bench_expand_regex(
+    license_text TEXT,
+    license_mappings license_mapping[]
+) RETURNS TEXT AS $$
+DECLARE
+    result_text TEXT := license_text;
+    mapping license_mapping;
+BEGIN
+    IF license_text IS NULL
+       OR POSITION('LicenseRef-' IN license_text) = 0
+       OR license_mappings IS NULL
+       OR array_length(license_mappings, 1) IS NULL THEN
+        RETURN license_text;
+    END IF;
+
+    FOREACH mapping IN ARRAY license_mappings
+    LOOP
+        IF POSITION('LicenseRef-' IN result_text) = 0 THEN
+            EXIT;
+        END IF;
+        result_text := regexp_replace(
+            result_text,
+            '\m' || mapping.license_id || '(?![a-zA-Z0-9.\-])',
+            mapping.name, 'g'
+        );
+    END LOOP;
+
+    RETURN result_text;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+
+-- New version: replace()-based (no regex, boundary-aware via SPDX delimiters)
+CREATE OR REPLACE FUNCTION bench_expand_replace(
+    license_text TEXT,
+    license_mappings license_mapping[]
+) RETURNS TEXT AS $$
+DECLARE
+    result_text TEXT;
+    mapping license_mapping;
+BEGIN
+    IF license_text IS NULL
+       OR POSITION('LicenseRef-' IN license_text) = 0
+       OR license_mappings IS NULL
+       OR array_length(license_mappings, 1) IS NULL THEN
+        RETURN license_text;
+    END IF;
+
+    result_text := ' ' || license_text || ' ';
+
+    FOREACH mapping IN ARRAY license_mappings
+    LOOP
+        IF POSITION('LicenseRef-' IN result_text) = 0 THEN
+            EXIT;
+        END IF;
+
+        result_text := replace(result_text, ' ' || mapping.license_id || ' ',  ' ' || mapping.name || ' ');
+        result_text := replace(result_text, ' ' || mapping.license_id || ')',  ' ' || mapping.name || ')');
+        result_text := replace(result_text, ' ' || mapping.license_id || '+',  ' ' || mapping.name || '+');
+        result_text := replace(result_text, '(' || mapping.license_id || ' ',  '(' || mapping.name || ' ');
+        result_text := replace(result_text, '(' || mapping.license_id || ')',  '(' || mapping.name || ')');
+        result_text := replace(result_text, '(' || mapping.license_id || '+',  '(' || mapping.name || '+');
+    END LOOP;
+
+    RETURN substring(result_text FROM 2 FOR length(result_text) - 2);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+
+----------------------------------------------------------------------
+-- 2. Generate test data
+----------------------------------------------------------------------
+
+CREATE TEMPORARY TABLE bench_expressions (id SERIAL, expr TEXT);
+
+INSERT INTO bench_expressions (expr) VALUES
+    -- No LicenseRef (early-exit path)
+    ('MIT'),
+    ('Apache-2.0'),
+    ('GPL-3.0-only'),
+    ('BSD-2-Clause OR MIT'),
+    -- Single LicenseRef
+    ('LicenseRef-custom-1'),
+    ('LicenseRef-scancode-unknown-license-reference'),
+    -- Compound with LicenseRef
+    ('LicenseRef-custom-1 AND MIT'),
+    ('Apache-2.0 OR LicenseRef-custom-2'),
+    ('LicenseRef-custom-1 AND LicenseRef-custom-2'),
+    -- Parenthesized
+    ('(LicenseRef-custom-1 OR LicenseRef-custom-2) AND MIT'),
+    ('(LicenseRef-custom-1 AND Apache-2.0) OR (LicenseRef-custom-2 AND MIT)'),
+    -- With + modifier
+    ('LicenseRef-custom-1+'),
+    ('LicenseRef-custom-1+ AND LicenseRef-custom-2'),
+    -- Many refs
+    ('LicenseRef-custom-1 AND LicenseRef-custom-2 AND LicenseRef-custom-3 AND LicenseRef-custom-4 AND LicenseRef-custom-5'),
+    -- Complex nested
+    ('(LicenseRef-custom-1 OR LicenseRef-custom-2) AND (LicenseRef-custom-3 OR LicenseRef-custom-4) AND (LicenseRef-custom-5 OR MIT) AND (Apache-2.0 OR LicenseRef-custom-6)'),
+    -- Substring trap: LicenseRef-custom-1 must NOT match inside LicenseRef-custom-10
+    ('LicenseRef-custom-1 AND LicenseRef-custom-10'),
+    ('(LicenseRef-custom-10 OR LicenseRef-custom-1)');
+
+-- Replicate each expression 1000x for measurable timing
+CREATE TEMPORARY TABLE bench_data AS
+SELECT e.id, e.expr
+FROM bench_expressions e, generate_series(1, 1000);
+
+-- Realistic mapping array (7 mappings, typical for an SBOM with custom licenses)
+CREATE TEMPORARY TABLE bench_mappings AS
+SELECT ARRAY[
+    ROW('LicenseRef-custom-1',  'Custom License One')::license_mapping,
+    ROW('LicenseRef-custom-2',  'Custom License Two')::license_mapping,
+    ROW('LicenseRef-custom-3',  'Custom License Three')::license_mapping,
+    ROW('LicenseRef-custom-4',  'Custom License Four')::license_mapping,
+    ROW('LicenseRef-custom-5',  'Custom License Five')::license_mapping,
+    ROW('LicenseRef-custom-6',  'Custom License Six')::license_mapping,
+    ROW('LicenseRef-custom-10', 'Custom License Ten')::license_mapping,
+    ROW('LicenseRef-scancode-unknown-license-reference', 'Unknown License Reference')::license_mapping
+] AS mappings;
+
+----------------------------------------------------------------------
+-- 3. Correctness check (must pass before timing matters)
+----------------------------------------------------------------------
+
+DO $$
+DECLARE
+    mismatches BIGINT;
+    sample_regex TEXT;
+    sample_replace TEXT;
+    sample_expr TEXT;
+BEGIN
+    SELECT count(*) INTO mismatches
+    FROM bench_expressions e, bench_mappings m
+    WHERE bench_expand_regex(e.expr, m.mappings)
+          IS DISTINCT FROM
+          bench_expand_replace(e.expr, m.mappings);
+
+    IF mismatches > 0 THEN
+        -- Show first mismatch for debugging
+        SELECT e.expr,
+               bench_expand_regex(e.expr, m.mappings),
+               bench_expand_replace(e.expr, m.mappings)
+        INTO sample_expr, sample_regex, sample_replace
+        FROM bench_expressions e, bench_mappings m
+        WHERE bench_expand_regex(e.expr, m.mappings)
+              IS DISTINCT FROM
+              bench_expand_replace(e.expr, m.mappings)
+        LIMIT 1;
+
+        RAISE EXCEPTION E'CORRECTNESS FAILURE: % mismatches\n  input:   %\n  regex:   %\n  replace: %',
+            mismatches, sample_expr, sample_regex, sample_replace;
+    END IF;
+
+    RAISE NOTICE 'correctness: PASSED (all % expressions produce identical results)',
+        (SELECT count(*) FROM bench_expressions);
+END $$;
+
+----------------------------------------------------------------------
+-- 4. Warmup (populate caches, JIT compile if enabled)
+----------------------------------------------------------------------
+
+DO $$
+DECLARE dummy BIGINT;
+BEGIN
+    SELECT count(bench_expand_regex(d.expr, m.mappings)) INTO dummy
+    FROM bench_data d, bench_mappings m;
+    SELECT count(bench_expand_replace(d.expr, m.mappings)) INTO dummy
+    FROM bench_data d, bench_mappings m;
+END $$;
+
+----------------------------------------------------------------------
+-- 5. Timed runs (3 iterations each, report min/avg)
+----------------------------------------------------------------------
+
+DO $$
+DECLARE
+    t_start  TIMESTAMPTZ;
+    t_end    TIMESTAMPTZ;
+    dummy    BIGINT;
+    ms       NUMERIC;
+    row_cnt  BIGINT;
+
+    regex_times   NUMERIC[] := '{}';
+    replace_times NUMERIC[] := '{}';
+    i INT;
+BEGIN
+    SELECT count(*) INTO row_cnt FROM bench_data;
+
+    FOR i IN 1..3 LOOP
+        -- regex
+        t_start := clock_timestamp();
+        SELECT count(bench_expand_regex(d.expr, m.mappings)) INTO dummy
+        FROM bench_data d, bench_mappings m;
+        t_end := clock_timestamp();
+        ms := EXTRACT(EPOCH FROM (t_end - t_start)) * 1000;
+        regex_times := regex_times || ms;
+
+        -- replace
+        t_start := clock_timestamp();
+        SELECT count(bench_expand_replace(d.expr, m.mappings)) INTO dummy
+        FROM bench_data d, bench_mappings m;
+        t_end := clock_timestamp();
+        ms := EXTRACT(EPOCH FROM (t_end - t_start)) * 1000;
+        replace_times := replace_times || ms;
+    END LOOP;
+
+    RAISE NOTICE '';
+    RAISE NOTICE '=== Benchmark Results (% rows per run) ===', row_cnt;
+    RAISE NOTICE '';
+    RAISE NOTICE 'regex   : run1=% ms  run2=% ms  run3=% ms  avg=% ms',
+        round(regex_times[1], 1),
+        round(regex_times[2], 1),
+        round(regex_times[3], 1),
+        round((regex_times[1] + regex_times[2] + regex_times[3]) / 3, 1);
+    RAISE NOTICE 'replace : run1=% ms  run2=% ms  run3=% ms  avg=% ms',
+        round(replace_times[1], 1),
+        round(replace_times[2], 1),
+        round(replace_times[3], 1),
+        round((replace_times[1] + replace_times[2] + replace_times[3]) / 3, 1);
+    RAISE NOTICE '';
+    RAISE NOTICE 'speedup : %x',
+        round(
+            ((regex_times[1] + regex_times[2] + regex_times[3])
+            / NULLIF(replace_times[1] + replace_times[2] + replace_times[3], 0)),
+            2
+        );
+END $$;
+
+----------------------------------------------------------------------
+-- 6. Cleanup
+----------------------------------------------------------------------
+
+DROP TABLE bench_data;
+DROP TABLE bench_expressions;
+DROP TABLE bench_mappings;
+DROP FUNCTION bench_expand_regex;
+DROP FUNCTION bench_expand_replace;

--- a/migration/src/m0002120_normalize_expanded_license/down.sql
+++ b/migration/src/m0002120_normalize_expanded_license/down.sql
@@ -2,6 +2,34 @@
 DROP TABLE IF EXISTS sbom_license_expanded;
 DROP TABLE IF EXISTS expanded_license;
 
+-- Restore expand_license_expression_with_mappings to the m0002110 regex-based version
+CREATE OR REPLACE FUNCTION expand_license_expression_with_mappings(
+    license_text TEXT,
+    license_mappings license_mapping[]
+) RETURNS TEXT AS $$
+DECLARE
+    result_text TEXT := license_text;
+    mapping license_mapping;
+BEGIN
+    IF license_text IS NULL
+       OR POSITION('LicenseRef-' IN license_text) = 0
+       OR license_mappings IS NULL
+       OR array_length(license_mappings, 1) IS NULL THEN
+        RETURN license_text;
+    END IF;
+
+    FOREACH mapping IN ARRAY license_mappings
+    LOOP
+        IF POSITION('LicenseRef-' IN result_text) = 0 THEN
+            EXIT;
+        END IF;
+        result_text := regexp_replace(result_text, '\m' || mapping.license_id || '(?![a-zA-Z0-9.\-])', mapping.name, 'g');
+    END LOOP;
+
+    RETURN result_text;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+
 -- Restore old functions for backward compatibility
 
 -- expand_license_expression (from m0001160)

--- a/migration/src/m0002120_normalize_expanded_license/up.sql
+++ b/migration/src/m0002120_normalize_expanded_license/up.sql
@@ -25,36 +25,72 @@ CREATE TABLE IF NOT EXISTS sbom_license_expanded (
 CREATE INDEX IF NOT EXISTS idx_sle_expanded_license_id
 ON sbom_license_expanded (expanded_license_id);
 
+-- Update planner statistics before backfill for accurate cost estimates
+ANALYZE sbom_package_license;
+ANALYZE licensing_infos;
+ANALYZE sbom_license_expanded;
+ANALYZE license;
+
 -- Backfill Step 1: Insert unique expanded texts into dictionary
--- Pre-deduplicate by (text, sbom_id) to avoid millions of redundant function calls
+-- Split into two passes to avoid the expensive LEFT JOIN with licensing_infos
+-- and PL/pgSQL function calls for the majority of rows that don't contain LicenseRef-.
+
+-- Pass 1a: Texts WITHOUT LicenseRef- (majority, no expansion needed)
+-- Skips the LEFT JOIN with licensing_infos and the function call entirely.
+-- Subquery is flattened so the planner can push the anti-join before the sort.
+INSERT INTO expanded_license (expanded_text)
+SELECT DISTINCT l.text
+FROM sbom_package_license spl
+JOIN license l ON l.id = spl.license_id
+WHERE l.text NOT LIKE '%LicenseRef-%'
+  AND NOT EXISTS (
+      SELECT 1 FROM sbom_license_expanded sle
+      WHERE sle.sbom_id = spl.sbom_id
+  )
+ON CONFLICT (text_hash) DO NOTHING;
+
+-- Pass 1b: Texts WITH LicenseRef- (minority, needs expansion via license mappings)
 INSERT INTO expanded_license (expanded_text)
 SELECT DISTINCT expand_license_expression_with_mappings(
-    uls.text,
+    l.text,
     COALESCE(lim.license_mapping, ARRAY[]::license_mapping[])
 )
-FROM (
-    SELECT DISTINCT l.text, spl.sbom_id
-    FROM sbom_package_license spl
-    JOIN license l ON l.id = spl.license_id
-) uls
+FROM sbom_package_license spl
+JOIN license l ON l.id = spl.license_id
 LEFT JOIN (
     SELECT array_agg(ROW(license_id, name)::license_mapping) AS license_mapping, sbom_id
     FROM licensing_infos
     GROUP BY sbom_id
-) lim ON lim.sbom_id = uls.sbom_id
--- Filter at SBOM level (not per-license-id) since SBOMs are immutable once ingested.
--- If ANY license from an SBOM has been backfilled, all have been backfilled.
-WHERE NOT EXISTS (
-    SELECT 1 FROM sbom_license_expanded sle
-    WHERE sle.sbom_id = uls.sbom_id
-)
+) lim ON lim.sbom_id = spl.sbom_id
+WHERE l.text LIKE '%LicenseRef-%'
+  AND NOT EXISTS (
+      SELECT 1 FROM sbom_license_expanded sle
+      WHERE sle.sbom_id = spl.sbom_id
+  )
 ON CONFLICT (text_hash) DO NOTHING;
 
 -- Backfill Step 2: Insert junction rows
--- Use a CTE (license_expansions) to call expand_license_expression_with_mappings() only once per
--- (sbom_id, license_id) pair; the result is then joined against the already-populated
--- expanded_license dictionary by md5 hash, avoiding a second expensive function call.
-WITH license_expansions AS (
+-- Split into two passes matching Step 1's LicenseRef- split.
+
+-- Pass 2a: Texts WITHOUT LicenseRef- (direct hash join, no function call)
+INSERT INTO sbom_license_expanded (sbom_id, license_id, expanded_license_id)
+SELECT DISTINCT spl.sbom_id, spl.license_id, el.id
+FROM sbom_package_license spl
+JOIN license l ON l.id = spl.license_id
+JOIN expanded_license el ON el.text_hash = md5(l.text)
+WHERE l.text NOT LIKE '%LicenseRef-%'
+  AND NOT EXISTS (
+      SELECT 1 FROM sbom_license_expanded sle
+      WHERE sle.sbom_id = spl.sbom_id AND sle.license_id = spl.license_id
+  )
+ON CONFLICT (sbom_id, license_id) DO UPDATE
+SET expanded_license_id = EXCLUDED.expanded_license_id;
+
+-- Pass 2b: Texts WITH LicenseRef- (CTE calls expansion function once per pair)
+-- MATERIALIZED prevents PostgreSQL from inlining the CTE, which would cause
+-- expand_license_expression_with_mappings() to be evaluated twice per row
+-- (once for DISTINCT, once for the md5 join with expanded_license).
+WITH license_expansions AS MATERIALIZED (
     SELECT DISTINCT
         spl.sbom_id,
         spl.license_id,
@@ -69,10 +105,11 @@ WITH license_expansions AS (
         FROM licensing_infos
         GROUP BY sbom_id
     ) lim ON lim.sbom_id = spl.sbom_id
-    WHERE NOT EXISTS (
-        SELECT 1 FROM sbom_license_expanded sle
-        WHERE sle.sbom_id = spl.sbom_id AND sle.license_id = spl.license_id
-    )
+    WHERE l.text LIKE '%LicenseRef-%'
+      AND NOT EXISTS (
+          SELECT 1 FROM sbom_license_expanded sle
+          WHERE sle.sbom_id = spl.sbom_id AND sle.license_id = spl.license_id
+      )
 )
 INSERT INTO sbom_license_expanded (sbom_id, license_id, expanded_license_id)
 SELECT ne.sbom_id, ne.license_id, el.id

--- a/migration/src/m0002120_normalize_expanded_license/up.sql
+++ b/migration/src/m0002120_normalize_expanded_license/up.sql
@@ -25,6 +25,48 @@ CREATE TABLE IF NOT EXISTS sbom_license_expanded (
 CREATE INDEX IF NOT EXISTS idx_sle_expanded_license_id
 ON sbom_license_expanded (expanded_license_id);
 
+-- Replace regex-based expansion with faster string replace.
+-- SPDX expressions have well-defined delimiters (space, parentheses, +), so we can
+-- use replace() with all valid boundary combinations instead of regexp_replace()
+-- with dynamically compiled patterns.
+CREATE OR REPLACE FUNCTION expand_license_expression_with_mappings(
+    license_text TEXT,
+    license_mappings license_mapping[]
+) RETURNS TEXT AS $$
+DECLARE
+    result_text TEXT;
+    mapping license_mapping;
+BEGIN
+    IF license_text IS NULL
+       OR POSITION('LicenseRef-' IN license_text) = 0
+       OR license_mappings IS NULL
+       OR array_length(license_mappings, 1) IS NULL THEN
+        RETURN license_text;
+    END IF;
+
+    -- Sentinel spaces handle start/end-of-string boundaries uniformly
+    result_text := ' ' || license_text || ' ';
+
+    FOREACH mapping IN ARRAY license_mappings
+    LOOP
+        IF POSITION('LicenseRef-' IN result_text) = 0 THEN
+            EXIT;
+        END IF;
+
+        -- Replace whole-token matches using all valid SPDX boundary pairs.
+        -- Before: space or '('  |  After: space, ')', or '+'
+        result_text := replace(result_text, ' ' || mapping.license_id || ' ',  ' ' || mapping.name || ' ');
+        result_text := replace(result_text, ' ' || mapping.license_id || ')',  ' ' || mapping.name || ')');
+        result_text := replace(result_text, ' ' || mapping.license_id || '+',  ' ' || mapping.name || '+');
+        result_text := replace(result_text, '(' || mapping.license_id || ' ',  '(' || mapping.name || ' ');
+        result_text := replace(result_text, '(' || mapping.license_id || ')',  '(' || mapping.name || ')');
+        result_text := replace(result_text, '(' || mapping.license_id || '+',  '(' || mapping.name || '+');
+    END LOOP;
+
+    RETURN substring(result_text FROM 2 FOR length(result_text) - 2);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+
 -- Update planner statistics before backfill for accurate cost estimates
 ANALYZE sbom_package_license;
 ANALYZE licensing_infos;


### PR DESCRIPTION
## Summary

* Split migration backfill queries into two passes (LicenseRef- vs non-LicenseRef-), avoiding the expensive LEFT JOIN with `licensing_infos` and PL/pgSQL function calls for the majority of rows
* Add `ANALYZE` before backfill and use `MATERIALIZED` CTE to fix planner misestimates and prevent double function evaluation
* Replace `regexp_replace()` with boundary-aware `replace()` calls in `expand_license_expression_with_mappings()` for a ~2.16x speedup

### Query plan improvement

The original single-query backfill had a planner cost of ~1.8B due to a 170x row overestimate (7B vs ~40M) on the Hash Left Join. After splitting and adding ANALYZE, the LicenseRef- pass drops to ~15M cost (~120x reduction).

### Function benchmark (17 expression patterns x 1000 iterations, 8 mappings)

```
regex   : run1=226.3 ms  run2=226.8 ms  run3=226.4 ms  avg=226.5 ms
replace : run1=105.3 ms  run2=104.8 ms  run3=104.6 ms  avg=104.9 ms
speedup : 2.16x
```

## Test plan

- [ ] Run `cargo build -p trustify-migration` (passes)
- [ ] Run the benchmark script against a test database: `psql -f migration/src/m0002120_normalize_expanded_license/bench_expand.sql`
- [ ] Verify migration applies cleanly on a database with existing SBOM data
- [ ] Verify rollback (`down.sql`) restores the regex-based function

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize the expanded license migration backfill for performance and planner stability.

New Features:
- Add a standalone SQL benchmark script to compare regex-based vs replace()-based license expression expansion.

Enhancements:
- Replace the regex-based expand_license_expression_with_mappings() implementation with a boundary-aware replace()-based version for faster expansion.
- Split the migration backfill into separate passes for LicenseRef and non-LicenseRef licenses to avoid unnecessary joins and function calls.
- Add ANALYZE statements and use a MATERIALIZED CTE in the backfill to improve query planner estimates and avoid duplicate function evaluations.