### PR TITLE
fix(ci): upgrade xtask container to UBI 10

### DIFF
--- a/.github/scripts/Containerfile.xtask
+++ b/.github/scripts/Containerfile.xtask
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest as builder
+FROM registry.access.redhat.com/ubi10/ubi:latest as builder
 
 ARG tag
 
@@ -14,7 +14,7 @@ RUN cd unpack && \
 
 RUN chmod a+x /unpack/xtask
 
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi10/ubi:latest
 
 LABEL \
     org.opencontainers.image.description="Trustify - xtask binary" \


### PR DESCRIPTION
## Summary

* The CI upgrade to UBI 10 missed the xtask Containerfile, which was still referencing UBI 9 in both builder and runtime stages
* Updates both `FROM` lines from `ubi9/ubi:latest` to `ubi10/ubi:latest`

## Test plan

- [ ] CI builds the xtask container successfully with UBI 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Align the xtask Containerfile used in CI with the rest of the pipeline by upgrading its base images from UBI 9 to UBI 10.