### PR TITLE
ci: add automated release preparation workflow

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -20,7 +20,7 @@ on:
         default: ""
 
 concurrency:
-  group: prepare-release
+  group: prepare-release-${{ github.ref_name }}
   cancel-in-progress: true
 
 env:
@@ -84,8 +84,9 @@ jobs:
       - name: Install cargo-binstall
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binstall
 
       - name: Install cargo-release
         env:
@@ -143,5 +144,5 @@ jobs:
           - Updated dependencies (\`cargo update\`)
           - Regenerated schemas and OpenAPI spec
 
-          After merging, follow [RELEASE.md](../blob/main/RELEASE.md) for tagging." \
+          After merging, follow [RELEASE.md](https://github.com/guacsec/trustify/blob/main/RELEASE.md) for tagging." \
             --base "${BASE}"

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,147 @@
+name: prepare-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - rc
+          - patch
+          - minor
+          - alpha
+          - beta
+      version-override:
+        description: "Full version override (e.g., 0.6.0-alpha.1). Takes precedence over bump type."
+        required: false
+        type: string
+        default: ""
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  prepare:
+    if: github.repository_owner == 'guacsec'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check permissions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" --jq '.permission')
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "maintain" ]]; then
+            echo "::error::Only maintainers can trigger this workflow. Your permission level: $PERMISSION"
+            exit 1
+          fi
+
+      - name: Validate bump type for release branches
+        run: |
+          REF="${{ github.ref_name }}"
+          BUMP="${{ inputs.bump }}"
+          OVERRIDE="${{ inputs.version-override }}"
+
+          if [[ "$REF" != release/* ]]; then
+            exit 0
+          fi
+
+          if [[ -z "$OVERRIDE" && "$BUMP" == "minor" ]]; then
+            echo "::error::Cannot use 'minor' bump on a release branch. Only alpha, beta, rc, and patch are allowed."
+            exit 1
+          fi
+
+          if [[ -n "$OVERRIDE" ]]; then
+            CURRENT_VERSION=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+            CURRENT_MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
+            OVERRIDE_MINOR=$(echo "$OVERRIDE" | cut -d. -f2)
+            if [[ "$CURRENT_MINOR" != "$OVERRIDE_MINOR" ]]; then
+              echo "::error::Version override changes minor version ($CURRENT_MINOR -> $OVERRIDE_MINOR), which is not allowed on release branches."
+              exit 1
+            fi
+          fi
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.TRUSTIFICATION_BOT_ID }}
+          private-key: ${{ secrets.TRUSTIFICATION_BOT_KEY }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-binstall
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+      - name: Install cargo-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo binstall -y cargo-release
+
+      - name: Bump version
+        run: |
+          VERSION_ARG="${{ inputs.version-override || inputs.bump }}"
+          echo "Bumping version with: $VERSION_ARG"
+          cargo release version "${VERSION_ARG}" -x
+
+      - name: Determine new version
+        id: version
+        run: |
+          VERSION=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "New version: ${VERSION}"
+
+      - name: Update dependencies
+        run: cargo update
+
+      - name: Regenerate schemas
+        run: cargo xtask generate-schemas
+
+      - name: Regenerate OpenAPI spec
+        run: cargo xtask openapi
+
+      - name: Create branch, commit, and push
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          git config user.name "trustification-ci-bot[bot]"
+          git config user.email "199085543+trustification-ci-bot[bot]@users.noreply.github.com"
+          git checkout -b "prepare/${VERSION}"
+          git add -A
+          git commit -m "chore: prepare release ${VERSION}"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin "prepare/${VERSION}"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BASE="${{ github.ref_name }}"
+
+          gh pr create \
+            --title "chore: prepare release ${VERSION}" \
+            --body "Automated release preparation:
+
+          - Bumped workspace version to \`${VERSION}\`
+          - Updated dependencies (\`cargo update\`)
+          - Regenerated schemas and OpenAPI spec
+
+          After merging, follow [RELEASE.md](../blob/main/RELEASE.md) for tagging." \
+            --base "${BASE}"

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -8,11 +8,11 @@ on:
         required: true
         type: choice
         options:
+          - alpha
+          - beta
           - rc
           - patch
           - minor
-          - alpha
-          - beta
       version-override:
         description: "Full version override (e.g., 0.6.0-alpha.1). Takes precedence over bump type."
         required: false
@@ -29,7 +29,7 @@ env:
 jobs:
   prepare:
     if: github.repository_owner == 'guacsec'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,7 +23,59 @@ We also don't publish to crates.io, only release a tag, binary artifacts and con
 
 For `1.0.0` and beyond, this should work differently. Maybe even before. However, there are no plans for that yet.
 
-## Pre-requisites
+## Performing the release
+
+### 1. Prepare release (automated)
+
+The [prepare-release](https://github.com/guacsec/trustify/actions/workflows/prepare-release.yaml) workflow automates
+the release preparation. It bumps versions, updates dependencies, and regenerates schemas and the OpenAPI spec.
+
+1. Go to [Actions → prepare-release](https://github.com/guacsec/trustify/actions/workflows/prepare-release.yaml)
+2. Click **"Run workflow"**
+3. Select the target branch (`main` or a `release/*` branch)
+4. Choose the bump type (`rc`, `patch`, `minor`, `alpha`, `beta`) or provide a full version override
+5. Click **"Run workflow"**
+
+The workflow creates a PR against the selected branch. Review, pass CI, and merge.
+
+> [!NOTE]
+> On `release/*` branches, only `alpha`, `beta`, `rc`, and `patch` bumps are allowed. Minor bumps would break the
+> release stream.
+
+> [!NOTE]
+> Only maintainers can trigger this workflow.
+
+### 2. Update release branch
+
+* Cherry-pick the commits from the release preparation PR to the release branch
+* Update the versions again, ensuring that `trustify-ui` gets updated from the corresponding release branch
+* Create (and merge) another PR against the release branch
+
+### 3. Tag and publish
+
+Switch to release branch and make sure your local checkout is up-to-date.
+```shell
+> git switch release/<stream>
+> git fetch --all
+> git rebase upstream/<stream>
+```
+
+Create (signed) tag.
+```shell
+> git tag -S v0.0.0-alpha.1
+```
+
+Push tag, which triggers GitHub release workflow.
+```shell
+> git push upstream v0.0.0-alpha.1
+```
+Congratulations, the release is now building - [monitor](https://github.com/guacsec/trustify/actions) the outcome!
+
+## Manual release preparation (fallback)
+
+If the automated workflow is unavailable, you can prepare the release manually.
+
+### Pre-requisites
 
 * You have some common developer tools for Rust installed (e.g. `cargo`, `git`)
 * Your local `main` branch is in sync with the upstream `main` branch. The git remote for upstream is named `upstream`.
@@ -31,27 +83,7 @@ For `1.0.0` and beyond, this should work differently. Maybe even before. However
     * This includes having backported all relevant changes to this branch
 * You have `cargo release` installed. This can be done using `cargo install cargo-release`.
 
-## Performing the release
-
-In a nutshell, the steps are:
-
-* Prepare release on `main`
-    * Ensure the cargo versions are aligned with the release tag that we create next
-    * Re-generate the OpenAPI spec, as it contains the version
-    * Update dependencies
-    * Create a PR, merging changes into `main`
-* Port release preparation to `release/<stream>`
-    * Tag the release
-    * Push the tag
-
-To clarify what got released and what is part of the next release, it makes sense to create a PR *before*
-pushing the release tag. This will also make step 1 easier for the *next* release, as that's already been taken care of.
-
-The following instructions walk you through the process on the example of releasing `0.0.0-alpha.1`, which you need
-to replace with the actual release. Note that during release process we should avoid merging any other PRs to `main`
-branch.
-
-### 1. Prepare Branch
+### Steps
 
 Switch to main branch and make sure your local checkout is up-to-date.
 ```shell
@@ -62,12 +94,8 @@ Switch to main branch and make sure your local checkout is up-to-date.
 
 Checkout branch to prepare release from.
 ```shell
-> git checkout -b 0.0.0-alpha.1-prepare
+> git checkout -b prepare/0.0.0-alpha.1
 ```
-
-_Note - This is not a release branch!_
-
-### 2. Create Pull Request
 
 Dry run to check that we can safely bump release.
 ```shell
@@ -96,44 +124,10 @@ Commit (and sign) changes.
 
 Push commit.
 ```shell
-> git push upstream 0.0.0-alpha.1-prepare
+> git push upstream prepare/0.0.0-alpha.1
 ```
 
-### 3. Raise PR, pass CI, review and merge
-
-Goto [github](https://github.com/guacsec/trustify/pulls) and raise PR.
-
-PR should pass CI.
-
-Get a friend to review.
-
-On successful review go ahead and merge!
-
-### 4. Update release branch
-
-* Cherry-pick the commits from the release preparation PR to the release branch
-* Update the versions again, ensuring that `trustify-ui` gets updated from the corresponding release branch
-* Create (and merge) another PR against the release branch
-
-### 4. Create release
-
-Switch to release branch and make sure your local checkout is up-to-date.
-```shell
-> git switch release/<stream>
-> git fetch --all
-> git rebase upstream/<stream>
-```
-
-Create (signed) tag.
-```shell
-> git tag -S v0.0.0-alpha.1
-```
-
-Push tag, which triggers GitHub release workflow.
-```shell
-> git push upstream v0.0.0-alpha.1
-```
-Congratulations, the release is now building - [monitor](https://github.com/guacsec/trustify/actions) the outcome! 🎂
+Raise a PR, pass CI, review and merge.
 
 ## If things go wrong
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -75,7 +75,7 @@ Congratulations, the release is now building - [monitor](https://github.com/guac
 
 If the automated workflow is unavailable, you can prepare the release manually.
 
-### Pre-requisites
+### Prerequisites
 
 * You have some common developer tools for Rust installed (e.g. `cargo`, `git`)
 * Your local `main` branch is in sync with the upstream `main` branch. The git remote for upstream is named `upstream`.


### PR DESCRIPTION
## Summary

- Add `prepare-release.yaml` workflow that automates release preparation (version bump, `cargo update`, schema/OpenAPI regeneration) and creates a PR for review
- Supports `main` and `release/*` branches, with guards preventing `minor` bumps on release branches
- Restricted to maintainers only
- Rewrite `RELEASE.md` to lead with the automated workflow, with manual steps as fallback

Relates: [TC-5109](https://redhat.atlassian.net/browse/TC-5109)

## Test plan

- [ ] Push to a fork and trigger via Actions UI with each bump type (`rc`, `patch`, `minor`)
- [ ] Verify the created PR has correct version bumps, updated `Cargo.lock`, and regenerated schemas/OpenAPI
- [ ] Confirm CI triggers on the created PR

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

[TC-5109]: https://redhat.atlassian.net/browse/TC-5109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce an automated GitHub Actions workflow to prepare releases and update release documentation to prioritize the new workflow with a manual fallback process.

Build:
- Add a prepare-release GitHub Actions workflow that automates version bumps, dependency updates, schema/OpenAPI regeneration, and PR creation for release preparation.

CI:
- Restrict the prepare-release workflow to maintainers, enforce safe bump types on release branches, and run release preparation on controlled branches via a GitHub App token.

Documentation:
- Rewrite RELEASE.md to document the automated release preparation workflow, add guidance for tagging and publishing, and retain a streamlined manual fallback procedure.