### PR TITLE
build: pin sequoia-openpgp below 2.4 to remove bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,16 +383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "annotate-snippets"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
-dependencies = [
- "anstyle",
- "unicode-width",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,27 +1131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "annotate-snippets",
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex 1.3.0",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "biscuit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,16 +1489,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 2.0.1",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
+ "shlex",
 ]
 
 [[package]]
@@ -1636,17 +1596,6 @@ checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "crypto-common 0.2.2",
  "inout",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -2122,16 +2071,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ctor"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb22e947478ccf9dc44d8922042c677a63fbb88f2cb468521d1145816e5087cb"
-dependencies = [
- "link-section",
- "linktime-proc-macro",
 ]
 
 [[package]]
@@ -4328,16 +4267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "liblzma"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4410,18 +4339,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "link-section"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9"
-
-[[package]]
-name = "linktime-proc-macro"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4913,9 +4830,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -4959,11 +4876,10 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
- "bindgen",
  "cc",
  "libc",
  "openssl-src",
@@ -5083,19 +4999,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "ossl"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f34df8ca6a2920b0fae969ced913c714b41f23b655a434a45c6a9843a75c019"
-dependencies = [
- "bindgen",
- "cfg-if",
- "libc",
- "openssl-sys",
- "pkg-config",
 ]
 
 [[package]]
@@ -7006,16 +6909,15 @@ dependencies = [
 
 [[package]]
 name = "sequoia-openpgp"
-version = "2.4.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbc8f9818a6fad141d85993777ba298ee52c80a09bd23d45dda461a6b7c83cb"
+checksum = "c847f0f148cf238c3aec88d092fd3c4301c21e906829ea9e415ea7531f7ec094"
 dependencies = [
  "anyhow",
  "argon2",
  "base64 0.22.1",
  "buffered-reader",
  "chrono",
- "ctor",
  "dyn-clone",
  "getrandom 0.2.17",
  "idna",
@@ -7023,8 +6925,8 @@ dependencies = [
  "lalrpop-util",
  "libc",
  "memsec",
+ "openssl",
  "openssl-sys",
- "ossl",
  "regex",
  "regex-syntax",
  "sha1collisiondetection",
@@ -7297,12 +7199,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"
@@ -8744,7 +8640,6 @@ dependencies = [
  "log",
  "mime",
  "openssl",
- "openssl-sys",
  "opentelemetry",
  "opentelemetry-instrumentation-actix-web",
  "opentelemetry-otlp",
@@ -8950,6 +8845,7 @@ dependencies = [
  "schemars 1.2.1",
  "sea-orm",
  "sea-query",
+ "sequoia-openpgp",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -9008,6 +8904,7 @@ dependencies = [
  "sea-orm",
  "sea-query",
  "semver",
+ "sequoia-openpgp",
  "serde",
  "serde-cyclonedx",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8472,7 +8472,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-auth"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8505,7 +8505,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-cli"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8524,7 +8524,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-common"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8581,7 +8581,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-db"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8598,7 +8598,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-entity"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "cpe",
@@ -8625,7 +8625,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-infrastructure"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "actix-cors",
  "actix-tls",
@@ -8660,7 +8660,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-migration"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8695,7 +8695,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-analysis"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8744,7 +8744,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-fundamental"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8821,7 +8821,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-importer"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8877,7 +8877,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ingestor"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8932,7 +8932,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-storage"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8964,7 +8964,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ui"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "actix-web",
  "actix-web-static-files",
@@ -8986,7 +8986,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-user"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9008,14 +9008,14 @@ dependencies = [
 
 [[package]]
 name = "trustify-query"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "utoipa",
 ]
 
 [[package]]
 name = "trustify-query-derive"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-server"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -9061,7 +9061,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-test-context"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9111,7 +9111,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-trustd"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -10045,7 +10045,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 edition = "2024"
 publish = false
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,8 @@ native-tls = "0.2"
 num-traits = "0.2"
 oci-client = "0.17.0"
 openid = "0.23.0"
-openssl = "=0.10.80" # FIXME: issue with bindgen and clang
-openssl-sys = "=0.9.116" # FIXME: issue with bindgen and clang
+openssl = "0.10"
+sequoia-openpgp = { version = ">=2, <2.4", default-features = false } # pin below 2.4 which pulls in ossl/bindgen
 opentelemetry = "0.32"
 opentelemetry-otlp = "0.32"
 opentelemetry_sdk = "0.32"

--- a/common/infrastructure/Cargo.toml
+++ b/common/infrastructure/Cargo.toml
@@ -20,7 +20,6 @@ http = { workspace = true }
 log = { workspace = true }
 mime = { workspace = true }
 openssl = { workspace = true }
-openssl-sys = { workspace = true } # FIXME: issue with bindgen and clang
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"] }
 opentelemetry_sdk = { workspace = true, features = ["metrics"] }

--- a/modules/importer/Cargo.toml
+++ b/modules/importer/Cargo.toml
@@ -34,6 +34,7 @@ sbom-walker = { workspace = true }
 schemars = { workspace = true, features = ["url2"] }
 sea-orm = { workspace = true, features = ["sea-query-binder", "sqlx-postgres", "runtime-tokio-rustls", "macros", "debug-print"] }
 sea-query = { workspace = true }
+sequoia-openpgp = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }

--- a/modules/ingestor/Cargo.toml
+++ b/modules/ingestor/Cargo.toml
@@ -35,6 +35,7 @@ sbom-walker = { workspace = true }
 sea-orm = { workspace = true }
 sea-query = { workspace = true }
 semver = { workspace = true }
+sequoia-openpgp = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde-cyclonedx = { workspace = true }
 serde_json = { workspace = true }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache License, Version 2.0
     identifier: Apache-2.0
-  version: 0.5.0-rc.3
+  version: 0.5.0-rc.4
 paths:
   /.well-known/trustify:
     get:


### PR DESCRIPTION
## Summary

- Pin `sequoia-openpgp` to `<2.4` with `default-features = false` to prevent `bindgen` from entering the dependency tree
- Revert the ineffective `openssl`/`openssl-sys` version pins from PR #2470
- Remove the unnecessary `openssl-sys` dependency from `common/infrastructure`

`sequoia-openpgp` 2.4 replaced direct `openssl`/`openssl-sys` usage with the `ossl` crate, which unconditionally pulls in `bindgen` as a build-dependency. The previous fix (pinning `openssl-sys`) did not address this. Disabling default features also avoids the `crypto-nettle` backend, whose `nettle-sys` crate also depends on `bindgen`.

## Test plan

- [x] `cargo tree -i bindgen` returns exit code 101 (not found)
- [x] `cargo check --all-targets --all-features` passes
- [x] `cargo update` does not re-introduce bindgen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Pin OpenPGP dependencies to avoid bindgen while cleaning up related OpenSSL configuration.

New Features:
- Introduce a workspace-managed sequoia-openpgp dependency for importer and ingestor modules.

Bug Fixes:
- Prevent bindgen from entering the dependency tree by pinning sequoia-openpgp below 2.4 with default features disabled.

Enhancements:
- Relax the OpenSSL crate version pin to the general 0.10 series.
- Remove the unused openssl-sys dependency from the common infrastructure crate.