### PR TITLE
ci: upgrade ubuntu to 24.04 and container base to UBI 10

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -48,6 +48,14 @@ runs:
       shell: bash
       run: buildah images
 
+    - name: Smoke test container (trustd)
+      shell: bash
+      run: podman run --rm trustd:${{ inputs.image_tag }} --help
+
+    - name: Smoke test container (xtask)
+      shell: bash
+      run: podman run --rm xtask:${{ inputs.image_tag }} --help
+
     # We save the container image here. But when loading it, the multi-arch aspect of it will be gone.
     - name: Save image
       shell: bash

--- a/.github/scripts/Containerfile
+++ b/.github/scripts/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest as builder
+FROM registry.access.redhat.com/ubi10/ubi:latest as builder
 
 ARG tag
 
@@ -30,7 +30,7 @@ RUN cp -av /unpack/trustd /stage/usr/local/bin
 RUN find /stage
 RUN du -h /stage
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.access.redhat.com/ubi10/ubi-micro:latest
 
 LABEL \
     org.opencontainers.image.description="Trustify - Main server binary" \

--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -49,11 +49,11 @@ jobs:
 
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             install: |
               sudo apt install -y libssl-dev
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
             install: |
               sudo apt install -y libssl-dev
 


### PR DESCRIPTION
## Summary
* Upgrade Ubuntu CI runners from 22.04 to 24.04 (OpenSSL too old on 22.04)
* Switch container base images from UBI 9 to UBI 10
* Add container smoke tests before saving images

Backport of ca4fab84 and 722f0046 from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Upgrade CI build environment to newer Ubuntu and UBI base images and add container smoke checks before image export.

New Features:
- Add smoke test steps that run trustd and xtask containers with the specified image tag before saving images.

Enhancements:
- Switch container build and runtime base images from UBI 9 to UBI 10 for the Trustify server.
- Update binary build workflow matrix to use Ubuntu 24.04 runners for x86_64 and aarch64 targets instead of Ubuntu 22.04 variants.

CI:
- Refresh GitHub Actions workflows to target Ubuntu 24.04 images for Linux builds and validate built containers during CI.