### PR TITLE
perf: api/v3/license query performance

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -64,6 +64,7 @@ mod m0002190_vulnerability_base_score_advisory;
 mod m0002200_source_document_ingested_index;
 mod m0002210_sbom_node_name_index;
 mod m0002220_drop_qualified_purl_gist_indexes;
+mod m0002230_sle_license_id_index;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -143,6 +144,7 @@ impl MigratorExt for Migrator {
             .normal(m0002200_source_document_ingested_index::Migration)
             .normal(m0002210_sbom_node_name_index::Migration)
             .normal(m0002220_drop_qualified_purl_gist_indexes::Migration)
+            .normal(m0002230_sle_license_id_index::Migration)
     }
 }
 

--- a/migration/src/m0002230_sle_license_id_index.rs
+++ b/migration/src/m0002230_sle_license_id_index.rs
@@ -1,0 +1,36 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // The NOT EXISTS subquery in GET /v3/license correlates on
+        // sbom_license_expanded.license_id, but the composite PK is
+        // (sbom_id, license_id) so license_id-only lookups require a
+        // sequential scan. This index enables an index-only anti-join.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                CREATE INDEX IF NOT EXISTS idx_sle_license_id
+                ON sbom_license_expanded (license_id)
+                "#,
+            )
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("DROP INDEX IF EXISTS idx_sle_license_id")
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
The query in api/v3/license is GET /v3/license (license/service/mod.rs:318-328) eg. the NOT EXISTS subquery in:
``` 
WHERE NOT EXISTS(
  SELECT $1 FROM "sbom_license_expanded"
  WHERE "sbom_license_expanded"."license_id" = "license"."id"
)
```

is very slow and ties up postgres resources.

The **sbom_license_expanded** table has a composite primary key (sbom_id, license_id). 

In a B-tree composite index, the leading column is `sbom_id` which a correlated lookup on `license_id` alone cannot use this index.  

Postgres is falling back to a sequential scan of the entire `sbom_license_expanded table` for every row in license.  That is an O(N*M) nested loop with no index support, explaining the **277-second** execution time!

The fix is to add index:

**Before**
```
EXPLAIN (ANALYZE, BUFFERS, TIMING)
SELECT DISTINCT "expanded_license"."expanded_text" AS "text"
FROM "expanded_license"
UNION
(SELECT DISTINCT "license"."text" AS "text"
 FROM "license"
 WHERE NOT EXISTS(
   SELECT 1 FROM "sbom_license_expanded"
   WHERE "sbom_license_expanded"."license_id" = "license"."id"
 ))
ORDER BY text ASC
LIMIT 10 OFFSET 0;
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                                                                          |
|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Limit  (cost=36963.58..36963.63 rows=10 width=32) (actual time=277495.012..277495.022 rows=10 loops=1)                                                                                                              |
|   Buffers: shared hit=117804069                                                                                                                                                                                     |
|   ->  Unique  (cost=36963.58..36988.75 rows=5034 width=32) (actual time=277495.011..277495.019 rows=10 loops=1)                                                                                                     |
|         Buffers: shared hit=117804069                                                                                                                                                                               |
|         ->  Sort  (cost=36963.58..36976.16 rows=5034 width=32) (actual time=277495.010..277495.014 rows=10 loops=1)                                                                                                 |
|               Sort Key: expanded_license.expanded_text                                                                                                                                                              |
|               Sort Method: quicksort  Memory: 97kB                                                                                                                                                                  |
|               Buffers: shared hit=117804069                                                                                                                                                                         |
|               ->  Append  (cost=83.33..36654.05 rows=5034 width=32) (actual time=0.896..277485.154 rows=3415 loops=1)                                                                                               |
|                     Buffers: shared hit=117803573                                                                                                                                                                   |
|                     ->  HashAggregate  (cost=83.33..110.78 rows=2746 width=62) (actual time=0.896..1.162 rows=2746 loops=1)                                                                                         |
|                           Group Key: expanded_license.expanded_text                                                                                                                                                 |
|                           Batches: 1  Memory Usage: 625kB                                                                                                                                                           |
|                           Buffers: shared hit=57                                                                                                                                                                    |
|                           ->  Seq Scan on expanded_license  (cost=0.00..76.46 rows=2746 width=62) (actual time=0.009..0.202 rows=2746 loops=1)                                                                      |
|                                 Buffers: shared hit=49                                                                                                                                                              |
|                     ->  Subquery Scan on "*SELECT* 2"  (cost=36483.78..36518.10 rows=2288 width=32) (actual time=277483.508..277483.731 rows=669 loops=1)                                                           |
|                           Buffers: shared hit=117803516                                                                                                                                                             |
|                           ->  Unique  (cost=36483.78..36495.22 rows=2288 width=62) (actual time=277483.505..277483.654 rows=669 loops=1)                                                                            |
|                                 Buffers: shared hit=117803516                                                                                                                                                       |
|                                 ->  Sort  (cost=36483.78..36489.50 rows=2288 width=62) (actual time=277483.503..277483.539 rows=669 loops=1)                                                                        |
|                                       Sort Key: license.text                                                                                                                                                        |
|                                       Sort Method: quicksort  Memory: 25kB                                                                                                                                          |
|                                       Buffers: shared hit=117803516                                                                                                                                                 |
|                                       ->  Nested Loop Anti Join  (cost=0.56..36356.11 rows=2288 width=62) (actual time=276.649..277481.399 rows=669 loops=1)                                                        |
|                                             Buffers: shared hit=117803478                                                                                                                                           |
|                                             ->  Seq Scan on license  (cost=0.00..100.33 rows=3333 width=78) (actual time=0.006..2.721 rows=3333 loops=1)                                                            |
|                                                   Buffers: shared hit=67                                                                                                                                            |
|                                             ->  Index Only Scan using sbom_license_expanded_pkey on sbom_license_expanded  (cost=0.56..95838.38 rows=12208 width=16) (actual time=83.250..83.250 rows=1 loops=3333) |
|                                                   Index Cond: (license_id = license.id)                                                                                                                             |
|                                                   Heap Fetches: 0                                                                                                                                                   |
|                                                   Buffers: shared hit=117803411                                                                                                                                     |
| Planning:                                                                                                                                                                                                           |
|   Buffers: shared hit=22                                                                                                                                                                                            |
| Planning Time: 0.254 ms                                                                                                                                                                                             |
| Execution Time: 277495.071 ms                                                                                                                                                                                       |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
EXPLAIN 36


```

