### PR TITLE
perf: add optional advisory severity summary to SBOM list endpoint

### DIFF
--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -624,6 +624,7 @@ impl ReadOnly {
     }
 
     /// Begins a read-only transaction.
+    #[instrument(skip(self), err(level=tracing::Level::INFO))]
     pub async fn begin(&self) -> Result<DatabaseTransaction, DbError> {
         Ok(self
             .0
@@ -634,6 +635,7 @@ impl ReadOnly {
     /// Begins a read-only transaction with the given isolation level.
     ///
     /// The access mode is always forced to `ReadOnly`; passing `ReadWrite` returns an error.
+    #[instrument(skip(self), err(level=tracing::Level::INFO))]
     pub async fn begin_with_config(
         &self,
         isolation_level: Option<IsolationLevel>,

--- a/etc/test-data/csaf/cve-2023-0044-multi-score.json
+++ b/etc/test-data/csaf/cve-2023-0044-multi-score.json
@@ -1,0 +1,161 @@
+{
+    "document": {
+      "aggregate_severity": {
+        "namespace": "https://access.redhat.com/security/updates/classification/",
+        "text": "low"
+      },
+      "category": "csaf_vex",
+      "csaf_version": "2.0",
+      "distribution": {
+        "text": "Copyright © Red Hat, Inc. All rights reserved.",
+        "tlp": {
+          "label": "WHITE",
+          "url": "https://www.first.org/tlp/"
+        }
+      },
+      "lang": "en",
+      "notes": [
+        {
+          "category": "description",
+          "text": "Synthetic CSAF advisory created for trustify integration tests. Derived from cve-2023-0044.json with an additional CVSS v2 score to test multi-score deduplication.",
+          "title": "Test Data"
+        }
+      ],
+      "publisher": {
+        "category": "other",
+        "contact_details": "https://github.com/guacsec/trustify",
+        "issuing_authority": "Synthetic test data — not a real advisory.",
+        "name": "trustify test suite",
+        "namespace": "https://github.com/guacsec/trustify"
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "Canonical URL",
+          "url": "https://access.redhat.com/security/data/csaf/beta/vex/2023/cve-2023-0044-multi-score.json"
+        }
+      ],
+      "title": "quarkus-vertx-http: multi-score test variant",
+      "tracking": {
+        "current_release_date": "2023-11-13T11:31:31+00:00",
+        "generator": {
+          "date": "2023-11-13T12:16:30+00:00",
+          "engine": {
+            "name": "trustify test suite (synthetic)",
+            "version": "0.0.0"
+          }
+        },
+        "id": "CVE-2023-0044-multi-score",
+        "initial_release_date": "2023-01-04T00:00:00+00:00",
+        "revision_history": [
+          {
+            "date": "2023-01-04T00:00:00+00:00",
+            "number": "1",
+            "summary": "Initial version"
+          }
+        ],
+        "status": "final",
+        "version": "1"
+      }
+    },
+    "product_tree": {
+      "branches": [
+        {
+          "branches": [
+            {
+              "category": "product_name",
+              "name": "Red Hat build of Quarkus",
+              "product": {
+                "name": "Red Hat build of Quarkus",
+                "product_id": "red_hat_build_of_quarkus",
+                "product_identification_helper": {
+                  "cpe": "cpe:/a:redhat:quarkus:2"
+                }
+              }
+            },
+            {
+              "category": "product_version",
+              "name": "io.quarkus/quarkus-vertx-http",
+              "product": {
+                "name": "io.quarkus/quarkus-vertx-http",
+                "product_id": "io.quarkus/quarkus-vertx-http"
+              }
+            }
+          ],
+          "category": "vendor",
+          "name": "Red Hat"
+        }
+      ],
+      "relationships": [
+        {
+          "category": "default_component_of",
+          "full_product_name": {
+            "name": "io.quarkus/quarkus-vertx-http as a component of Red Hat build of Quarkus",
+            "product_id": "red_hat_build_of_quarkus:io.quarkus/quarkus-vertx-http"
+          },
+          "product_reference": "io.quarkus/quarkus-vertx-http",
+          "relates_to_product_reference": "red_hat_build_of_quarkus"
+        }
+      ]
+    },
+    "vulnerabilities": [
+      {
+        "cve": "CVE-2023-0044",
+        "discovery_date": "2023-01-04T00:00:00+00:00",
+        "product_status": {
+          "known_affected": [
+            "red_hat_build_of_quarkus:io.quarkus/quarkus-vertx-http"
+          ]
+        },
+        "references": [
+          {
+            "category": "self",
+            "summary": "Canonical URL",
+            "url": "https://access.redhat.com/security/cve/CVE-2023-0044"
+          }
+        ],
+        "release_date": "2023-01-04T00:00:00+00:00",
+        "remediations": [
+          {
+            "category": "none_available",
+            "details": "Affected",
+            "product_ids": [
+              "red_hat_build_of_quarkus:io.quarkus/quarkus-vertx-http"
+            ]
+          }
+        ],
+        "scores": [
+          {
+            "cvss_v3": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "availabilityImpact": "NONE",
+              "baseScore": 5.3,
+              "baseSeverity": "MEDIUM",
+              "confidentialityImpact": "LOW",
+              "integrityImpact": "NONE",
+              "privilegesRequired": "NONE",
+              "scope": "UNCHANGED",
+              "userInteraction": "NONE",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+              "version": "3.1"
+            },
+            "products": [
+              "red_hat_build_of_quarkus:io.quarkus/quarkus-vertx-http"
+            ]
+          },
+          {
+            "cvss_v2": {
+              "baseScore": 3.5,
+              "vectorString": "AV:N/AC:M/Au:S/C:P/I:N/A:N",
+              "version": "2.0"
+            },
+            "products": [
+              "red_hat_build_of_quarkus:io.quarkus/quarkus-vertx-http"
+            ]
+          }
+        ],
+        "title": "quarkus-vertx-http: multi-score test"
+      }
+    ]
+  }

--- a/etc/test-data/csaf/cve-2099-0001.json
+++ b/etc/test-data/csaf/cve-2099-0001.json
@@ -1,0 +1,151 @@
+{
+    "document": {
+      "aggregate_severity": {
+        "namespace": "https://access.redhat.com/security/updates/classification/",
+        "text": "high"
+      },
+      "category": "csaf_vex",
+      "csaf_version": "2.0",
+      "distribution": {
+        "text": "Copyright © Red Hat, Inc. All rights reserved.",
+        "tlp": {
+          "label": "WHITE",
+          "url": "https://www.first.org/tlp/"
+        }
+      },
+      "lang": "en",
+      "notes": [
+        {
+          "category": "description",
+          "text": "Synthetic CSAF advisory created for trustify integration tests. Not a real vulnerability.",
+          "title": "Test Data"
+        }
+      ],
+      "publisher": {
+        "category": "other",
+        "contact_details": "https://github.com/guacsec/trustify",
+        "issuing_authority": "Synthetic test data — not a real advisory.",
+        "name": "trustify test suite",
+        "namespace": "https://github.com/guacsec/trustify"
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "Canonical URL",
+          "url": "https://access.redhat.com/security/data/csaf/beta/vex/2099/cve-2099-0001.json"
+        }
+      ],
+      "title": "netty-handler: synthetic high-severity test advisory",
+      "tracking": {
+        "current_release_date": "2099-01-01T00:00:00+00:00",
+        "generator": {
+          "date": "2099-01-01T00:00:00+00:00",
+          "engine": {
+            "name": "trustify test suite (synthetic)",
+            "version": "0.0.0"
+          }
+        },
+        "id": "CVE-2099-0001",
+        "initial_release_date": "2099-01-01T00:00:00+00:00",
+        "revision_history": [
+          {
+            "date": "2099-01-01T00:00:00+00:00",
+            "number": "1",
+            "summary": "Initial version"
+          }
+        ],
+        "status": "final",
+        "version": "1"
+      }
+    },
+    "product_tree": {
+      "branches": [
+        {
+          "branches": [
+            {
+              "category": "product_name",
+              "name": "Red Hat build of Apache ZooKeeper",
+              "product": {
+                "name": "Red Hat build of Apache ZooKeeper",
+                "product_id": "red_hat_zookeeper",
+                "product_identification_helper": {
+                  "cpe": "cpe:/a:redhat:zookeeper:3"
+                }
+              }
+            },
+            {
+              "category": "product_version",
+              "name": "io.netty/netty-handler",
+              "product": {
+                "name": "io.netty/netty-handler",
+                "product_id": "io.netty/netty-handler"
+              }
+            }
+          ],
+          "category": "vendor",
+          "name": "Red Hat"
+        }
+      ],
+      "relationships": [
+        {
+          "category": "default_component_of",
+          "full_product_name": {
+            "name": "io.netty/netty-handler as a component of Red Hat build of Apache ZooKeeper",
+            "product_id": "red_hat_zookeeper:io.netty/netty-handler"
+          },
+          "product_reference": "io.netty/netty-handler",
+          "relates_to_product_reference": "red_hat_zookeeper"
+        }
+      ]
+    },
+    "vulnerabilities": [
+      {
+        "cve": "CVE-2099-0001",
+        "discovery_date": "2099-01-01T00:00:00+00:00",
+        "product_status": {
+          "known_affected": [
+            "red_hat_zookeeper:io.netty/netty-handler"
+          ]
+        },
+        "references": [
+          {
+            "category": "self",
+            "summary": "Canonical URL",
+            "url": "https://access.redhat.com/security/cve/CVE-2099-0001"
+          }
+        ],
+        "release_date": "2099-01-01T00:00:00+00:00",
+        "remediations": [
+          {
+            "category": "none_available",
+            "details": "Affected",
+            "product_ids": [
+              "red_hat_zookeeper:io.netty/netty-handler"
+            ]
+          }
+        ],
+        "scores": [
+          {
+            "cvss_v3": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "availabilityImpact": "HIGH",
+              "baseScore": 7.5,
+              "baseSeverity": "HIGH",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "NONE",
+              "privilegesRequired": "NONE",
+              "scope": "UNCHANGED",
+              "userInteraction": "NONE",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "version": "3.1"
+            },
+            "products": [
+              "red_hat_zookeeper:io.netty/netty-handler"
+            ]
+          }
+        ],
+        "title": "netty-handler: synthetic high-severity test vulnerability"
+      }
+    ]
+  }

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -217,6 +217,13 @@ mod v2 {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Default, serde::Deserialize, IntoParams)]
+pub struct SbomListParams {
+    /// Include advisory severity summary per SBOM
+    #[serde(default)]
+    pub advisories: bool,
+}
+
 mod v3 {
     use super::*;
     use crate::sbom::model::SbomPackageSummary;
@@ -229,17 +236,20 @@ mod v3 {
             Query,
             Paginated,
             GroupFilterQuery,
+            SbomListParams,
         ),
         responses(
             (status = 200, description = "Matching SBOMs", body = PaginatedResults<SbomSummary<SbomPackageSummary>>),
         ),
     )]
     #[get("/v3/sbom")]
