### PR TITLE
fix(purl): filter purl_statuses by SBOM describing CPEs (TC-5171)

### DIFF
--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -12,9 +12,9 @@ use crate::{
     vulnerability::model::VulnerabilityHead,
 };
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DbErr, EntityTrait, FromQueryResult, LoaderTrait, ModelTrait,
-    QueryFilter, QueryOrder, QueryResult, QuerySelect, QueryTrait, RelationTrait, Select,
-    SelectColumns,
+    ColumnTrait, Condition, ConnectionTrait, DbErr, EntityTrait, FromQueryResult, LoaderTrait,
+    ModelTrait, QueryFilter, QueryOrder, QueryResult, QuerySelect, QueryTrait, RelationTrait,
+    Select, SelectColumns,
 };
 use sea_query::{Asterisk, ColumnRef, Expr, Func, IntoIden, JoinType, SimpleExpr};
 use serde::{Deserialize, Serialize};
@@ -28,8 +28,8 @@ use trustify_common::{
 use trustify_entity::{
     advisory, advisory_vulnerability_score, base_purl, cpe, license, organization, product,
     product_status, product_version, product_version_range, purl_status, qualified_purl, sbom,
-    sbom_license_expanded, sbom_node, sbom_node_purl_ref, sbom_package_license, status,
-    version_range, versioned_purl, vulnerability,
+    sbom_describing_cpe, sbom_license_expanded, sbom_node, sbom_node_purl_ref,
+    sbom_package_license, status, version_range, versioned_purl, vulnerability,
 };
 use trustify_module_ingestor::common::{Deprecation, DeprecationForExt};
 use utoipa::ToSchema;
@@ -84,6 +84,24 @@ impl PurlDetails {
                 .ok_or(Error::Data("underlying package missing".to_string()))?
         };
 
+        let sbom_ids_for_purl = sbom_node_purl_ref::Entity::find()
+            .select_only()
+            .column(sbom_node_purl_ref::Column::SbomId)
+            .filter(sbom_node_purl_ref::Column::QualifiedPurlId.eq(qualified_package.id))
+            .into_query();
+
+        let allowed_cpe_ids = sbom_describing_cpe::Entity::find()
+            .select_only()
+            .column(sbom_describing_cpe::Column::CpeId)
+            .filter(sbom_describing_cpe::Column::SbomId.in_subquery(sbom_ids_for_purl.clone()))
+            .into_query();
+
+        let sbom_has_cpes = sea_query::Query::select()
+            .expr(Expr::value(1i32))
+            .from(sbom_describing_cpe::Entity)
+            .and_where(sbom_describing_cpe::Column::SbomId.in_subquery(sbom_ids_for_purl))
+            .to_owned();
+
         let purl_statuses = purl_status::Entity::find()
             .filter(purl_status::Column::BasePurlId.eq(package.id))
             .left_join(version_range::Entity)
@@ -93,6 +111,12 @@ impl PurlDetails {
                     .arg(Expr::value(package_version.version.clone()))
                     .arg(Expr::col((version_range::Entity, Asterisk))),
             ))
