### PR TITLE
chore: add cache hit/miss instrumentation to pagination total cache

### DIFF
--- a/common/src/db/pagination_cache.rs
+++ b/common/src/db/pagination_cache.rs
@@ -2,6 +2,7 @@ use actix_web::{HttpResponse, ResponseError, body::BoxBody};
 use moka::future::Cache;
 use opentelemetry::{global, metrics::Counter};
 use std::{sync::Arc, time::Duration};
+use tracing::instrument;
 
 use crate::error::ErrorInformation;
 
@@ -57,6 +58,7 @@ impl PaginationCache {
     }
 
     /// Return a cached total count, computing it at most once for concurrent requests with the same key.
+    #[instrument(skip(self, compute), fields(cache_hit = true))]
     pub async fn cached_total(
         &self,
         key: String,
@@ -67,6 +69,7 @@ impl PaginationCache {
         self.cache
             .try_get_with(key, async {
                 misses.add(1, &[]);
+                tracing::Span::current().record("cache_hit", false);
                 compute().await
             })
             .await


### PR DESCRIPTION
## Summary

* Add `#[instrument]` to `PaginationCache::cached_total` with the cache key and a `cache_hit` field
* Defaults to `cache_hit = true`; the init closure sets it to `false` when actually called (cache miss)
* Helps diagnose whether the pagination total cache is working as expected

## Test plan

- [ ] Verify `cache_hit` field appears in traces for paginated list endpoints
- [ ] Confirm first request shows `cache_hit=false`, subsequent identical requests show `cache_hit=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Add tracing instrumentation to pagination total cache lookups, including a cache_hit field that distinguishes between cache hits and misses.