### PR TITLE
perf: batch N+1 queries in SBOM and advisory summary construction

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -61,6 +61,7 @@ mod m0002160_fix_ref_fk;
 mod m0002170_drop_cvss_tables;
 mod m0002180_advisory_fk_indexes;
 mod m0002190_vulnerability_base_score_advisory;
+mod m0002200_source_document_ingested_index;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -137,6 +138,7 @@ impl MigratorExt for Migrator {
             .normal(m0002110_sbom_describing_cpe::Migration)
             .normal(m0002120_ancestor_walk_index::Migration)
             .normal(m0002130_sbom_ancestor::Migration)
+            .normal(m0002200_source_document_ingested_index::Migration)
     }
 }
 

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -62,6 +62,7 @@ mod m0002170_drop_cvss_tables;
 mod m0002180_advisory_fk_indexes;
 mod m0002190_vulnerability_base_score_advisory;
 mod m0002200_source_document_ingested_index;
+mod m0002210_sbom_node_name_index;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -139,6 +140,7 @@ impl MigratorExt for Migrator {
             .normal(m0002120_ancestor_walk_index::Migration)
             .normal(m0002130_sbom_ancestor::Migration)
             .normal(m0002200_source_document_ingested_index::Migration)
+            .normal(m0002210_sbom_node_name_index::Migration)
     }
 }
 

--- a/migration/src/m0002200_source_document_ingested_index.rs
+++ b/migration/src/m0002200_source_document_ingested_index.rs
@@ -1,0 +1,51 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Index on source_document(ingested DESC) to speed up advisory listing
+        // sorted by ingestion date. Without this, the query must scan and sort
+        // ~1M rows just to return the first page.
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(SourceDocument::Table)
+                    .name(Indexes::IdxSourceDocumentIngested.to_string())
+                    .col((SourceDocument::Ingested, IndexOrder::Desc))
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(SourceDocument::Table)
+                    .name(Indexes::IdxSourceDocumentIngested.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Indexes {
+    IdxSourceDocumentIngested,
+}
+
+#[derive(DeriveIden)]
+enum SourceDocument {
+    Table,
+    Ingested,
+}

--- a/migration/src/m0002210_sbom_node_name_index.rs
+++ b/migration/src/m0002210_sbom_node_name_index.rs
@@ -1,0 +1,34 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Covering index to support ORDER BY name with early termination at
+        // LIMIT. INCLUDE columns enable the join to sbom without a heap fetch.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                CREATE INDEX IF NOT EXISTS sbom_node_name_covering_idx
+                ON sbom_node (name) INCLUDE (sbom_id, node_id)
+                "#,
+            )
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("DROP INDEX IF EXISTS sbom_node_name_covering_idx")
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+}

--- a/modules/fundamental/src/advisory/model/summary.rs
+++ b/modules/fundamental/src/advisory/model/summary.rs
@@ -1,14 +1,19 @@
-use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QuerySelect};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, prelude::Uuid};
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use tracing::{Instrument, info_span, instrument};
 use trustify_common::memo::Memo;
-use trustify_entity::{advisory_vulnerability, advisory_vulnerability_score, vulnerability};
+use trustify_entity::{
+    advisory_vulnerability, advisory_vulnerability_score, vulnerability, vulnerability_description,
+};
 use utoipa::ToSchema;
 
 use crate::Error;
 use crate::advisory::model::{AdvisoryHead, AdvisoryVulnerabilityHead};
 use crate::advisory::service::AdvisoryCatcher;
+use crate::common::model::ScoredVector;
 use crate::source_document::model::SourceDocument;