**After**
```
EXPLAIN (ANALYZE, BUFFERS, TIMING)
SELECT DISTINCT "expanded_license"."expanded_text" AS "text"
FROM "expanded_license"
UNION
(SELECT DISTINCT "license"."text" AS "text"
 FROM "license"
 WHERE NOT EXISTS(
   SELECT 1 FROM "sbom_license_expanded"
   WHERE "sbom_license_expanded"."license_id" = "license"."id"
 ))
ORDER BY text ASC
LIMIT 10 OFFSET 0;
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                                                            |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Limit  (cost=2007.76..2007.78 rows=10 width=32) (actual time=10.791..10.795 rows=10 loops=1)                                                                                                          |
|   Buffers: shared hit=10640                                                                                                                                                                           |
|   ->  Sort  (cost=2007.76..2020.30 rows=5017 width=32) (actual time=10.790..10.792 rows=10 loops=1)                                                                                                   |
|         Sort Key: expanded_license.expanded_text                                                                                                                                                      |
|         Sort Method: still in progress  Memory: 0kB                                                                                                                                                   |
|         Buffers: shared hit=10640                                                                                                                                                                     |
|         ->  HashAggregate  (cost=1849.17..1899.34 rows=5017 width=32) (actual time=9.771..10.150 rows=3407 loops=1)                                                                                   |
|               Group Key: expanded_license.expanded_text                                                                                                                                               |
|               Batches: 1  Memory Usage: 721kB                                                                                                                                                         |
|               Buffers: shared hit=10630                                                                                                                                                               |
|               ->  Append  (cost=83.33..1836.63 rows=5017 width=32) (actual time=0.887..9.012 rows=3415 loops=1)                                                                                       |
|                     Buffers: shared hit=10620                                                                                                                                                         |
|                     ->  HashAggregate  (cost=83.33..110.78 rows=2746 width=62) (actual time=0.886..1.155 rows=2746 loops=1)                                                                           |
|                           Group Key: expanded_license.expanded_text                                                                                                                                   |
|                           Batches: 1  Memory Usage: 625kB                                                                                                                                             |
|                           Buffers: shared hit=57                                                                                                                                                      |
|                           ->  Seq Scan on expanded_license  (cost=0.00..76.46 rows=2746 width=62) (actual time=0.010..0.202 rows=2746 loops=1)                                                        |
|                                 Buffers: shared hit=49                                                                                                                                                |
|                     ->  Subquery Scan on "*SELECT* 2"  (cost=1655.34..1700.76 rows=2271 width=32) (actual time=7.425..7.593 rows=669 loops=1)                                                         |
|                           Buffers: shared hit=10563                                                                                                                                                   |
|                           ->  HashAggregate  (cost=1655.34..1678.05 rows=2271 width=62) (actual time=7.422..7.520 rows=669 loops=1)                                                                   |
|                                 Group Key: license.text                                                                                                                                               |
|                                 Batches: 1  Memory Usage: 241kB                                                                                                                                       |
|                                 Buffers: shared hit=10563                                                                                                                                             |
|                                 ->  Nested Loop Anti Join  (cost=0.43..1649.66 rows=2271 width=62) (actual time=0.013..7.239 rows=669 loops=1)                                                        |
|                                       Buffers: shared hit=10561                                                                                                                                       |
|                                       ->  Seq Scan on license  (cost=0.00..100.33 rows=3333 width=78) (actual time=0.006..0.295 rows=3333 loops=1)                                                    |
|                                             Buffers: shared hit=67                                                                                                                                    |
|                                       ->  Index Only Scan using idx_sle_license_id on sbom_license_expanded  (cost=0.43..214.28 rows=12012 width=16) (actual time=0.002..0.002 rows=1 loops=3333) |
|                                             Index Cond: (license_id = license.id)                                                                                                                     |
|                                             Heap Fetches: 0                                                                                                                                           |
|                                             Buffers: shared hit=10494                                                                                                                                 |
| Planning:                                                                                                                                                                                             |
|   Buffers: shared hit=14                                                                                                                                                                              |
| Planning Time: 0.214 ms                                                                                                                                                                               |
| Execution Time: 10.848 ms                                                                                                                                                                             |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
EXPLAIN 36
```

going from **277 seconds** to **10.8 ms** is not too shabby ;)

## Summary by Sourcery

Enhancements:
- Introduce a new migration that creates and drops an index on sbom_license_expanded(license_id) to optimize NOT EXISTS lookups in the license API.