### PR TITLE
fix: set conventional commit title to the auto generated openapi PR

### DIFF
--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           path: ./trustify-ui
           commit-message: "update client/openapi/trustd.yaml"
-          title: ":seedling: [${{ github.ref_name }}] update client/openapi/trustd.yaml"
+          title: "chore(openapi): [${{ github.ref_name }}] update client/openapi/trustd.yaml"
           body: |
             The openapi.yaml of trustify has changed
         env:


### PR DESCRIPTION
Set conventional commit title to the automatic PR that the backend generates each time there is a change on the openapi spec file

## Summary by Sourcery

Enhancements:
- Align the autogenerated OpenAPI update PR title with the conventional commits format.