### PR TITLE
perf: add oidc auth to /perf-tool and some more tests

### DIFF
--- a/.github/workflows/perf-test.yaml
+++ b/.github/workflows/perf-test.yaml
@@ -142,11 +142,13 @@ jobs:
       - name: Run perf tests
         working-directory: tools/perf
         env:
-          TOOLS_PERF_SCENARIO_FILE: etc/scenarios/empty.json5
+          TOOLS_PERF_SCENARIO_FILE: etc/scenarios/main/full-20260412.json5
+          TOOLS_PERF_WAIT_TIME_FROM: "0"
+          TOOLS_PERF_WAIT_TIME_TO: "0"
         run: |
           uv run locust \
             --host http://localhost:8080 \
-            -u 10 -r 2 -t 5m \
+            -u 10 -r 2 -t 10m \
             --headless \
             --html=report.html \
             --csv=results

--- a/tools/perf/README.md
+++ b/tools/perf/README.md
@@ -9,6 +9,7 @@ coverage from [trustify-scale-testing](https://github.com/guacsec/trustify-scale
 - Python 3.13+
 - [uv](https://docs.astral.sh/uv/)
 - A running trustify instance
+- OIDC credentials (unless running with `AUTH_DISABLED=true`)
 
 ## Quickstart (Makefile)
 
@@ -165,6 +166,39 @@ uv run locust --host http://localhost:8080 -u 10 --tags sbom detail
 uv run locust --host http://localhost:8080 -u 10 --exclude-tags slow labels
 ```
 
+## Authentication (OIDC)
+
+By default, the perf tool authenticates against the trustify instance using
+OIDC client credentials. Set the following environment variables:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ISSUER_URL` | Yes | -- | OIDC issuer URL (e.g. `https://sso.example.com/realms/trustify`) |
+| `CLIENT_ID` | Yes | -- | OAuth2 client ID |
+| `CLIENT_SECRET` | Yes | -- | OAuth2 client secret |
+| `OIDC_REFRESH_BEFORE` | No | `30` | Seconds before token expiry to proactively refresh |
+| `AUTH_DISABLED` | No | `false` | Set to `true` to skip OIDC and run unauthenticated |
+
+The tool performs OIDC discovery (`/.well-known/openid-configuration`),
+acquires a token via the `client_credentials` grant, and injects it as
+`Authorization: Bearer <token>` on every request. Tokens are cached and
+refreshed automatically before expiry.
+
+### Authenticated run
+
+```bash
+export ISSUER_URL=https://sso.example.com/realms/trustify
+export CLIENT_ID=testing
+export CLIENT_SECRET=s3cret
+make test HOST=https://trustify.example.com
+```
+
+### Unauthenticated run (local dev)
+
+```bash
+AUTH_DISABLED=true make test
+```
+
 ## Environment variables
 
 | Variable | Default | Description |
@@ -173,6 +207,11 @@ uv run locust --host http://localhost:8080 -u 10 --exclude-tags slow labels
 | `TOOLS_PERF_WAIT_TIME_FROM` | `1` | Min seconds between requests per user |
 | `TOOLS_PERF_WAIT_TIME_TO` | `3` | Max seconds between requests per user |
 | `TOOLS_PERF_SCENARIO_FILE` | (unset) | Path to a JSON5 scenario file with pre-computed IDs |
+| `ISSUER_URL` | (unset) | OIDC issuer URL |
+| `CLIENT_ID` | (unset) | OAuth2 client ID |
+| `CLIENT_SECRET` | (unset) | OAuth2 client secret |
+| `OIDC_REFRESH_BEFORE` | `30` | Seconds before token expiry to refresh |
+| `AUTH_DISABLED` | `false` | Set to `true` to skip OIDC auth |
 
 Set both wait time variables to `0` for max throughput (no delay between requests).
 
@@ -273,10 +312,11 @@ version-agnostic):
 ```python
 # users/v3/my_feature.py
 
-from locust import HttpUser, tag, task
+from locust import tag, task
 from config import WAIT_TIME
+from users.base import AuthenticatedHttpUser
 
-class MyFeatureUserV3(HttpUser):
+class MyFeatureUserV3(AuthenticatedHttpUser):
     weight = 2
     wait_time = WAIT_TIME
 
@@ -348,6 +388,7 @@ def validated_get(self) -> None:
 tools/perf/
 ├── pyproject.toml      # Dependencies (locust, json5)
 ├── locustfile.py       # Entry point -- API version dispatch
+├── auth.py             # OIDC token provider (client_credentials)
 ├── config.py           # Shared wait time configuration
 ├── scenario.py         # Scenario data loader (JSON5)
 ├── etc/
@@ -364,6 +405,7 @@ tools/perf/
 │               └── full-20260412_qe_atlas.json5 # QE Atlas analysis-only
 └── users/
     ├── __init__.py
+    ├── base.py              # AuthenticatedHttpUser (OIDC base class)
     ├── website.py           # WebsiteUser (version-agnostic)
     ├── v3/
     │   ├── __init__.py

--- a/tools/perf/auth.py
+++ b/tools/perf/auth.py
@@ -1,0 +1,136 @@
+"""OIDC token provider for authenticated load testing.
+
+Performs OpenID Connect discovery and acquires tokens via the OAuth2
+client_credentials grant.  Tokens are cached and refreshed proactively
+before expiry.
+
+Environment variables
+---------------------
+ISSUER_URL          OIDC issuer URL (required unless AUTH_DISABLED=true).
+CLIENT_ID           OAuth2 client ID (required unless AUTH_DISABLED=true).
+CLIENT_SECRET       OAuth2 client secret (required unless AUTH_DISABLED=true).
+OIDC_REFRESH_BEFORE Seconds before expiry to refresh (default: 30).
+AUTH_DISABLED        Set to "true" or "1" to skip authentication entirely.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+
+import requests as _requests
+
+logger = logging.getLogger(__name__)
+
+_AUTH_DISABLED = os.environ.get("AUTH_DISABLED", "").lower() in ("true", "1")
+_REFRESH_BEFORE = int(os.environ.get("OIDC_REFRESH_BEFORE", "30"))
+
+
+def is_auth_disabled() -> bool:
+    """Return True when authentication is disabled."""
+    return _AUTH_DISABLED
+
+
+class OidcTokenProvider:
+    """Acquires and caches OIDC tokens using the client_credentials grant."""
+
+    def __init__(
+        self,
+        issuer_url: str,
+        client_id: str,
+        client_secret: str,
+        refresh_before: int = _REFRESH_BEFORE,
+    ) -> None:
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._refresh_before = refresh_before
+        self._token: str | None = None
+        self._expires_at: float = 0.0
+        self._lock = threading.Lock()
+        self._token_endpoint = self._discover_token_endpoint(issuer_url)
+
+    def _discover_token_endpoint(self, issuer_url: str) -> str:
+        """Fetch the OIDC discovery document and extract the token endpoint."""
+        url = issuer_url.rstrip("/") + "/.well-known/openid-configuration"
+        logger.info("OIDC discovery: %s", url)
+        resp = _requests.get(url, timeout=30)
+        resp.raise_for_status()
+        endpoint = resp.json().get("token_endpoint")
+        if not endpoint:
+            msg = (
+                f"No 'token_endpoint' in OIDC discovery document at {url}"
+            )
+            raise ValueError(msg)
+        logger.info("OIDC token endpoint: %s", endpoint)
+        return endpoint
+
+    def _fetch_token(self) -> None:
+        """Request a new token using the client_credentials grant."""
+        logger.debug("Requesting new OIDC token via client_credentials")
+        resp = _requests.post(
+            self._token_endpoint,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": self._client_id,
+                "client_secret": self._client_secret,
+            },
+            timeout=30,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        self._token = body["access_token"]
+        expires_in = body.get("expires_in", 300)
+        self._expires_at = time.monotonic() + expires_in
+        logger.info(
+            "OIDC token acquired (expires_in=%ds, refresh_before=%ds)",
+            expires_in,
+            self._refresh_before,
+        )
+
+    def _needs_refresh(self) -> bool:
+        if self._token is None:
+            return True
+        return time.monotonic() >= (self._expires_at - self._refresh_before)
+
+    def get_token(self) -> str:
+        """Return a valid access token, refreshing if necessary."""
+        if not self._needs_refresh():
+            return self._token  # type: ignore[return-value]
+
+        with self._lock:
+            if self._needs_refresh():
+                self._fetch_token()
+            return self._token  # type: ignore[return-value]
+
+
+def create_provider() -> OidcTokenProvider:
+    """Build an OidcTokenProvider from environment variables.
+
+    Raises ValueError if required env vars are missing.
+    """
+    issuer_url = os.environ.get("ISSUER_URL", "")
+    client_id = os.environ.get("CLIENT_ID", "")
+    client_secret = os.environ.get("CLIENT_SECRET", "")
+
+    missing = []
+    if not issuer_url:
+        missing.append("ISSUER_URL")
+    if not client_id:
+        missing.append("CLIENT_ID")
+    if not client_secret:
+        missing.append("CLIENT_SECRET")
+    if missing:
+        msg = (
+            "OIDC authentication is enabled but the following "
+            f"environment variables are missing: {', '.join(missing)}. "
+            "Set them or disable auth with AUTH_DISABLED=true."
+        )
+        raise ValueError(msg)
+
+    return OidcTokenProvider(
+        issuer_url=issuer_url,
+        client_id=client_id,
+        client_secret=client_secret,
+    )

--- a/tools/perf/etc/scenarios/empty.json5
+++ b/tools/perf/etc/scenarios/empty.json5
@@ -3,6 +3,7 @@
 {
   "get_sbom": null,
   "get_sbom_advisories": null,
+  "get_sbom_advisories_by_uuid": null,
   "get_sbom_packages": null,
   "get_sbom_related": null,
   "get_vulnerability": null,

--- a/tools/perf/etc/scenarios/main/full-20250323.json5
+++ b/tools/perf/etc/scenarios/main/full-20250323.json5
@@ -2,6 +2,7 @@
   // RHOSE-4.14 seems to be the biggest (by packages)
   "get_sbom": "sha256:f293eb898192085804419f9dd40a738f20d67dd81846e88c6720f692ec5f3081",
   "get_sbom_advisories": "sha256:f293eb898192085804419f9dd40a738f20d67dd81846e88c6720f692ec5f3081",
+  "get_sbom_advisories_by_uuid": null,
   "get_sbom_packages": "0195baea-42e3-7842-a0e3-4c7874263954",
   "get_sbom_related": "0195baea-42e3-7842-a0e3-4c7874263954",
   "get_vulnerability": "CVE-2023-39325",

--- a/tools/perf/etc/scenarios/main/full-20250604.json5
+++ b/tools/perf/etc/scenarios/main/full-20250604.json5
@@ -2,6 +2,7 @@
   // RHOSE-4.14 seems to be the biggest (by packages)
   "get_sbom": "sha256:720e4451b0c13f028e55e48b9d522fee8a20124b41379c99a939656247164447",
   "get_sbom_advisories": "sha256:720e4451b0c13f028e55e48b9d522fee8a20124b41379c99a939656247164447",
+  "get_sbom_advisories_by_uuid": null,
   "get_sbom_packages": "01973124-d4ab-7163-b104-331632a21144",
   "get_sbom_related": "01973124-d4ab-7163-b104-331632a21144",
   "get_vulnerability": "CVE-2023-39325",

--- a/tools/perf/etc/scenarios/main/full-20260317T023702Z.json5
+++ b/tools/perf/etc/scenarios/main/full-20260317T023702Z.json5
@@ -2,6 +2,7 @@
   "get_sbom": "sha256:a04260d90fbbbc5f4e1f25754bbfa46771140c06c2bc351ea6046a828fcd17e5",
   // FIXME: "get_sbom_advisories": "sha256:a04260d90fbbbc5f4e1f25754bbfa46771140c06c2bc351ea6046a828fcd17e5",
   "get_sbom_advisories": null,
+  "get_sbom_advisories_by_uuid": null,
   // "get_sbom_packages": null,
   "get_sbom_packages": "urn:uuid:019cf03d-89b1-7aa1-876e-43a3bfd8a2f5",
   // "get_sbom_related": null,

--- a/tools/perf/etc/scenarios/main/full-20260412.json5
+++ b/tools/perf/etc/scenarios/main/full-20260412.json5
@@ -1,6 +1,7 @@
 {
   "get_sbom": "sha256:b42cf13f3318f5293a41bf0dc0cb9ec1333fde8b0d3f4bb79a6ed3916d3b06d6",
   "get_sbom_advisories": "sha256:b42cf13f3318f5293a41bf0dc0cb9ec1333fde8b0d3f4bb79a6ed3916d3b06d6",
+  "get_sbom_advisories_by_uuid": "019cbe1f-fdf6-7131-8169-19f37b0cfa63",
   "get_sbom_packages": "019a4555-a1ae-7830-85aa-bc505cdd1de8",
   "get_sbom_related": "019a4555-a1ae-7830-85aa-bc505cdd1de8",
   "get_vulnerability": "CVE-2023-39325",

--- a/tools/perf/etc/scenarios/main/full-20260412.json5
+++ b/tools/perf/etc/scenarios/main/full-20260412.json5
@@ -149,7 +149,9 @@
   "get_organization": "9410ac75-c8fb-483b-ae03-f8c26732d7fc",
   "get_base_purl": "pkg:maven/io.quarkus/quarkus-smallrye-fault-tolerance-deployment",
   "get_analysis_component": [
-    "stratisd", "sankit", "nbdkit", "tang", "clevis", "libqb"
+    "stratisd", "sankit", "nbdkit", "tang", "clevis", "libqb",
+    "pkg:oci/quay-builder-qemu-rhcos-rhel8", "pkg:pypi/pypdf", "pkg:pypi/requests", "pkg:rpm/redhat/libsoup", "pkg:rpm/redhat/harfbuzz", "pkg:rpm/redhat/python-setuptools", "pkg:maven/com.fasterxml.jackson.core/jackson-databind", "pkg:golang/crypto/x509", "pkg:golang/k8s.io/api",
+    "glibc", "openssl", "bash", "coreutils", "systemd", "kernel", "zlib"
   ],
   "render_sbom_graph": "urn:uuid:019a4555-a1ae-7830-85aa-bc505cdd1de8",
   "get_importer": null,

--- a/tools/perf/etc/scenarios/releases/0.4.z/full-20260412_atlas.json5
+++ b/tools/perf/etc/scenarios/releases/0.4.z/full-20260412_atlas.json5
@@ -1,6 +1,7 @@
 {
   "get_sbom": null,
   "get_sbom_advisories": null,
+  "get_sbom_advisories_by_uuid": null,
   "get_sbom_packages": null,
   "get_sbom_related": null,
   "get_vulnerability": null,

--- a/tools/perf/etc/scenarios/releases/0.4.z/full-20260412_qe_atlas.json5
+++ b/tools/perf/etc/scenarios/releases/0.4.z/full-20260412_qe_atlas.json5
@@ -1,6 +1,7 @@
 {
   "get_sbom": null,
   "get_sbom_advisories": null,
+  "get_sbom_advisories_by_uuid": null,
   "get_sbom_packages": null,
   "get_sbom_related": null,
   "get_vulnerability": null,

--- a/tools/perf/locustfile.py
+++ b/tools/perf/locustfile.py
@@ -29,7 +29,13 @@ Environment variables:
     TOOLS_PERF_SCENARIO_FILE   Path to a JSON5 scenario file with pre-computed IDs.
                                If unset, scenario-dependent tests are skipped.
 
-See scenario.py and the users/ modules for details.
+    ISSUER_URL                 OIDC issuer URL (required unless AUTH_DISABLED).
+    CLIENT_ID                  OAuth2 client ID (required unless AUTH_DISABLED).
+    CLIENT_SECRET              OAuth2 client secret (required unless AUTH_DISABLED).
+    OIDC_REFRESH_BEFORE        Seconds before expiry to refresh token (default: 30).
+    AUTH_DISABLED              Set to "true" or "1" to skip OIDC auth.
+
+See auth.py, scenario.py, and the users/ modules for details.
 """
 
 import os

--- a/tools/perf/pyproject.toml
+++ b/tools/perf/pyproject.toml
@@ -16,5 +16,6 @@ build-backend = "hatchling.build"
 packages = ["users"]
 
 [tool.hatch.build.targets.wheel.force-include]
+"auth.py" = "auth.py"
 "config.py" = "config.py"
 "scenario.py" = "scenario.py"

--- a/tools/perf/scenario.py
+++ b/tools/perf/scenario.py
@@ -40,6 +40,7 @@ class Scenario:
 
     get_sbom: str | None = None
     get_sbom_advisories: str | None = None
+    get_sbom_advisories_by_uuid: str | None = None
     get_sbom_packages: str | None = None
     get_sbom_related: str | None = None
     get_vulnerability: str | None = None

--- a/tools/perf/users/base.py
+++ b/tools/perf/users/base.py
@@ -1,0 +1,46 @@
+"""Base user class with optional OIDC authentication.
+
+All user classes should extend AuthenticatedHttpUser instead of
+HttpUser directly.  When AUTH_DISABLED is not set (or false), the
+OIDC token is acquired on_start and set as the default Authorization
+header on the requests session.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from locust import HttpUser
+
+from auth import create_provider, is_auth_disabled, OidcTokenProvider
+
+logger = logging.getLogger(__name__)
+
+_provider: OidcTokenProvider | None = None
+
+
+def _get_provider() -> OidcTokenProvider:
+    """Lazily create and cache the singleton OIDC token provider."""
+    global _provider  # noqa: PLW0603
+    if _provider is None:
+        _provider = create_provider()
+    return _provider
+
+
+class AuthenticatedHttpUser(HttpUser):
+    """HttpUser subclass that injects an OIDC Bearer token on startup.
+
+    When AUTH_DISABLED=true, behaves identically to plain HttpUser.
+    """
+
+    abstract = True
+
+    def on_start(self) -> None:
+        if is_auth_disabled():
+            logger.debug("Auth disabled -- skipping OIDC token")
+            return
+
+        provider = _get_provider()
+        token = provider.get_token()
+        self.client.headers["Authorization"] = f"Bearer {token}"
+        logger.info("OIDC Bearer token set for user %s", type(self).__name__)

--- a/tools/perf/users/v2/analysis.py
+++ b/tools/perf/users/v2/analysis.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import random
 from urllib.parse import quote
 
-from locust import HttpUser, tag, task
+from locust import tag, task
 from config import WAIT_TIME
+from users.base import AuthenticatedHttpUser
 
 from scenario import SCENARIO
 
@@ -19,7 +20,7 @@ from scenario import SCENARIO
 # not exist in v2, so there is no equivalent task here.
 
 
-class AnalysisUserV2(HttpUser):
+class AnalysisUserV2(AuthenticatedHttpUser):
     """Exercises trustify v2 analysis and graph endpoints."""
 
     weight = 1

--- a/tools/perf/users/v2/rest_api.py
+++ b/tools/perf/users/v2/rest_api.py
@@ -79,6 +79,14 @@ class RestAPIUserV2(AuthenticatedHttpUser):
 
     @tag("v2", "advisory", "list")
     @task
+    def list_advisory_sorted_ingested(self) -> None:
+        self.client.get(
+            "/api/v2/advisory?limit=10&offset=0&sort=ingested:desc&q=",
+            name="/api/v2/advisory?limit=10&sort=ingested:desc",
+        )
+
+    @tag("v2", "advisory", "list")
+    @task
     def list_advisory_deprecated(self) -> None:
         self.client.get(
             "/api/v2/advisory?deprecated=Consider",
@@ -176,6 +184,14 @@ class RestAPIUserV2(AuthenticatedHttpUser):
 
     @tag("v2", "sbom", "list")
     @task
+    def list_sbom_sorted_name(self) -> None:
+        self.client.get(
+            "/api/v2/sbom?limit=10&offset=0&sort=name:asc&q=",
+            name="/api/v2/sbom?limit=10&sort=name:asc",
+        )
+
+    @tag("v2", "sbom", "list")
+    @task
     def list_sbom_by_label(self) -> None:
         self.client.get(
             "/api/v2/sbom?q=label:type=product",
@@ -188,6 +204,14 @@ class RestAPIUserV2(AuthenticatedHttpUser):
         self.client.get(
             "/api/v2/sbom-labels",
             name="/api/v2/sbom-labels",
+        )
+
+    @tag("v2", "sbom", "list")
+    @task
+    def list_sbom_labels_filtered(self) -> None:
+        self.client.get(
+            "/api/v2/sbom-labels?limit=10&filter_text=",
+            name="/api/v2/sbom-labels?limit=10&filter_text=",
         )
 
     # -- PURL list endpoints --------------------------------------------
@@ -330,6 +354,22 @@ class RestAPIUserV2(AuthenticatedHttpUser):
 
     @tag("v2", "license", "list")
     @task
+    def list_license(self) -> None:
+        self.client.get(
+            "/api/v2/license",
+            name="/api/v2/license",
+        )
+
+    @tag("v2", "license", "list")
+    @task
+    def list_license_sorted(self) -> None:
+        self.client.get(
+            "/api/v2/license?limit=10&offset=0&q=&sort=license:asc",
+            name="/api/v2/license?limit=10&sort=license:asc",
+        )
+
+    @tag("v2", "license", "list")
+    @task
     def list_spdx_license(self) -> None:
         self.client.get(
             "/api/v2/license/spdx/license",
@@ -420,6 +460,20 @@ class RestAPIUserV2(AuthenticatedHttpUser):
         with self.client.get(
             f"/api/v2/sbom/{quote(key, safe='')}/advisory",
             name=f"v2/get_sbom_advisories[{key[:16]}...]",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code != 200:
+                resp.failure(f"status {resp.status_code}")
+
+    @tag("v2", "sbom", "detail")
+    @task
+    def get_sbom_advisories_by_uuid(self) -> None:
+        if not SCENARIO.get_sbom_advisories_by_uuid:
+            return
+        uid = SCENARIO.get_sbom_advisories_by_uuid
+        with self.client.get(
+            f"/api/v2/sbom/urn%3Auuid%3A{uid}/advisory",
+            name=f"v2/get_sbom_advisories_by_uuid[{uid[:12]}...]",
             catch_response=True,
         ) as resp:
             if resp.status_code != 200:

--- a/tools/perf/users/v2/rest_api.py
+++ b/tools/perf/users/v2/rest_api.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 from urllib.parse import quote
 
-from locust import HttpUser, tag, task
+from locust import tag, task
 from config import WAIT_TIME
+from users.base import AuthenticatedHttpUser
 
 from scenario import SCENARIO
 
 
-class RestAPIUserV2(HttpUser):
+class RestAPIUserV2(AuthenticatedHttpUser):
     """Exercises the trustify v2 REST API with realistic query patterns."""
 
     weight = 10

--- a/tools/perf/users/v2/rest_api_slow.py
+++ b/tools/perf/users/v2/rest_api_slow.py
@@ -6,11 +6,12 @@ sets, producing heavier database load.
 
 from __future__ import annotations
 
-from locust import HttpUser, tag, task
+from locust import tag, task
 from config import WAIT_TIME
+from users.base import AuthenticatedHttpUser
 
 
-class RestAPIUserSlowV2(HttpUser):
+class RestAPIUserSlowV2(AuthenticatedHttpUser):
     """Slow license-related queries against the trustify v2 REST API."""
 
     weight = 1

--- a/tools/perf/users/v3/analysis.py
+++ b/tools/perf/users/v3/analysis.py
@@ -10,15 +10,16 @@ from __future__ import annotations
 import itertools
 from urllib.parse import quote
 
-from locust import HttpUser, tag, task
+from locust import tag, task
 from config import WAIT_TIME
+from users.base import AuthenticatedHttpUser
 
 from scenario import SCENARIO
 
 _HARDCODED_CPE = "cpe:/a:redhat:openshift_container_platform:4.17::el9"
 
 
-class AnalysisUserV3(HttpUser):
+class AnalysisUserV3(AuthenticatedHttpUser):
     """Exercises trustify v3 analysis and graph endpoints."""
 
     weight = 2

--- a/tools/perf/users/v3/analysis.py
+++ b/tools/perf/users/v3/analysis.py
@@ -22,7 +22,7 @@ _HARDCODED_CPE = "cpe:/a:redhat:openshift_container_platform:4.17::el9"
 class AnalysisUserV3(AuthenticatedHttpUser):
     """Exercises trustify v3 analysis and graph endpoints."""
 
-    weight = 2
+    weight = 3
     wait_time = WAIT_TIME
     _component_cycle = itertools.cycle(
         SCENARIO.get_analysis_component

--- a/tools/perf/users/v3/labels.py
+++ b/tools/perf/users/v3/labels.py
@@ -9,19 +9,21 @@ from __future__ import annotations
 import random
 from urllib.parse import quote
 
-from locust import HttpUser, tag, task
+from locust import tag, task
 from config import WAIT_TIME
+from users.base import AuthenticatedHttpUser
 
 from scenario import SCENARIO
 
 
-class AdvisoryLabelUserV3(HttpUser):
+class AdvisoryLabelUserV3(AuthenticatedHttpUser):
     """Finds random advisories and mutates their v3 labels."""
 
     weight = 2
     wait_time = WAIT_TIME
 
     def on_start(self) -> None:
+        super().on_start()
         self._advisory_uuid: str | None = None
 
     def _find_random_advisory(self) -> str | None:
@@ -101,7 +103,7 @@ class AdvisoryLabelUserV3(HttpUser):
         )
 
 
-class SBOMLabelUserV3(HttpUser):
+class SBOMLabelUserV3(AuthenticatedHttpUser):
     """Mutates SBOM labels using scenario-provided SBOM IDs (v3)."""
 
     weight = 2

--- a/tools/perf/users/v3/rest_api.py
+++ b/tools/perf/users/v3/rest_api.py
@@ -82,6 +82,14 @@ class RestAPIUserV3(AuthenticatedHttpUser):
 
     @tag("v3", "advisory", "list")
     @task
+    def list_advisory_sorted_ingested(self) -> None:
+        self.client.get(
+            "/api/v3/advisory?limit=10&offset=0&sort=ingested:desc&q=&total=true",
+            name="/api/v3/advisory?limit=10&sort=ingested:desc&total=true",
+        )
+
+    @tag("v3", "advisory", "list")
+    @task
     def list_advisory_deprecated(self) -> None:
         self.client.get(
             "/api/v3/advisory?deprecated=Consider&total=true",
@@ -182,6 +190,14 @@ class RestAPIUserV3(AuthenticatedHttpUser):
 
     @tag("v3", "sbom", "list")
     @task
+    def list_sbom_sorted_name(self) -> None:
+        self.client.get(
+            "/api/v3/sbom?limit=10&offset=0&sort=name:asc&q=&total=true",
+            name="/api/v3/sbom?limit=10&sort=name:asc&total=true",
+        )
+
+    @tag("v3", "sbom", "list")
+    @task
     def list_sbom_by_label(self) -> None:
         self.client.get(
             "/api/v3/sbom?q=label:type=product&total=true",
@@ -194,6 +210,14 @@ class RestAPIUserV3(AuthenticatedHttpUser):
         self.client.get(
             "/api/v3/sbom-labels?total=true",
             name="/api/v3/sbom-labels?total=true",
+        )
+
+    @tag("v3", "sbom", "list")
+    @task
+    def list_sbom_labels_filtered(self) -> None:
+        self.client.get(
+            "/api/v3/sbom-labels?limit=10&filter_text=&total=true",
+            name="/api/v3/sbom-labels?limit=10&filter_text=&total=true",
         )
 
     # -- PURL list endpoints --------------------------------------------
@@ -350,6 +374,14 @@ class RestAPIUserV3(AuthenticatedHttpUser):
 
     @tag("v3", "license", "list")
     @task
+    def list_license_sorted(self) -> None:
+        self.client.get(
+            "/api/v3/license?limit=10&offset=0&q=&sort=license:asc&total=true",
+            name="/api/v3/license?limit=10&sort=license:asc&total=true",
+        )
+
+    @tag("v3", "license", "list")
+    @task
     def list_spdx_license(self) -> None:
         self.client.get(
             "/api/v3/license/spdx/license?total=true",
@@ -495,6 +527,20 @@ class RestAPIUserV3(AuthenticatedHttpUser):
         with self.client.get(
             f"/api/v3/sbom/{quote(key, safe='')}/advisory",
             name=f"get_sbom_advisories[{key[:16]}...]",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code != 200:
+                resp.failure(f"status {resp.status_code}")
+
+    @tag("v3", "sbom", "detail")
+    @task
+    def get_sbom_advisories_by_uuid(self) -> None:
+        if not SCENARIO.get_sbom_advisories_by_uuid:
+            return
+        uid = SCENARIO.get_sbom_advisories_by_uuid
+        with self.client.get(
+            f"/api/v3/sbom/urn%3Auuid%3A{uid}/advisory",
+            name=f"get_sbom_advisories_by_uuid[{uid[:12]}...]",
             catch_response=True,
         ) as resp:
             if resp.status_code != 200:

--- a/tools/perf/users/v3/rest_api.py
+++ b/tools/perf/users/v3/rest_api.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 from urllib.parse import quote
 
-from locust import HttpUser, tag, task
+from locust import tag, task
 from config import WAIT_TIME
+from users.base import AuthenticatedHttpUser
 
 from scenario import SCENARIO
 
 
-class RestAPIUserV3(HttpUser):
+class RestAPIUserV3(AuthenticatedHttpUser):
     """Exercises the trustify v3 REST API with realistic query patterns."""
 
     weight = 2

--- a/tools/perf/users/v3/rest_api_slow.py
+++ b/tools/perf/users/v3/rest_api_slow.py
@@ -6,11 +6,12 @@ sets, producing heavier database load.
 
 from __future__ import annotations
 
-from locust import HttpUser, tag, task
+from locust import tag, task
 from config import WAIT_TIME
+from users.base import AuthenticatedHttpUser
 
 
-class RestAPIUserSlowV3(HttpUser):
+class RestAPIUserSlowV3(AuthenticatedHttpUser):
     """Slow license-related queries against the trustify v3 REST API."""
 
     weight = 2

--- a/tools/perf/users/website.py
+++ b/tools/perf/users/website.py
@@ -5,11 +5,12 @@ Hits the main HTML pages a real user would navigate through.
 
 from __future__ import annotations
 
-from locust import HttpUser, tag, task
+from locust import tag, task
 from config import WAIT_TIME
+from users.base import AuthenticatedHttpUser
 
 
-class WebsiteUser(HttpUser):
+class WebsiteUser(AuthenticatedHttpUser):
     """Simulates a user browsing the trustify web UI."""
 
     weight = 1


### PR DESCRIPTION
perf tools should be usable against auth ... (setting **ISSUER_URL**, **CLIENT_ID**, **CLIENT_SECRET**) ... also added some key tests for TC-3742.

_Note - this will require setting of env vars for perf-test CI job once landed into main branch._

## Summary by Sourcery

Introduce optional OIDC-based authentication to the perf tool and update all Locust users to use a shared authenticated base class.

New Features:
- Add OIDC client-credentials token provider and integrate it into perf-tool HTTP users via an AuthenticatedHttpUser base class.
- Support disabling authentication via environment configuration to allow unauthenticated local runs.

Enhancements:
- Document perf-tool authentication behavior and required OIDC-related environment variables, including examples for authenticated and unauthenticated runs.
- Expose new OIDC-related environment variables in the perf tool README and usage comments.

Documentation:
- Expand perf tool README with an Authentication (OIDC) section and example commands, plus updated environment variable reference for auth settings.

## Summary by Sourcery

Add optional OIDC-based authentication to the perf perf-tool using a shared authenticated Locust user base class, and expand perf scenarios and docs to cover new endpoints and auth configuration.

New Features:
- Introduce an OIDC client-credentials token provider and shared AuthenticatedHttpUser base class for perf-tool users.
- Add new perf scenarios and tasks to cover additional advisory, SBOM, license, and SBOM-advisory-by-UUID endpoints in v2 and v3.

Enhancements:
- Switch existing perf Locust users to use the authenticated base user class, centralizing auth behavior.
- Update perf-tool documentation and examples to describe OIDC authentication, environment variables, and unauthenticated runs.
- Expose the new auth module and base user module in the perf-tool package metadata and environment variable reference.