### PR TITLE
chore: add callback URL for swagger-ui

### DIFF
--- a/docs/book/modules/admin/examples/trustify/sso.tf
+++ b/docs/book/modules/admin/examples/trustify/sso.tf
@@ -113,6 +113,7 @@ resource "aws_cognito_user_pool_client" "frontend" {
     var.console-url,
     "${var.console-url}/",
     "${var.console-url}/openapi/oauth-receiver.html",
+    "${var.console-url}/swagger-ui/oauth2-redirect.html",
   ]
   logout_urls = [
     "${var.console-url}/",


### PR DESCRIPTION
When trying to login using the TPA 3.x swagger-ui web interface, the `/swagger-ui/oauth2-redirect.html` path is used as a redirect. However, Cognito does not recognize this URL by default. This fixes the issue. 