+use crate::vulnerability::model::VulnerabilityHead;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct AdvisorySummary {
@@ -24,6 +29,8 @@ pub struct AdvisorySummary {
 }
 
 impl AdvisorySummary {
+    /// Batch-constructs advisory summaries, loading all related data upfront
+    /// instead of per-advisory.
     #[instrument(
         skip_all,
         err(level=tracing::Level::INFO),
@@ -33,47 +40,131 @@ impl AdvisorySummary {
         entities: &[AdvisoryCatcher],
         tx: &C,
     ) -> Result<Vec<Self>, Error> {
-        let mut summaries = Vec::with_capacity(entities.len());
+        if entities.is_empty() {
+            return Ok(vec![]);
+        }
 
-        // Batch-load all scores for all advisories in a single query.
-        let advisory_ids = entities.iter().map(|e| e.advisory.id).collect::<Vec<_>>();
+        let advisory_ids: Vec<_> = entities.iter().map(|e| e.advisory.id).collect();
+
+        // Batch-load all scores for all advisories.
         let all_scores = advisory_vulnerability_score::Entity::find()
-            .filter(advisory_vulnerability_score::Column::AdvisoryId.is_in(advisory_ids))
+            .filter(advisory_vulnerability_score::Column::AdvisoryId.is_in(advisory_ids.clone()))
             .all(tx)
             .instrument(info_span!("load all advisory scores"))
             .await?;
 
-        for each in entities {
-            let vulnerabilities = vulnerability::Entity::find()
-                .right_join(advisory_vulnerability::Entity)
-                .column_as(
-                    advisory_vulnerability::Column::VulnerabilityId,
-                    vulnerability::Column::Id,
-                )
-                .filter(advisory_vulnerability::Column::AdvisoryId.eq(each.advisory.id))
-                .all(tx)
-                .instrument(info_span!("find advisory vulnerabilities", advisory=%each.advisory.id))
-                .await?;
+        // Batch-load all advisory_vulnerability join records.
+        let all_av = advisory_vulnerability::Entity::find()
+            .filter(advisory_vulnerability::Column::AdvisoryId.is_in(advisory_ids))
+            .all(tx)
+            .instrument(info_span!("load all advisory vulnerabilities"))
+            .await?;
 
-            // Distribute pre-loaded scores to each vulnerability in this advisory.
-            let scores_by_vuln: Vec<Vec<_>> = vulnerabilities
+        let mut scores_by_key: HashMap<(Uuid, String), Vec<advisory_vulnerability_score::Model>> =
+            HashMap::new();
+        for score in all_scores {
+            scores_by_key
+                .entry((score.advisory_id, score.vulnerability_id.clone()))
+                .or_default()
+                .push(score);
+        }
+
+        let mut av_by_advisory: HashMap<Uuid, Vec<advisory_vulnerability::Model>> = HashMap::new();
+        let mut vuln_ids: HashSet<String> = HashSet::new();
+        for av in all_av {
+            vuln_ids.insert(av.vulnerability_id.clone());
+            av_by_advisory.entry(av.advisory_id).or_default().push(av);
+        }
+
+        // Batch-load all vulnerability records. Entries in
+        // advisory_vulnerability may reference vulnerability IDs that have
+        // no row in the vulnerability table yet, so we insert stub models
+        // for any missing IDs to match the original RIGHT JOIN semantics.
+        let mut all_vulns: HashMap<String, vulnerability::Model> = vulnerability::Entity::find()
+            .filter(vulnerability::Column::Id.is_in(vuln_ids.iter().cloned().collect::<Vec<_>>()))
+            .all(tx)
+            .instrument(info_span!("load all vulnerabilities"))
+            .await?
+            .into_iter()
+            .map(|v| (v.id.clone(), v))
+            .collect();
+
+        for id in &vuln_ids {
+            all_vulns
+                .entry(id.clone())
+                .or_insert_with(|| vulnerability::Model {
+                    id: id.clone(),
+                    title: None,
+                    reserved: None,
+                    published: None,
+                    modified: None,
+                    withdrawn: None,
+                    cwes: None,
+                    base_score: None,
+                    base_severity: None,
+                    base_type: None,
+                    authoritative_advisory_id: None,
+                    id_sort_key: None,
+                });
+        }
+
+        // Batch-load descriptions for vulnerabilities that have their own title
+        // (those use from_vulnerability_entity which fetches the description).
+        let vulns_needing_description: Vec<String> = all_vulns
+            .values()
+            .filter(|v| v.title.is_some())
+            .map(|v| v.id.clone())
+            .collect();
+
+        let all_descriptions: HashMap<String, String> = if vulns_needing_description.is_empty() {
+            HashMap::new()
+        } else {
+            vulnerability_description::Entity::find()
+                .filter(
+                    vulnerability_description::Column::VulnerabilityId
+                        .is_in(vulns_needing_description),
+                )
+                .filter(vulnerability_description::Column::Lang.eq("en"))
+                .all(tx)
+                .instrument(info_span!("load all vulnerability descriptions"))
+                .await?
+                .into_iter()
+                .map(|d| (d.vulnerability_id, d.description))
+                .collect()
+        };
+
+        // Build summaries from pre-fetched data (no more per-advisory queries).
+        let mut summaries = Vec::with_capacity(entities.len());
+
+        for each in entities {
+            let advisory_vulns = av_by_advisory
+                .get(&each.advisory.id)
+                .map(|v| v.as_slice())
+                .unwrap_or_default();
+
+            let vulnerabilities: Vec<AdvisoryVulnerabilityHead> = advisory_vulns
                 .iter()
-                .map(|v| {
-                    all_scores
-                        .iter()
-                        .filter(|s| s.advisory_id == each.advisory.id && s.vulnerability_id == v.id)
-                        .cloned()
-                        .collect()
+                .filter_map(|av| {
+                    let vuln = all_vulns.get(&av.vulnerability_id)?;
+
+                    let scores: Vec<ScoredVector> = scores_by_key
+                        .get(&(each.advisory.id, vuln.id.clone()))
+                        .map(|s| s.iter().cloned().map(ScoredVector::from).collect())
+                        .unwrap_or_default();
+
+                    let head = if vuln.title.is_some() {
+                        let description = all_descriptions.get(&vuln.id).cloned();
+                        VulnerabilityHead::from_vulnerability_entity_and_description(
+                            vuln,
+                            description,
+                        )
+                    } else {
+                        VulnerabilityHead::from_advisory_vulnerability_entity(av, vuln)
+                    };
+
+                    Some(AdvisoryVulnerabilityHead { head, scores })
                 })
                 .collect();
-
-            let vulnerabilities = AdvisoryVulnerabilityHead::from_entities(
-                &each.advisory,
-                &vulnerabilities,
-                scores_by_vuln,
-                tx,
-            )
-            .await?;
 
             summaries.push(AdvisorySummary {
                 head: AdvisoryHead::from_advisory(
@@ -84,7 +175,7 @@ impl AdvisorySummary {
                 .await?,
                 source_document: SourceDocument::from_entity(&each.source_document),
                 vulnerabilities,
-            })
+            });
         }
 
         Ok(summaries)

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -44,7 +44,10 @@ impl AdvisoryService {
     ) -> Result<PaginatedResults<AdvisorySummary>, Error> {
         let limiter = advisory::Entity::find()
             .with_deprecation(deprecation)
-            .join(JoinType::InnerJoin, advisory::Relation::SourceDocument.def())
+            .join(
+                JoinType::InnerJoin,
+                advisory::Relation::SourceDocument.def(),
+            )
             .join(JoinType::LeftJoin, advisory::Relation::Issuer.def())
             .filtering_with(
                 search,

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -44,7 +44,7 @@ impl AdvisoryService {
     ) -> Result<PaginatedResults<AdvisorySummary>, Error> {
         let limiter = advisory::Entity::find()
             .with_deprecation(deprecation)
-            .left_join(source_document::Entity)
+            .join(JoinType::InnerJoin, advisory::Relation::SourceDocument.def())
             .join(JoinType::LeftJoin, advisory::Relation::Issuer.def())
             .filtering_with(
                 search,

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -104,6 +104,45 @@ impl<P: IntoPackage> SbomSummary<P> {
             described_by,
         })
     }
+
+    /// Batch-convert multiple SBOM entity tuples into summaries, using two
+    /// queries total instead of two per SBOM.
+    #[instrument(skip_all, err(level=tracing::Level::INFO), fields(count=entities.len()))]
+    pub async fn from_entities<C: ConnectionTrait>(
+        entities: Vec<(sbom::Model, sbom_node::Model, source_document::Model)>,
+        service: &SbomService,
+        db: &C,
+    ) -> Result<Vec<Self>, Error> {
+        if entities.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let sbom_ids: Vec<Uuid> = entities.iter().map(|(s, _, _)| s.sbom_id).collect();
+
+        let mut describes_map = service.batch_describes_packages(&sbom_ids, db).await?;
+        let counts_map = service.batch_package_counts(&sbom_ids, db).await?;
+
+        let results = entities
+            .into_iter()
+            .map(|(sbom, node, source_document)| SbomSummary {
+                head: SbomHead {
+                    id: sbom.sbom_id,
+                    document_id: sbom.document_id,
+                    labels: sbom.labels,
+                    published: sbom.published,
+                    authors: sbom.authors,
+                    suppliers: sbom.suppliers,
+                    name: node.name,
+                    data_licenses: sbom.data_licenses,
+                    number_of_packages: counts_map.get(&sbom.sbom_id).copied().unwrap_or(0),
+                },
+                source_document: SourceDocument::from_entity(&source_document),
+                described_by: describes_map.remove(&sbom.sbom_id).unwrap_or_default(),
+            })
+            .collect();
+
+        Ok(results)
+    }
 }
 
 #[derive(FromQueryResult)]

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -8,7 +8,6 @@ use crate::{
         SbomPackageRelation, SbomPackageSummary, SbomSummary, Which, details::SbomDetails,
     },
 };
-use futures_util::{StreamExt, TryStreamExt, stream};
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DbErr, EntityTrait, FromJsonQueryResult, FromQueryResult,
     IntoSimpleExpr, QueryFilter, QueryOrder, QueryResult, QuerySelect, QueryTrait, RelationTrait,
@@ -296,15 +295,14 @@ impl SbomService {
         } = limiter.fetch().await?;
         let total = total.requested(paginated.total()).await?;
 
-        let items = stream::iter(
-            sboms
-                .into_iter()
-                .filter_map(|(sbom, node, source_document)| Some((sbom, node?, source_document?))),
-        )
-        .then(|row| async { SbomSummary::from_entity(row, self, connection).await })
-        .try_collect()
-        .instrument(info_span!("from_entity"))
-        .await?;
+        let filtered: Vec<_> = sboms
+            .into_iter()
+            .filter_map(|(sbom, node, source_document)| Some((sbom, node?, source_document?)))
+            .collect();
+
+        let items = SbomSummary::from_entities(filtered, self, connection)
+            .instrument(info_span!("from_entities"))
+            .await?;
 
         Ok(PaginatedResults { total, items })
     }
@@ -560,6 +558,91 @@ impl SbomService {
         .map(|r| r.map_all(|rel| rel.package))
     }
 
+    /// Count packages for multiple SBOMs in a single query.
+    #[instrument(skip(self, db), err(level=tracing::Level::INFO))]
+    pub async fn batch_package_counts<C: ConnectionTrait>(
+        &self,
+        sbom_ids: &[Uuid],
+        db: &C,
+    ) -> Result<HashMap<Uuid, u64>, Error> {
+        if sbom_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let counts: Vec<(Uuid, i64)> = sbom_package::Entity::find()
+            .select_only()
+            .column(sbom_package::Column::SbomId)
+            .column_as(sbom_package::Column::NodeId.count(), "count")
+            .filter(sbom_package::Column::SbomId.is_in(sbom_ids.to_vec()))
+            .group_by(sbom_package::Column::SbomId)
+            .into_tuple()
+            .all(db)
+            .await?;
+        Ok(counts.into_iter().map(|(id, c)| (id, c as u64)).collect())
+    }
+
+    /// Fetch describing packages for multiple SBOMs in a single batch query.
+    #[instrument(skip(self, db), err(level=tracing::Level::INFO))]
+    pub async fn batch_describes_packages<C, P>(
+        &self,
+        sbom_ids: &[Uuid],
+        db: &C,
+    ) -> Result<HashMap<Uuid, Vec<P>>, Error>
+    where
+        C: ConnectionTrait,
+        P: IntoPackage,
+    {
+        if sbom_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut query = package_relates_to_package::Entity::find()
+            .filter(package_relates_to_package::Column::SbomId.is_in(sbom_ids.to_vec()))
+            .filter(package_relates_to_package::Column::Relationship.eq(Relationship::Describes))
+            .select_only()
+            .select_column(package_relates_to_package::Column::SbomId)
+            .select_column_as(sbom_node::Column::NodeId, "id")
+            .select_column_as(sbom_node::Column::Name, "name")
+            .select_column_as(sbom_package::Column::Group, "group")
+            .select_column_as(sbom_package::Column::Version, "version")
+            // join the right side (the described node) → package
+            .join(
+                JoinType::Join,
+                package_relates_to_package::Relation::Right.def(),
+            )
+            .join(JoinType::Join, sbom_node::Relation::Package.def())
+            .join(JoinType::Join, sbom_node::Relation::Sbom.def());
+
+        query = P::build_query(query);
+
+        // All selected columns must appear in GROUP BY. For SbomPackage,
+        // P::build_query already adds most of these (duplicates are harmless);
+        // for SbomPackageSummary (no-op build_query), these are essential.
+        query = query
+            .group_by(package_relates_to_package::Column::SbomId)
+            .group_by(sbom_node::Column::NodeId)
+            .group_by(sbom_node::Column::Name)
+            .group_by(sbom_package::Column::Group)
+            .group_by(sbom_package::Column::Version);
+
+        #[derive(FromQueryResult)]
+        struct BatchRow<R: FromQueryResult> {
+            sbom_id: Uuid,
+            #[sea_orm(nested)]
+            package: R,
+        }
+
+        let rows: Vec<BatchRow<P::Row>> = query.into_model().all(db).await?;
+
+        let mut result: HashMap<Uuid, Vec<P>> = HashMap::new();
+        for row in rows {
+            result
+                .entry(row.sbom_id)
+                .or_default()
+                .push(P::from_row(row.package));
+        }
+        Ok(result)
+    }
+
     #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
     pub async fn count_related_sboms<C: ConnectionTrait>(
         &self,
@@ -681,16 +764,14 @@ impl SbomService {
         } = limiter.fetch().await?;
         let total = total.requested(paginated.total()).await?;
 
-        // collect results
+        let filtered: Vec<_> = sboms
+            .into_iter()
+            .filter_map(|(sbom, node, source_document)| Some((sbom, node?, source_document?)))
+            .collect();
 
-        let items = stream::iter(
-            sboms
-                .into_iter()
-                .filter_map(|(sbom, node, source_document)| Some((sbom, node?, source_document?))),
-        )
-        .then(|row| async { SbomSummary::from_entity(row, self, connection).await })
-        .try_collect()
-        .await?;
+        let items = SbomSummary::from_entities(filtered, self, connection)
+            .instrument(info_span!("from_entities"))
+            .await?;
 
         Ok(PaginatedResults { items, total })
     }

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -269,14 +269,14 @@ impl SbomService {
         }
 
         let limiter = query
-            .find_also_linked(sbom::SbomNodeLink)
+            .join(JoinType::InnerJoin, sbom::Relation::SbomNode.def())
+            .select_also(sbom_node::Entity)
             .find_also_related(source_document::Entity)
             .filtering_with(
                 search,
                 Columns::from_entity::<sbom::Entity>()
                     .add_columns(sbom_node::Entity)
                     .add_columns(source_document::Entity)
-                    .alias("sbom_node", "r0")
                     .translator(|f, op, v| match f.split_once(':') {
                         Some(("label", key)) => Some(format!("labels:{key}{op}{v}")),
                         _ => match f {


### PR DESCRIPTION
## Summary by Sourcery

Batch advisory and SBOM summary construction to reduce N+1 database queries and improve listing performance.

New Features:
- Add batch construction of advisory summaries using preloaded vulnerabilities, scores, and descriptions.
- Add batch SBOM summary construction that reuses shared queries for package counts and describing packages across multiple SBOMs.

Enhancements:
- Optimize advisory queries by prefetching related vulnerabilities, join records, scores, and descriptions instead of per-advisory lookups.
- Add reusable batch helpers in SbomService for counting packages and fetching describing packages for multiple SBOMs.
- Update advisory listing to use an inner join with source documents and add an index on source document ingestion time to speed sorted listings.