### PR TITLE
fix: change openapi auto generated commit message

### DIFF
--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: guacsec/trustify-release-tools/.github/actions/create-pr@main
         with:
           path: ./trustify-ui
-          commit-message: "update client/openapi/trustd.yaml"
+          commit-message: "chore(openapi): update client/openapi/trustd.yaml"
           title: "chore(openapi): [${{ github.ref_name }}] update client/openapi/trustd.yaml"
           body: |
             The openapi.yaml of trustify has changed


### PR DESCRIPTION
Setting conventional commit messages to the auto generated openapi PR that is created against the UI repository

## Summary by Sourcery

Build:
- Adjust the OpenAPI PR workflow commit message to follow the 'chore(openapi): ...' conventional commit format.