### PR TITLE
ci: add container smoke test and switch to UBI 10

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -63,6 +63,14 @@ runs:
       shell: bash
       run: buildah images
 
+    - name: Smoke test container (trustd)
+      shell: bash
+      run: podman run --rm trustd:${{ inputs.image_tag }} --help
+
+    - name: Smoke test container (xtask)
+      shell: bash
+      run: podman run --rm xtask:${{ inputs.image_tag }} --help
+
     # We save the container image here. But when loading it, the multi-arch aspect of it will be gone.
     - name: Save image
       shell: bash

--- a/.github/scripts/Containerfile
+++ b/.github/scripts/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest as builder
+FROM registry.access.redhat.com/ubi10/ubi:latest as builder
 
 ARG tag
 
@@ -30,7 +30,7 @@ RUN cp -av /unpack/trustd /stage/usr/local/bin
 RUN find /stage
 RUN du -h /stage
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.access.redhat.com/ubi10/ubi-micro:latest
 
 LABEL \
     org.opencontainers.image.description="Trustify - Main server binary" \


### PR DESCRIPTION
## Summary
- Add smoke test steps (`podman run --rm <image> --help`) for `trustd` and `xtask` containers after build but before save/push, catching glibc or shared library mismatches in CI
- Switch the `trustd` Containerfile from UBI 9 (glibc 2.34) to UBI 10 (glibc 2.40) to fix the glibc linker error with binaries compiled on Ubuntu 24.04 (glibc 2.39)

## Test plan
- [ ] Verify the smoke test step runs in the `build-container` composite action
- [ ] Confirm `podman run --rm trustd:TAG --help` passes with UBI 10
- [ ] Verify no regressions in the container image (runtime libs still install correctly from UBI 10 repos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add container smoke tests in CI and update the trustd container base image to UBI 10.

Build:
- Switch trustd Containerfile builder and runtime base images from UBI 9 to UBI 10.

CI:
- Add podman-based smoke test steps for trustd and xtask containers in the build-container GitHub Action.