### PR TITLE
perf(analysis): batch ancestor resolution queries by SBOM ID

### DIFF
--- a/modules/analysis/src/service/collector.rs
+++ b/modules/analysis/src/service/collector.rs
@@ -85,6 +85,71 @@ impl AncestorCache {
         .await
         .cloned()
     }
+
+    /// Batch-prefetch ancestor results for all `PackageNode`s in a
+    /// graph that share the given `sbom_id`.
+    ///
+    /// Collects every `PackageNode.node_id` from the graph that is
+    /// not already cached, issues a single batched SQL query via
+    /// [`resolve_rh_external_sbom_ancestors_batch`], and populates
+    /// the cache with the results.  Subsequent per-node `resolve`
+    /// calls for these keys become cheap cache hits.
+    ///
+    /// Node IDs already present in the cache are skipped — this is
+    /// safe because entries are immutable once written (backed by
+    /// `OnceCell`).
+    pub(super) async fn prefetch<C: ConnectionTrait>(
+        &self,
+        sbom_id: Uuid,
+        graph: &NodeGraph,
+        connection: &C,
+    ) -> Result<(), Error> {
+        // Collect uncached node_ids under the lock, then release it.
+        let uncached_node_ids: Vec<String> = {
+            let map = self.cache.lock();
+            graph
+                .node_weights()
+                .filter_map(|node| match node {
+                    graph::Node::Package(pkg) if pkg.sbom_id == sbom_id => {
+                        let key = (sbom_id, pkg.node_id.clone());
+                        if map.contains_key(&key) {
+                            None
+                        } else {
+                            Some(pkg.node_id.clone())
+                        }
+                    }
+                    _ => None,
+                })
+                .collect()
+        };
+
+        if uncached_node_ids.is_empty() {
+            return Ok(());
+        }
+
+        // Batch-resolve all uncached node_ids in a single SQL query
+        // (chunked to stay under the PostgreSQL bind-parameter limit).
+        let chunk_size = ((u16::MAX - 128) as usize / 2).max(1);
+        for chunk in uncached_node_ids.chunks(chunk_size) {
+            let batch_result =
+                resolve_rh_external_sbom_ancestors_batch(sbom_id, chunk, connection).await?;
+
+            // Populate the cache with results.
+            let mut map = self.cache.lock();
+            for node_id in chunk {
+                let key = (sbom_id, node_id.clone());
+                if map.contains_key(&key) {
+                    continue;
+                }
+                let results = batch_result.get(node_id).cloned().unwrap_or_default();
+                let cell: AncestorCell =
+                    Arc::new(tokio::sync::OnceCell::new_with(Some(Arc::new(results))));
+                map.insert(key, cell);
+            }
+        }
+
+        Ok(())
+    }
 }
 
 /// Collector, helping on collector nodes from a graph.
@@ -283,6 +348,11 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             ));
         };
 
+        // Batch-prefetch ancestor results before recursing.
+        self.ancestor_cache
+            .prefetch(external_sbom_id, &external_graph, self.connection)
+            .await?;
+
         // find the node in retrieved external graph
         let Some(external_node_index) = external_graph
             .node_indices()
@@ -396,6 +466,17 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
                     );
                     return Ok(vec![]);
                 };
+
+                // Batch-prefetch ancestor results for all
+                // PackageNodes in this external graph.  This
+                // collapses N per-node SQL queries into a single
+                // batched query, so the recursive walk below finds
+                // warm cache entries instead of issuing individual
+                // queries.
+                collector
+                    .ancestor_cache
+                    .prefetch(ext_sbom_id, &external_graph, collector.connection)
+                    .await?;
 
                 // Find the entry-point node in the ancestor graph.
                 let Some(external_node_index) = external_graph

--- a/modules/analysis/src/service/collector.rs
+++ b/modules/analysis/src/service/collector.rs
@@ -27,6 +27,15 @@ type AncestorResult = Arc<Vec<ResolvedSbom>>;
 type AncestorCell = Arc<tokio::sync::OnceCell<AncestorResult>>;
 type AncestorMap = HashMap<(Uuid, String), AncestorCell>;
 
+/// Coalescing barrier for [`AncestorCache::prefetch`].
+///
+/// When multiple concurrent tasks call `prefetch` for the same
+/// `sbom_id`, only the first executes the batch SQL query — the
+/// rest await the same `OnceCell` and then find the per-node cache
+/// already populated.
+type PrefetchCell = Arc<tokio::sync::OnceCell<()>>;
+type PrefetchMap = HashMap<Uuid, PrefetchCell>;
+
 /// Request-scoped cache for [`resolve_rh_external_sbom_ancestors`] results.
 ///
 /// # Why this exists
