### PR TITLE
chore: updates opentelemetry-collector to 0.152.1

### DIFF
--- a/etc/deploy/compose/compose-otel.yaml
+++ b/etc/deploy/compose/compose-otel.yaml
@@ -43,7 +43,7 @@ services:
     restart: unless-stopped
 
   collector:
-    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.140.0
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.152.1
     command: ["--config=/otel-collector-config.yaml"]
     volumes:
       - './config-collector.yaml:/otel-collector-config.yaml:z'


### PR DESCRIPTION
* Aligns with https://github.com/os-observability/redhat-opentelemetry-collector/releases

Dev environment working fine:

<img width="1346" height="800" alt="metrics" src="https://github.com/user-attachments/assets/3731256c-f954-4749-a930-cc564d4d79d2" />
<img width="1541" height="279" alt="traces" src="https://github.com/user-attachments/assets/d32f5444-068d-4bbd-a418-87897974253a" />

## Summary by Sourcery

Build:
- Bump OpenTelemetry Collector image in compose-otel deployment from 0.140.0 to 0.152.1.