### PR TITLE
feat(entity): add exploit intelligence job tracking entities and migration

### DIFF
--- a/entity/src/exploit_intelligence_job.rs
+++ b/entity/src/exploit_intelligence_job.rs
@@ -1,0 +1,113 @@
+/// Entity model for tracking Exploit Intelligence analysis jobs.
+///
+/// Each row represents a single analysis request submitted to the Exploit Intelligence
+/// service, tracking its lifecycle from submission through completion. Per-component
+/// results (scan IDs, findings, advisories) live on the related
+/// [`exploit_intelligence_job_component`](super::exploit_intelligence_job_component) rows —
+/// even for single-component CycloneDX jobs, which have exactly one component record.
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+
+/// Lifecycle status of an Exploit Intelligence analysis job.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(
+    rs_type = "String",
+    db_type = "Enum",
+    enum_name = "exploit_intelligence_job_status"
+)]
+pub enum ExploitIntelligenceJobStatus {
+    /// Job has been created but not yet started.
+    #[sea_orm(string_value = "pending")]
+    Pending,
+    /// Analysis is in progress.
+    #[sea_orm(string_value = "running")]
+    Running,
+    /// Analysis completed successfully.
+    #[sea_orm(string_value = "completed")]
+    Completed,
+    /// Analysis failed with an error.
+    #[sea_orm(string_value = "failed")]
+    Failed,
+}
+
+/// Analysis finding from the Exploit Intelligence service.
+///
+/// Represents the outcome of a vulnerability analysis for a given component/CVE pair.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "ei_finding")]
+pub enum Finding {
+    /// The analysed component is vulnerable to the CVE.
+    #[sea_orm(string_value = "vulnerable")]
+    Vulnerable,
+    /// The analysed component is not vulnerable to the CVE.
+    #[sea_orm(string_value = "not_vulnerable")]
+    NotVulnerable,
+    /// The analysis was inconclusive.
+    #[sea_orm(string_value = "uncertain")]
+    Uncertain,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "exploit_intelligence_job")]
+pub struct Model {
+    /// The database internal ID.
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+
+    /// FK to the SBOM being analysed.
+    pub sbom_id: Uuid,
+
+    /// CVE identifier (e.g., "CVE-2024-9680").
+    pub vulnerability_id: String,
+
+    /// Current lifecycle status of the job.
+    pub status: ExploitIntelligenceJobStatus,
+
+    /// Error details for failed analyses.
+    pub error_message: Option<String>,
+
+    /// EI product ID for SPDX multi-component flow (`None` for single-component).
+    pub product_id: Option<String>,
+
+    /// Expected number of components in the product.
+    pub total_components: Option<i32>,
+
+    /// Timestamp when the job was created.
+    pub created: OffsetDateTime,
+
+    /// Timestamp when the job was last updated.
+    pub updated: OffsetDateTime,
+}
+
+/// Foreign-key relationships for the exploit intelligence job entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// Link to the SBOM that was analysed.
+    #[sea_orm(
+        belongs_to = "super::sbom::Entity",
+        from = "Column::SbomId",
+        to = "super::sbom::Column::SbomId"
+    )]
+    Sbom,
+
+    /// Link to the per-component analysis results.
+    #[sea_orm(has_many = "super::exploit_intelligence_job_component::Entity")]
+    Components,
+}
+
+/// Navigate from an exploit intelligence job to its SBOM.
+impl Related<super::sbom::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Sbom.def()
+    }
+}
+
+/// Navigate from an exploit intelligence job to its components.
+impl Related<super::exploit_intelligence_job_component::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Components.def()
+    }
+}
+
+/// Default active-model behaviour (no custom hooks).
+impl ActiveModelBehavior for ActiveModel {}

