### PR TITLE
fix: return HTTP 404 instead of 400 for non-existent SBOM IDs

### DIFF
--- a/modules/fundamental/src/error.rs
+++ b/modules/fundamental/src/error.rs
@@ -138,7 +138,7 @@ impl ResponseError for Error {
             Self::Query(err) => {
                 HttpResponse::BadRequest().json(ErrorInformation::new("QueryError", err))
             }
-            Self::IdKey(err) => HttpResponse::BadRequest().json(ErrorInformation::new("Key", err)),
+            Self::IdKey(err) => HttpResponse::NotFound().json(ErrorInformation::new("Key", err)),
             Self::StorageKey(err) => {
                 HttpResponse::BadRequest().json(ErrorInformation::new("StorageKey", err))
             }

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -100,7 +100,7 @@ const CONTENT_TYPE_GZIP: &str = "application/gzip";
     ),
     responses(
         (status = 200, description = "fetch all unique license id and license info id", body = Vec<LicenseRefMapping>),
-        (status = 400, description = "Invalid UUID format."),
+        (status = 404, description = "The SBOM could not be found"),
     ),
 )]
 #[get("/v3/sbom/{id}/all-license-ids")]

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -447,7 +447,7 @@ async fn fetch_unique_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::NOT_FOUND, response.status());
 
-    // badly formatted Id
+    // badly formatted Id -> 404 (not 400: the resource simply does not exist)
     let req = TestRequest::get()
         .uri("/api/v3/sbom/sha123:1234/all-license-ids")
         .to_request();
@@ -1121,6 +1121,34 @@ async fn get_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // assert expected fields
     assert_eq!(sbom["id"], format!("urn:uuid:{id}"));
     assert_eq!(sbom["number_of_packages"], 1053);
+
+    // Non-existent UUID -> 404
+    let req = TestRequest::get()
+        .uri("/api/v3/sbom/urn:uuid:00000000-0000-0000-0000-000000000000")
+        .to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+    // Non-existent hash -> 404
+    let req = TestRequest::get()
+        .uri("/api/v3/sbom/sha256:0000000000000000000000000000000000000000000000000000000000000000")
+        .to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+    // Invalid identifier (no prefix) -> 404 (not 400)
+    let req = TestRequest::get()
+        .uri("/api/v3/sbom/not-an-id")
+        .to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+    // Unsupported prefix -> 404 (not 400)
+    let req = TestRequest::get()
+        .uri("/api/v3/sbom/sha123:abcd")
+        .to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::NOT_FOUND, response.status());
 
     Ok(())
 }
@@ -2176,6 +2204,15 @@ async fn packages_by_hash(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::NOT_FOUND, response.status());
 
+    // Bad query parameter -> 400 (query errors remain bad requests)
+    let req = TestRequest::get()
+        .uri(&format!(
+            "/api/v3/sbom/urn:uuid:{id}/packages?sort=nonexistent_column:asc"
+        ))
+        .to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::BAD_REQUEST, response.status());
+
     Ok(())
 }
 
@@ -2230,6 +2267,15 @@ async fn related_by_hash(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .to_request();
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+    // Bad query parameter -> 400 (query errors remain bad requests)
+    let req = TestRequest::get()
+        .uri(&format!(
+            "/api/v3/sbom/urn:uuid:{id}/related?sort=nonexistent_column:asc"
+        ))
+        .to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::BAD_REQUEST, response.status());
 
     Ok(())
 }

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -452,7 +452,7 @@ async fn fetch_unique_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
         .uri("/api/v3/sbom/sha123:1234/all-license-ids")
         .to_request();
     let response = app.call_service(req).await;
-    assert_eq!(StatusCode::BAD_REQUEST, response.status());
+    assert_eq!(StatusCode::NOT_FOUND, response.status());
 
     // Test license IDs are case-insensitive https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/#case-sensitivity
     // because, so far, the test ingested `Apache-2.0` licenses but the next SBOM contains
@@ -2162,19 +2162,19 @@ async fn packages_by_hash(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::NOT_FOUND, response.status());
 
-    // Invalid identifier (no prefix) -> 400
+    // Invalid identifier (no prefix) -> 404
     let req = TestRequest::get()
         .uri("/api/v3/sbom/not-an-id/packages")
         .to_request();
     let response = app.call_service(req).await;
-    assert_eq!(StatusCode::BAD_REQUEST, response.status());
+    assert_eq!(StatusCode::NOT_FOUND, response.status());
 
-    // Unsupported prefix -> 400
+    // Unsupported prefix -> 404
     let req = TestRequest::get()
         .uri("/api/v3/sbom/sha123:abcd/packages")
         .to_request();
     let response = app.call_service(req).await;
-    assert_eq!(StatusCode::BAD_REQUEST, response.status());
+    assert_eq!(StatusCode::NOT_FOUND, response.status());
 
     Ok(())
 }
@@ -2217,19 +2217,19 @@ async fn related_by_hash(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::NOT_FOUND, response.status());
 
-    // Invalid identifier (no prefix) -> 400
+    // Invalid identifier (no prefix) -> 404
     let req = TestRequest::get()
         .uri("/api/v3/sbom/not-an-id/related")
         .to_request();
     let response = app.call_service(req).await;
-    assert_eq!(StatusCode::BAD_REQUEST, response.status());
+    assert_eq!(StatusCode::NOT_FOUND, response.status());
 
-    // Unsupported prefix -> 400
+    // Unsupported prefix -> 404
     let req = TestRequest::get()
         .uri("/api/v3/sbom/sha123:abcd/related")
         .to_request();
     let response = app.call_service(req).await;
-    assert_eq!(StatusCode::BAD_REQUEST, response.status());
+    assert_eq!(StatusCode::NOT_FOUND, response.status());
 
     Ok(())
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3201,8 +3201,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/LicenseRefMapping'
-        '400':
-          description: Invalid UUID format.
+        '404':
+          description: The SBOM could not be found
   /api/v3/sbom/{id}/label:
     put:
       tags:


### PR DESCRIPTION
Return HTTP 404 for SBOM ID key lookup failures and align tests with the new behavior.

Bug Fixes:
- Change SBOM ID key errors to respond with HTTP 404 Not Found instead of HTTP 400 Bad Request.

Tests:
- Update SBOM endpoint tests to expect HTTP 404 for invalid or unsupported SBOM identifiers and non-existent SBOM IDs.

addresses TC-5278