@@ -47,6 +56,11 @@ type AncestorMap = HashMap<(Uuid, String), AncestorCell>;
 /// ensures only one task executes the query; the others await its
 /// result.
 ///
+/// Prefetch calls are also coalesced per `sbom_id` — if several
+/// concurrent graph walks discover the same external SBOM, only the
+/// first caller executes the batch query; the others await its
+/// completion and find the per-node cache warm.
+///
 /// # Scope
 ///
 /// One `AncestorCache` is created per top-level `run_graph_query`
@@ -57,6 +71,7 @@ type AncestorMap = HashMap<(Uuid, String), AncestorCell>;
 #[derive(Default, Clone)]
 pub struct AncestorCache {
     cache: Arc<Mutex<AncestorMap>>,
+    prefetch_barriers: Arc<Mutex<PrefetchMap>>,
 }
 
 impl AncestorCache {
@@ -95,10 +110,33 @@ impl AncestorCache {
     /// the cache with the results.  Subsequent per-node `resolve`
     /// calls for these keys become cheap cache hits.
     ///
-    /// Node IDs already present in the cache are skipped — this is
-    /// safe because entries are immutable once written (backed by
-    /// `OnceCell`).
+    /// Concurrent callers for the same `sbom_id` are coalesced: the
+    /// first caller runs the batch query while others await the same
+    /// barrier, then all find the per-node cache already populated.
     pub(super) async fn prefetch<C: ConnectionTrait>(
+        &self,
+        sbom_id: Uuid,
+        graph: &NodeGraph,
+        connection: &C,
+    ) -> Result<(), Error> {
+        // Acquire or create the per-sbom_id coalescing barrier.
+        // All concurrent callers for the same sbom_id share one
+        // OnceCell; only the first will execute the query.
+        let barrier = {
+            let mut barriers = self.prefetch_barriers.lock();
+            barriers.entry(sbom_id).or_default().clone()
+        };
+
+        barrier
+            .get_or_try_init(|| async { self.do_prefetch(sbom_id, graph, connection).await })
+            .await?;
+
+        Ok(())
+    }
+
+    /// Inner prefetch logic, executed exactly once per `sbom_id`
+    /// thanks to the coalescing barrier in [`Self::prefetch`].
+    async fn do_prefetch<C: ConnectionTrait>(
         &self,
         sbom_id: Uuid,
         graph: &NodeGraph,

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -300,6 +300,28 @@ struct ChecksumWithCpes {
     graph_node_id: Option<String>,
 }
 
+/// Extended version of [`ChecksumWithCpes`] used by the batch query.
+///
+/// Includes `input_node_id` so results from a multi-node query can be
+/// partitioned back into per-node cache entries.
+#[derive(Debug, FromQueryResult)]
+struct BatchChecksumWithCpes {
+    /// The `node_id` value from the input array that produced this
+    /// row (i.e. `snc_self.node_id`).
+    input_node_id: String,
+    /// `sbom_external_node.sbom_id` — the ancestor (product) SBOM.
+    sbom_id: Uuid,
+    /// `sbom_external_node.external_node_ref` — the ref the ancestor
+    /// SBOM uses to point at the component.
+    node_id: String,
+    /// Aggregated `sbom_describing_cpe.cpe_id` values for the
+    /// ancestor SBOM (empty array when none exist).
+    cpe_ids: Vec<Uuid>,
+    /// `sbom_external_node.node_id` — the graph-internal node ID
+    /// within the ancestor SBOM, used to skip a follow-up query.
+    graph_node_id: Option<String>,
+}
+
 /// Find ancestor (product) SBOMs that reference a given component node.
 ///
 /// # Background — Red Hat product→component model
@@ -406,6 +428,84 @@ async fn resolve_rh_external_sbom_ancestors<C: ConnectionTrait>(
             graph_node_id: r.graph_node_id,
         })
         .collect())
+}
+
+/// Batch variant of [`resolve_rh_external_sbom_ancestors`].
+///
+/// Resolves ancestor SBOMs for **multiple** node IDs within a single
+/// component SBOM in one SQL query, instead of issuing one query per
+/// node.  The query is identical to the single-node version except
+/// that the `snc_self.node_id = $2` equality is replaced with
+/// `snc_self.node_id = ANY($2)`, and the `snc_self.node_id` column
+/// is included in the SELECT list (as `input_node_id`) and GROUP BY
+/// so the caller can partition results per input node.
+///
+/// Returns a map from each input `node_id` to its resolved ancestors.
+/// Node IDs with no ancestors are mapped to an empty `Vec`.
+#[instrument(
+    skip(node_refs, connection),
+    fields(node_count = node_refs.len()),
+    err(level = tracing::Level::INFO)
+)]
+async fn resolve_rh_external_sbom_ancestors_batch<C: ConnectionTrait>(
+    sbom_id: Uuid,
+    node_refs: &[String],
+    connection: &C,
+) -> Result<HashMap<String, Vec<ResolvedSbom>>, Error> {
+    if node_refs.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows = BatchChecksumWithCpes::find_by_statement(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        r#"
+            SELECT snc_self.node_id AS input_node_id,
+                   sen.sbom_id,
+                   sen.external_node_ref AS node_id,
+                   COALESCE(
+                       array_agg(sdc.cpe_id)
+                           FILTER (WHERE sdc.cpe_id IS NOT NULL),
+                       ARRAY[]::uuid[]
+                   ) AS cpe_ids,
+                   sen.node_id AS graph_node_id
+            FROM sbom_ancestor sa
+            JOIN sbom_external_node sen
+              ON sen.sbom_id = sa.ancestor_sbom_id
+            JOIN sbom_node_checksum snc_ref
+              ON snc_ref.sbom_id = sen.sbom_id
+             AND snc_ref.node_id = sen.external_node_ref
+            JOIN sbom_node_checksum snc_self
+              ON snc_self.sbom_id = $1
+             AND snc_self.node_id = ANY($2)
+             AND snc_self.value = snc_ref.value
+            LEFT JOIN sbom_describing_cpe sdc
+              ON sdc.sbom_id = sen.sbom_id
+            WHERE sa.sbom_id = $1
+            GROUP BY snc_self.node_id,
+                     sen.sbom_id,
+                     sen.external_node_ref,
+                     sen.node_id
+            "#,
+        [sbom_id.into(), node_refs.to_vec().into()],
+    ))
+    .all(connection)
+    .await?;
+
+    let mut result = HashMap::<String, Vec<ResolvedSbom>>::with_capacity(node_refs.len());
+
+    for r in rows {
+        result
+            .entry(r.input_node_id)
+            .or_default()
+            .push(ResolvedSbom {
+                sbom_id: r.sbom_id,
+                node_id: r.node_id,
+                cpe_ids: r.cpe_ids,
+                graph_node_id: r.graph_node_id,
+            });
+    }
+
+    Ok(result)
 }
 
 impl AnalysisService {
@@ -630,6 +730,15 @@ impl AnalysisService {
 
         let loader = &GraphLoader::new(self.clone());
         let ancestor_cache = AncestorCache::default();
+
+        // Batch-prefetch ancestor results for all PackageNodes in
+        // the initial set of graphs.  This replaces N individual
+        // SQL queries (one per node) with one batched query per SBOM,
+        // dramatically reducing DB round-trips for the first level
+        // of ancestor resolution.
+        for (sbom_id, graph) in graphs {
+            ancestor_cache.prefetch(*sbom_id, graph, connection).await?;
+        }
 
         self.collect_graph(
             query,


### PR DESCRIPTION
During analysis graph traversal, `resolve_rh_external_sbom_ancestors` is called once per `PackageNode` to find cross-SBOM product->component links. 

For rare components like **stratisd** that appear across multiple SBOMs with dozens of package nodes each, this produces 72+ individual 5-table JOIN queries — all with the same `sbom_id`, differing only in `node_id`. 

For example, with **stratisd** the existing `AncestorCache` deduplicates repeated visits to the same (sbom_id, node_id) pair, but all 72 pairs are unique (different arch RPMs, source tarballs, cargo packages), so every call hits postgres.

This PR adds a further batch-prefetch mechanism that collapses N per-node queries into one query per SBOM ID:

**BEFORE**
```
cold cache GET /api/v3/analysis/latest/component/stratisd?ancestor=5 22.5 s
warm cache GET /api/v3/analysis/latest/component/stratisd?ancestor=5 15.7 s
```

**AFTER** 
```
cold cache GET /api/v3/analysis/latest/component/stratisd?ancestor=5 14.4 s
warm cache GET /api/v3/analysis/latest/component/stratisd?ancestor=5  6.15 s
```

Cold cache benefits by **36%**, warm cache by **61%** though impact is not universal across all component _prevalence_ that is for ubiquitous components its more like **10%** cold cache and **20%** warm cache.

Important to note that this change does not increase memory or CPU usage in any meaningful way (which I also checked manually). The only transient mem alloc is the HashMap<String, Vec<ResolvedSbom>> returned by the batch query which is immediately consumed to populate cache and then dropped. Trustify usage of CPU may even decrease slightly ... the real improvement is postgres does less work.

Using a similar idea also coalesced concurrent ancestor prefetch calls per SBOM ID.

Kudos to @vobratil who observed how rare components did not seem to benefit much from warm graph cache!