--- a/entity/src/exploit_intelligence_job_component.rs
+++ b/entity/src/exploit_intelligence_job_component.rs
@@ -1,0 +1,83 @@
+/// Entity model for tracking per-component analysis results within a multi-component
+/// Exploit Intelligence product job.
+///
+/// Each row represents one container image component within an SPDX product SBOM,
+/// independently analysed by the Exploit Intelligence service. The parent
+/// `exploit_intelligence_job` holds product-level metadata while this entity holds
+/// the per-component scan results.
+use super::exploit_intelligence_job::{ExploitIntelligenceJobStatus, Finding};
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "exploit_intelligence_job_component")]
+pub struct Model {
+    /// The database internal ID.
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+
+    /// FK to the parent exploit intelligence job.
+    pub job_id: Uuid,
+
+    /// Identifier of the component (purl or container image reference).
+    pub component_ref: String,
+
+    /// EI scan ID for this component's report (unique, nullable).
+    #[sea_orm(unique)]
+    pub scan_id: Option<String>,
+
+    /// Current lifecycle status of this component's analysis.
+    pub status: ExploitIntelligenceJobStatus,
+
+    /// Analysis finding for the component (set on completion).
+    pub finding: Option<Finding>,
+
+    /// FK to advisory — set when a VEX document is ingested from the result.
+    pub advisory_id: Option<Uuid>,
+
+    /// Error details for failed analyses.
+    pub error_message: Option<String>,
+
+    /// Timestamp when the component record was created.
+    pub created: OffsetDateTime,
+
+    /// Timestamp when the component record was last updated.
+    pub updated: OffsetDateTime,
+}
+
+/// Foreign-key relationships for the exploit intelligence job component entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// Link to the parent exploit intelligence job.
+    #[sea_orm(
+        belongs_to = "super::exploit_intelligence_job::Entity",
+        from = "Column::JobId",
+        to = "super::exploit_intelligence_job::Column::Id"
+    )]
+    Job,
+
+    /// Link to the advisory ingested from the analysis result.
+    #[sea_orm(
+        belongs_to = "super::advisory::Entity",
+        from = "Column::AdvisoryId",
+        to = "super::advisory::Column::Id"
+    )]
+    Advisory,
+}
+
+/// Navigate from a component to its parent job.
+impl Related<super::exploit_intelligence_job::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Job.def()
+    }
+}
+
+/// Navigate from a component to its advisory.
+impl Related<super::advisory::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Advisory.def()
+    }
+}
+
+/// Default active-model behaviour (no custom hooks).
+impl ActiveModelBehavior for ActiveModel {}

--- a/entity/src/lib.rs
+++ b/entity/src/lib.rs
@@ -4,6 +4,8 @@ pub mod advisory_vulnerability_score;
 pub mod base_purl;
 pub mod cpe;
 pub mod expanded_license;
+pub mod exploit_intelligence_job;
+pub mod exploit_intelligence_job_component;
 pub mod importer;
 pub mod importer_report;
 pub mod labels;

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -64,6 +64,7 @@ mod m0002190_vulnerability_base_score_advisory;
 mod m0002200_source_document_ingested_index;
 mod m0002210_sbom_node_name_index;
 mod m0002220_drop_qualified_purl_gist_indexes;
+mod m0002230_create_exploit_intelligence_job;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -143,6 +144,7 @@ impl MigratorExt for Migrator {
             .normal(m0002200_source_document_ingested_index::Migration)
             .normal(m0002210_sbom_node_name_index::Migration)
             .normal(m0002220_drop_qualified_purl_gist_indexes::Migration)
+            .normal(m0002230_create_exploit_intelligence_job::Migration)
     }
 }
 

