### PR TITLE
fix(ingestor): compute CVSS scores from vector string instead of JSON fields

### DIFF
--- a/docs/design/cvss_scoring.md
+++ b/docs/design/cvss_scoring.md
@@ -1,0 +1,213 @@
+# CVSS Score Model
+
+This document describes how CVSS scores are stored, selected, and surfaced
+across the system. A single vulnerability can receive scores from multiple
+advisories (CVE, CSAF, OSV), each carrying one or more CVSS versions
+(v2.0, v3.0, v3.1, v4.0). The rules below govern which score appears in
+each context.
+
+## Storage
+
+Scores are stored at two levels:
+
+### Per-advisory scores (`advisory_vulnerability_score`)
+
+Every advisory that reports a vulnerability may contribute CVSS scores.
+These are stored in the `advisory_vulnerability_score` table, keyed by
+`(advisory_id, vulnerability_id)`:
+
+| Column           | Type       | Description                         |
+|------------------|------------|-------------------------------------|
+| `id`             | UUID       | Primary key (v7)                    |
+| `advisory_id`    | UUID       | FK to `advisory`                    |
+| `vulnerability_id` | String  | FK to `vulnerability`               |
+| `type`           | ScoreType  | CVSS version (`2.0`, `3.0`, `3.1`, `4.0`) |
+| `vector`         | String     | Raw CVSS vector string              |
+| `score`          | f32        | Computed numeric base score         |
+| `severity`       | Severity   | `none`, `low`, `medium`, `high`, `critical` |
+
+Multiple rows can exist for the same `(advisory_id, vulnerability_id)` pair
+when an advisory provides scores in multiple CVSS versions.
+
+Multiple advisories can contribute scores for the same vulnerability. Their
+rows coexist in the table, distinguished by `advisory_id`.
+
+### Denormalized best score (`vulnerability` table)
+
+The `vulnerability` table carries a single "best" score for quick filtering
+and display:
+
+| Column                     | Type       | Description                              |
+|----------------------------|------------|------------------------------------------|
+| `base_score`               | f64        | Best numeric CVSS score                  |
+| `base_severity`            | Severity   | Severity derived from `base_score`       |
+| `base_type`                | ScoreType  | CVSS version of the best score           |
+| `authoritative_advisory_id`| UUID       | The advisory that contributed this score |
+
+These columns are populated exclusively by the CVE loader (see below).
+
+## Ingestion: How Each Loader Contributes Scores
+
+### CVE loader
+
+The CVE loader is the only loader that sets the vulnerability-level score.
+It performs two operations:
+
+1. **Per-advisory scores**: Parses `vectorString` fields from CNA and ADP
+   metrics using `FromStr` and computes the numeric score via
+   `calculated_base_score()`. All parsed scores are written to
+   `advisory_vulnerability_score` via `ScoreCreator`.
+
+2. **Vulnerability base score**: Selects the single "best" score from the
+   CVE record using `extract_base_score()`, which applies these precedence
+   rules:
+   - CNA scores take priority over ADP scores (ADP is used only if CNA
+     yields no parseable scores)
+   - Higher CVSS versions take priority (v4.0 > v3.1 > v3.0 > v2.0)
+   - Within the same version, the higher numeric score wins
+
+   This best score is written to `vulnerability.base_score` /
+   `base_severity` / `base_type` via the `VulnerabilityCreator` (which uses
+   `ON CONFLICT ... UPDATE`).
+
+3. **Authoritative advisory**: The CVE loader unconditionally sets
+   `vulnerability.authoritative_advisory_id` to its own advisory ID via a
+   direct `UPDATE` statement. This is not conditional — every CVE ingestion
+   overwrites it.
+
+### CSAF loader
+
+The CSAF loader writes per-advisory scores to `advisory_vulnerability_score`
+but **never touches** the vulnerability-level `base_score` or
+`authoritative_advisory_id`. It passes `()` as vulnerability information to
+`VulnerabilityCreator`, which triggers `ON CONFLICT DO NOTHING` — preserving
+any existing base score set by a CVE.
+
+### OSV loader
+
+Same behavior as CSAF: writes per-advisory scores only, never touches the
+vulnerability-level columns.
+
+## Score Re-ingestion
+
+`ScoreCreator` uses a **delete-and-replace** strategy: when an advisory is
+re-ingested, all existing `advisory_vulnerability_score` rows for that
+`advisory_id` are deleted before the new scores are inserted. This means
+re-ingestion always reflects the current state of the advisory document.
+
+Scores from other advisories are not affected — only the re-ingested
+advisory's rows are replaced.
+
+## Score Selection by API Context
+
+Different API endpoints surface different scores depending on the use case:
+
+### Vulnerability list / detail (`GET /v3/vulnerability[/{id}]`)
+
+- **`base_score`** on `VulnerabilityHead`: the denormalized best score from
+  the `vulnerability` table. This is the CVE-derived score.
+- **`scores`** on `VulnerabilityDetails` (opt-in via `?scores=true`):
+  returns all `advisory_vulnerability_score` rows from the **authoritative
+  advisory only** (filtered by `authoritative_advisory_id`).
+- **Per-advisory scores** on `VulnerabilityAdvisorySummary`: each advisory
+  listed under the vulnerability includes its own `scores` array with all
+  CVSS scores that advisory provides.
+
+### Advisory list / detail (`GET /v3/advisory[/{id}]`)
+
+Each `AdvisoryVulnerabilityHead` includes a `scores` array containing all
+`advisory_vulnerability_score` rows for that specific advisory-vulnerability
+pair. This shows the advisory's own assessment, which may differ from the
+CVE's base score.
+
+### SBOM severity counts
+
+The raw SQL query for SBOM severity aggregation picks the **highest
+severity** per `(sbom_id, vulnerability_id)` across **all advisories** that
+affect that SBOM. It uses `DISTINCT ON` with a severity ranking
+(`critical=5` down to `none=1`, missing scores as `unknown=0`).
+
+This means the SBOM severity summary reflects the worst-case assessment
+from any advisory, not just the authoritative CVE.
+
+### SBOM detail status
+
+Each `SbomStatus` entry includes `scores` from the specific advisory that
+reported the affected status for that package. If Advisory A says a package
+is affected and Advisory B also says it is affected, each status entry
+carries its respective advisory's scores.
+
+### PURL detail (`GET /v3/purl/{id}`)
+
+`PurlStatus` includes all scores related to the vulnerability via
+`find_related`, which returns scores from **all advisories** — not just
+the one that reported the PURL status.
+
+### Vulnerability analysis (`POST /v3/vulnerability/analyze`)
+
+Returns `VulnerabilityHead` (with `base_score` from the vulnerability
+table) plus `PurlStatus` entries (with scores from all advisories, as
+described above).
+
+## Upload Order Invariants
+
+The system is designed so that the vulnerability-level `base_score` is
+**order-independent** across different advisory types:
+
+| Scenario              | Result                                      |
+|-----------------------|---------------------------------------------|
+| CVE only              | `base_score` reflects the CVE's best score  |
+| CSAF then CVE         | `base_score` reflects CVE (CSAF never overwrites) |
+| CVE then CSAF         | `base_score` reflects CVE (CSAF uses DO NOTHING) |
+| OSV then CVE          | `base_score` reflects CVE                   |
+| CVE then OSV          | `base_score` reflects CVE                   |
+| CVE without scores    | `base_score` is NULL                        |
+
+These invariants are verified by integration tests in
+`modules/fundamental/src/vulnerability/endpoints/test.rs`
+(`base_score_after_ingestion`).
+
+## Edge Cases
+
+### Multiple CVEs for the same vulnerability
+
+If two different CVE records reference the same vulnerability ID (rare but
+possible), the system is **last-write-wins**: the second CVE ingestion
+overwrites `base_score` and `authoritative_advisory_id`. Both CVEs'
+per-advisory scores coexist in `advisory_vulnerability_score`.
+
+### CVE record without CVSS scores
+
+Some CVE records lack metrics entirely, or contain only metrics without a
+`vectorString` field. In this case `extract_base_score()` returns `None`
+and the vulnerability's `base_score` is NULL. The `authoritative_advisory_id`
+is still set (the CVE is authoritative regardless of whether it carries
+scores).
+
+### Invalid vector strings
+
+When a CVE metric contains a `vectorString` that fails to parse, the
+failure is reported as both a `tracing::warn!` log message and an
+ingestion warning in the `IngestResult` API response. The metric is skipped
+and does not contribute a score.
+
+### CSAF and CVE disagreeing on score
+
+A CSAF advisory may assign a different CVSS score to a vulnerability than
+the CVE record does. Both scores are stored in
+`advisory_vulnerability_score` under their respective advisory IDs. The
+vulnerability-level `base_score` always reflects the CVE's assessment. The
+SBOM severity counts use the highest severity from any advisory, so the
+CSAF's score may influence SBOM-level severity even if it differs from the
+CVE's score.
+
+## Summary: Score Selection Matrix
+
+| Context                      | Score source                              |
+|------------------------------|-------------------------------------------|
+| `vulnerability.base_score`   | CVE's best score (denormalized)           |
+| Vulnerability detail scores  | Authoritative advisory's scores only      |
+| Advisory detail scores       | That advisory's scores                    |
+| SBOM severity counts         | Highest severity across all advisories    |
+| SBOM status scores           | Reporting advisory's scores               |
+| PURL status scores           | All advisories' scores for the vuln       |

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -66,6 +66,7 @@ mod m0002210_sbom_node_name_index;
 mod m0002220_drop_qualified_purl_gist_indexes;
 mod m0002230_sle_license_id_index;
 mod m0002240_product_version_sbom_index;
