### PR TITLE
perf: remove gist indexes on qualified_purl to ensure query planner chooses optimal plan searching for packages

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -63,6 +63,7 @@ mod m0002180_advisory_fk_indexes;
 mod m0002190_vulnerability_base_score_advisory;
 mod m0002200_source_document_ingested_index;
 mod m0002210_sbom_node_name_index;
+mod m0002220_drop_qualified_purl_gist_indexes;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -141,6 +142,7 @@ impl MigratorExt for Migrator {
             .normal(m0002130_sbom_ancestor::Migration)
             .normal(m0002200_source_document_ingested_index::Migration)
             .normal(m0002210_sbom_node_name_index::Migration)
+            .normal(m0002220_drop_qualified_purl_gist_indexes::Migration)
     }
 }
 

--- a/migration/src/m0002220_drop_qualified_purl_gist_indexes.rs
+++ b/migration/src/m0002220_drop_qualified_purl_gist_indexes.rs
@@ -1,0 +1,65 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Drop GiST trigram indexes on qualified_purl that were
+        // accidentally reintroduced by the migration squash (a53ef329).
+        // These were intentionally removed in cab2b594 because the
+        // codebase only uses ILIKE queries, which are served by the
+        // existing GIN trigram indexes on the same columns. The GiST
+        // indexes cause the planner to pick a slower scan path.
+        for idx in GIST_INDEXES {
+            manager
+                .drop_index(
+                    Index::drop()
+                        .if_exists()
+                        .name(*idx)
+                        .table(QualifiedPurl::Table)
+                        .to_owned(),
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for (idx, expr) in GIST_INDEXES.iter().zip(GIST_EXPRS.iter()) {
+            manager
+                .get_connection()
+                .execute_unprepared(&format!(
+                    r#"CREATE INDEX IF NOT EXISTS {idx}
+                       ON qualified_purl
+                       USING GIST (({expr}) gist_trgm_ops)"#,
+                ))
+                .await
+                .map(|_| ())?;
+        }
+
+        Ok(())
+    }
+}
+
+const GIST_INDEXES: &[&str] = &[
+    "qualifiedpurlnamejsongistidx",
+    "qualifiedpurlnamespacejsongistidx",
+    "qualifiedpurltypejsongistidx",
+    "qualifiedpurlversionjsongistidx",
+];
+
+const GIST_EXPRS: &[&str] = &[
+    "purl ->> 'name'",
+    "purl ->> 'namespace'",
+    "purl ->> 'ty'",
+    "purl ->> 'version'",
+];
+
+#[derive(DeriveIden)]
+pub enum QualifiedPurl {
+    Table,
+}


### PR DESCRIPTION
Looking at the underlying endpoints when searching for packages in ux

>http://localhost:8080/api/v3/purl?limit=10&offset=20&q=curl&total=false
>http://localhost:8080/api/v3/purl?limit=10&offset=20&q=curl&total=true