--- a/migration/src/m0002230_create_exploit_intelligence_job.rs
+++ b/migration/src/m0002230_create_exploit_intelligence_job.rs
@@ -1,0 +1,340 @@
+use crate::Now;
+use sea_orm::sea_query::extension::postgres::Type;
+use sea_orm_migration::prelude::*;
+use trustify_common::db::create_enum_if_not_exists;
+
+use strum::VariantNames;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        create_enum_if_not_exists(
+            manager,
+            ExploitIntelligenceJobStatus::Table,
+            ExploitIntelligenceJobStatus::VARIANTS
+                .iter()
+                .skip(1)
+                .copied(),
+        )
+        .await?;
+
+        create_enum_if_not_exists(
+            manager,
+            EiFinding::Table,
+            EiFinding::VARIANTS.iter().skip(1).copied(),
+        )
+        .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(ExploitIntelligenceJob::Table)
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJob::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJob::SbomId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJob::VulnerabilityId)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJob::Status)
+                            .custom(ExploitIntelligenceJobStatus::Table)
+                            .not_null()
+                            .default("pending"),
+                    )
+                    .col(ColumnDef::new(ExploitIntelligenceJob::ErrorMessage).string())
+                    .col(ColumnDef::new(ExploitIntelligenceJob::ProductId).string())
+                    .col(ColumnDef::new(ExploitIntelligenceJob::TotalComponents).integer())
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJob::Created)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Func::cust(Now)),
+                    )
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJob::Updated)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Func::cust(Now)),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from_col(ExploitIntelligenceJob::SbomId)
+                            .to(Sbom::Table, Sbom::SbomId)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(ExploitIntelligenceJob::Table)
+                    .name(Indexes::ExploitIntelligenceJobSbomIdx.to_string())
+                    .col(ExploitIntelligenceJob::SbomId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(ExploitIntelligenceJob::Table)
+                    .name(Indexes::ExploitIntelligenceJobSbomVulnIdx.to_string())
+                    .col(ExploitIntelligenceJob::SbomId)
+                    .col(ExploitIntelligenceJob::VulnerabilityId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(ExploitIntelligenceJobComponent::Table)
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJobComponent::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJobComponent::JobId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJobComponent::ComponentRef)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJobComponent::ScanId)
+                            .string()
+                            .unique_key(),
+                    )
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJobComponent::Status)
+                            .custom(ExploitIntelligenceJobStatus::Table)
+                            .not_null()
+                            .default("pending"),
+                    )
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJobComponent::Finding)
+                            .custom(EiFinding::Table),
+                    )
+                    .col(ColumnDef::new(ExploitIntelligenceJobComponent::AdvisoryId).uuid())
+                    .col(ColumnDef::new(ExploitIntelligenceJobComponent::ErrorMessage).string())
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJobComponent::Created)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Func::cust(Now)),
+                    )
+                    .col(
+                        ColumnDef::new(ExploitIntelligenceJobComponent::Updated)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Func::cust(Now)),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from_col(ExploitIntelligenceJobComponent::JobId)
+                            .to(ExploitIntelligenceJob::Table, ExploitIntelligenceJob::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from_col(ExploitIntelligenceJobComponent::AdvisoryId)
+                            .to(Advisory::Table, Advisory::Id)
+                            .on_delete(ForeignKeyAction::SetNull),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(ExploitIntelligenceJobComponent::Table)
+                    .name(Indexes::EiJobComponentJobIdx.to_string())
+                    .col(ExploitIntelligenceJobComponent::JobId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(ExploitIntelligenceJobComponent::Table)
+                    .name(Indexes::EiJobComponentAdvisoryIdx.to_string())
+                    .col(ExploitIntelligenceJobComponent::AdvisoryId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(ExploitIntelligenceJobComponent::Table)
+                    .name(Indexes::EiJobComponentAdvisoryIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(ExploitIntelligenceJobComponent::Table)
+                    .name(Indexes::EiJobComponentJobIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(ExploitIntelligenceJobComponent::Table)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(ExploitIntelligenceJob::Table)
+                    .name(Indexes::ExploitIntelligenceJobSbomVulnIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(ExploitIntelligenceJob::Table)
+                    .name(Indexes::ExploitIntelligenceJobSbomIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(ExploitIntelligenceJob::Table)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_type(Type::drop().if_exists().name(EiFinding::Table).to_owned())
+            .await?;
+
+        manager
+            .drop_type(
+                Type::drop()
+                    .if_exists()
+                    .name(ExploitIntelligenceJobStatus::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+enum Indexes {
+    ExploitIntelligenceJobSbomIdx,
+    ExploitIntelligenceJobSbomVulnIdx,
+    EiJobComponentJobIdx,
+    EiJobComponentAdvisoryIdx,
+}
+
+#[derive(DeriveIden)]
+enum ExploitIntelligenceJob {
+    Table,
+    Id,
+    SbomId,
+    VulnerabilityId,
+    Status,
+    ErrorMessage,
+    ProductId,
+    TotalComponents,
+    Created,
+    Updated,
+}
+
+#[derive(DeriveIden)]
+enum ExploitIntelligenceJobComponent {
+    Table,
+    Id,
+    JobId,
+    ComponentRef,
+    ScanId,
+    Status,
+    Finding,
+    AdvisoryId,
+    ErrorMessage,
+    Created,
+    Updated,
+}
+
+#[derive(DeriveIden, strum::VariantNames, strum::Display, Clone)]
+#[strum(serialize_all = "snake_case")]
+#[allow(unused)]
+enum ExploitIntelligenceJobStatus {
+    Table,
+    Pending,
+    Running,
+    Completed,
+    Failed,
+}
+
+#[derive(DeriveIden, strum::VariantNames, strum::Display, Clone)]
+#[strum(serialize_all = "snake_case")]
+#[allow(unused)]
+enum EiFinding {
+    Table,
+    Vulnerable,
+    NotVulnerable,
+    Uncertain,
+}
+
+#[derive(DeriveIden)]
+enum Sbom {
+    Table,
+    SbomId,
+}
+
+#[derive(DeriveIden)]
+enum Advisory {
+    Table,
+    Id,
+}


### PR DESCRIPTION
## Summary

Add database entities and migrations for tracking Exploit Intelligence analysis jobs in trustify. This is the data-layer foundation for integrating the Exploit Intelligence (EI) service, which performs automated vulnerability reachability analysis and produces VEX advisories.

## Jira

Implements [TC-4675](https://redhat.atlassian.net/browse/TC-4675)

### What changed

**New entities:**
- `exploit_intelligence_job` — tracks the lifecycle of each EI analysis request (submission → completion), including scan ID, status, associated SBOM/vulnerability, and the result (VEX advisory link or error). Supports both single-component (CycloneDX) and multi-component (SPDX product) flows via `product_id`/`total_components`.
- `exploit_intelligence_job_component` — tracks per-component analysis results within a multi-component SPDX product job. Each row represents one container image component independently analysed by the EI service.

**New enums:**
- `ExploitIntelligenceJobStatus` — `Pending`, `Running`, `Completed`, `Failed`
- `Finding` — `Vulnerable`, `NotVulnerable`, `Uncertain`

**Migration (`m0002200`):**
- Creates both tables in a single migration
- FK constraints to `sbom` and `advisory` tables (both nullable)
- CASCADE delete from job → components
- UNIQUE constraint on `scan_id` (both tables)
- FK indexes on all foreign key columns

[TC-4675]: https://redhat.atlassian.net/browse/TC-4675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce database support for tracking Exploit Intelligence analysis jobs and their per-component results.

New Features:
- Add exploit_intelligence_job entity to represent Exploit Intelligence analysis jobs with lifecycle status, findings, and links to SBOMs and advisories.
- Add exploit_intelligence_job_component entity to capture per-component analysis details for multi-component Exploit Intelligence product jobs.

Enhancements:
- Register new entities in the entity module and add a migration to create the exploit_intelligence_job and exploit_intelligence_job_component tables with appropriate indexes and foreign keys.