+mod m0002250_backfill_vulnerability_base_score;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -147,6 +148,7 @@ impl MigratorExt for Migrator {
             .normal(m0002220_drop_qualified_purl_gist_indexes::Migration)
             .normal(m0002230_sle_license_id_index::Migration)
             .normal(m0002240_product_version_sbom_index::Migration)
+            .normal(m0002250_backfill_vulnerability_base_score::Migration)
     }
 }
 

--- a/migration/src/m0002010_add_advisory_scores.rs
+++ b/migration/src/m0002010_add_advisory_scores.rs
@@ -8,7 +8,10 @@ use strum::VariantNames;
 use trustify_common::db::create_enum_if_not_exists;
 use trustify_module_ingestor::{
     graph::cvss::ScoreCreator,
-    service::advisory::{csaf, cve, osv},
+    service::{
+        Warnings,
+        advisory::{csaf, cve, osv},
+    },
 };
 
 #[derive(DeriveMigrationName)]
@@ -98,10 +101,11 @@ impl MigrationTraitWithData for Migration {
 
         manager
             .process(self, async |advisory, id: Id, tx: &DatabaseTransaction| {
+                let warnings = Warnings::new();
                 let mut creator = ScoreCreator::new(id.advisory);
                 match advisory {
                     Advisory::Cve(advisory) => {
-                        cve::extract_scores(&advisory, &mut creator);
+                        cve::extract_scores(&advisory, &mut creator, &warnings);
                     }
                     Advisory::Csaf(advisory) => {
                         csaf::extract_scores(&advisory, &mut creator);

--- a/migration/src/m0002250_backfill_vulnerability_base_score.rs
+++ b/migration/src/m0002250_backfill_vulnerability_base_score.rs
@@ -1,0 +1,29 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+/// Backfills `vulnerability.base_score/base_severity/base_type` from
+/// `advisory_vulnerability_score`, selecting the best score (highest CVSS version,
+/// then highest numeric score) from the authoritative advisory.
+///
+/// See `up.sql` for the raw SQL and instructions for manual execution.
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0002250_backfill_vulnerability_base_score/up.sql"
+            ))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // No-op: the columns predate this migration and clearing them would lose
+        // values set by normal ingestion. Re-run up() to reapply the backfill.
+        Ok(())
+    }
+}

--- a/migration/src/m0002250_backfill_vulnerability_base_score/up.sql
+++ b/migration/src/m0002250_backfill_vulnerability_base_score/up.sql
@@ -1,0 +1,35 @@
+-- Backfill vulnerability.base_score / base_severity / base_type from
+-- advisory_vulnerability_score, picking the best score (highest CVSS version,
+-- then highest numeric score) from the authoritative advisory.
+--
+-- Prerequisites:
+--   advisory_vulnerability_score must already be populated. If you skipped the
+--   m0002010_add_advisory_scores data migration or need to re-derive scores
+--   after a parser fix, run it first:
+--
+--     trustd db data m0002010_add_advisory_scores
+--
+-- Manual execution (after the prerequisite above):
+--
+--     psql -d <database> -f up.sql
+--
+-- This is safe to re-run: it overwrites existing values with the current best
+-- score from advisory_vulnerability_score.
+
+UPDATE vulnerability v
+SET
+    base_score = sub.score::float8,
+    base_severity = sub.severity,
+    base_type = sub."type"
+FROM (
+    SELECT DISTINCT ON (avs.vulnerability_id)
+        avs.vulnerability_id,
+        avs.score,
+        avs.severity,
+        avs."type"
+    FROM advisory_vulnerability_score avs
+    JOIN vulnerability v2 ON v2.id = avs.vulnerability_id
+    WHERE v2.authoritative_advisory_id = avs.advisory_id
+    ORDER BY avs.vulnerability_id, avs."type" DESC, avs.score DESC
+) sub
+WHERE v.id = sub.vulnerability_id;

--- a/migration/tests/data/m0002250.rs
+++ b/migration/tests/data/m0002250.rs
@@ -1,0 +1,73 @@
+use migration::{
+    Migrator,
+    data::{Database, Direction, MigrationWithData, Options, Runner},
+};
+use sea_orm::{ConnectionTrait, Statement};
+use sea_orm_migration::MigratorTrait;
+use test_context::test_context;
+use test_log::test;
+use trustify_test_context::{TrustifyMigrationContext, commit};
+
+use crate::MigratorTest;
+
+// Same pre-m0002010 commit used by m0002010.rs tests
+commit!(PreScores("6d3ea814b4b44fe16ea8f21724dda5abb0fc7932"));
+
+/// Verify the full score pipeline: m0002010 populates advisory_vulnerability_score
+/// using the vector-string parser, then m0002250 backfills vulnerability.base_score.
+#[test_context(TrustifyMigrationContext<PreScores>)]
+#[test(tokio::test)]
+async fn backfill_vulnerability_base_score(
+    ctx: &TrustifyMigrationContext<PreScores>,
+) -> Result<(), anyhow::Error> {
+    let data_migrations = vec!["m0002010_add_advisory_scores".into()];
+
+    // Run the data migration with the current (fixed) code
+    Runner {
+        direction: Direction::Up,
+        storage: ctx.storage.clone().into(),
+        migrations: data_migrations.clone(),
+        database: Database::Provided(ctx.db.clone().into_connection()),
+        options: Default::default(),
+    }
+    .run::<Migrator>()
+    .await?;
+
+    // Run all remaining schema migrations (including m0002250), skipping the
+    // already-applied data migration
+    MigrationWithData::run_with_test(
+        ctx.storage.clone(),
+        Options {
+            skip: data_migrations,
+            ..Default::default()
+        },
+        async { MigratorTest::up(&ctx.db, None).await },
+    )
+    .await?;
+
+    // After m0002250: every vulnerability whose authoritative advisory has scores
+    // in advisory_vulnerability_score must have base_score populated.
+    let missing = ctx
+        .db
+        .query_all(Statement::from_string(
+            ctx.db.get_database_backend(),
+            r#"
+SELECT v.id
+FROM vulnerability v
+JOIN advisory_vulnerability_score avs
+    ON avs.advisory_id = v.authoritative_advisory_id
+    AND avs.vulnerability_id = v.id
+WHERE v.base_score IS NULL
+"#,
+        ))
+        .await?;
+
+    assert!(
+        missing.is_empty(),
+        "expected all vulnerabilities with authoritative scores to have base_score populated, \
+         but {} still have NULL",
+        missing.len()
+    );
+
+    Ok(())
+}

--- a/migration/tests/data/main.rs
+++ b/migration/tests/data/main.rs
@@ -1,4 +1,5 @@
 mod m0002010;
+mod m0002250;
 
 use migration::{
     Migrator, MigratorExt,

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -65,7 +65,7 @@ impl<'g> CveLoader<'g> {
             assigned,
             affected,
             information,
-        } = Self::extract_vuln_info(&cve);
+        } = Self::extract_vuln_info(&cve, &warnings);
 
         let cwes = information.cwes.clone();
         let release_date = information.published;
@@ -113,7 +113,7 @@ impl<'g> CveLoader<'g> {
             .await?;
 
         let mut score_creator = ScoreCreator::new(advisory.advisory.id);
-        extract_scores(&cve, &mut score_creator);
+        extract_scores(&cve, &mut score_creator, &warnings);
         score_creator.create(tx).await?;
 
         // A CVE advisory is always the authoritative source for its vulnerability,
@@ -227,7 +227,7 @@ impl<'g> CveLoader<'g> {
             .map(|desc| desc.value.as_str())
     }
 
-    fn extract_vuln_info(cve: &Cve) -> VulnerabilityDetails<'_> {
+    fn extract_vuln_info<'a>(cve: &'a Cve, warnings: &Warnings) -> VulnerabilityDetails<'a> {
         let reserved = cve
             .common_metadata()
             .date_reserved
@@ -298,7 +298,7 @@ impl<'g> CveLoader<'g> {
             ),
         };
 
