### PR TITLE
perf: fix /perf-test CI job

### DIFF
--- a/.github/workflows/perf-test.yaml
+++ b/.github/workflows/perf-test.yaml
@@ -63,7 +63,13 @@ jobs:
         with:
           ref: ${{ steps.pr.outputs.sha }}
 
-      - uses: ./.github/actions/setup-rust
+      # Inlined from .github/actions/setup-rust (can't use local actions
+      # with issue_comment trigger — they resolve before checkout runs).
+      # Keep toolchain version in sync with .github/actions/setup-rust/action.yaml
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+          cache: false
       - uses: Swatinem/rust-cache@v2
 
       - name: Setup cargo-binstall


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Switch perf-test workflow from a local Rust setup action to actions-rust-lang/setup-rust-toolchain@v1 with Rust toolchain 1.96.0 and caching disabled.