+    #[allow(clippy::too_many_arguments)]
     pub async fn all(
         fetch: web::Data<SbomService>,
         db: web::Data<db::ReadOnly>,
         web::Query(search): web::Query<Query>,
         web::Query(paginated): web::Query<Paginated>,
+        web::Query(params): web::Query<SbomListParams>,
         QsQuery(group_filter): QsQuery<GroupFilterQuery>,
         authorizer: web::Data<Authorizer>,
         user: UserInformation,
@@ -247,7 +257,7 @@ mod v3 {
         authorizer.require(&user, Permission::ReadSbom)?;
 
         let tx = db.begin().await?;
-        let mut options = FetchOptions::default();
+        let mut options = FetchOptions::default().advisories(params.advisories);
         if !group_filter.group.is_empty() {
             options = options.groups(group_filter.group);
         }

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -2228,3 +2228,89 @@ async fn related_by_hash(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     Ok(())
 }
+
+/// Verify the optional `?advisories=true` enrichment on the SBOM list endpoint.
+///
+/// The `expected` array contains the expected `advisories` value for each SBOM,
+/// sorted alphabetically by SBOM name.
+#[test_context(TrustifyContext)]
+#[rstest]
+// Without ?advisories param, the field should be absent from the response
+#[case::without_param(
+    &["quarkus-bom-2.13.8.Final-redhat-00004.json"],
+    false,
+    json!([null]),
+)]
+// With ?advisories=true but no matching advisory data, the field is present but empty
+#[case::no_advisory_data(
+    &["quarkus-bom-2.13.8.Final-redhat-00004.json"],
+    true,
+    json!([{}]),
+)]
+// CSAF advisory with CVSS 5.3 produces a medium severity count
+#[case::medium_severity(
+    &["quarkus-bom-2.13.8.Final-redhat-00004.json", "csaf/cve-2023-0044.json"],
+    true,
+    json!([{"medium": 1}]),
+)]
+// CVE without CVSS scores maps to unknown severity
+#[case::unknown_severity(
+    &["quarkus-bom-2.13.8.Final-redhat-00004.json", "cve/CVE-2024-26308.json"],
+    true,
+    json!([{"unknown": 1}]),
+)]
+// Multiple CVSS versions (v2 low + v3.1 medium) should pick the highest severity
+#[case::multi_score_highest_wins(
+    &["quarkus-bom-2.13.8.Final-redhat-00004.json", "csaf/cve-2023-0044-multi-score.json"],
+    true,
+    json!([{"medium": 1}]),
+)]
+// Multiple severities from different advisories for the same SBOM
+#[case::multiple_severities(
+    &["quarkus-bom-2.13.8.Final-redhat-00004.json", "csaf/cve-2023-0044.json", "cve/CVE-2024-26308.json"],
+    true,
+    json!([{"medium": 1, "unknown": 1}]),
+)]
+// Multiple SBOMs: only one matches the advisory (sorted by name: quarkus, zookeeper)
+#[case::multiple_sboms_one_match(
+    &["quarkus-bom-2.13.8.Final-redhat-00004.json", "zookeeper-3.9.2-cyclonedx.json", "csaf/cve-2023-0044.json"],
+    true,
+    json!([{"medium": 1}, {}]),
+)]
+// Multiple SBOMs: both match different advisories with different severities
+#[case::multiple_sboms_both_match(
+    &["quarkus-bom-2.13.8.Final-redhat-00004.json", "zookeeper-3.9.2-cyclonedx.json", "csaf/cve-2023-0044.json", "csaf/cve-2099-0001.json"],
+    true,
+    json!([{"medium": 1}, {"high": 1}]),
+)]
+#[test_log::test(actix_web::test)]
+async fn list_sboms_advisory_summary(
+    ctx: &TrustifyContext,
+    #[case] docs: &[&str],
+    #[case] advisories_param: bool,
+    #[case] expected: Value,
+) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    ctx.ingest_documents(docs).await?;
+
+    let advisories_query = if advisories_param {
+        "&advisories=true"
+    } else {
+        ""
+    };
+    let uri = format!("/api/v3/sbom?sort=name{advisories_query}");
+    let response: Value = app
+        .call_and_read_body_json(TestRequest::get().uri(&uri).to_request())
+        .await;
+
+    let items = response["items"]
+        .as_array()
+        .expect("items should be an array");
+    let actual = items
+        .iter()
+        .map(|i| i["advisories"].clone())
+        .collect::<Vec<_>>();
+    assert_eq!(Value::Array(actual), expected);
+
+    Ok(())
+}

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -4,21 +4,56 @@ pub mod raw_sql;
 use super::service::SbomService;
 use crate::{
     Error,
-    common::{LicenseInfo, LicenseRefMapping},
+    common::{LicenseInfo, LicenseRefMapping, model::Severity},
     purl::model::summary::purl::PurlSummary,
     sbom::service::sbom::IntoPackage,
     source_document::model::SourceDocument,
 };
