### PR TITLE
fix(ci): upgrade xtask container builder to UBI 10

### DIFF
--- a/.github/scripts/Containerfile.xtask
+++ b/.github/scripts/Containerfile.xtask
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest as builder
+FROM registry.access.redhat.com/ubi10/ubi:latest as builder
 
 ARG tag
 


### PR DESCRIPTION
## Summary

* The CI upgrade to UBI 10 missed the builder stage of the xtask Containerfile, which was still referencing UBI 9
* Updates the builder `FROM` line from `ubi9/ubi:latest` to `ubi10/ubi:latest`

## Test plan

- [ ] CI builds the xtask container successfully with UBI 10 builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update the xtask Containerfile builder stage to use the UBI 10 base image instead of UBI 9.