### PR TITLE
ci: upgrade ubuntu to 22.04

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -51,11 +51,11 @@ jobs:
 
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             install: |
               sudo apt install -y libssl-dev
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
             install: |
               sudo apt install -y libssl-dev
 


### PR DESCRIPTION
This is required due to OpenSSL being
too old on the Ubuntu runner image.

This should fix the "latest container" build.

## Summary by Sourcery

Upgrade Linux build job environments in the binary build workflow to use Ubuntu 24.04 images to address OpenSSL compatibility issues.

Bug Fixes:
- Update CI build matrix to use newer Ubuntu images to resolve OpenSSL-related build failures.

Build:
- Switch Linux build jobs from ubuntu-22.04/ubuntu-22.04-arm to ubuntu-24.04/ubuntu-24.04-arm in the GitHub Actions workflow.