the backing SQL is
```
EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
  SELECT "qualified_purl"."id",
         "qualified_purl"."versioned_purl_id",
         "qualified_purl"."qualifiers",
         "qualified_purl"."purl"
  FROM "qualified_purl"
  WHERE (("qualified_purl"."purl" ->> 'ty') ILIKE '%curl%')
     OR (("qualified_purl"."purl" ->> 'namespace') ILIKE '%curl%')
     OR (("qualified_purl"."purl" ->> 'name') ILIKE '%curl%')
     OR (("qualified_purl"."purl" ->> 'version') ILIKE '%curl%')
     OR (("qualified_purl"."qualifiers" ->> 'arch') ILIKE '%curl%')
     OR (("qualified_purl"."qualifiers" ->> 'distro') ILIKE '%curl%')
     OR (("qualified_purl"."qualifiers" ->> 'repository_url') ILIKE '%curl%')
  ORDER BY "qualified_purl"."purl" ->> 'name' ASC
  LIMIT 10 OFFSET 20;

  +----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                     |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Limit  (cost=1256.25..1256.27 rows=10 width=374) (actual time=449.120..449.126 rows=10 loops=1)                                                                                                                                                                                                                                                                                                                |
|   Buffers: shared hit=107096                                                                                                                                                                                                                                                                                                                                                                                   |
|   ->  Sort  (cost=1256.20..1258.36 rows=864 width=374) (actual time=449.116..449.122 rows=30 loops=1)                                                                                                                                                                                                                                                                                                          |
|         Sort Key: ((purl ->> 'name'::text))                                                                                                                                                                                                                                                                                                                                                                    |
|         Sort Method: top-N heapsort  Memory: 49kB                                                                                                                                                                                                                                                                                                                                                              |
|         Buffers: shared hit=107096                                                                                                                                                                                                                                                                                                                                                                             |
|         ->  Bitmap Heap Scan on qualified_purl  (cost=246.17..1230.68 rows=864 width=374) (actual time=440.698..448.051 rows=3830 loops=1)                                                                                                                                                                                                                                                                     |
|               Recheck Cond: (((purl ->> 'ty'::text) ~~* '%curl%'::text) OR ((purl ->> 'namespace'::text) ~~* '%curl%'::text) OR ((purl ->> 'name'::text) ~~* '%curl%'::text) OR ((purl ->> 'version'::text) ~~* '%curl%'::text) OR ((qualifiers ->> 'arch'::text) ~~* '%curl%'::text) OR ((qualifiers ->> 'distro'::text) ~~* '%curl%'::text) OR ((qualifiers ->> 'repository_url'::text) ~~* '%curl%'::text)) |
|               Heap Blocks: exact=1262                                                                                                                                                                                                                                                                                                                                                                          |
|               Buffers: shared hit=107096                                                                                                                                                                                                                                                                                                                                                                       |
|               ->  BitmapOr  (cost=246.17..246.17 rows=864 width=0) (actual time=440.565..440.568 rows=0 loops=1)                                                                                                                                                                                                                                                                                               |
|                     Buffers: shared hit=105834                                                                                                                                                                                                                                                                                                                                                                 |
|                     ->  Bitmap Index Scan on qualifiedpurltypejsongistidx  (cost=0.00..1.54 rows=3 width=0) (actual time=0.029..0.029 rows=0 loops=1)                                                                                                                                                                                                                                                          |
|                           Index Cond: ((purl ->> 'ty'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                                               |
|                           Buffers: shared hit=5                                                                                                                                                                                                                                                                                                                                                                |
|                     ->  Bitmap Index Scan on qualifiedpurlnamespacejsongistidx  (cost=0.00..3.36 rows=99 width=0) (actual time=70.519..70.519 rows=3 loops=1)                                                                                                                                                                                                                                                  |
|                           Index Cond: ((purl ->> 'namespace'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                                        |
|                           Buffers: shared hit=19224                                                                                                                                                                                                                                                                                                                                                            |
|                     ->  Bitmap Index Scan on qualifiedpurlnamejsongistidx  (cost=0.00..7.34 rows=337 width=0) (actual time=122.515..122.515 rows=3829 loops=1)                                                                                                                                                                                                                                                 |
|                           Index Cond: ((purl ->> 'name'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                                             |
|                           Buffers: shared hit=25346                                                                                                                                                                                                                                                                                                                                                            |
|                     ->  Bitmap Index Scan on qualifiedpurlversionjsongistidx  (cost=0.00..10.78 rows=355 width=0) (actual time=247.446..247.446 rows=25 loops=1)                                                                                                                                                                                                                                               |
|                           Index Cond: ((purl ->> 'version'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                                          |
|                           Buffers: shared hit=61243                                                                                                                                                                                                                                                                                                                                                            |
|                     ->  Bitmap Index Scan on qualifiedpurlqualifierarchjsonginidx  (cost=0.00..136.55 rows=1 width=0) (actual time=0.019..0.019 rows=0 loops=1)                                                                                                                                                                                                                                                |
|                           Index Cond: ((qualifiers ->> 'arch'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                                       |
|                           Buffers: shared hit=5                                                                                                                                                                                                                                                                                                                                                                |
|                     ->  Bitmap Index Scan on qualifiedpurlqualifierdistrojsonginidx  (cost=0.00..67.94 rows=1 width=0) (actual time=0.005..0.005 rows=0 loops=1)                                                                                                                                                                                                                                               |
|                           Index Cond: ((qualifiers ->> 'distro'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                                     |
|                           Buffers: shared hit=5                                                                                                                                                                                                                                                                                                                                                                |
|                     ->  Bitmap Index Scan on qualifiedpurlqualifierrepositoryurljsonginidx  (cost=0.00..17.15 rows=71 width=0) (actual time=0.028..0.028 rows=0 loops=1)                                                                                                                                                                                                                                       |
|                           Index Cond: ((qualifiers ->> 'repository_url'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                             |
|                           Buffers: shared hit=6                                                                                                                                                                                                                                                                                                                                                                |
| Planning:                                                                                                                                                                                                                                                                                                                                                                                                      |
|   Buffers: shared hit=78                                                                                                                                                                                                                                                                                                                                                                                       |
| Planning Time: 0.965 ms                                                                                                                                                                                                                                                                                                                                                                                        |
| Execution Time: 449.182 ms 
```
which is using GIST indexes ... which are terrible performance ...  removing GIST indexes the query planner uses the much better GIN indexes.