+use isx::IsDefault;
 use sea_orm::{ConnectionTrait, FromQueryResult, ModelTrait, PaginatorTrait, prelude::Uuid};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use time::OffsetDateTime;
 use tracing::{info_span, instrument};
 use tracing_futures::Instrument;
-use trustify_common::{cpe::Cpe, purl::Purl, requested_field::RequestedField};
+use trustify_common::{
+    cpe::Cpe,
+    purl::Purl,
+    requested_field::{BoolRequestedField, RequestedField},
+};
 use trustify_entity::{
     labels::Labels, relationship::Relationship, sbom, sbom_node, sbom_package, source_document,
 };
 use utoipa::ToSchema;
+
+/// Severity level for affected vulnerabilities, extending the shared `Severity`
+/// enum with an `Unknown` variant for vulnerabilities that have no CVSS score.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum AffectedSeverity {
+    Unknown,
+    None,
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl From<Option<Severity>> for AffectedSeverity {
+    fn from(value: Option<Severity>) -> Self {
+        match value {
+            Option::None => AffectedSeverity::Unknown,
+            Some(Severity::None) => AffectedSeverity::None,
+            Some(Severity::Low) => AffectedSeverity::Low,
+            Some(Severity::Medium) => AffectedSeverity::Medium,
+            Some(Severity::High) => AffectedSeverity::High,
+            Some(Severity::Critical) => AffectedSeverity::Critical,
+        }
+    }
+}
+
+/// Per-SBOM summary of affected vulnerability counts grouped by severity.
+pub type SbomAdvisorySummary = HashMap<AffectedSeverity, u64>;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema, Default)]
 pub struct SbomHead {
@@ -86,6 +121,9 @@ pub struct SbomSummary<P: IntoPackage = SbomPackage> {
     pub source_document: SourceDocument,
 
     pub described_by: Vec<P>,
+
+    #[serde(default, skip_serializing_if = "IsDefault::is_default")]
+    pub advisories: RequestedField<SbomAdvisorySummary>,
 }
 
 impl<P: IntoPackage> SbomSummary<P> {
@@ -102,6 +140,7 @@ impl<P: IntoPackage> SbomSummary<P> {
             head: SbomHead::from_entity(&sbom, &node, db).await?,
             source_document: SourceDocument::from_entity(&source_document),
             described_by,
+            advisories: RequestedField::NotRequested,
         })
     }
 
