### PR TITLE
chore: ignore CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 .envrc
 .env
 
+CLAUDE.md
+
 *.cdx.json
 *.folded
 *-secret.*


### PR DESCRIPTION
The idea is that people can bring their own, without having a conflict or accidentally pushing it.

## Summary by Sourcery

Update .gitignore configuration to ignore the CLAUDE.md file so contributors can use their own without causing conflicts.