### PR TITLE
build: drop removing the toolchain file

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,8 +13,6 @@ WORKDIR /build
 
 RUN ls
 
-RUN rm rust-toolchain.toml
-
 RUN cargo build --release
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Remove the step that deletes rust-toolchain.toml from the Containerfile.