@@ -111,6 +150,7 @@ impl<P: IntoPackage> SbomSummary<P> {
     pub async fn from_entities<C: ConnectionTrait>(
         entities: Vec<(sbom::Model, sbom_node::Model, source_document::Model)>,
         service: &SbomService,
+        include_advisories: bool,
         db: &C,
     ) -> Result<Vec<Self>, Error> {
         if entities.is_empty() {
@@ -121,23 +161,39 @@ impl<P: IntoPackage> SbomSummary<P> {
 
         let mut describes_map = service.batch_describes_packages(&sbom_ids, db).await?;
         let counts_map = service.batch_package_counts(&sbom_ids, db).await?;
+        let advisories_map = if include_advisories {
+            Some(
+                service
+                    .batch_advisory_severity_counts(&sbom_ids, db)
+                    .await?,
+            )
+        } else {
+            None
+        };
 
         let results = entities
             .into_iter()
-            .map(|(sbom, node, source_document)| SbomSummary {
-                head: SbomHead {
-                    id: sbom.sbom_id,
-                    document_id: sbom.document_id,
-                    labels: sbom.labels,
-                    published: sbom.published,
-                    authors: sbom.authors,
-                    suppliers: sbom.suppliers,
-                    name: node.name,
-                    data_licenses: sbom.data_licenses,
-                    number_of_packages: counts_map.get(&sbom.sbom_id).copied().unwrap_or(0),
-                },
-                source_document: SourceDocument::from_entity(&source_document),
-                described_by: describes_map.remove(&sbom.sbom_id).unwrap_or_default(),
+            .map(|(sbom, node, source_document)| {
+                let advisory_summary = advisories_map
+                    .as_ref()
+                    .and_then(|m| m.get(&sbom.sbom_id).cloned());
+                SbomSummary {
+                    head: SbomHead {
+                        id: sbom.sbom_id,
+                        document_id: sbom.document_id,
+                        labels: sbom.labels,
+                        published: sbom.published,
+                        authors: sbom.authors,
+                        suppliers: sbom.suppliers,
+                        name: node.name,
+                        data_licenses: sbom.data_licenses,
+                        number_of_packages: counts_map.get(&sbom.sbom_id).copied().unwrap_or(0),
+                    },
+                    source_document: SourceDocument::from_entity(&source_document),
+                    described_by: describes_map.remove(&sbom.sbom_id).unwrap_or_default(),
+                    advisories: include_advisories
+                        .then_requested(|| Some(advisory_summary.unwrap_or_default())),
+                }
             })
             .collect();
 

--- a/modules/fundamental/src/sbom/model/raw_sql.rs
+++ b/modules/fundamental/src/sbom/model/raw_sql.rs
@@ -34,6 +34,171 @@ pub const CONTEXT_CPE_FILTER_SQL: &str = r#"
 )
 "#;
 
+/// Returns SQL that counts affected vulnerabilities grouped by severity for
+/// multiple SBOMs in a single query. Combines both PURL-based matching (via
+/// `purl_status` + `version_matches()`) and CPE-based matching (via
+/// `product_status` + package name matching). Takes `$1 = Uuid[]` and returns
+/// `(sbom_id, severity, count)` rows.
+///
+/// Uses a shared `sbom_purl_info` CTE (referenced 3x) that PostgreSQL
+/// auto-materializes, acting as a barrier that prevents the planner from
+/// inlining the SBOM's package set and scanning the full `versioned_purl`
+/// table. The advisory filter is deferred to a separate CTE so the
+/// expensive `version_matches()` narrows the set before any advisory
+/// lookups.
+pub fn batch_severity_counts_sql() -> &'static str {
+    r#"
+    WITH
+    -- Unnest the input array of SBOM IDs
+    input_sboms AS (
+        SELECT unnest($1::uuid[]) AS sbom_id
+    ),
+
+    -- Shared CTE: SBOM package info including version, base_purl_id,
+    -- and name/namespace. Referenced 3x so PostgreSQL auto-materializes
+    -- it, preventing the planner from inlining and scanning the full
+    -- versioned_purl table. Including base_purl here nudges the planner
+    -- to hash the small side (20k rows) instead of the large one (1.6M).
+    sbom_purl_info AS (
+        SELECT
+            spr.sbom_id,
+            vp.version,
+            vp.base_purl_id,
+            bp.name,
+            bp.namespace
+        FROM input_sboms i
+        JOIN sbom_node_purl_ref spr ON spr.sbom_id = i.sbom_id
+        JOIN qualified_purl qp ON spr.qualified_purl_id = qp.id
+        JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
+        JOIN base_purl bp ON vp.base_purl_id = bp.id
+    ),
+
+    -- PURL-based matching: version_matches called only for SBOM's packages,
+    -- advisory filter deferred to avoid unnecessary lookups.
+    purl_version_matches AS (
+        SELECT DISTINCT
+            sp.sbom_id,
+            pst.advisory_id,
+            pst.vulnerability_id
+        FROM sbom_purl_info sp
+        JOIN purl_status pst ON pst.base_purl_id = sp.base_purl_id
+        JOIN version_range vr ON pst.version_range_id = vr.id
+        JOIN status ON pst.status_id = status.id
+        WHERE status.slug = 'affected'
+          AND version_matches(sp.version, vr.*)
+    ),
+    purl_matches AS (
+        SELECT pm.sbom_id, pm.advisory_id, pm.vulnerability_id
+        FROM purl_version_matches pm
+        WHERE NOT EXISTS (
+            SELECT 1 FROM advisory a
+            WHERE a.id = pm.advisory_id AND a.deprecated
+        )
+    ),
+
+    -- CPE-based matching: per-SBOM allowed CPE IDs with generalized matching
+    sbom_cpes AS (
+        SELECT i.sbom_id, cpe.*
+        FROM input_sboms i
+        JOIN sbom_describing_cpe sdc ON sdc.sbom_id = i.sbom_id
+        JOIN cpe ON sdc.cpe_id = cpe.id
+    ),
+    sbom_generalized_cpes AS (
+        SELECT sc.sbom_id, c.*
+        FROM sbom_cpes sc
+        JOIN cpe c ON c.vendor = sc.vendor
+            AND c.product = sc.product
+            AND c.version = split_part(sc.version, '.', 1)
+            AND (c.edition IS NULL OR c.edition = '*')
+    ),
+    sbom_allowed_cpes AS (
+        SELECT sbom_id, id AS cpe_id FROM sbom_cpes
+        UNION
+        SELECT sbom_id, id AS cpe_id FROM sbom_generalized_cpes
+    ),
+    sbom_has_cpes AS (
+        SELECT DISTINCT sbom_id FROM sbom_cpes
+    ),
+
+    -- CPE product_status matches by name
+    cpe_matches_name AS (
+        SELECT DISTINCT
+            sp.sbom_id,
+            ps.advisory_id,
+            ps.vulnerability_id
+        FROM product_status ps
+        JOIN sbom_purl_info sp ON ps.package = sp.name
+        JOIN status ON ps.status_id = status.id
+        JOIN advisory ON ps.advisory_id = advisory.id
+        WHERE status.slug = 'affected'
+          AND advisory.deprecated = false
+          AND (
+              ps.context_cpe_id IS NULL
+              OR ps.context_cpe_id IN (SELECT cpe_id FROM sbom_allowed_cpes sac WHERE sac.sbom_id = sp.sbom_id)
+              OR sp.sbom_id NOT IN (SELECT sbom_id FROM sbom_has_cpes)
+          )
+    ),
+
+    -- CPE product_status matches by namespace/name
+    cpe_matches_ns AS (
+        SELECT DISTINCT
+            sp.sbom_id,
+            ps.advisory_id,
+            ps.vulnerability_id
+        FROM product_status ps
+        JOIN sbom_purl_info sp ON ps.package = CONCAT(sp.namespace, '/', sp.name)
+        JOIN status ON ps.status_id = status.id
+        JOIN advisory ON ps.advisory_id = advisory.id
+        WHERE sp.namespace IS NOT NULL
+          AND status.slug = 'affected'
+          AND advisory.deprecated = false
+          AND (
+              ps.context_cpe_id IS NULL
+              OR ps.context_cpe_id IN (SELECT cpe_id FROM sbom_allowed_cpes sac WHERE sac.sbom_id = sp.sbom_id)
+              OR sp.sbom_id NOT IN (SELECT sbom_id FROM sbom_has_cpes)
+          )
+    ),
+
+    -- Union all matches
+    all_affected AS (
+        SELECT * FROM purl_matches
+        UNION
+        SELECT * FROM cpe_matches_name
+        UNION
+        SELECT * FROM cpe_matches_ns
+    ),
+
+    -- Pick the highest severity per (sbom, advisory, vulnerability),
+    -- collapsing multiple CVSS versions (e.g. v2 + v3.1) into one row.
+    -- Unknown (no CVSS score) is treated as the highest severity.
+    scored AS (
+        SELECT DISTINCT ON (a.sbom_id, a.advisory_id, a.vulnerability_id)
+            a.sbom_id,
+            COALESCE(avs.severity::text, 'unknown') AS severity
+        FROM all_affected a
+        LEFT JOIN advisory_vulnerability_score avs
+            ON avs.advisory_id = a.advisory_id
+            AND avs.vulnerability_id = a.vulnerability_id
+        ORDER BY a.sbom_id, a.advisory_id, a.vulnerability_id,
+            CASE avs.severity::text
+                WHEN 'critical' THEN 5
+                WHEN 'high' THEN 4
+                WHEN 'medium' THEN 3
+                WHEN 'low' THEN 2
+                WHEN 'none' THEN 1
+                ELSE 6
+            END DESC
+    )
+
+    SELECT
+        sbom_id,
+        severity,
+        COUNT(*) AS count
+    FROM scored
+    GROUP BY sbom_id, severity
+    "#
+}
+
 pub fn product_advisory_info_sql() -> String {
     r#"
         WITH

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -191,6 +191,10 @@ impl SbomService {
     }
 
     /// fetch all SBOMs
+    #[instrument(
+        skip(self, connection),
+        err(level=tracing::Level::INFO)
+    )]
     pub async fn fetch_sboms<C, P>(
         &self,
         search: Query,
@@ -300,9 +304,8 @@ impl SbomService {
             .filter_map(|(sbom, node, source_document)| Some((sbom, node?, source_document?)))
             .collect();
 
-        let items = SbomSummary::from_entities(filtered, self, connection)
-            .instrument(info_span!("from_entities"))
-            .await?;
+        let items =
+            SbomSummary::from_entities(filtered, self, connection).await?;
 
         Ok(PaginatedResults { total, items })
     }

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -4,8 +4,9 @@ use crate::{
     common::license_filtering::{LICENSE, license_text_coalesce},
     purl::model::summary::purl::PurlSummary,
     sbom::model::{
-        ModelCatcher, SbomExternalPackageReference, SbomModel, SbomNodeReference, SbomPackage,
-        SbomPackageRelation, SbomPackageSummary, SbomSummary, Which, details::SbomDetails,
+        AffectedSeverity, ModelCatcher, SbomAdvisorySummary, SbomExternalPackageReference,
+        SbomModel, SbomNodeReference, SbomPackage, SbomPackageRelation, SbomPackageSummary,
+        SbomSummary, Which, details::SbomDetails, raw_sql,
     },
 };
 use sea_orm::{
@@ -46,6 +47,7 @@ use trustify_entity::{
 pub struct FetchOptions {
     labels: Labels,
     groups: Option<Vec<Uuid>>,
+    pub advisories: bool,
 }
 
 impl FetchOptions {
@@ -61,6 +63,12 @@ impl FetchOptions {
                 .filter_map(|s| Uuid::parse_str(s.as_ref()).ok())
                 .collect(),
         );
+        self
+    }
+
+    /// Include advisory severity summary counts in the response.
+    pub fn advisories(mut self, advisories: bool) -> Self {
+        self.advisories = advisories;
         self
     }
 }
@@ -305,7 +313,7 @@ impl SbomService {
             .collect();
 
         let items =
-            SbomSummary::from_entities(filtered, self, connection).await?;
+            SbomSummary::from_entities(filtered, self, options.advisories, connection).await?;
 
         Ok(PaginatedResults { total, items })
     }
@@ -646,6 +654,50 @@ impl SbomService {
         Ok(result)
     }
 
+    /// Count affected vulnerabilities grouped by severity for multiple SBOMs
+    /// in a single batch query, combining both PURL and CPE matching paths.
+    #[instrument(skip(self, db), err(level=tracing::Level::INFO))]
+    pub async fn batch_advisory_severity_counts<C: ConnectionTrait>(
+        &self,
+        sbom_ids: &[Uuid],
+        db: &C,
+    ) -> Result<HashMap<Uuid, SbomAdvisorySummary>, Error> {
+        if sbom_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let stmt = Statement::from_sql_and_values(
+            db.get_database_backend(),
+            raw_sql::batch_severity_counts_sql(),
+            vec![sbom_ids.to_vec().into()],
+        );
+
+        let rows = db.query_all(stmt).await?;
+
+        let mut result: HashMap<Uuid, SbomAdvisorySummary> = HashMap::new();
+        for row in rows {
+            let sbom_id: Uuid = row.try_get("", "sbom_id")?;
+            let severity_str: String = row.try_get("", "severity")?;
+            let count: i64 = row.try_get("", "count")?;
+
+            let severity = match severity_str.as_str() {
+                "none" => AffectedSeverity::None,
+                "low" => AffectedSeverity::Low,
+                "medium" => AffectedSeverity::Medium,
+                "high" => AffectedSeverity::High,
+                "critical" => AffectedSeverity::Critical,
+                _ => AffectedSeverity::Unknown,
+            };
+
+            result
+                .entry(sbom_id)
+                .or_default()
+                .insert(severity, count as u64);
+        }
+
+        Ok(result)
+    }
+
     #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
     pub async fn count_related_sboms<C: ConnectionTrait>(
         &self,
@@ -772,9 +824,7 @@ impl SbomService {
             .filter_map(|(sbom, node, source_document)| Some((sbom, node?, source_document?)))
             .collect();
 
-        let items = SbomSummary::from_entities(filtered, self, connection)
-            .instrument(info_span!("from_entities"))
-            .await?;
+        let items = SbomSummary::from_entities(filtered, self, false, connection).await?;
 
         Ok(PaginatedResults { items, total })
     }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2668,6 +2668,12 @@ paths:
           type: array
           items:
             type: string
+      - name: advisories
+        in: query
+        description: Include advisory severity summary per SBOM
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: Matching SBOMs
@@ -5550,6 +5556,8 @@ components:
               required:
               - described_by
               properties:
+                advisories:
+                  $ref: '#/components/schemas/RequestedField_HashMap_HashMap'
                 described_by:
                   type: array
                   items:
@@ -5575,6 +5583,8 @@ components:
               required:
               - described_by
               properties:
+                advisories:
+                  $ref: '#/components/schemas/RequestedField_HashMap_HashMap'
                 described_by:
                   type: array
                   items:
@@ -5650,6 +5660,8 @@ components:
               required:
               - described_by
               properties:
+                advisories:
+                  $ref: '#/components/schemas/RequestedField_HashMap_HashMap'
                 described_by:
                   type: array
                   items:
@@ -6095,6 +6107,26 @@ components:
           type: string
           format: date-time
           description: Start of the import run
+    RequestedField_HashMap_HashMap:
+      oneOf:
+      - type: 'null'
+      - type: object
+        additionalProperties:
+          type: integer
+          format: int64
+          minimum: 0
+        propertyNames:
+          type: string
+          description: |-
+            Severity level for affected vulnerabilities, extending the shared `Severity`
+            enum with an `Unknown` variant for vulnerabilities that have no CVSS score.
+          enum:
+          - unknown
+          - none
+          - low
+          - medium
+          - high
+          - critical
     RequestedField_Vec_Vec_ScoredVector:
       oneOf:
       - type: 'null'
@@ -6371,6 +6403,8 @@ components:
         required:
         - described_by
         properties:
+          advisories:
+            $ref: '#/components/schemas/RequestedField_HashMap_HashMap'
           described_by:
             type: array
             items:


### PR DESCRIPTION
## Summary

* Add `?advisories=true` query parameter to `GET /v3/sbom` that includes per-SBOM vulnerability severity counts in the list response
* Eliminates N+1 HTTP request pattern where the UI makes separate `GET /sbom/{id}/advisory` calls (~4s each) for every SBOM row to display severity badges
* Batch SQL query combines both PURL-based (`purl_status` + `version_matches()`) and CPE-based (`product_status` + package name matching) advisory matching into a single query across all listed SBOMs

## Details

New types:
* `AffectedSeverity` enum - extends the shared `Severity` with an `Unknown` variant for vulnerabilities without CVSS scores
* `SbomAdvisorySummary` - `HashMap<AffectedSeverity, u64>` mapping severity to count

Uses the existing `RequestedField<T>` pattern so the field is omitted from the JSON response when not requested, maintaining backward compatibility.

## Test plan

- [ ] Existing SBOM endpoint tests pass (49 tests verified)
- [ ] `GET /v3/sbom` without `?advisories=true` returns response without `advisories` field
- [ ] `GET /v3/sbom?advisories=true` returns severity counts per SBOM
- [ ] Verify severity counts match individual `GET /sbom/{id}/advisory` responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add optional advisory severity summaries to the SBOM list API and optimize related advisory and SBOM listing queries.

New Features:
- Expose an optional `advisories` query parameter on the `/v3/sbom` endpoint to include per-SBOM vulnerability severity counts in list responses.
- Extend SBOM summaries with an advisories field that reports counts of affected vulnerabilities grouped by severity, including an unknown bucket for unscored issues.

Enhancements:
- Batch-load SBOM summaries, described packages, package counts, and advisory data to avoid N+1 queries when listing SBOMs.
- Refine advisory summary construction to prefetch related vulnerabilities, scores, and descriptions in bulk instead of per advisory.
- Add database indexes and join adjustments to speed up SBOM and advisory listing queries, including ordering by SBOM name and advisory ingestion time.
- Instrument read-only transactions and SBOM fetching paths for improved observability.

Documentation:
- Update OpenAPI specification to document the new `advisories` query parameter and advisories field on SBOM summary responses.

Tests:
- Add integration tests covering the `?advisories` parameter behavior, including presence/absence of the field and severity aggregation across multiple SBOMs and advisories.