-        let base_score = extract_base_score(cve);
+        let base_score = extract_base_score(cve, warnings);
 
         VulnerabilityDetails {
             org_name,
@@ -503,7 +503,7 @@ mod test {
         }
 
         assert_eq!(
-            ApproxBaseScore(extract_base_score(&cve.into())),
+            ApproxBaseScore(extract_base_score(&cve.into(), &Warnings::new())),
             ApproxBaseScore(expected)
         );
     }

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -1,4 +1,3 @@
-use crate::graph::vulnerability::BaseScore;
 use crate::{
     graph::{
         Graph,
@@ -16,7 +15,7 @@ use crate::{
     model::IngestResult,
     service::{
         Error, Warnings,
-        advisory::cve::{divination::divine_purl, extract_scores},
+        advisory::cve::{divination::divine_purl, extract_base_score, extract_scores},
     },
 };
 use cve::{
@@ -25,13 +24,10 @@ use cve::{
 };
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, TransactionTrait};
 use sea_query::Expr;
-use serde_json::Value;
-use std::str::FromStr;
 use std::{collections::HashSet, fmt::Debug};
 use time::OffsetDateTime;
 use tracing::instrument;
 use trustify_common::hashing::Digests;
-use trustify_entity::advisory_vulnerability_score::{ScoreType, Severity};
 use trustify_entity::{labels::Labels, version_scheme::VersionScheme, vulnerability};
 
 /// Loader capable of parsing a CVE Record JSON file
@@ -302,7 +298,7 @@ impl<'g> CveLoader<'g> {
             ),
         };
 
-        let base_score = Self::extract_base_score(cve);
+        let base_score = extract_base_score(cve);
 
         VulnerabilityDetails {
             org_name,
@@ -320,92 +316,6 @@ impl<'g> CveLoader<'g> {
             },
         }
     }