```
EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
 SELECT "qualified_purl"."id",
        "qualified_purl"."versioned_purl_id",
        "qualified_purl"."qualifiers",
        "qualified_purl"."purl"
 FROM "qualified_purl"
 WHERE (("qualified_purl"."purl" ->> 'ty') ILIKE '%curl%')
    OR (("qualified_purl"."purl" ->> 'namespace') ILIKE '%curl%')
    OR (("qualified_purl"."purl" ->> 'name') ILIKE '%curl%')
    OR (("qualified_purl"."purl" ->> 'version') ILIKE '%curl%')
    OR (("qualified_purl"."qualifiers" ->> 'arch') ILIKE '%curl%')
    OR (("qualified_purl"."qualifiers" ->> 'distro') ILIKE '%curl%')
    OR (("qualified_purl"."qualifiers" ->> 'repository_url') ILIKE '%curl%')
 ORDER BY "qualified_purl"."purl" ->> 'name' ASC
 LIMIT 10 OFFSET 20;

+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                     |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Limit  (cost=1378.50..1378.52 rows=10 width=373) (actual time=23.070..23.076 rows=10 loops=1)                                                                                                                                                                                                                                                                                                                  |
|   Buffers: shared hit=1307 read=18                                                                                                                                                                                                                                                                                                                                                                             |
|   I/O Timings: shared read=13.755                                                                                                                                                                                                                                                                                                                                                                              |
|   ->  Sort  (cost=1378.45..1380.60 rows=862 width=373) (actual time=23.067..23.072 rows=30 loops=1)                                                                                                                                                                                                                                                                                                            |
|         Sort Key: ((purl ->> 'name'::text))                                                                                                                                                                                                                                                                                                                                                                    |
|         Sort Method: top-N heapsort  Memory: 49kB                                                                                                                                                                                                                                                                                                                                                              |
|         Buffers: shared hit=1307 read=18                                                                                                                                                                                                                                                                                                                                                                       |
|         I/O Timings: shared read=13.755                                                                                                                                                                                                                                                                                                                                                                        |
|         ->  Bitmap Heap Scan on qualified_purl  (cost=370.76..1352.99 rows=862 width=373) (actual time=14.620..22.000 rows=3830 loops=1)                                                                                                                                                                                                                                                                       |
|               Recheck Cond: (((purl ->> 'ty'::text) ~~* '%curl%'::text) OR ((purl ->> 'namespace'::text) ~~* '%curl%'::text) OR ((purl ->> 'name'::text) ~~* '%curl%'::text) OR ((purl ->> 'version'::text) ~~* '%curl%'::text) OR ((qualifiers ->> 'arch'::text) ~~* '%curl%'::text) OR ((qualifiers ->> 'distro'::text) ~~* '%curl%'::text) OR ((qualifiers ->> 'repository_url'::text) ~~* '%curl%'::text)) |
|               Heap Blocks: exact=1262                                                                                                                                                                                                                                                                                                                                                                          |
|               Buffers: shared hit=1307 read=18                                                                                                                                                                                                                                                                                                                                                                 |
|               I/O Timings: shared read=13.755                                                                                                                                                                                                                                                                                                                                                                  |
|               ->  BitmapOr  (cost=370.76..370.76 rows=862 width=0) (actual time=14.491..14.495 rows=0 loops=1)                                                                                                                                                                                                                                                                                                 |
|                     Buffers: shared hit=45 read=18                                                                                                                                                                                                                                                                                                                                                             |
|                     I/O Timings: shared read=13.755                                                                                                                                                                                                                                                                                                                                                            |
|                     ->  Bitmap Index Scan on qualifiedpurlpurltyjsonginidx  (cost=0.00..96.15 rows=5 width=0) (actual time=3.011..3.011 rows=0 loops=1)                                                                                                                                                                                                                                                        |
|                           Index Cond: ((purl ->> 'ty'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                                               |
|                           Buffers: shared hit=2 read=3                                                                                                                                                                                                                                                                                                                                                         |
|                           I/O Timings: shared read=2.976                                                                                                                                                                                                                                                                                                                                                       |
|                     ->  Bitmap Index Scan on qualifiedpurlpurlnamespacejsonginidx  (cost=0.00..13.89 rows=99 width=0) (actual time=7.183..7.183 rows=3 loops=1)                                                                                                                                                                                                                                                |
|                           Index Cond: ((purl ->> 'namespace'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                                        |
|                           Buffers: shared hit=5 read=10                                                                                                                                                                                                                                                                                                                                                        |
|                           I/O Timings: shared read=7.076                                                                                                                                                                                                                                                                                                                                                       |
|                     ->  Bitmap Index Scan on qualifiedpurlpurlnamejsonginidx  (cost=0.00..13.85 rows=337 width=0) (actual time=0.536..0.536 rows=3829 loops=1)                                                                                                                                                                                                                                                 |
|                           Index Cond: ((purl ->> 'name'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                                             |
|                           Buffers: shared hit=20                                                                                                                                                                                                                                                                                                                                                               |
|                     ->  Bitmap Index Scan on qualifiedpurlpurlversionjsonginidx  (cost=0.00..23.73 rows=353 width=0) (actual time=3.719..3.720 rows=25 loops=1)                                                                                                                                                                                                                                                |
|                           Index Cond: ((purl ->> 'version'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                                          |
|                           Buffers: shared hit=2 read=5                                                                                                                                                                                                                                                                                                                                                         |
|                           I/O Timings: shared read=3.702                                                                                                                                                                                                                                                                                                                                                       |
|                     ->  Bitmap Index Scan on qualifiedpurlqualifierarchjsonginidx  (cost=0.00..136.55 rows=1 width=0) (actual time=0.008..0.008 rows=0 loops=1)                                                                                                                                                                                                                                                |
|                           Index Cond: ((qualifiers ->> 'arch'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                                       |
|                           Buffers: shared hit=5                                                                                                                                                                                                                                                                                                                                                                |
|                     ->  Bitmap Index Scan on qualifiedpurlqualifierdistrojsonginidx  (cost=0.00..67.94 rows=1 width=0) (actual time=0.005..0.005 rows=0 loops=1)                                                                                                                                                                                                                                               |
|                           Index Cond: ((qualifiers ->> 'distro'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                                     |
|                           Buffers: shared hit=5                                                                                                                                                                                                                                                                                                                                                                |
|                     ->  Bitmap Index Scan on qualifiedpurlqualifierrepositoryurljsonginidx  (cost=0.00..17.14 rows=67 width=0) (actual time=0.026..0.026 rows=0 loops=1)                                                                                                                                                                                                                                       |
|                           Index Cond: ((qualifiers ->> 'repository_url'::text) ~~* '%curl%'::text)                                                                                                                                                                                                                                                                                                             |
|                           Buffers: shared hit=6                                                                                                                                                                                                                                                                                                                                                                |
| Planning:                                                                                                                                                                                                                                                                                                                                                                                                      |
|   Buffers: shared hit=199                                                                                                                                                                                                                                                                                                                                                                                      |
| Planning Time: 1.223 ms                                                                                                                                                                                                                                                                                                                                                                                        |
| Execution Time: 23.130 ms                                                                                                                                                                                                                                                                                                                                                                                      |
+-----------------------------
```

There is no where in the codebase anymore that uses GIST indexes which also saves us at ingestion time and drops 1+GB of indexes (no longer needed).

On large dataset

**before**
<img width="1090" height="309" alt="image" src="https://github.com/user-attachments/assets/ddfafb7e-c1bc-4519-8a71-fc3780fa4344" />
**after**
<img width="1090" height="289" alt="image" src="https://github.com/user-attachments/assets/6b78f190-81e1-421e-b7d3-03cfc6ad0211" />


fixes TC-5026