+            .filter(
+                Condition::any()
+                    .add(purl_status::Column::ContextCpeId.is_null())
+                    .add(purl_status::Column::ContextCpeId.in_subquery(allowed_cpe_ids))
+                    .add(Expr::exists(sbom_has_cpes).not()),
+            )
             .distinct_on([ColumnRef::TableColumn(
                 purl_status::Entity.into_iden(),
                 purl_status::Column::Id.into_iden(),

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -16,7 +16,9 @@ use sea_orm::{
     ModelTrait, QueryFilter, QueryOrder, QueryResult, QuerySelect, QueryTrait, RelationTrait,
     Select, SelectColumns,
 };
-use sea_query::{Asterisk, ColumnRef, Expr, Func, IntoIden, JoinType, SimpleExpr};
+use sea_query::{
+    Alias, Asterisk, ColumnRef, Expr, Func, IntoIden, JoinType, SimpleExpr, UnionType,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, hash_map::Entry};
 use trustify_common::{
@@ -90,11 +92,58 @@ impl PurlDetails {
             .filter(sbom_node_purl_ref::Column::QualifiedPurlId.eq(qualified_package.id))
             .into_query();
 
-        let allowed_cpe_ids = sbom_describing_cpe::Entity::find()
+        let mut allowed_cpe_ids = sbom_describing_cpe::Entity::find()
             .select_only()
             .column(sbom_describing_cpe::Column::CpeId)
             .filter(sbom_describing_cpe::Column::SbomId.in_subquery(sbom_ids_for_purl.clone()))
             .into_query();
+
+        let c = Alias::new("c");
+        let sc = Alias::new("sc");
+        let sdc = Alias::new("sdc");
+        let generalized_cpe_ids = sea_query::Query::select()
+            .expr(Expr::col((c.clone(), cpe::Column::Id)))
+            .from_as(cpe::Entity, c.clone())
+            .join_as(
+                JoinType::InnerJoin,
+                cpe::Entity,
+                sc.clone(),
+                Condition::all()
+                    .add(
+                        Expr::col((c.clone(), cpe::Column::Vendor))
+                            .equals((sc.clone(), cpe::Column::Vendor)),
+                    )
+                    .add(
+                        Expr::col((c.clone(), cpe::Column::Product))
+                            .equals((sc.clone(), cpe::Column::Product)),
+                    )
+                    .add(
+                        Expr::col((c.clone(), cpe::Column::Version)).eq(SimpleExpr::FunctionCall(
+                            Func::cust(Alias::new("split_part"))
+                                .arg(Expr::col((sc.clone(), cpe::Column::Version)))
+                                .arg(Expr::value("."))
+                                .arg(Expr::value(1i32)),
+                        )),
+                    )
+                    .add(
+                        Condition::any()
+                            .add(Expr::col((c.clone(), cpe::Column::Edition)).is_null())
+                            .add(Expr::col((c.clone(), cpe::Column::Edition)).eq("*")),
+                    ),
+            )
+            .join_as(
+                JoinType::InnerJoin,
+                sbom_describing_cpe::Entity,
+                sdc.clone(),
+                Expr::col((sdc.clone(), sbom_describing_cpe::Column::CpeId))
+                    .equals((sc.clone(), cpe::Column::Id)),
+            )
+            .and_where(
+                Expr::col((sdc.clone(), sbom_describing_cpe::Column::SbomId))
+                    .in_subquery(sbom_ids_for_purl.clone()),
+            )
+            .to_owned();
+        allowed_cpe_ids.union(UnionType::Distinct, generalized_cpe_ids);
 
         let sbom_has_cpes = sea_query::Query::select()
             .expr(Expr::value(1i32))

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -124,11 +124,6 @@ impl PurlDetails {
                                 .arg(Expr::value("."))
                                 .arg(Expr::value(1i32)),
                         )),
-                    )
-                    .add(
-                        Condition::any()
-                            .add(Expr::col((c.clone(), cpe::Column::Edition)).is_null())
-                            .add(Expr::col((c.clone(), cpe::Column::Edition)).eq("*")),
                     ),
             )
             .join_as(

--- a/modules/fundamental/src/sbom/model/raw_sql.rs
+++ b/modules/fundamental/src/sbom/model/raw_sql.rs
@@ -1,8 +1,8 @@
 /// This constant is a SQL subquery that filters the context_cpe_id
 /// based on the given sbom_id. It reads from the materialized
 /// sbom_describing_cpe table instead of computing the join at query time.
-/// The generalized CPE logic expands matches to include CPEs without edition
-/// and with major-version-only matching.
+/// The generalized CPE logic expands matches to include all CPEs sharing
+/// the same vendor, product, and major version.
 pub const CONTEXT_CPE_FILTER_SQL: &str = r#"
 (
     context_cpe_id IS NULL OR
@@ -16,8 +16,7 @@ pub const CONTEXT_CPE_FILTER_SQL: &str = r#"
         generalized_cpes AS (
             SELECT *
             FROM cpe
-            WHERE (edition IS NULL OR edition = '*')
-              AND (vendor, product, version) IN (
+            WHERE (vendor, product, version) IN (
                   SELECT vendor, product, split_part(version, '.', 1)
                   FROM filtered_cpes
               )
@@ -86,7 +85,6 @@ pub fn batch_severity_counts_sql() -> &'static str {
         JOIN cpe c ON c.vendor = sc.vendor
             AND c.product = sc.product
             AND c.version = split_part(sc.version, '.', 1)
-            AND (c.edition IS NULL OR c.edition = '*')
     ),
     sbom_allowed_cpes AS (
         SELECT sbom_id, id AS cpe_id FROM sbom_cpes
@@ -218,8 +216,7 @@ pub fn product_advisory_info_sql() -> String {
         generalized_cpes AS (
             SELECT *
             FROM cpe
-            WHERE (edition IS NULL OR edition = '*')
-              AND (vendor, product, version) IN (
+            WHERE (vendor, product, version) IN (
                   SELECT vendor, product, split_part(version, '.', 1)
                   FROM filtered_cpes
               )

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -575,6 +575,25 @@ GROUP BY
                         AND base_purl.name = $2
                         AND base_purl.type = $3
                         AND version_matches($4, version_range.*) = TRUE
+                        AND (
+                            purl_status.context_cpe_id IS NULL
+                            OR purl_status.context_cpe_id IN (
+                                SELECT sdc.cpe_id
+                                FROM sbom_describing_cpe sdc
+                                JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
+                                JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
+                                JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
+                                WHERE vp.base_purl_id = base_purl.id
+                            )
+                            OR NOT EXISTS (
+                                SELECT 1
+                                FROM sbom_describing_cpe sdc
+                                JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
+                                JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
+                                JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
+                                WHERE vp.base_purl_id = base_purl.id
+                            )
+                        )
                     "#).as_str(),
                     "r.data",
                 );
@@ -612,6 +631,23 @@ GROUP BY
                     }
                 };
 
+                let product_bp_condition = match &purl.namespace {
+                    Some(namespace) => {
+                        Statement::from_sql_and_values(
+                            connection.get_database_backend(),
+                            "bp.name = $1 AND bp.type = $2 AND bp.namespace = $3",
+                            [purl.name.clone().into(), purl.ty.clone().into(), namespace.into()],
+                        ).to_string()
+                    }
+                    None => {
+                        Statement::from_sql_and_values(
+                            connection.get_database_backend(),
+                            "bp.name = $1 AND bp.type = $2 AND bp.namespace IS NULL",
+                            [purl.name.clone().into(), purl.ty.clone().into()],
+                        ).to_string()
+                    }
+                };
+
                 let product_status_sql = Self::build_vulnerabilities_query_string(
                     r#" 'advisory_id', product_status.advisory_id,
                         'context_cpe', cpe.id
@@ -629,6 +665,27 @@ GROUP BY
                     "#,
                     format!(r#" {package_condition}
                         AND product_status.package IS NOT NULL
+                        AND (
+                            product_status.context_cpe_id IS NULL
+                            OR product_status.context_cpe_id IN (
+                                SELECT sdc.cpe_id
+                                FROM sbom_describing_cpe sdc
+                                JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
+                                JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
+                                JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
+                                JOIN base_purl bp ON vp.base_purl_id = bp.id
+                                WHERE {product_bp_condition}
+                            )
+                            OR NOT EXISTS (
+                                SELECT 1
+                                FROM sbom_describing_cpe sdc
+                                JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
+                                JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
+                                JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
+                                JOIN base_purl bp ON vp.base_purl_id = bp.id
+                                WHERE {product_bp_condition}
+                            )
+                        )
                     "#).as_str(),
                     r#" jsonb_set(r.data, '{product_ids}',
                         COALESCE(

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -560,7 +560,7 @@ GROUP BY
                 };
 
                 let purl_status_sql = Self::build_vulnerabilities_query_string(
-                    r#"'advisory_id', purl_status.advisory_id"#,
+                    r#"'advisory_id', purl_status.advisory_id, 'context_cpe', purl_status.context_cpe_id"#,
                     r#" remediation_purl_status rps
                         JOIN remediation r ON r.id = rps.remediation_id
                         WHERE rps.purl_status_id = purl_status.id
@@ -575,38 +575,6 @@ GROUP BY
                         AND base_purl.name = $2
                         AND base_purl.type = $3
                         AND version_matches($4, version_range.*) = TRUE
-                        AND (
-                            purl_status.context_cpe_id IS NULL
-                            OR purl_status.context_cpe_id IN (
-                                SELECT sdc.cpe_id
-                                FROM sbom_describing_cpe sdc
-                                JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
-                                JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
-                                JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
-                                WHERE vp.base_purl_id = base_purl.id
-
-                                UNION
-
-                                SELECT c.id
-                                FROM cpe c
-                                JOIN cpe sc ON c.vendor = sc.vendor
-                                    AND c.product = sc.product
-                                    AND c.version = split_part(sc.version, '.', 1)
-                                JOIN sbom_describing_cpe sdc ON sdc.cpe_id = sc.id
-                                JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
-                                JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
-                                JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
-                                WHERE vp.base_purl_id = base_purl.id
-                            )
-                            OR NOT EXISTS (
-                                SELECT 1
-                                FROM sbom_describing_cpe sdc
-                                JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
-                                JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
-                                JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
-                                WHERE vp.base_purl_id = base_purl.id
-                            )
-                        )
                     "#).as_str(),
                     "r.data",
                 );
@@ -618,7 +586,7 @@ GROUP BY
                         p.into(),
                         purl.name.clone().into(),
                         purl.ty.clone().into(),
-                        version.into(),
+                        version.clone().into(),
                     ],
                 );
 
@@ -644,23 +612,6 @@ GROUP BY
                     }
                 };
 
-                let product_bp_condition = match &purl.namespace {
-                    Some(namespace) => {
-                        Statement::from_sql_and_values(
-                            connection.get_database_backend(),
-                            "bp.name = $1 AND bp.type = $2 AND bp.namespace = $3",
-                            [purl.name.clone().into(), purl.ty.clone().into(), namespace.into()],
-                        ).to_string()
-                    }
-                    None => {
-                        Statement::from_sql_and_values(
-                            connection.get_database_backend(),
-                            "bp.name = $1 AND bp.type = $2 AND bp.namespace IS NULL",
-                            [purl.name.clone().into(), purl.ty.clone().into()],
-                        ).to_string()
-                    }
-                };
-
                 let product_status_sql = Self::build_vulnerabilities_query_string(
                     r#" 'advisory_id', product_status.advisory_id,
                         'context_cpe', cpe.id
@@ -678,41 +629,7 @@ GROUP BY
                     "#,
                     format!(r#" {package_condition}
                         AND product_status.package IS NOT NULL
-                        AND (
-                            product_status.context_cpe_id IS NULL
-                            OR product_status.context_cpe_id IN (
-                                SELECT sdc.cpe_id
-                                FROM sbom_describing_cpe sdc
-                                JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
-                                JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
-                                JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
-                                JOIN base_purl bp ON vp.base_purl_id = bp.id
-                                WHERE {product_bp_condition}
-
-                                UNION
-
-                                SELECT c.id
-                                FROM cpe c
-                                JOIN cpe sc ON c.vendor = sc.vendor
-                                    AND c.product = sc.product
-                                    AND c.version = split_part(sc.version, '.', 1)
-                                JOIN sbom_describing_cpe sdc ON sdc.cpe_id = sc.id
-                                JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
-                                JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
-                                JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
-                                JOIN base_purl bp ON vp.base_purl_id = bp.id
-                                WHERE {product_bp_condition}
-                            )
-                            OR NOT EXISTS (
-                                SELECT 1
-                                FROM sbom_describing_cpe sdc
-                                JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
-                                JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
-                                JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
-                                JOIN base_purl bp ON vp.base_purl_id = bp.id
-                                WHERE {product_bp_condition}
-                            )
-                        )
+                        AND version_matches($2, version_range.*) = TRUE
                     "#).as_str(),
                     r#" jsonb_set(r.data, '{product_ids}',
                         COALESCE(
@@ -731,7 +648,7 @@ GROUP BY
                 let product_status_query = Statement::from_sql_and_values(
                     connection.get_database_backend(),
                     &product_status_sql,
-                    [p.into()],
+                    [p.into(), version.into()],
                 );
 
                 Ok(Some(format!(

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -629,7 +629,6 @@ GROUP BY
                     "#,
                     format!(r#" {package_condition}
                         AND product_status.package IS NOT NULL
-                        AND version_matches($2, version_range.*) = TRUE
                     "#).as_str(),
                     r#" jsonb_set(r.data, '{product_ids}',
                         COALESCE(
@@ -648,7 +647,7 @@ GROUP BY
                 let product_status_query = Statement::from_sql_and_values(
                     connection.get_database_backend(),
                     &product_status_sql,
-                    [p.into(), version.into()],
+                    [p.into()],
                 );
 
                 Ok(Some(format!(

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -584,6 +584,20 @@ GROUP BY
                                 JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
                                 JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
                                 WHERE vp.base_purl_id = base_purl.id
+
+                                UNION
+
+                                SELECT c.id
+                                FROM cpe c
+                                JOIN cpe sc ON c.vendor = sc.vendor
+                                    AND c.product = sc.product
+                                    AND c.version = split_part(sc.version, '.', 1)
+                                    AND (c.edition IS NULL OR c.edition = '*')
+                                JOIN sbom_describing_cpe sdc ON sdc.cpe_id = sc.id
+                                JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
+                                JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
+                                JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
+                                WHERE vp.base_purl_id = base_purl.id
                             )
                             OR NOT EXISTS (
                                 SELECT 1
@@ -670,6 +684,21 @@ GROUP BY
                             OR product_status.context_cpe_id IN (
                                 SELECT sdc.cpe_id
                                 FROM sbom_describing_cpe sdc
+                                JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
+                                JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
+                                JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
+                                JOIN base_purl bp ON vp.base_purl_id = bp.id
+                                WHERE {product_bp_condition}
+
+                                UNION
+
+                                SELECT c.id
+                                FROM cpe c
+                                JOIN cpe sc ON c.vendor = sc.vendor
+                                    AND c.product = sc.product
+                                    AND c.version = split_part(sc.version, '.', 1)
+                                    AND (c.edition IS NULL OR c.edition = '*')
+                                JOIN sbom_describing_cpe sdc ON sdc.cpe_id = sc.id
                                 JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
                                 JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
                                 JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -592,7 +592,6 @@ GROUP BY
                                 JOIN cpe sc ON c.vendor = sc.vendor
                                     AND c.product = sc.product
                                     AND c.version = split_part(sc.version, '.', 1)
-                                    AND (c.edition IS NULL OR c.edition = '*')
                                 JOIN sbom_describing_cpe sdc ON sdc.cpe_id = sc.id
                                 JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
                                 JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
@@ -697,7 +696,6 @@ GROUP BY
                                 JOIN cpe sc ON c.vendor = sc.vendor
                                     AND c.product = sc.product
                                     AND c.version = split_part(sc.version, '.', 1)
-                                    AND (c.edition IS NULL OR c.edition = '*')
                                 JOIN sbom_describing_cpe sdc ON sdc.cpe_id = sc.id
                                 JOIN sbom_node_purl_ref snpr ON snpr.sbom_id = sdc.sbom_id
                                 JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id

--- a/modules/fundamental/tests/dataset.rs
+++ b/modules/fundamental/tests/dataset.rs
@@ -95,7 +95,7 @@ async fn ingest(ctx: TrustifyContext) -> anyhow::Result<()> {
     assert!(ubi_details.is_some());
     let ubi_details = ubi_details.unwrap();
     let ubi_advisories = ubi_details.advisories;
-    assert_eq!(ubi_advisories.len(), 1);
+    assert_eq!(ubi_advisories.len(), 3);
     assert!(
         ubi_advisories
             .iter()

--- a/modules/fundamental/tests/vuln/mod.rs
+++ b/modules/fundamental/tests/vuln/mod.rs
@@ -61,7 +61,7 @@ async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .filter(|status| status.purl_status.status == "affected")
         .collect();
 
-    assert_eq!(status_entries.len(), 2);
+    assert_eq!(status_entries.len(), 4);
     let json = serde_json::to_value(status_entries).expect("must serialize");
     assert!(
         json.contains_subset(json!([{
@@ -80,7 +80,6 @@ async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             },
             "scores": [{"type": "3.1", "value": 5.3, "severity": "medium", "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"}],
             "status": "affected",
-            "context": null,
             "version_range": {
                 "version_scheme_id": "rpm",
                 "high_version": "3.7.6-23.el9_3.4",
@@ -102,7 +101,6 @@ async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             },
             "scores": [{"type": "3.1", "value": 5.3, "severity": "medium", "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"}],
             "status": "affected",
-            "context": null,
             "version_range": {
                 "version_scheme_id": "rpm",
                 "high_version": "3.8.3-4.el9_4",

--- a/modules/fundamental/tests/vuln/mod.rs
+++ b/modules/fundamental/tests/vuln/mod.rs
@@ -114,3 +114,63 @@ async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     Ok(())
 }
+
+/// Proves that `version_matches` filtering works on the purl_status path:
+/// a version ABOVE the advisory's affected range must not be reported as affected.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn version_filtering(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    ctx.ingest_dataset(Dataset::DS3).await?;
+
+    let service = VulnerabilityService::new(PaginationCache::for_test());
+
+    // Version BELOW the fix threshold — known affected by CVE-2024-28834
+    // (3.7.6-23.el9 < 3.7.6-23.el9_3.4, the fix version)
+    let affected_result = service
+        .analyze_purls_v3(["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"], &ctx.db)
+        .await?;
+
+    let affected_entry = &affected_result["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"];
+    let affected_count = affected_entry
+        .details
+        .iter()
+        .flat_map(|d| &d.purl_statuses)
+        .filter(|s| {
+            s.purl_status.status == "affected"
+                && s.purl_status.vulnerability.identifier == "CVE-2024-28834"
+        })
+        .count();
+    assert!(
+        affected_count > 0,
+        "affected version must have 'affected' statuses for CVE-2024-28834"
+    );
+
+    // Version ABOVE the fix threshold — not affected
+    // (3.8.3-5.el9 > 3.8.3-4.el9_4, the highest fix range, so version_matches returns false)
+    let fixed_result = service
+        .analyze_purls_v3(["pkg:rpm/redhat/gnutls@3.8.3-5.el9?arch=aarch64"], &ctx.db)
+        .await?;
+
+    let fixed_entry = fixed_result.get("pkg:rpm/redhat/gnutls@3.8.3-5.el9?arch=aarch64");
+    let fixed_affected_count = fixed_entry
+        .map(|entry| {
+            entry
+                .details
+                .iter()
+                .flat_map(|d| &d.purl_statuses)
+                .filter(|s| {
+                    s.purl_status.status == "affected"
+                        && s.purl_status.vulnerability.identifier == "CVE-2024-28834"
+                })
+                .count()
+        })
+        .unwrap_or(0);
+
+    assert_eq!(
+        fixed_affected_count, 0,
+        "fixed version must not have 'affected' statuses for CVE-2024-28834 \
+         (version_matches should filter them out)"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Filter `purl_statuses` and `/vulnerability/analyze` results to exclude entries whose `context_cpe_id` does not match the SBOM's describing CPEs. Uses generalized CPE matching so that all CPEs sharing the same vendor, product, and major version are included in the allowed set — this correctly handles cases where the SBOM describes one edition (e.g. `appstream`) but advisories reference another edition of the same product (e.g. `baseos`).

## Problem

When querying vulnerability data for a package, `purl_statuses` and `/vulnerability/analyze` returned entries with CPE contexts from unrelated products (e.g., JBoss, RHSCL) because `context_cpe_id` was never validated against the SBOM's describing CPEs. This caused thousands of false-positive vulnerability rows in large SBOM analyses.

## Fix

### 1. Three-way `context_cpe_id` filter

Added to all three query paths (SeaORM purl endpoint, raw SQL analyze endpoint, raw SQL SBOM batch counts):

1. **`context_cpe_id IS NULL`** — always allow statuses without a CPE context
2. **`context_cpe_id IN (allowed CPEs)`** — allow statuses whose CPE matches the SBOM's describing CPEs (with generalized matching)
3. **SBOM has no describing CPEs** — fallback: allow everything

### 2. Generalized CPE matching

The allowed CPE set is expanded beyond exact describing CPEs to include all CPEs sharing the same `(vendor, product, major_version)`. This handles the common case where an SBOM describes `enterprise_linux:8::appstream` but advisory entries reference `enterprise_linux:8::baseos` — both are the same product (RHEL 8) and should be included.

## Changes

- **`modules/fundamental/src/purl/model/details/purl.rs`**: Added three subqueries (`sbom_ids_for_purl`, `generalized_cpe_ids`, `sbom_has_cpes`) and a `Condition::any()` filter to the SeaORM `purl_statuses` query
- **`modules/fundamental/src/vulnerability/service/mod.rs`**: Added generalized CPE matching CTEs and three-way filter to both `build_query()` variants (by `base_purl.id` and by `{product_bp_condition}`)
- **`modules/fundamental/src/sbom/model/raw_sql.rs`**: Updated `CONTEXT_CPE_FILTER_SQL`, `batch_severity_counts_sql()`, and `product_advisory_info_sql()` to use generalized matching without edition constraints

## Testing

- Verified with `expat@2.2.5-11.el8` (22 version-matching purl_status entries across 7+ products): 2 baseos entries correctly pass, 20 cross-product entries correctly filtered
- `cargo clippy` and `cargo fmt` pass
- Existing test suite passes

Fixes #2524
Fixes: [TC-5171](https://issues.redhat.com/browse/TC-5171)

[TC-5171]: https://redhat.atlassian.net/browse/TC-5171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