### PR TITLE
perf: resolve rh external SBOM ancestors perf

### DIFF
--- a/modules/analysis/src/service/collector.rs
+++ b/modules/analysis/src/service/collector.rs
@@ -54,17 +54,11 @@ impl AncestorCache {
     ) -> Result<AncestorResult, Error> {
         let cell = {
             let mut map = self.cache.lock();
-            map.entry((sbom_id, node_id.clone()))
-                .or_default()
-                .clone()
+            map.entry((sbom_id, node_id.clone())).or_default().clone()
         };
 
         cell.get_or_try_init(|| async {
-            let result =
-                resolve_rh_external_sbom_ancestors(
-                    sbom_id, node_id, connection,
-                )
-                .await?;
+            let result = resolve_rh_external_sbom_ancestors(sbom_id, node_id, connection).await?;
             Ok(Arc::new(result))
         })
         .await
@@ -327,36 +321,25 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
                 // When `graph_node_id` is populated (RH ancestor path), we
                 // already know both values from the single SQL query and can
                 // skip the follow-up `sbom_external_node` lookup entirely.
-                let (ext_sbom_id, ext_graph_node_id) =
-                    if let Some(gid) = &resolved.graph_node_id {
-                        (resolved.sbom_id, gid.clone())
-                    } else {
-                        // Fallback: verify via sbom_external_node (SPDX / CDX path)
-                        let Some(matched) = sbom_external_node::Entity::find()
-                            .filter(
-                                sbom_external_node::Column::SbomId
-                                    .eq(resolved.sbom_id),
-                            )
-                            .filter(
-                                sbom_external_node::Column::ExternalNodeRef
-                                    .eq(&resolved.node_id),
-                            )
-                            .one(self.connection)
-                            .await?
-                        else {
-                            log::debug!(
-                                "no external sbom sbom_external_node {resolved:?}"
-                            );
-                            return Ok(vec![]);
-                        };
-                        (matched.sbom_id, matched.node_id)
+                let (ext_sbom_id, ext_graph_node_id) = if let Some(gid) = &resolved.graph_node_id {
+                    (resolved.sbom_id, gid.clone())
+                } else {
+                    // Fallback: verify via sbom_external_node (SPDX / CDX path)
+                    let Some(matched) = sbom_external_node::Entity::find()
+                        .filter(sbom_external_node::Column::SbomId.eq(resolved.sbom_id))
+                        .filter(sbom_external_node::Column::ExternalNodeRef.eq(&resolved.node_id))
+                        .one(self.connection)
+                        .await?
+                    else {
+                        log::debug!("no external sbom sbom_external_node {resolved:?}");
+                        return Ok(vec![]);
                     };
+                    (matched.sbom_id, matched.node_id)
+                };
 
                 // get the external sbom graph
 
-                let Some(external_graph) =
-                    self.load_external_graph(ext_sbom_id).await?
-                else {
+                let Some(external_graph) = self.load_external_graph(ext_sbom_id).await? else {
                     log::warn!(
                         "external sbom graph {ext_sbom_id} not found \
                          in graph cache or database",
@@ -368,9 +351,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
 
                 let Some(external_node_index) = external_graph
                     .node_indices()
-                    .find(|&node| {
-                        external_graph[node].node_id.eq(&ext_graph_node_id)
-                    })
+                    .find(|&node| external_graph[node].node_id.eq(&ext_graph_node_id))
                 else {
                     log::warn!(
                         "Node with ID {current_node_id} not found \
@@ -382,11 +363,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
                 // recurse into those external sbom nodes and save
 
                 collector
-                    .with(
-                        ext_sbom_id,
-                        external_graph.as_ref(),
-                        external_node_index,
-                    )
+                    .with(ext_sbom_id, external_graph.as_ref(), external_node_index)
                     .collect_graph()
                     .await
             })

--- a/modules/analysis/src/service/collector.rs
+++ b/modules/analysis/src/service/collector.rs
@@ -27,31 +27,52 @@ type AncestorResult = Arc<Vec<ResolvedSbom>>;
 type AncestorCell = Arc<tokio::sync::OnceCell<AncestorResult>>;
 type AncestorMap = HashMap<(Uuid, String), AncestorCell>;
 
-/// Cache for `resolve_rh_external_sbom_ancestors` results.
+/// Request-scoped cache for [`resolve_rh_external_sbom_ancestors`] results.
 ///
-/// Keyed by `(sbom_id, node_id)` so that repeated lookups for the
-/// same node during ancestor traversal are served from memory.
+/// # Why this exists
 ///
-/// Uses `tokio::sync::OnceCell` per key so that concurrent callers
-/// for the same key coalesce onto a single in-flight DB query
-/// instead of each hitting the database independently.
+/// During ancestor traversal (`Direction::Incoming`) every
+/// `PackageNode` visited triggers a call to
+/// `resolve_rh_external_sbom_ancestors`.  A single component SBOM
+/// can contain hundreds of package nodes, many of which share the
+/// same `(sbom_id, node_id)` coordinates across different graph
+/// traversal paths.  Without caching, the same expensive SQL query
+/// is issued for each visit.
+///
+/// # Coalescing
+///
+/// A `tokio::sync::OnceCell` is stored per unique key.  When
+/// multiple concurrent tasks (spawned by `buffer_unordered`) request
+/// the same key simultaneously, the `OnceCell`'s internal semaphore
+/// ensures only one task executes the query; the others await its
+/// result.
+///
+/// # Scope
+///
+/// One `AncestorCache` is created per top-level `run_graph_query`
+/// call (i.e. per HTTP request) and shared across **all** collector
+/// instances via `Arc`.  This means results computed while
+/// processing one result-set node are reused by later nodes and by
+/// both the ancestor and descendant collectors.
 #[derive(Default, Clone)]
 pub struct AncestorCache {
     cache: Arc<Mutex<AncestorMap>>,
 }
 
 impl AncestorCache {
-    /// Look up or compute ancestor resolution for a node.
+    /// Resolve ancestors for `(sbom_id, node_id)`, returning a cached
+    /// result when available.
     ///
-    /// Concurrent calls with the same `(sbom_id, node_id)` share a
-    /// single DB query; the first caller drives the query and all
-    /// others await its result.
+    /// The first caller for a given key drives the DB query; concurrent
+    /// and subsequent callers receive a cheap `Arc` clone of the result.
     async fn resolve<C: ConnectionTrait>(
         &self,
         sbom_id: Uuid,
         node_id: String,
         connection: &C,
     ) -> Result<AncestorResult, Error> {
+        // Acquire or create the per-key OnceCell under the lock,
+        // then immediately drop the lock before awaiting the query.
         let cell = {
             let mut map = self.cache.lock();
             map.entry((sbom_id, node_id.clone())).or_default().clone()
@@ -290,15 +311,36 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
         ))
     }
 
+    /// Collect ancestor (or descendant) nodes for a `PackageNode`,
+    /// including any cross-SBOM links discovered through RH-style
+    /// checksum matching.
+    ///
+    /// Two things happen here:
+    ///
+    /// 1. **Cross-SBOM ancestors** — For every `PackageNode`, we ask
+    ///    "does any *other* SBOM claim to be an ancestor of the SBOM
+    ///    that contains this node?"  If so, we load that ancestor
+    ///    SBOM's graph, find the entry-point node, and recursively
+    ///    collect its graph.  This is what makes product→component
+    ///    relationships visible in the API response.
+    ///
+    /// 2. **Intra-SBOM traversal** — We then call `collect_graph` to
+    ///    walk the edges of the *current* SBOM's graph from this node
+    ///    in the configured direction (ancestors or descendants).
+    ///
+    /// The results from both steps are merged into the output.
     async fn collect_package(
         self,
         current_node: &PackageNode,
     ) -> Result<(Option<Vec<Node>>, Vec<String>), Error> {
-        // collect external sbom ancestor nodes
         let current_sbom_id = &current_node.sbom_id;
         let current_sbom_uuid = *current_sbom_id;
         let current_node_id = &current_node.node_id;
 
+        // Step 1: find ancestor SBOMs that reference this node via
+        // shared checksums.  Results are cached per (sbom_id,
+        // node_id) so repeated visits to the same node (common
+        // during recursive graph traversal) do not hit the DB.
         let find_sbom_externals = self
             .ancestor_cache
             .resolve(
@@ -308,23 +350,31 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             )
             .await?;
 
+        // For each ancestor SBOM found, load its graph and recurse.
         let resolved_external_nodes: Vec<Node> = stream::iter(find_sbom_externals.iter().cloned())
             .map(async |resolved| {
                 let collector = self.clone();
 
+                // Skip self-references (the current SBOM can appear
+                // in its own ancestor set due to how checksums are
+                // shared).
                 if &resolved.sbom_id == current_sbom_id {
                     return Ok::<_, Error>(vec![]);
                 }
 
-                // Determine the ancestor SBOM id and graph node id.
+                // Determine the ancestor SBOM id and the node_id to
+                // look up in its in-memory graph.
                 //
-                // When `graph_node_id` is populated (RH ancestor path), we
-                // already know both values from the single SQL query and can
-                // skip the follow-up `sbom_external_node` lookup entirely.
+                // The RH ancestor path (`graph_node_id` populated)
+                // already resolved both values in the single SQL
+                // query, so no extra DB round-trip is needed.
+                //
+                // The SPDX/CycloneDX path (`graph_node_id` is None)
+                // must fall back to a `sbom_external_node` lookup to
+                // map the external_node_ref to the graph's node_id.
                 let (ext_sbom_id, ext_graph_node_id) = if let Some(gid) = &resolved.graph_node_id {
                     (resolved.sbom_id, gid.clone())
                 } else {
-                    // Fallback: verify via sbom_external_node (SPDX / CDX path)
                     let Some(matched) = sbom_external_node::Entity::find()
                         .filter(sbom_external_node::Column::SbomId.eq(resolved.sbom_id))
                         .filter(sbom_external_node::Column::ExternalNodeRef.eq(&resolved.node_id))
@@ -337,8 +387,8 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
                     (matched.sbom_id, matched.node_id)
                 };
 
-                // get the external sbom graph
-
+                // Load the ancestor SBOM's in-memory graph (from the
+                // request-scoped or global graph cache).
                 let Some(external_graph) = self.load_external_graph(ext_sbom_id).await? else {
                     log::warn!(
                         "external sbom graph {ext_sbom_id} not found \
@@ -347,8 +397,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
                     return Ok(vec![]);
                 };
 
-                // find the node in retrieved external graph
-
+                // Find the entry-point node in the ancestor graph.
                 let Some(external_node_index) = external_graph
                     .node_indices()
                     .find(|&node| external_graph[node].node_id.eq(&ext_graph_node_id))
@@ -360,8 +409,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
                     return Ok(vec![]);
                 };
 
-                // recurse into those external sbom nodes and save
-
+                // Recurse: collect the ancestor graph from this node.
                 collector
                     .with(ext_sbom_id, external_graph.as_ref(), external_node_index)
                     .collect_graph()
@@ -373,6 +421,8 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             .try_collect()
             .await?;
 
+        // Step 2: walk the current SBOM's own graph edges and merge
+        // the cross-SBOM results.
         let mut result = self.collect_graph().await?;
         result.extend(resolved_external_nodes);
 

--- a/modules/analysis/src/service/collector.rs
+++ b/modules/analysis/src/service/collector.rs
@@ -23,6 +23,55 @@ impl DiscoveredTracker {
     }
 }
 
+type AncestorResult = Arc<Vec<ResolvedSbom>>;
+type AncestorCell = Arc<tokio::sync::OnceCell<AncestorResult>>;
+type AncestorMap = HashMap<(Uuid, String), AncestorCell>;
+
+/// Cache for `resolve_rh_external_sbom_ancestors` results.
+///
+/// Keyed by `(sbom_id, node_id)` so that repeated lookups for the
+/// same node during ancestor traversal are served from memory.
+///
+/// Uses `tokio::sync::OnceCell` per key so that concurrent callers
+/// for the same key coalesce onto a single in-flight DB query
+/// instead of each hitting the database independently.
+#[derive(Default, Clone)]
+pub struct AncestorCache {
+    cache: Arc<Mutex<AncestorMap>>,
+}
+
+impl AncestorCache {
+    /// Look up or compute ancestor resolution for a node.
+    ///
+    /// Concurrent calls with the same `(sbom_id, node_id)` share a
+    /// single DB query; the first caller drives the query and all
+    /// others await its result.
+    async fn resolve<C: ConnectionTrait>(
+        &self,
+        sbom_id: Uuid,
+        node_id: String,
+        connection: &C,
+    ) -> Result<AncestorResult, Error> {
+        let cell = {
+            let mut map = self.cache.lock();
+            map.entry((sbom_id, node_id.clone()))
+                .or_default()
+                .clone()
+        };
+
+        cell.get_or_try_init(|| async {
+            let result =
+                resolve_rh_external_sbom_ancestors(
+                    sbom_id, node_id, connection,
+                )
+                .await?;
+            Ok(Arc::new(result))
+        })
+        .await
+        .cloned()
+    }
+}
+
 /// Collector, helping on collector nodes from a graph.
 ///
 /// Keeping track of all relevant information.
@@ -37,6 +86,7 @@ pub struct Collector<'a, C: ConnectionTrait> {
     depth: u64,
     discovered: DiscoveredTracker,
     loaded_graphs: Arc<Mutex<HashMap<Uuid, Arc<PackageGraph>>>>,
+    ancestor_cache: AncestorCache,
     relationships: &'a HashSet<Relationship>,
     connection: &'a C,
     concurrency: usize,
@@ -55,6 +105,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             depth: self.depth,
             discovered: self.discovered.clone(),
             loaded_graphs: self.loaded_graphs.clone(),
+            ancestor_cache: self.ancestor_cache.clone(),
             relationships: self.relationships,
             connection: self.connection,
             concurrency: self.concurrency,
@@ -87,6 +138,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             depth,
             discovered: Default::default(),
             loaded_graphs: Default::default(),
+            ancestor_cache: Default::default(),
             relationships,
             connection,
             concurrency,
@@ -121,6 +173,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             depth: self.depth.saturating_sub(1),
             discovered: self.discovered.clone(),
             loaded_graphs: self.loaded_graphs.clone(),
+            ancestor_cache: self.ancestor_cache.clone(),
             relationships: self.relationships,
             connection: self.connection,
             concurrency: self.concurrency,
@@ -192,7 +245,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
         let Some(ResolvedSbom {
             sbom_id: external_sbom_id,
             node_id: external_node_id,
-            cpe_ids: _,
+            ..
         }) = resolve_external_sbom(&external_node.node_id, self.connection).await?
         else {
             return Ok((
@@ -251,43 +304,62 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
         let current_sbom_uuid = *current_sbom_id;
         let current_node_id = &current_node.node_id;
 
-        let find_sbom_externals = resolve_rh_external_sbom_ancestors(
-            current_sbom_uuid,
-            current_node.node_id.clone().to_string(),
-            self.connection,
-        )
-        .await?;
+        let find_sbom_externals = self
+            .ancestor_cache
+            .resolve(
+                current_sbom_uuid,
+                current_node.node_id.clone().to_string(),
+                self.connection,
+            )
+            .await?;
 
-        let resolved_external_nodes: Vec<Node> = stream::iter(find_sbom_externals)
-            .map(async |sbom_external_node| {
+        let resolved_external_nodes: Vec<Node> = stream::iter(find_sbom_externals.iter().cloned())
+            .map(async |resolved| {
                 let collector = self.clone();
 
-                if &sbom_external_node.sbom_id == current_sbom_id {
+                if &resolved.sbom_id == current_sbom_id {
                     return Ok::<_, Error>(vec![]);
                 }
 
-                // check this is a valid external relationship
-
-                let Some(matched) = sbom_external_node::Entity::find()
-                    .filter(sbom_external_node::Column::SbomId.eq(sbom_external_node.sbom_id))
-                    .filter(
-                        sbom_external_node::Column::ExternalNodeRef.eq(&sbom_external_node.node_id),
-                    )
-                    .one(self.connection)
-                    .await?
-                else {
-                    log::debug!("no external sbom sbom_external_node {sbom_external_node:?}");
-                    return Ok(vec![]);
-                };
+                // Determine the ancestor SBOM id and graph node id.
+                //
+                // When `graph_node_id` is populated (RH ancestor path), we
+                // already know both values from the single SQL query and can
+                // skip the follow-up `sbom_external_node` lookup entirely.
+                let (ext_sbom_id, ext_graph_node_id) =
+                    if let Some(gid) = &resolved.graph_node_id {
+                        (resolved.sbom_id, gid.clone())
+                    } else {
+                        // Fallback: verify via sbom_external_node (SPDX / CDX path)
+                        let Some(matched) = sbom_external_node::Entity::find()
+                            .filter(
+                                sbom_external_node::Column::SbomId
+                                    .eq(resolved.sbom_id),
+                            )
+                            .filter(
+                                sbom_external_node::Column::ExternalNodeRef
+                                    .eq(&resolved.node_id),
+                            )
+                            .one(self.connection)
+                            .await?
+                        else {
+                            log::debug!(
+                                "no external sbom sbom_external_node {resolved:?}"
+                            );
+                            return Ok(vec![]);
+                        };
+                        (matched.sbom_id, matched.node_id)
+                    };
 
                 // get the external sbom graph
 
-                let Some(external_graph) = self.load_external_graph(matched.sbom_id).await? else {
+                let Some(external_graph) =
+                    self.load_external_graph(ext_sbom_id).await?
+                else {
                     log::warn!(
-                        "external sbom graph {} not found in graph cache or database",
-                        matched.sbom_id
+                        "external sbom graph {ext_sbom_id} not found \
+                         in graph cache or database",
                     );
-
                     return Ok(vec![]);
                 };
 
@@ -295,9 +367,14 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
 
                 let Some(external_node_index) = external_graph
                     .node_indices()
-                    .find(|&node| external_graph[node].node_id.eq(&matched.node_id))
+                    .find(|&node| {
+                        external_graph[node].node_id.eq(&ext_graph_node_id)
+                    })
                 else {
-                    log::warn!("Node with ID {current_node_id} not found in external sbom");
+                    log::warn!(
+                        "Node with ID {current_node_id} not found \
+                         in external sbom"
+                    );
                     return Ok(vec![]);
                 };
 
@@ -305,7 +382,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
 
                 collector
                     .with(
-                        matched.sbom_id,
+                        ext_sbom_id,
                         external_graph.as_ref(),
                         external_node_index,
                     )

--- a/modules/analysis/src/service/collector.rs
+++ b/modules/analysis/src/service/collector.rs
@@ -127,6 +127,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
         connection: &'a C,
         concurrency: usize,
         loader: &'a GraphLoader,
+        ancestor_cache: AncestorCache,
     ) -> Self {
         Self {
             graph_cache,
@@ -138,7 +139,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             depth,
             discovered: Default::default(),
             loaded_graphs: Default::default(),
-            ancestor_cache: Default::default(),
+            ancestor_cache,
             relationships,
             connection,
             concurrency,

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -29,10 +29,10 @@ use petgraph::{
     visit::{VisitMap, Visitable},
 };
 use sea_orm::{
-    ColumnTrait, EntityOrSelect, EntityTrait, FromQueryResult, PaginatorTrait, QueryFilter,
-    QueryOrder, QuerySelect, RelationTrait, prelude::ConnectionTrait,
+    ColumnTrait, DatabaseBackend, EntityOrSelect, EntityTrait, FromQueryResult, PaginatorTrait,
+    QueryFilter, QueryOrder, QuerySelect, RelationTrait, Statement, prelude::ConnectionTrait,
 };
-use sea_query::{Expr, JoinType};
+use sea_query::JoinType;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
@@ -262,44 +262,56 @@ struct ChecksumWithCpes {
     cpe_ids: Vec<Uuid>,
 }
 
-/// Resolves external SBOM ancestors by checksum matching, including their describing CPEs.
+/// Resolves external SBOM ancestors using the materialized `sbom_ancestor` table.
 ///
-/// Uses `array_agg` to collect CPE IDs per `(sbom_id, node_id)` directly in the database
-/// rather than expanding rows per CPE and grouping in Rust.
+/// Finds ancestor SBOMs for the current node's SBOM through the pre-computed
+/// `sbom_ancestor` links, then joins with `sbom_external_node` to get the
+/// external node references and with `sbom_describing_cpe` for CPE IDs.
+///
+/// This replaces an earlier implementation that performed expensive runtime
+/// checksum matching (two sequential queries per node) with a single query
+/// against the materialized table.
 #[instrument(skip(connection), err(level=tracing::Level::INFO))]
 async fn resolve_rh_external_sbom_ancestors<C: ConnectionTrait>(
     sbom_external_sbom_id: Uuid,
     sbom_external_node_ref: String,
     connection: &C,
 ) -> Result<Vec<ResolvedSbom>, Error> {
-    let Some(entity) = sbom_node_checksum::Entity::find()
-        .filter(sbom_node_checksum::Column::NodeId.eq(sbom_external_node_ref.clone()))
-        .filter(sbom_node_checksum::Column::SbomId.eq(sbom_external_sbom_id))
-        .one(connection)
-        .await?
-    else {
-        return Ok(vec![]);
-    };
-
-    let rows = sbom_node_checksum::Entity::find()
-        .select_only()
-        .column(sbom_node_checksum::Column::SbomId)
-        .column(sbom_node_checksum::Column::NodeId)
-        .column_as(
-            Expr::cust(r#"COALESCE(array_agg("sbom_describing_cpe"."cpe_id") FILTER (WHERE "sbom_describing_cpe"."cpe_id" IS NOT NULL), ARRAY[]::uuid[])"#),
-            "cpe_ids",
-        )
-        .join(
-            JoinType::LeftJoin,
-            sbom_node_checksum::Relation::DescribingCpe.def(),
-        )
-        .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
-        .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
-        .group_by(sbom_node_checksum::Column::SbomId)
-        .group_by(sbom_node_checksum::Column::NodeId)
-        .into_model::<ChecksumWithCpes>()
-        .all(connection)
-        .await?;
+    // Single query: look up ancestor SBOMs from the materialized table,
+    // join with sbom_external_node to find the external_node_ref matching
+    // the current node via checksum, and aggregate CPE IDs.
+    let rows = ChecksumWithCpes::find_by_statement(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        r#"
+        SELECT sen.sbom_id,
+               sen.external_node_ref AS node_id,
+               COALESCE(
+                   array_agg(sdc.cpe_id)
+                       FILTER (WHERE sdc.cpe_id IS NOT NULL),
+                   ARRAY[]::uuid[]
+               ) AS cpe_ids
+        FROM sbom_ancestor sa
+        JOIN sbom_external_node sen
+          ON sen.sbom_id = sa.ancestor_sbom_id
+        JOIN sbom_node_checksum snc_ref
+          ON snc_ref.sbom_id = sen.sbom_id
+         AND snc_ref.node_id = sen.external_node_ref
+        JOIN sbom_node_checksum snc_self
+          ON snc_self.sbom_id = $1
+         AND snc_self.node_id = $2
+         AND snc_self.value = snc_ref.value
+        LEFT JOIN sbom_describing_cpe sdc
+          ON sdc.sbom_id = sen.sbom_id
+        WHERE sa.sbom_id = $1
+        GROUP BY sen.sbom_id, sen.external_node_ref
+        "#,
+        [
+            sbom_external_sbom_id.into(),
+            sbom_external_node_ref.into(),
+        ],
+    ))
+    .all(connection)
+    .await?;
 
     Ok(rows
         .into_iter()

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -315,10 +315,7 @@ async fn resolve_rh_external_sbom_ancestors<C: ConnectionTrait>(
         WHERE sa.sbom_id = $1
         GROUP BY sen.sbom_id, sen.external_node_ref, sen.node_id
         "#,
-        [
-            sbom_external_sbom_id.into(),
-            sbom_external_node_ref.into(),
-        ],
+        [sbom_external_sbom_id.into(), sbom_external_node_ref.into()],
     ))
     .all(connection)
     .await?;

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -94,15 +94,33 @@ pub struct AnalysisService {
     concurrency: usize,
 }
 
+/// A cross-SBOM link resolved by checksum or document-reference matching.
+///
+/// Represents a target SBOM (and entry-point node within it) that was
+/// found to reference the same component as the node being analysed.
+/// Used by both the descendant path (SPDX/CycloneDX external
+/// references) and the ancestor path (Red Hat product→component
+/// checksum matching).
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct ResolvedSbom {
+    /// The SBOM that contains the external reference.
     pub sbom_id: Uuid,
+    /// The `external_node_ref` value from `sbom_external_node` — this
+    /// is the identifier the referencing SBOM uses to point at the
+    /// component (e.g. a pURL, SPDX ref, or checksum-based ref).
     pub node_id: String,
+    /// CPE IDs that describe the referencing SBOM, aggregated from
+    /// `sbom_describing_cpe`.
     pub cpe_ids: Vec<Uuid>,
-    /// The graph-internal node ID within the ancestor SBOM.
+    /// The internal `sbom_external_node.node_id` within the ancestor
+    /// SBOM's in-memory graph.
     ///
-    /// When populated by `resolve_rh_external_sbom_ancestors`, the
-    /// collector can skip the follow-up `sbom_external_node` lookup.
+    /// When populated (the RH ancestor path fills this from SQL), the
+    /// collector can look up the node directly in the graph and skip
+    /// the extra `sbom_external_node` query that would otherwise be
+    /// needed to map `node_id` (the external ref) back to the graph
+    /// node.  `None` for SPDX/CycloneDX paths, which resolve via a
+    /// different mechanism.
     pub graph_node_id: Option<String>,
 }
 
@@ -262,33 +280,82 @@ async fn resolve_rh_external_sbom_descendants<C: ConnectionTrait>(
         }))
 }
 
-/// Result row from a checksum lookup with aggregated CPE IDs.
+/// A single row returned by `resolve_rh_external_sbom_ancestors`.
+///
+/// Maps directly to the SQL SELECT list: one row per ancestor SBOM
+/// that references the queried node through a shared checksum, with
+/// CPE IDs aggregated via `array_agg`.
 #[derive(Debug, FromQueryResult)]
 struct ChecksumWithCpes {
+    /// `sbom_external_node.sbom_id` — the ancestor (product) SBOM.
     sbom_id: Uuid,
+    /// `sbom_external_node.external_node_ref` — the ref the ancestor
+    /// SBOM uses to point at the component.
     node_id: String,
+    /// Aggregated `sbom_describing_cpe.cpe_id` values for the
+    /// ancestor SBOM (empty array when none exist).
     cpe_ids: Vec<Uuid>,
+    /// `sbom_external_node.node_id` — the graph-internal node ID
+    /// within the ancestor SBOM, used to skip a follow-up query.
     graph_node_id: Option<String>,
 }
 
-/// Resolves external SBOM ancestors using the materialized `sbom_ancestor` table.
+/// Find ancestor (product) SBOMs that reference a given component node.
 ///
-/// Finds ancestor SBOMs for the current node's SBOM through the pre-computed
-/// `sbom_ancestor` links, then joins with `sbom_external_node` to get the
-/// external node references and with `sbom_describing_cpe` for CPE IDs.
+/// # Background — Red Hat product→component model
 ///
-/// This replaces an earlier implementation that performed expensive runtime
-/// checksum matching (two sequential queries per node) with a single query
-/// against the materialized table.
+/// Red Hat product SBOMs reference component SBOMs indirectly: the
+/// product SBOM contains an `sbom_external_node` row whose
+/// `external_node_ref` is a package identifier (pURL / SPDX ref).
+/// That identifier is linked to the component SBOM through a shared
+/// checksum stored in `sbom_node_checksum`.
+///
+/// At ingest time, these cross-SBOM links are materialized into the
+/// `sbom_ancestor` table (see migration `m0002130_sbom_ancestor`).
+/// This function reads those pre-computed links at query time rather
+/// than re-discovering them through expensive runtime checksum scans.
+///
+/// # Parameters
+///
+/// * `sbom_external_sbom_id` — the SBOM that contains the component
+///   node we are analysing (the "child" / component SBOM).
+/// * `sbom_external_node_ref` — the `node_id` of the specific node
+///   within that SBOM (e.g. `SPDXRef-SRPM`, a pURL, etc.).
+///
+/// # Query walkthrough
+///
+/// ```text
+///   sbom_ancestor          "which product SBOMs are ancestors of $1?"
+///       │
+///       ▼
+///   sbom_external_node     "what external-node entries exist in those
+///       │                   ancestor SBOMs?"
+///       ▼
+///   sbom_node_checksum     "does the external_node_ref in the ancestor
+///   (snc_ref + snc_self)    share a checksum with node $2 in SBOM $1?"
+///       │
+///       ▼
+///   sbom_describing_cpe    "what CPEs describe the ancestor SBOM?"
+/// ```
+///
+/// The result is one row per matching ancestor, carrying:
+/// - the ancestor SBOM ID and its external_node_ref (for the caller),
+/// - aggregated CPE IDs from `sbom_describing_cpe`,
+/// - the graph-internal `node_id` from `sbom_external_node` so the
+///   collector can look the node up in the in-memory graph without a
+///   follow-up DB query.
+///
+/// # Caching
+///
+/// This function is called once per unique `(sbom_id, node_id)` pair
+/// thanks to [`AncestorCache`], which coalesces concurrent requests
+/// and caches results across the entire request.
 #[instrument(skip(connection), err(level=tracing::Level::INFO))]
 async fn resolve_rh_external_sbom_ancestors<C: ConnectionTrait>(
     sbom_external_sbom_id: Uuid,
     sbom_external_node_ref: String,
     connection: &C,
 ) -> Result<Vec<ResolvedSbom>, Error> {
-    // Single query: look up ancestor SBOMs from the materialized table,
-    // join with sbom_external_node to find the external_node_ref matching
-    // the current node via checksum, and aggregate CPE IDs.
     let rows = ChecksumWithCpes::find_by_statement(Statement::from_sql_and_values(
         DatabaseBackend::Postgres,
         r#"
@@ -299,17 +366,27 @@ async fn resolve_rh_external_sbom_ancestors<C: ConnectionTrait>(
                        FILTER (WHERE sdc.cpe_id IS NOT NULL),
                    ARRAY[]::uuid[]
                ) AS cpe_ids,
+               -- The graph-internal node_id from sbom_external_node.
+               -- This lets the collector skip the follow-up
+               -- sbom_external_node lookup when walking ancestors.
                sen.node_id AS graph_node_id
         FROM sbom_ancestor sa
+        -- Find external-node entries in each ancestor SBOM.
         JOIN sbom_external_node sen
           ON sen.sbom_id = sa.ancestor_sbom_id
+        -- Look up the checksum the ancestor recorded for its
+        -- external_node_ref (the package it points at).
         JOIN sbom_node_checksum snc_ref
           ON snc_ref.sbom_id = sen.sbom_id
          AND snc_ref.node_id = sen.external_node_ref
+        -- Match that checksum against the node we are analysing.
+        -- This is the join that proves "ancestor's external ref
+        -- points at the same artefact as node $2 in SBOM $1".
         JOIN sbom_node_checksum snc_self
           ON snc_self.sbom_id = $1
          AND snc_self.node_id = $2
          AND snc_self.value = snc_ref.value
+        -- Optionally pick up CPEs that describe the ancestor SBOM.
         LEFT JOIN sbom_describing_cpe sdc
           ON sdc.sbom_id = sen.sbom_id
         WHERE sa.sbom_id = $1

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -99,6 +99,11 @@ struct ResolvedSbom {
     pub sbom_id: Uuid,
     pub node_id: String,
     pub cpe_ids: Vec<Uuid>,
+    /// The graph-internal node ID within the ancestor SBOM.
+    ///
+    /// When populated by `resolve_rh_external_sbom_ancestors`, the
+    /// collector can skip the follow-up `sbom_external_node` lookup.
+    pub graph_node_id: Option<String>,
 }
 
 #[instrument(skip(connection), err(level=tracing::Level::INFO))]
@@ -160,6 +165,7 @@ async fn resolve_external_sbom<C: ConnectionTrait>(
                     sbom_id: entity.sbom_id,
                     node_id: sbom_external_node.external_node_ref,
                     cpe_ids: vec![],
+                    graph_node_id: None,
                 }))
         }
         ExternalType::CycloneDx => {
@@ -187,6 +193,7 @@ async fn resolve_external_sbom<C: ConnectionTrait>(
                     sbom_id: entity.sbom_id,
                     node_id: sbom_external_node.external_node_ref,
                     cpe_ids: vec![],
+                    graph_node_id: None,
                 }))
         }
         ExternalType::RedHatProductComponent => {
@@ -251,6 +258,7 @@ async fn resolve_rh_external_sbom_descendants<C: ConnectionTrait>(
             sbom_id: matched_model.sbom_id,
             node_id: matched_model.node_id,
             cpe_ids: vec![],
+            graph_node_id: None,
         }))
 }
 
@@ -260,6 +268,7 @@ struct ChecksumWithCpes {
     sbom_id: Uuid,
     node_id: String,
     cpe_ids: Vec<Uuid>,
+    graph_node_id: Option<String>,
 }
 
 /// Resolves external SBOM ancestors using the materialized `sbom_ancestor` table.
@@ -289,7 +298,8 @@ async fn resolve_rh_external_sbom_ancestors<C: ConnectionTrait>(
                    array_agg(sdc.cpe_id)
                        FILTER (WHERE sdc.cpe_id IS NOT NULL),
                    ARRAY[]::uuid[]
-               ) AS cpe_ids
+               ) AS cpe_ids,
+               sen.node_id AS graph_node_id
         FROM sbom_ancestor sa
         JOIN sbom_external_node sen
           ON sen.sbom_id = sa.ancestor_sbom_id
@@ -303,7 +313,7 @@ async fn resolve_rh_external_sbom_ancestors<C: ConnectionTrait>(
         LEFT JOIN sbom_describing_cpe sdc
           ON sdc.sbom_id = sen.sbom_id
         WHERE sa.sbom_id = $1
-        GROUP BY sen.sbom_id, sen.external_node_ref
+        GROUP BY sen.sbom_id, sen.external_node_ref, sen.node_id
         "#,
         [
             sbom_external_sbom_id.into(),
@@ -319,6 +329,7 @@ async fn resolve_rh_external_sbom_ancestors<C: ConnectionTrait>(
             sbom_id: r.sbom_id,
             node_id: r.node_id,
             cpe_ids: r.cpe_ids,
+            graph_node_id: r.graph_node_id,
         })
         .collect())
 }

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -555,6 +555,7 @@ impl AnalysisService {
         log::debug!("relations: {:?}", relationships);
 
         let loader = &GraphLoader::new(self.clone());
+        let ancestor_cache = AncestorCache::default();
 
         self.collect_graph(
             query,
@@ -563,6 +564,7 @@ impl AnalysisService {
             |graph, node_index, node| {
                 let graph_cache = self.inner.graph_cache.clone();
                 let relationships = relationships.clone();
+                let ancestor_cache = ancestor_cache.clone();
                 async move {
                     log::trace!(
                         "Discovered node - sbom: {}, node: {}",
@@ -582,6 +584,7 @@ impl AnalysisService {
                         connection,
                         self.concurrency,
                         loader,
+                        ancestor_cache.clone(),
                     )
                     .collect();
 
@@ -597,6 +600,7 @@ impl AnalysisService {
                         connection,
                         self.concurrency,
                         loader,
+                        ancestor_cache,
                     )
                     .collect();
 

--- a/modules/analysis/src/service/test/mod.rs
+++ b/modules/analysis/src/service/test/mod.rs
@@ -738,9 +738,8 @@ async fn resolve_sbom_cdx_external_node_sbom(ctx: &TrustifyContext) -> Result<()
         resolve_external_sbom("urn:cdx:a4f16b62-fea9-42c1-8365-d72d3cef37d1/2#a", &ctx.db).await?;
     assert!(get_external_sbom.is_some());
     if let Some(ResolvedSbom {
-        sbom_id: _,
         node_id: external_node_id,
-        cpe_ids: _,
+        ..
     }) = get_external_sbom
     {
         assert_eq!(external_node_id, "a");
@@ -762,9 +761,8 @@ async fn resolve_sbom_spdx_external_node_sbom(ctx: &TrustifyContext) -> Result<(
     let get_external_sbom = resolve_external_sbom("DocumentRef-ext-b:SPDXRef-A", &ctx.db).await?;
     assert!(get_external_sbom.is_some());
     if let Some(ResolvedSbom {
-        sbom_id: _,
         node_id: external_node_id,
-        cpe_ids: _,
+        ..
     }) = get_external_sbom
     {
         assert_eq!(external_node_id, "SPDXRef-A");
@@ -801,7 +799,7 @@ async fn resolve_sbom_spdx_rh_variant_external_node_sbom(
     if let Some(ResolvedSbom {
         sbom_id: external_sbom_id,
         node_id: external_node_id,
-        cpe_ids: _,
+        ..
     }) = get_external_sbom
     {
         assert_eq!(external_node_id, "SPDXRef-SRPM".to_string());
@@ -847,7 +845,7 @@ async fn resolve_sbom_cdx_rh_variant_external_node_sbom(
     if let Some(ResolvedSbom {
         sbom_id: external_sbom_id,
         node_id: external_node_id,
-        cpe_ids: _,
+        ..
     }) = get_external_sbom
     {
         assert_eq!(


### PR DESCRIPTION
When performing latest queries with ancestor resolution there were a few issues causing less then optimal performance.

> http://localhost:8080/api/v3/analysis/latest/component/clevis?total=false&ancestors=5

**resolve_rh_external_sbom_ancestors** (modules/analysis/src/service/mod.rs:270) is performing 2 seq DB queries per PackageNode visited during ancestor traversal (and in other places) - the fix was to ensure we further use materialised **sbom_ancestor** table.

Needed to also fix Ancestor cache which was not working as efficiently due to race condition by using a coalescing pattern so concurrent requests, for the same key, share a single 'in flight' query instead of each hitting the DB independently (causing resource contention).

Lastly we needed to ensure that the AncestorCache is created only once for a request, in **run_graph_query**, and then shared across all Collector instances for the entire request:
- All nodes in the result set share one cache
- Both ancestor and descendant collectors for the same node share the cache


## Summary by Sourcery

Optimize resolution of Red Hat external SBOM ancestors and share ancestor resolution results across collectors via a per-request cache.

Enhancements:
- Introduce an AncestorCache layer using OnceCell to coalesce concurrent ancestor-resolution queries and reuse results across graph traversal.
- Refactor resolve_rh_external_sbom_ancestors to query the materialized sbom_ancestor table and return graph node identifiers, reducing per-node database roundtrips.
- Extend ResolvedSbom to carry optional graph node IDs and adjust collectors to avoid redundant sbom_external_node lookups when this data is available.

Tests:
- Update existing external SBOM resolution tests to align with the extended ResolvedSbom structure.

**Before**
<img width="1847" height="1018" alt="image" src="https://github.com/user-attachments/assets/a7280ab6-a342-4de6-80be-4ab9b7e0aa02" />

**After**
<img width="1847" height="1018" alt="image" src="https://github.com/user-attachments/assets/a70ed612-2860-4e5e-917d-64011bc59dff" />

your eye should look at the times for **resolve_rh_external_sbom_ancestors** where we should now have much less invokes (and no competing equiv invokes) and better run times. 

Roughly a 75% reduction in aggregated time.