### PR TITLE
chore: allow sign-out url for Cognito

### DIFF
--- a/docs/book/modules/admin/examples/trustify/sso.tf
+++ b/docs/book/modules/admin/examples/trustify/sso.tf
@@ -116,6 +116,7 @@ resource "aws_cognito_user_pool_client" "frontend" {
     "${var.console-url}/swagger-ui/oauth2-redirect.html",
   ]
   logout_urls = [
+    "${var.console-url}",
     "${var.console-url}/",
     "${var.console-url}/notloggedin",
   ]


### PR DESCRIPTION
When trying to log out of TPA with AWS infrastructure, this URL is not allowed in Cognito by default, which causes a redirect to the login page to fail. This fixes the issue.