### PR TITLE
perf: focus on main entities used by ux.

### DIFF
--- a/modules/fundamental/src/license/service/mod.rs
+++ b/modules/fundamental/src/license/service/mod.rs
@@ -306,7 +306,6 @@ impl LicenseService {
         // Build query for SPDX licenses (from expanded_license dictionary)
         let mut spdx_query = expanded_license::Entity::find()
             .select_only()
-            .distinct()
             .column_as(expanded_license::Column::ExpandedText, LICENSE_TEXT);
 
         // Build query for licenses not yet linked to any SBOM: includes both
@@ -329,7 +328,6 @@ impl LicenseService {
 
         let mut non_sbom_query = license::Entity::find()
             .select_only()
-            .distinct()
             .column_as(license::Column::Text, LICENSE_TEXT)
             .filter(Expr::exists(exists_subquery).not());
 
@@ -358,22 +356,25 @@ impl LicenseService {
         non_sbom_query = non_sbom_query.filtering_with(filter_only, non_sbom_columns)?;
 
         // Union the two queries
-        QueryTrait::query(&mut spdx_query).union(UnionType::Distinct, non_sbom_query.into_query());
+        QueryTrait::query(&mut spdx_query).union(UnionType::All, non_sbom_query.into_query());
         // Add an expression for the license field and use it as the default sort
         let expr = SimpleExpr::Custom(LICENSE_TEXT.into());
-        spdx_query = spdx_query
-            .filtering_with(
-                q("").sort(&search.sort),
-                Columns::default().add_expr("license", expr.clone(), sea_orm::ColumnType::Text),
-            )?
-            .order_by_asc(expr);
+        spdx_query = spdx_query.filtering_with(
+            q("").sort(&search.sort),
+            Columns::default().add_expr("license", expr.clone(), sea_orm::ColumnType::Text),
+        )?;
+        if search.sort.is_empty() {
+            spdx_query = spdx_query.order_by_asc(expr);
+        }
 
         let mut union_query = spdx_query.into_query();
 
-        // Count total results
+        // Count total results (strip ORDER BY — it's meaningless inside COUNT)
+        let mut count_subquery = union_query.clone();
+        count_subquery.clear_order_by();
         let count_query = sea_query::Query::select()
             .expr_as(Func::count(Expr::col(Asterisk)), "num_items")
-            .from_subquery(union_query.clone(), "subquery")
+            .from_subquery(count_subquery, "subquery")
             .to_owned();
 
         #[derive(Debug, Default, Clone, Serialize, Deserialize, ToSchema, FromQueryResult)]

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use sea_orm::{ConnectionTrait, FromQueryResult, ModelTrait, PaginatorTrait, prelude::Uuid};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use time::OffsetDateTime;
 use tracing::{info_span, instrument};
 use tracing_futures::Instrument;
@@ -63,7 +64,19 @@ impl SbomHead {
             .count(db)
             .instrument(info_span!("counting packages"))
             .await?;
-        Ok(Self {
+        Ok(Self::from_parts(sbom, sbom_node, number_of_packages))
+    }
+
+    /// Build an `SbomHead` without issuing a database query.
+    ///
+    /// Use this when the package count has already been fetched in
+    /// a batch (see [`SbomService::batch_package_counts`]).
+    pub fn from_parts(
+        sbom: &sbom::Model,
+        sbom_node: &sbom_node::Model,
+        number_of_packages: u64,
+    ) -> Self {
+        Self {
             id: sbom.sbom_id,
             document_id: sbom.document_id.clone(),
             labels: sbom.labels.clone(),
@@ -73,7 +86,7 @@ impl SbomHead {
             name: sbom_node.name.clone(),
             data_licenses: sbom.data_licenses.clone(),
             number_of_packages,
-        })
+        }
     }
 }
 
@@ -95,7 +108,6 @@ impl<P: IntoPackage> SbomSummary<P> {
         service: &SbomService,
         db: &C,
     ) -> Result<Self, Error> {
-        // TODO: consider improving the n-select issues here
         let described_by = service.describes_packages(sbom.sbom_id, (), db).await?;
 
         Ok(SbomSummary {
@@ -103,6 +115,45 @@ impl<P: IntoPackage> SbomSummary<P> {
             source_document: SourceDocument::from_entity(&source_document),
             described_by,
         })
+    }
+
+    /// Convert a batch of entity tuples into `SbomSummary` values using
+    /// only two queries (one for package counts, one for describes
+    /// packages) instead of 2*N.
+    #[instrument(skip(rows, service, db), err(level=tracing::Level::INFO))]
+    pub async fn from_entities_batch<C: ConnectionTrait>(
+        rows: Vec<(sbom::Model, sbom_node::Model, source_document::Model)>,
+        service: &SbomService,
+        db: &C,
+    ) -> Result<Vec<Self>, Error> {
+        if rows.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let sbom_ids: Vec<Uuid> = rows.iter().map(|(s, _, _)| s.sbom_id).collect();
+
+        let counts = service.batch_package_counts(&sbom_ids, db).await?;
+        let mut describes: HashMap<Uuid, Vec<P>> =
+            service.batch_describes_packages(&sbom_ids, db).await?;
+
+        let items = rows
+            .into_iter()
+            .map(|(sbom, node, source_document)| {
+                let count = counts.get(&sbom.sbom_id).copied().unwrap_or(0);
+                let described_by = describes
+                    .remove(&sbom.sbom_id)
+                    .unwrap_or_default();
+                SbomSummary {
+                    head: SbomHead::from_parts(&sbom, &node, count),
+                    source_document: SourceDocument::from_entity(
+                        &source_document,
+                    ),
+                    described_by,
+                }
+            })
+            .collect();
+
+        Ok(items)
     }
 }
 

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -8,7 +8,6 @@ use crate::{
         SbomPackageRelation, SbomPackageSummary, SbomSummary, Which, details::SbomDetails,
     },
 };
-use futures_util::{StreamExt, TryStreamExt, stream};
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DbErr, EntityTrait, FromJsonQueryResult, FromQueryResult,
     IntoSimpleExpr, QueryFilter, QueryOrder, QueryResult, QuerySelect, QueryTrait, RelationTrait,
@@ -296,15 +295,14 @@ impl SbomService {
         } = limiter.fetch().await?;
         let total = total.requested(paginated.total()).await?;
 
-        let items = stream::iter(
-            sboms
-                .into_iter()
-                .filter_map(|(sbom, node, source_document)| Some((sbom, node?, source_document?))),
-        )
-        .then(|row| async { SbomSummary::from_entity(row, self, connection).await })
-        .try_collect()
-        .instrument(info_span!("from_entity"))
-        .await?;
+        let rows: Vec<_> = sboms
+            .into_iter()
+            .filter_map(|(sbom, node, source_document)| Some((sbom, node?, source_document?)))
+            .collect();
+
+        let items = SbomSummary::from_entities_batch(rows, self, connection)
+            .instrument(info_span!("from_entities_batch"))
+            .await?;
 
         Ok(PaginatedResults { total, items })
     }
@@ -560,6 +558,100 @@ impl SbomService {
         .map(|r| r.map_all(|rel| rel.package))
     }
 
+    /// Count packages for multiple SBOMs in a single query.
+    ///
+    /// Returns a map from `sbom_id` to the number of packages in that SBOM.
+    #[instrument(skip(self, db), err(level=tracing::Level::INFO))]
+    pub async fn batch_package_counts<C: ConnectionTrait>(
+        &self,
+        sbom_ids: &[Uuid],
+        db: &C,
+    ) -> Result<HashMap<Uuid, u64>, Error> {
+        if sbom_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let rows: Vec<(Uuid, i64)> = sbom_package::Entity::find()
+            .select_only()
+            .column(sbom_package::Column::SbomId)
+            .column_as(sbom_package::Column::NodeId.count(), "count")
+            .filter(sbom_package::Column::SbomId.is_in(sbom_ids.iter().copied()))
+            .group_by(sbom_package::Column::SbomId)
+            .into_tuple()
+            .all(db)
+            .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(id, count)| (id, count as u64))
+            .collect())
+    }
+
+    /// Fetch "describes" packages for multiple SBOMs in a single query.
+    ///
+    /// Returns a map from `sbom_id` to the list of packages that describe it.
+    #[instrument(skip(self, db), err(level=tracing::Level::INFO))]
+    pub async fn batch_describes_packages<C, P>(
+        &self,
+        sbom_ids: &[Uuid],
+        db: &C,
+    ) -> Result<HashMap<Uuid, Vec<P>>, Error>
+    where
+        C: ConnectionTrait,
+        P: IntoPackage,
+    {
+        if sbom_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        #[derive(FromQueryResult)]
+        struct DescribesRow<R: FromQueryResult> {
+            sbom_id: Uuid,
+            #[sea_orm(nested)]
+            package: R,
+        }
+
+        let query = package_relates_to_package::Entity::find()
+            .filter(
+                package_relates_to_package::Column::SbomId
+                    .is_in(sbom_ids.iter().copied()),
+            )
+            .filter(
+                package_relates_to_package::Column::Relationship
+                    .eq(Relationship::Describes),
+            )
+            .select_only()
+            .column_as(
+                package_relates_to_package::Column::SbomId,
+                "sbom_id",
+            )
+            .select_column_as(sbom_node::Column::NodeId, "id")
+            .select_column_as(sbom_node::Column::Name, "name")
+            .select_column_as(sbom_package::Column::Group, "group")
+            .select_column_as(sbom_package::Column::Version, "version")
+            .join(
+                JoinType::Join,
+                package_relates_to_package::Relation::Right.def(),
+            )
+            .join(JoinType::Join, sbom_node::Relation::Package.def())
+            .join(JoinType::Join, sbom_node::Relation::Sbom.def());
+
+        let query = P::build_query(query);
+
+        let rows: Vec<DescribesRow<P::Row>> =
+            query.into_model().all(db).await?;
+
+        let mut result: HashMap<Uuid, Vec<P>> = HashMap::new();
+        for row in rows {
+            result
+                .entry(row.sbom_id)
+                .or_default()
+                .push(P::from_row(row.package));
+        }
+
+        Ok(result)
+    }
+
     #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
     pub async fn count_related_sboms<C: ConnectionTrait>(
         &self,
@@ -683,14 +775,12 @@ impl SbomService {
 
         // collect results
 
-        let items = stream::iter(
-            sboms
-                .into_iter()
-                .filter_map(|(sbom, node, source_document)| Some((sbom, node?, source_document?))),
-        )
-        .then(|row| async { SbomSummary::from_entity(row, self, connection).await })
-        .try_collect()
-        .await?;
+        let rows: Vec<_> = sboms
+            .into_iter()
+            .filter_map(|(sbom, node, source_document)| Some((sbom, node?, source_document?)))
+            .collect();
+
+        let items = SbomSummary::from_entities_batch(rows, self, connection).await?;
 
         Ok(PaginatedResults { items, total })
     }


### PR DESCRIPTION
## Summary by Sourcery

Optimize SBOM summary construction and license search queries to reduce per-entity database calls and improve performance.

New Features:
- Add batch queries to compute package counts and describes-packages for multiple SBOMs at once.

Enhancements:
- Refactor SBOM summary construction to use batched queries instead of per-entity lookups.
- Introduce an SbomHead::from_parts constructor for building summaries from pre-fetched data.
- Adjust license search union query to avoid DISTINCT, use UNION ALL, and conditionally apply ordering while ensuring correct count queries.