-
-    /// Extracts the best base score from a CVE record.
-    ///
-    /// Prefers CNA scores over ADP scores, only falling back to ADP if CNA yields no parseable
-    /// scores. Within each source, higher CVSS versions take precedence; within the same version,
-    /// the higher numeric score wins.
-    fn extract_base_score(cve: &Cve) -> Option<BaseScore> {
-        fn better_score(a: BaseScore, b: BaseScore) -> BaseScore {
-            if b.r#type > a.r#type || (b.r#type == a.r#type && b.score > a.score) {
-                b
-            } else {
-                a
-            }
-        }
-
-        let Cve::Published(published) = cve else {
-            return None;
-        };
-
-        let cna_result = published
-            .containers
-            .cna
-            .metrics
-            .iter()
-            .filter_map(score_from_metric)
-            .reduce(better_score);
-
-        cna_result.or_else(|| {
-            published
-                .containers
-                .adp
-                .iter()
-                .flat_map(|adp| adp.metrics.iter())
-                .filter_map(score_from_metric)
-                .reduce(better_score)
-        })
-    }
-}
-
-/// Extracts the base score and severity from a CVSS JSON object.
-/// For more information on the CVSS schema, see:
-/// https://github.com/CVEProject/cve-schema/tree/main/schema/imports/cvss
-fn get_score(cvss: &Value) -> Option<(ScoreType, f64, Severity)> {
-    let r#type = cvss
-        .get("version")
-        .and_then(Value::as_str)
-        .and_then(|s| ScoreType::from_str(s).ok())?;
-
-    let score = cvss.get("baseScore").and_then(Value::as_f64)?;
-    let severity = cvss
-        .get("baseSeverity")
-        .and_then(Value::as_str)
-        .and_then(|s| Severity::from_str(&s.to_lowercase()).ok());
-
-    match r#type {
-        // CVSS v2.0 does not have a baseSeverity field, so we need to calculate it from the score.
-        ScoreType::V2_0 => {
-            // CVSS v2 scores must be in the valid range [0.0, 10.0]
-            if !(0.0..=10.0).contains(&score) {
-                return None;
-            }
-            Some((r#type, score, (score, ScoreType::V2_0).into()))
-        }
-        _ => Some((r#type, score, severity?)),
-    }
-}
-
-/// Extracts the best score from a single metric, preferring higher CVSS versions.
-fn score_from_metric(metric: &cve::published::Metric) -> Option<BaseScore> {
-    metric
-        .cvss_v4_0
-        .as_ref()
-        .and_then(get_score)
-        .or_else(|| {
-            metric
-                .cvss_v3_1
-                .as_ref()
-                .or(metric.cvss_v3_0.as_ref())
-                .and_then(get_score)
-        })
-        .or_else(|| metric.cvss_v2_0.as_ref().and_then(get_score))
-        .map(|(r#type, score, severity)| BaseScore {
-            r#type,
-            score,
-            severity,
-        })
 }
 
 struct VulnerabilityDetails<'a> {
@@ -420,8 +330,11 @@ struct VulnerabilityDetails<'a> {
 mod test {
     use super::*;
     use crate::{
-        graph::Graph,
-        service::advisory::test::{AssertScore, assert_scores},
+        graph::{Graph, vulnerability::BaseScore},
+        service::advisory::{
+            cve::extract_base_score,
+            test::{AssertScore, assert_scores},
+        },
     };
     use hex::ToHex;
     use rstest::rstest;
@@ -433,6 +346,14 @@ mod test {
     use trustify_common::purl::Purl;
     use trustify_entity::advisory_vulnerability_score::{ScoreType, Severity};
     use trustify_test_context::{TrustifyContext, document};
+
+    // Well-known CVSS vector strings used across tests.
+    // Scores are computed by `calculated_base_score()`, not taken from JSON.
+    const V31_MEDIUM: &str = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N"; // 6.5
+    const V31_CRITICAL: &str = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"; // 9.8
+    const V30_HIGH: &str = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"; // 7.5
+    const V2_HIGH: &str = "AV:N/AC:L/Au:N/C:P/I:P/A:P"; // 7.5
+    const V4_CRITICAL: &str = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"; // 9.3
 
     enum MetricSource {
         Cna,
@@ -460,23 +381,24 @@ mod test {
             self
         }
 
-        fn add_v2(self, source: MetricSource, score: f64) -> Self {
-            self.add(
-                source,
-                json!({ "cvssV2_0": { "version": "2.0", "baseScore": score } }),
-            )
+        /// Adds a CVSS v2.0 metric with only a vector string.
+        fn add_v2(self, source: MetricSource, vector: &str) -> Self {
+            self.add(source, json!({ "cvssV2_0": { "vectorString": vector } }))
         }
 
-        fn add_v3_0(self, source: MetricSource, score: f64, severity: &str) -> Self {
-            self.add(source, json!({ "cvssV3_0": { "version": "3.0", "baseScore": score, "baseSeverity": severity } }))
+        /// Adds a CVSS v3.0 metric with only a vector string.
+        fn add_v3_0(self, source: MetricSource, vector: &str) -> Self {
+            self.add(source, json!({ "cvssV3_0": { "vectorString": vector } }))
         }
 
-        fn add_v3_1(self, source: MetricSource, score: f64, severity: &str) -> Self {
-            self.add(source, json!({ "cvssV3_1": { "version": "3.1", "baseScore": score, "baseSeverity": severity } }))
+        /// Adds a CVSS v3.1 metric with only a vector string.
+        fn add_v3_1(self, source: MetricSource, vector: &str) -> Self {
+            self.add(source, json!({ "cvssV3_1": { "vectorString": vector } }))
         }
 
-        fn add_v4(self, source: MetricSource, score: f64, severity: &str) -> Self {
-            self.add(source, json!({ "cvssV4_0": { "version": "4.0", "baseScore": score, "baseSeverity": severity } }))
+        /// Adds a CVSS v4.0 metric with only a vector string.
+        fn add_v4(self, source: MetricSource, vector: &str) -> Self {
+            self.add(source, json!({ "cvssV4_0": { "vectorString": vector } }))
         }
     }
 
@@ -519,39 +441,46 @@ mod test {
     #[rstest]
     #[case::no_metrics(CveBuilder::new(), None)]
     #[case::single_v3_1_in_cna(
-        CveBuilder::new().add_v3_1(Cna, 6.5, "MEDIUM"),
+        CveBuilder::new().add_v3_1(Cna, V31_MEDIUM),
         Some(BaseScore { r#type: ScoreType::V3_1, score: 6.5, severity: Severity::Medium })
     )]
     #[case::cna_preferred_over_adp(
-        CveBuilder::new().add_v3_1(Cna, 6.5, "MEDIUM").add_v3_1(Adp, 9.8, "CRITICAL"),
+        CveBuilder::new().add_v3_1(Cna, V31_MEDIUM).add_v3_1(Adp, V31_CRITICAL),
         Some(BaseScore { r#type: ScoreType::V3_1, score: 6.5, severity: Severity::Medium })
     )]
     #[case::adp_used_when_cna_empty(
-        CveBuilder::new().add_v3_1(Adp, 9.8, "CRITICAL"),
+        CveBuilder::new().add_v3_1(Adp, V31_CRITICAL),
         Some(BaseScore { r#type: ScoreType::V3_1, score: 9.8, severity: Severity::Critical })
     )]
     #[case::higher_version_wins(
-        CveBuilder::new().add_v3_1(Cna, 9.8, "CRITICAL").add_v4(Cna, 6.5, "MEDIUM"),
-        Some(BaseScore { r#type: ScoreType::V4_0, score: 6.5, severity: Severity::Medium })
+        CveBuilder::new().add_v3_1(Cna, V31_CRITICAL).add_v4(Cna, V4_CRITICAL),
+        // v4.0 preferred over v3.1 regardless of score
+        Some(BaseScore { r#type: ScoreType::V4_0, score: 9.3, severity: Severity::Critical })
     )]
     #[case::single_v3_0_in_cna(
-        CveBuilder::new().add_v3_0(Cna, 7.5, "HIGH"),
+        CveBuilder::new().add_v3_0(Cna, V30_HIGH),
         Some(BaseScore { r#type: ScoreType::V3_0, score: 7.5, severity: Severity::High })
     )]
     #[case::v3_1_preferred_over_v3_0(
-        CveBuilder::new().add_v3_0(Cna, 9.8, "CRITICAL").add_v3_1(Cna, 6.5, "MEDIUM"),
+        CveBuilder::new().add_v3_0(Cna, V30_HIGH).add_v3_1(Cna, V31_MEDIUM),
         Some(BaseScore { r#type: ScoreType::V3_1, score: 6.5, severity: Severity::Medium })
     )]
     #[case::higher_score_wins_within_same_version(
-        CveBuilder::new().add_v3_1(Cna, 6.5, "MEDIUM").add_v3_1(Cna, 9.8, "CRITICAL"),
+        CveBuilder::new().add_v3_1(Cna, V31_MEDIUM).add_v3_1(Cna, V31_CRITICAL),
         Some(BaseScore { r#type: ScoreType::V3_1, score: 9.8, severity: Severity::Critical })
     )]
     #[case::v2_severity_derived_from_score(
-        CveBuilder::new().add_v2(Cna, 7.5),
+        CveBuilder::new().add_v2(Cna, V2_HIGH),
         Some(BaseScore { r#type: ScoreType::V2_0, score: 7.5, severity: Severity::High })
     )]
-    #[case::v2_out_of_range_yields_none(
-        CveBuilder::new().add_v2(Cna, 11.0),
+    // Metric with no vectorString → parsed as None
+    #[case::missing_vector_string_yields_none(
+        CveBuilder::new().add(Cna, json!({ "cvssV3_1": { "baseScore": 9.8, "baseSeverity": "CRITICAL" } })),
+        None
+    )]
+    // Metric with invalid vectorString → FromStr fails → None
+    #[case::invalid_vector_yields_none(
+        CveBuilder::new().add_v3_1(Cna, "not-a-vector"),
         None
     )]
     #[std::prelude::v1::test]
@@ -566,7 +495,7 @@ mod test {
                     (Some(a), Some(b)) => {
                         a.r#type == b.r#type
                             && a.severity == b.severity
-                            && (a.score - b.score).abs() < 0.01
+                            && (a.score - b.score).abs() < 0.1
                     }
                     _ => false,
                 }
@@ -574,7 +503,7 @@ mod test {
         }
 
         assert_eq!(
-            ApproxBaseScore(CveLoader::extract_base_score(&cve.into())),
+            ApproxBaseScore(extract_base_score(&cve.into())),
             ApproxBaseScore(expected)
         );
     }

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -495,7 +495,7 @@ mod test {
                     (Some(a), Some(b)) => {
                         a.r#type == b.r#type
                             && a.severity == b.severity
-                            && (a.score - b.score).abs() < 0.1
+                            && (a.score - b.score).abs() < 0.02
                     }
                     _ => false,
                 }

--- a/modules/ingestor/src/service/advisory/cve/mod.rs
+++ b/modules/ingestor/src/service/advisory/cve/mod.rs
@@ -9,44 +9,34 @@ pub mod divination;
 pub mod loader;
 
 /// Parses all CVSS objects from a single CVE metric entry by extracting the vector string
-/// and parsing it with the appropriate version's `FromStr` impl. Returns one `Cvss` variant
+/// and parsing it with the appropriate version's `FromStr` impl. Yields one `Cvss` variant
 /// per successfully parsed version field.
-fn parse_cvss_from_metric(metric: &cve::published::Metric) -> Vec<Cvss> {
-    let mut result = Vec::with_capacity(1);
-
-    if let Some(cvss) = metric
+fn parse_cvss_from_metric(metric: &cve::published::Metric) -> impl Iterator<Item = Cvss> + '_ {
+    let v4 = metric
         .cvss_v4_0
         .as_ref()
         .and_then(parse_from_vector_string::<CvssV4>)
-    {
-        result.push(Cvss::V4(cvss));
-    }
+        .map(Cvss::V4);
 
-    if let Some(cvss) = metric
+    let v3_1 = metric
         .cvss_v3_1
         .as_ref()
         .and_then(parse_from_vector_string::<CvssV3>)
-    {
-        result.push(Cvss::V3_1(cvss));
-    }
+        .map(Cvss::V3_1);
 
-    if let Some(cvss) = metric
+    let v3_0 = metric
         .cvss_v3_0
         .as_ref()
         .and_then(parse_from_vector_string::<CvssV3>)
-    {
-        result.push(Cvss::V3_0(cvss));
-    }
+        .map(Cvss::V3_0);
 
-    if let Some(cvss) = metric
+    let v2 = metric
         .cvss_v2_0
         .as_ref()
         .and_then(parse_from_vector_string::<CvssV2>)
-    {
-        result.push(Cvss::V2(cvss));
-    }
+        .map(Cvss::V2);
 
-    result
+    v4.into_iter().chain(v3_1).chain(v3_0).chain(v2)
 }
 
 /// Extracts a `vectorString` from a JSON value and parses it via `FromStr`.

--- a/modules/ingestor/src/service/advisory/cve/mod.rs
+++ b/modules/ingestor/src/service/advisory/cve/mod.rs
@@ -1,45 +1,88 @@
-use crate::graph::cvss::ScoreCreator;
+use crate::graph::{cvss::ScoreCreator, vulnerability::BaseScore};
 use cve::Cve;
 use cvss::{Cvss, v2_0::CvssV2, v3::CvssV3, v4_0::CvssV4};
+use serde_json::Value;
+use std::str::FromStr;
+use trustify_entity::advisory_vulnerability_score::{ScoreType, Severity};
 
 pub mod divination;
 pub mod loader;
 
-#[derive(Clone, Debug, PartialEq, Default)]
-struct CvssMetric {
-    pub cvss_v2_0: Option<CvssV2>,
-    pub cvss_v3_0: Option<CvssV3>,
-    pub cvss_v3_1: Option<CvssV3>,
-    pub cvss_v4_0: Option<CvssV4>,
+/// Parses all CVSS objects from a single CVE metric entry by extracting the vector string
+/// and parsing it with the appropriate version's `FromStr` impl. Returns one `Cvss` variant
+/// per successfully parsed version field.
+fn parse_cvss_from_metric(metric: &cve::published::Metric) -> Vec<Cvss> {
+    let mut result = Vec::with_capacity(1);
+
+    if let Some(cvss) = metric
+        .cvss_v4_0
+        .as_ref()
+        .and_then(parse_from_vector_string::<CvssV4>)
+    {
+        result.push(Cvss::V4(cvss));
+    }
+
+    if let Some(cvss) = metric
+        .cvss_v3_1
+        .as_ref()
+        .and_then(parse_from_vector_string::<CvssV3>)
+    {
+        result.push(Cvss::V3_1(cvss));
+    }
+
+    if let Some(cvss) = metric
+        .cvss_v3_0
+        .as_ref()
+        .and_then(parse_from_vector_string::<CvssV3>)
+    {
+        result.push(Cvss::V3_0(cvss));
+    }
+
+    if let Some(cvss) = metric
+        .cvss_v2_0
+        .as_ref()
+        .and_then(parse_from_vector_string::<CvssV2>)
+    {
+        result.push(Cvss::V2(cvss));
+    }
+
+    result
 }
 
-impl From<&cve::published::Metric> for CvssMetric {
-    fn from(metric: &cve::published::Metric) -> Self {
-        Self {
-            cvss_v2_0: metric
-                .cvss_v2_0
-                .as_ref()
-                .and_then(|v| serde_json::from_value(v.clone()).ok()),
-            cvss_v3_0: metric
-                .cvss_v3_0
-                .as_ref()
-                .and_then(|v| serde_json::from_value(v.clone()).ok()),
-            cvss_v3_1: metric
-                .cvss_v3_1
-                .as_ref()
-                .and_then(|v| serde_json::from_value(v.clone()).ok()),
-            cvss_v4_0: metric
-                .cvss_v4_0
-                .as_ref()
-                .and_then(|v| serde_json::from_value(v.clone()).ok()),
+/// Extracts a `vectorString` from a JSON value and parses it via `FromStr`.
+fn parse_from_vector_string<T: FromStr>(value: &Value) -> Option<T> {
+    value
+        .get("vectorString")
+        .and_then(Value::as_str)
+        .and_then(|s| T::from_str(s).ok())
+}
+
+/// Computes a [`BaseScore`] from a parsed CVSS object using `calculated_base_score()`.
+fn base_score_from_cvss(cvss: &Cvss) -> Option<BaseScore> {
+    let (score, score_type) = match cvss {
+        Cvss::V4(c) => (c.calculated_base_score()?, ScoreType::V4_0),
+        Cvss::V3_1(c) | Cvss::V3_0(c) => {
+            let score_type = match c.version {
+                Some(cvss::version::VersionV3::V3_1) => ScoreType::V3_1,
+                _ => ScoreType::V3_0,
+            };
+            (c.calculated_base_score()?, score_type)
         }
-    }
+        Cvss::V2(c) => (c.calculated_base_score()?, ScoreType::V2_0),
+    };
+
+    Some(BaseScore {
+        r#type: score_type,
+        score,
+        severity: Severity::from((score, score_type)),
+    })
 }
 
 /// Extracts all CVSS scores from a CVE record and registers them with the given [`ScoreCreator`].
 ///
-/// Processes metrics from both CNA and ADP containers. All parseable CVSS scores (v2, v3, v4)
-/// are added, keyed by the CVE identifier. Rejected CVEs are skipped entirely.
+/// Parses vector strings from both CNA and ADP containers using `FromStr`, bypassing any
+/// dependency on JSON `baseScore`/`baseSeverity` fields. The `ScoreCreator` computes the
+/// actual score from parsed metrics via `calculated_base_score()`.
 pub fn extract_scores(cve: &Cve, creator: &mut ScoreCreator) {
     let Cve::Published(published) = cve else {
         return;
@@ -55,21 +98,48 @@ pub fn extract_scores(cve: &Cve, creator: &mut ScoreCreator) {
             .flat_map(|adp| adp.metrics.iter()),
     );
 
-    for cve_metric in all_metrics {
-        let metric = CvssMetric::from(cve_metric);
-
-        let cvss_objects: Vec<Cvss> = vec![
-            metric.cvss_v2_0.map(Cvss::V2),
-            metric.cvss_v3_0.map(Cvss::V3_0),
-            metric.cvss_v3_1.map(Cvss::V3_1),
-            metric.cvss_v4_0.map(Cvss::V4),
-        ]
-        .into_iter()
-        .flatten()
-        .collect();
-
-        for score in cvss_objects {
-            creator.add((vulnerability_id.clone(), score));
+    for metric in all_metrics {
+        for cvss in parse_cvss_from_metric(metric) {
+            creator.add((vulnerability_id.clone(), cvss));
         }
     }
+}
+
+/// Extracts the best base score from a CVE record by parsing vector strings.
+///
+/// Prefers CNA scores over ADP scores, only falling back to ADP if CNA yields no parseable
+/// scores. Within each source, higher CVSS versions take precedence; within the same version,
+/// the higher numeric score wins.
+pub fn extract_base_score(cve: &Cve) -> Option<BaseScore> {
+    fn better_score(a: BaseScore, b: BaseScore) -> BaseScore {
+        if b.r#type > a.r#type || (b.r#type == a.r#type && b.score > a.score) {
+            b
+        } else {
+            a
+        }
+    }
+
+    let Cve::Published(published) = cve else {
+        return None;
+    };
+
+    let cna_result = published
+        .containers
+        .cna
+        .metrics
+        .iter()
+        .flat_map(parse_cvss_from_metric)
+        .filter_map(|c| base_score_from_cvss(&c))
+        .reduce(better_score);
+
+    cna_result.or_else(|| {
+        published
+            .containers
+            .adp
+            .iter()
+            .flat_map(|adp| adp.metrics.iter())
+            .flat_map(parse_cvss_from_metric)
+            .filter_map(|c| base_score_from_cvss(&c))
+            .reduce(better_score)
+    })
 }

--- a/modules/ingestor/src/service/advisory/cve/mod.rs
+++ b/modules/ingestor/src/service/advisory/cve/mod.rs
@@ -1,4 +1,7 @@
-use crate::graph::{cvss::ScoreCreator, vulnerability::BaseScore};
+use crate::{
+    graph::{cvss::ScoreCreator, vulnerability::BaseScore},
+    service::Warnings,
+};
 use cve::Cve;
 use cvss::{Cvss, v2_0::CvssV2, v3::CvssV3, v4_0::CvssV4};
 use serde_json::Value;
@@ -11,40 +14,53 @@ pub mod loader;
 /// Parses all CVSS objects from a single CVE metric entry by extracting the vector string
 /// and parsing it with the appropriate version's `FromStr` impl. Yields one `Cvss` variant
 /// per successfully parsed version field.
-fn parse_cvss_from_metric(metric: &cve::published::Metric) -> impl Iterator<Item = Cvss> + '_ {
+fn parse_cvss_from_metric(
+    metric: &cve::published::Metric,
+    warnings: &Warnings,
+) -> impl Iterator<Item = Cvss> {
     let v4 = metric
         .cvss_v4_0
         .as_ref()
-        .and_then(parse_from_vector_string::<CvssV4>)
+        .and_then(|v| parse_from_vector_string::<CvssV4>(v, "v4.0", warnings))
         .map(Cvss::V4);
 
     let v3_1 = metric
         .cvss_v3_1
         .as_ref()
-        .and_then(parse_from_vector_string::<CvssV3>)
+        .and_then(|v| parse_from_vector_string::<CvssV3>(v, "v3.1", warnings))
         .map(Cvss::V3_1);
 
     let v3_0 = metric
         .cvss_v3_0
         .as_ref()
-        .and_then(parse_from_vector_string::<CvssV3>)
+        .and_then(|v| parse_from_vector_string::<CvssV3>(v, "v3.0", warnings))
         .map(Cvss::V3_0);
 
     let v2 = metric
         .cvss_v2_0
         .as_ref()
-        .and_then(parse_from_vector_string::<CvssV2>)
+        .and_then(|v| parse_from_vector_string::<CvssV2>(v, "v2.0", warnings))
         .map(Cvss::V2);
 
     v4.into_iter().chain(v3_1).chain(v3_0).chain(v2)
 }
 
 /// Extracts a `vectorString` from a JSON value and parses it via `FromStr`.
-fn parse_from_vector_string<T: FromStr>(value: &Value) -> Option<T> {
-    value
-        .get("vectorString")
-        .and_then(Value::as_str)
-        .and_then(|s| T::from_str(s).ok())
+/// Warns (both via `tracing::warn!` and the `Warnings` collector) when a
+/// `vectorString` is present but fails to parse.
+fn parse_from_vector_string<T: FromStr>(
+    value: &Value,
+    version: &str,
+    warnings: &Warnings,
+) -> Option<T> {
+    let raw = value.get("vectorString").and_then(Value::as_str)?;
+
+    T::from_str(raw).ok().or_else(|| {
+        let msg = format!("Failed to parse CVSS {version} vectorString: {raw}");
+        tracing::warn!("{msg}");
+        warnings.add(msg);
+        None
+    })
 }
 
 /// Computes a [`BaseScore`] from a parsed CVSS object using `calculated_base_score()`.
@@ -73,7 +89,7 @@ fn base_score_from_cvss(cvss: &Cvss) -> Option<BaseScore> {
 /// Parses vector strings from both CNA and ADP containers using `FromStr`, bypassing any
 /// dependency on JSON `baseScore`/`baseSeverity` fields. The `ScoreCreator` computes the
 /// actual score from parsed metrics via `calculated_base_score()`.
-pub fn extract_scores(cve: &Cve, creator: &mut ScoreCreator) {
+pub fn extract_scores(cve: &Cve, creator: &mut ScoreCreator, warnings: &Warnings) {
     let Cve::Published(published) = cve else {
         return;
     };
@@ -89,7 +105,7 @@ pub fn extract_scores(cve: &Cve, creator: &mut ScoreCreator) {
     );
 
     for metric in all_metrics {
-        for cvss in parse_cvss_from_metric(metric) {
+        for cvss in parse_cvss_from_metric(metric, warnings) {
             creator.add((vulnerability_id.clone(), cvss));
         }
     }
@@ -100,7 +116,7 @@ pub fn extract_scores(cve: &Cve, creator: &mut ScoreCreator) {
 /// Prefers CNA scores over ADP scores, only falling back to ADP if CNA yields no parseable
 /// scores. Within each source, higher CVSS versions take precedence; within the same version,
 /// the higher numeric score wins.
-pub fn extract_base_score(cve: &Cve) -> Option<BaseScore> {
+pub fn extract_base_score(cve: &Cve, warnings: &Warnings) -> Option<BaseScore> {
     fn better_score(a: BaseScore, b: BaseScore) -> BaseScore {
         if b.r#type > a.r#type || (b.r#type == a.r#type && b.score > a.score) {
             b
@@ -118,7 +134,7 @@ pub fn extract_base_score(cve: &Cve) -> Option<BaseScore> {
         .cna
         .metrics
         .iter()
-        .flat_map(parse_cvss_from_metric)
+        .flat_map(|m| parse_cvss_from_metric(m, warnings))
         .filter_map(|c| base_score_from_cvss(&c))
         .reduce(better_score);
 
@@ -128,7 +144,7 @@ pub fn extract_base_score(cve: &Cve) -> Option<BaseScore> {
             .adp
             .iter()
             .flat_map(|adp| adp.metrics.iter())
-            .flat_map(parse_cvss_from_metric)
+            .flat_map(|m| parse_cvss_from_metric(m, warnings))
             .filter_map(|c| base_score_from_cvss(&c))
             .reduce(better_score)
     })

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -301,7 +301,7 @@ impl IngestorService {
 
 /// Capture warnings from the import process
 #[derive(Default)]
-pub(crate) struct Warnings(Arc<Mutex<Vec<String>>>);
+pub struct Warnings(Arc<Mutex<Vec<String>>>);
 
 impl Warnings {
     pub fn new() -> Self {


### PR DESCRIPTION
## Summary

* Always parse CVSS from `vectorString` via `FromStr` + `calculated_base_score()`, removing the dependency on `baseScore`/`baseSeverity` JSON fields that many CVE producers omit (root cause of TC-5272)
* Consolidate the two divergent CVSS parsing paths (`extract_scores` and `extract_base_score`) into shared helpers in `mod.rs`, deleting the legacy `CvssMetric` struct, `get_score()`, and `score_from_metric()`
* Add schema migration `m0002250` to backfill `vulnerability.base_score/base_severity/base_type` from `advisory_vulnerability_score` for existing data
* Close testing gap: `CveBuilder` now builds metrics with only `vectorString`, plus explicit test cases for missing and invalid vector strings

### Data refresh on upgrade

The backfill migration (`m0002250`) runs automatically and updates the denormalized vulnerability columns from `advisory_vulnerability_score`.

If the `m0002010_add_advisory_scores` data migration was skipped or needs re-running with the fixed parser, run it first:

```sh
trustd db data m0002010_add_advisory_scores
```

Then re-run the backfill SQL manually if needed (idempotent):

```sh
psql -d <database> -f migration/src/m0002250_backfill_vulnerability_base_score/up.sql
```

Implements TC-5272

## Test plan

- [x] All existing CVE loader unit tests pass with vector-string-only test fixtures
- [x] New test: `missing_vector_string_yields_none` — metric with `baseScore` but no `vectorString` returns `None`
- [x] New test: `invalid_vector_yields_none` — garbage `vectorString` returns `None`
- [x] CSAF integration tests unaffected (separate code path)
- [x] `cargo xtask precommit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Parse CVSS scores from vector strings across the CVE ingestor and use them to compute and backfill vulnerability base scores.

Bug Fixes:
- Ensure CVSS base scores are derived from vectorString data instead of relying on often-missing baseScore/baseSeverity JSON fields, preventing missing scores for certain CVEs.

Enhancements:
- Unify CVSS parsing and base-score selection logic into shared helpers that work across CNA and ADP metrics and prefer higher CVSS versions.
- Relax base-score comparison in tests and switch CVE test fixtures to vector-string-only metrics to align with the new parsing approach.

Tests:
- Add unit and migration tests covering vector-string-only CVSS metrics, missing/invalid vector strings, and the base-score backfill behavior.