### PR TITLE
fix(deps): bump js-yaml to ^4.3.0 to fix merge-key DoS

### DIFF
--- a/.github/scripts/map-users/package-lock.json
+++ b/.github/scripts/map-users/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^4.3.0"
       }
     },
     "node_modules/argparse": {
@@ -14,9 +14,19 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/.github/scripts/map-users/package.json
+++ b/.github/scripts/map-users/package.json
@@ -6,6 +6,6 @@
   "main": "main.mjs",
   "private": true,
   "dependencies": {
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.3.0"
   }
 }


### PR DESCRIPTION
js-yaml 4.1.1 is vulnerable to algorithmic complexity denial of service via crafted YAML merge keys (<<). Repeating the same alias in a merge sequence causes O(K*M) work in mergeMappings() while input size is O(K+M), blocking the event loop with payloads as small as tens of KB.

Fixed upstream in 4.2.0 (merge deduplication) and hardened in 4.3.0 (maxTotalMergeKeys limit backport).

Assisted-by: Claude Code

## Summary by Sourcery

Build:
- Bump js-yaml from ^4.1.1 to ^4.3.0 in .github/scripts/map-users package configuration to address a security vulnerability.