### PR TITLE
fix(purl): add VersionMatches filter to product status query

### DIFF
--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -106,6 +106,7 @@ impl PurlDetails {
             qualified_package.id,
             &package.name,
             package.namespace.as_deref(),
+            &package_version.version,
         )
         .await?;
 
@@ -157,6 +158,7 @@ async fn get_product_statuses_for_purl<C: ConnectionTrait>(
     qualified_package_id: Uuid,
     purl_name: &str,
     namespace_name: Option<&str>,
+    version: &str,
 ) -> Result<Vec<ProductStatusCatcher>, Error> {
     // Subquery to get all SBOM IDs for the given purl
     let sbom_ids_query = sbom::Entity::find()
@@ -192,6 +194,11 @@ async fn get_product_statuses_for_purl<C: ConnectionTrait>(
             namespace_name.map_or(Expr::value(false), |ns| {
                 Expr::col(product_status::Column::Package).eq(format!("{ns}/{purl_name}"))
             }),
+        ))
+        .filter(SimpleExpr::FunctionCall(
+            Func::cust(VersionMatches)
+                .arg(Expr::value(version.to_string()))
+                .arg(Expr::col((version_range::Entity, Asterisk))),
         ))
         .distinct_on([
             (product_status::Entity, product_status::Column::ContextCpeId),

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -1102,3 +1102,55 @@ async fn version_range_boundary_semantics(ctx: &TrustifyContext) -> Result<(), a
 
     Ok(())
 }
+
+/// Proves that `version_matches` filtering works on the **product_status** path.
+///
+/// DS3 contains a CSAF advisory for CVE-2024-28834 affecting gnutls on RHEL 8
+/// AppStream, and an ubi8 SPDX SBOM whose product package carries the same CPE.
+/// The shared CPE bridges the product_status join chain:
+///   product_status → context_cpe → product (via cpe_key) → product_version → SBOM
+///
+/// gnutls@3.6.16-6.el8_7 (from the ubi8 SBOM) falls within the advisory's
+/// affected version range, so product_status entries with CPE context must appear.
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn product_status_version_filtering(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let service = PurlService::new(PaginationCache::for_test());
+    ctx.ingest_dataset(Dataset::DS3).await?;
+
+    // gnutls version from the ubi8 SBOM — affected (below fix 3.6.16-8.el8_9.3)
+    let purl = Purl::from_str("pkg:rpm/redhat/gnutls@3.6.16-6.el8_7?arch=x86_64")?;
+    let details = service
+        .purl_by_purl(&purl, Default::default(), &ctx.db)
+        .await?
+        .expect("gnutls purl must exist after DS3 ingestion");
+
+    // Product_status entries carry StatusContext::Cpe (not ::Purl).
+    let cpe_statuses: Vec<_> = details
+        .advisories
+        .iter()
+        .flat_map(|a| &a.status)
+        .filter(|s| matches!(&s.context, Some(StatusContext::Cpe(_))))
+        .collect();
+
+    assert!(
+        !cpe_statuses.is_empty(),
+        "affected gnutls version must have product_status entries with CPE context"
+    );
+
+    assert!(
+        cpe_statuses
+            .iter()
+            .any(|s| s.vulnerability.identifier == "CVE-2024-28834"),
+        "product_statuses must include CVE-2024-28834"
+    );
+
+    for s in &cpe_statuses {
+        assert!(
+            s.version_range.is_some(),
+            "every product_status entry must carry a version_range"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds the missing `VersionMatches` filter to the `get_product_statuses_for_purl` function, which was returning false-positive vulnerability matches
- Without this filter, RPM-specific version ranges were being returned for non-RPM packages, and already-fixed CVEs were reported as still affected
- The fix mirrors the same `VersionMatches` pattern already used by the `purl_statuses` query in the same file

Fixes #2522

## Jira

[TC-5170](https://issues.redhat.com/browse/TC-5170)

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy -p trustify-module-fundamental` — zero warnings
- [x] All purl unit tests pass (individually; bulk run has pre-existing DB contention flakes unrelated to this change)
- [ ] Verify with a non-RPM SBOM that product statuses no longer include RPM-only version ranges
- [ ] Verify that fixed CVEs are no longer reported as affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-5170]: https://redhat.atlassian.net/browse/TC-5170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