### PR TITLE
experiment (tools):  tools/gate CI/CD policy gate

### DIFF
--- a/tools/gate/.gitignore
+++ b/tools/gate/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.venv/
+.ruff_cache/
+uv.lock

--- a/tools/gate/Makefile
+++ b/tools/gate/Makefile
@@ -1,0 +1,36 @@
+# Trustify Gate - CI/CD Policy Gate
+#
+# Usage:
+#   make check SBOM=path/to/sbom.json                  Check a local SBOM (extract PURLs, analyze)
+#   make check-upload SBOM=path/to/sbom.json            Upload SBOM then check
+#   make check-name NAME="my-product-1.0"               Check an already-ingested SBOM by name
+#   make check-id ID=urn:uuid:...                       Check an already-ingested SBOM by ID
+#   make list-checkers                                  List available checker plugins
+#   make sync                                           Install dependencies
+
+.PHONY: check check-upload check-name check-id list-checkers sync
+
+TRUSTIFY_URL ?= http://localhost:8080
+CONFIG ?=
+FORMAT ?= table
+
+# Optional --config flag.
+_CONFIG_FLAG = $(if $(CONFIG),--config $(CONFIG),)
+
+check: ## Check a local SBOM file
+	TRUSTIFY_URL=$(TRUSTIFY_URL) uv run python gate.py check --sbom $(SBOM) $(_CONFIG_FLAG) --format $(FORMAT)
+
+check-upload: ## Upload SBOM to Trustify then check
+	TRUSTIFY_URL=$(TRUSTIFY_URL) uv run python gate.py check --sbom $(SBOM) --upload $(_CONFIG_FLAG) --format $(FORMAT)
+
+check-name: ## Check an SBOM already in Trustify (by name)
+	TRUSTIFY_URL=$(TRUSTIFY_URL) uv run python gate.py check --sbom-name "$(NAME)" $(_CONFIG_FLAG) --format $(FORMAT)
+
+check-id: ## Check an SBOM already in Trustify (by ID)
+	TRUSTIFY_URL=$(TRUSTIFY_URL) uv run python gate.py check --sbom-id "$(ID)" $(_CONFIG_FLAG) --format $(FORMAT)
+
+list-checkers: ## List available checker plugins
+	uv run python gate.py list-checkers
+
+sync: ## Install dependencies
+	uv sync

--- a/tools/gate/README.md
+++ b/tools/gate/README.md
@@ -1,0 +1,556 @@
+# Trustify Gate
+
+CI/CD policy gate that evaluates SBOMs against configurable security and
+compliance policies using data from a running Trustify instance. Exits
+non-zero when policy violations are found.
+
+## Prerequisites
+
+- Python 3.13+
+- [uv](https://docs.astral.sh/uv/)
+- A running Trustify instance
+- (Optional) [Conforma CLI](https://github.com/conforma/cli) for OPA/Rego policy checks
+
+## Quickstart
+
+```bash
+cd tools/gate
+uv sync
+```
+
+### Check a local SBOM (no upload)
+
+Extracts PURLs from the SBOM locally and runs vulnerability analysis via
+the Trustify API. The SBOM itself is not uploaded.
+
+```bash
+uv run python gate.py check --sbom ./build/sbom.json
+```
+
+### Upload an SBOM then check
+
+Uploads the SBOM to Trustify first, which enables full advisory and
+license analysis in addition to vulnerability checks.
+
+```bash
+uv run python gate.py check --sbom ./build/sbom.json --upload
+```
+
+### Check an SBOM already in Trustify
+
+```bash
+# By name
+uv run python gate.py check --sbom-name "my-product-1.0"
+
+# By ID
+uv run python gate.py check --sbom-id "urn:uuid:abc123..."
+```
+
+### Custom gate config
+
+```bash
+uv run python gate.py check --sbom ./sbom.json --config examples/builtin-only.json
+```
+
+### Output formats
+
+```bash
+uv run python gate.py check --sbom ./sbom.json --format json
+uv run python gate.py check --sbom ./sbom.json --format sarif --output results.sarif
+uv run python gate.py check --sbom ./sbom.json --format junit --output results.xml
+```
+
+## Quickstart (Makefile)
+
+The Makefile provides shortcuts. All commands assume you are in the
+`tools/gate/` directory.
+
+```bash
+make check SBOM=path/to/sbom.json                   # local SBOM, no upload
+make check-upload SBOM=path/to/sbom.json             # upload then check
+make check-name NAME="my-product-1.0"                # by name
+make check-id ID=urn:uuid:...                        # by ID
+make list-checkers                                   # show available plugins
+make sync                                            # install dependencies
+```
+
+Override defaults:
+
+```bash
+make check SBOM=sbom.json TRUSTIFY_URL=https://trustify.example.com
+make check SBOM=sbom.json CONFIG=examples/full-pipeline.json FORMAT=json
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRUSTIFY_URL` | `http://localhost:8080` | Target Trustify instance |
+| `CONFIG` | (unset) | Path to gate config file |
+| `FORMAT` | `table` | Output format: table, json, sarif, junit |
+
+## How it works
+
+```
+  Local SBOM file       or     SBOM already in Trustify
+       |                              |
+  extract PURLs locally          GET /sbom/{id}/packages
+       |                              |
+       +---------- PURLs ------------+
+                     |
+          POST /vulnerability/analyze
+          GET /sbom/{id}/advisory
+          GET /sbom/{id}/all-license-ids
+                     |
+              +-----------+
+              |  checkers  |
+              +-----------+
+              |           |
+           builtin    conforma    ...
+              |           |
+              +--- violations ---+
+                     |
+              pass (exit 0) / fail (exit 1)
+```
+
+1. **Resolve the SBOM** -- upload a local file, look up by name/ID, or
+   extract PURLs locally from CycloneDX/SPDX JSON
+2. **Fetch data from Trustify** -- vulnerability analysis, advisories,
+   license inventory
+3. **Run checker plugins** -- each checker evaluates the data against its
+   own policy configuration
+4. **Aggregate and report** -- all violations are collected, formatted,
+   and the process exits non-zero if any are found
+
+## Checker plugins
+
+Policy evaluation uses a plugin system. The gate config file specifies
+which checkers to run and their individual configuration:
+
+```json
+{
+  "checkers": [
+    {"name": "builtin", "config": { ... }},
+    {"name": "conforma", "config": { ... }}
+  ]
+}
+```
+
+Multiple checkers run sequentially; all violations are aggregated.
+
+### `builtin` -- threshold-based checker
+
+Evaluates vulnerability severity, CVSS scores, and licenses against
+declarative rules. No external tools required.
+
+```json
+{
+  "name": "builtin",
+  "config": {
+    "vulnerabilities": {
+      "max_severity": "high",
+      "max_score": 9.0,
+      "deny": ["CVE-2021-44228"],
+      "ignore": ["CVE-2024-9999"],
+      "ignore_unfixed": false
+    },
+    "licenses": {
+      "deny": ["GPL-3.0*", "AGPL-*"],
+      "allow": ["MIT", "Apache-2.0", "BSD-*"]
+    }
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `max_severity` | Fail if any vuln exceeds this level (none/low/medium/high/critical) |
+| `max_score` | Fail if any CVSS score exceeds this value |
+| `deny` | Always fail on these CVE IDs |
+| `ignore` | Skip these CVE IDs |
+| `ignore_unfixed` | Skip vulns with status not_affected or under_investigation |
+| `licenses.deny` | Glob patterns for denied licenses (e.g. `GPL-3.0*`) |
+| `licenses.allow` | If set, any license NOT matching is a violation |
+
+### `conforma` -- OPA/Rego policy checker
+
+Validates Trustify data against [Conforma](https://conforma.dev)
+(formerly Enterprise Contract) OPA/Rego policies. Requires the `ec`
+CLI binary or a running Conforma HTTP server.
+
+All Trustify data is available to Rego rules under `input.trustify`
+(SBOM metadata, PURLs, vulnerabilities, advisories, licenses).
+
+**CLI mode** (shells out to `ec validate input`):
+
+```json
+{
+  "name": "conforma",
+  "config": {
+    "mode": "cli",
+    "ec_binary": "ec",
+    "policy": "git::https://github.com/conforma/policy//policy/release",
+    "extra_args": ["--ignore-rekor"]
+  }
+}
+```
+
+**Server mode** (POSTs to a running Conforma HTTP service):
+
+```json
+{
+  "name": "conforma",
+  "config": {
+    "mode": "server",
+    "server_url": "http://localhost:8090"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `mode` | `cli` (subprocess) or `server` (HTTP POST) |
+| `ec_binary` | Path to `ec` binary (default: `ec` on PATH) |
+| `policy` | Conforma policy source (git URL, OCI ref, local path) |
+| `policy_file` | Path to an EnterpriseContractPolicy YAML file |
+| `server_url` | URL of a running Conforma HTTP server |
+| `extra_args` | Additional CLI arguments for `ec validate input` |
+
+### Writing a custom checker
+
+1. Create `checkers/mychecker.py`
+2. Implement a class with a `name` property and a `check(ctx, config)` method
+3. Call `register_checker("mychecker", MyClass)` at module level
+4. Import the module in `checkers/__init__.py`
+
+```python
+from checkers import CheckContext, register_checker
+from policy import Violation
+
+class MyChecker:
+    @property
+    def name(self) -> str:
+        return "mychecker"
+
+    def check(self, ctx: CheckContext, config: dict) -> list[Violation]:
+        violations = []
+        # ctx.purls, ctx.vuln_analysis, ctx.advisories, ctx.license_ids
+        # are all available here. Evaluate against config and append
+        # Violation objects for any failures.
+        return violations
+
+register_checker("mychecker", MyChecker)
+```
+
+## Output formats
+
+| Format | Flag | Use case |
+|--------|------|----------|
+| `table` | `--format table` | Human-readable terminal output (default) |
+| `json` | `--format json` | Machine-readable, CI artifact storage |
+| `sarif` | `--format sarif` | GitHub Code Scanning, IDE integration |
+| `junit` | `--format junit` | Jenkins, GitLab CI, JUnit-compatible systems |
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All checks passed |
+| `1` | Policy violations found |
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRUSTIFY_URL` | `http://localhost:8080` | Trustify server URL |
+| `TRUSTIFY_TOKEN` | (empty) | Bearer token for authentication |
+
+## Local development usage
+
+### Scenario 1: Developer checking a build locally
+
+```bash
+# Start Trustify locally (assumes it's already running on :8080)
+cd tools/gate
+
+# Check your build SBOM against default policy (fail on critical vulns)
+uv run python gate.py check --sbom ../../my-project/build/sbom.cdx.json
+
+# Use a stricter policy
+uv run python gate.py check \
+  --sbom ../../my-project/build/sbom.cdx.json \
+  --config examples/builtin-only.json
+
+# Upload the SBOM for full advisory + license checks
+uv run python gate.py check \
+  --sbom ../../my-project/build/sbom.cdx.json \
+  --upload
+
+# Get JSON output for scripting
+uv run python gate.py check \
+  --sbom ../../my-project/build/sbom.cdx.json \
+  --format json | jq '.summary'
+```
+
+### Scenario 2: Security team auditing an existing SBOM
+
+```bash
+# Check an SBOM that was already uploaded to Trustify
+uv run python gate.py check --sbom-name "rhel-9.4-container-image"
+
+# Use both builtin and Conforma checkers
+uv run python gate.py check \
+  --sbom-name "rhel-9.4-container-image" \
+  --config examples/full-pipeline.json
+```
+
+### Scenario 3: Using Conforma policies
+
+```bash
+# Requires the `ec` CLI: https://github.com/conforma/cli
+# Install: go install github.com/conforma/cli/cmd/ec@latest
+
+# Run with Conforma policies from a git repo
+uv run python gate.py check \
+  --sbom ./sbom.json \
+  --config examples/conforma-only.json
+
+# Or start a Conforma server and use HTTP mode
+ec validate input --server --server-port 8090 &
+uv run python gate.py check \
+  --sbom ./sbom.json \
+  --config examples/conforma-server.json
+```
+
+## GitHub Actions
+
+### Basic gate check
+
+```yaml
+name: Trustify Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Generate SBOM
+        run: |
+          # Example: generate SBOM with syft
+          syft . -o cyclonedx-json=sbom.cdx.json
+
+      - name: Run Trustify Gate
+        working-directory: tools/gate
+        env:
+          TRUSTIFY_URL: ${{ vars.TRUSTIFY_URL }}
+          TRUSTIFY_TOKEN: ${{ secrets.TRUSTIFY_TOKEN }}
+        run: |
+          uv sync
+          uv run python gate.py check \
+            --sbom ${{ github.workspace }}/sbom.cdx.json \
+            --upload \
+            --config examples/builtin-only.json
+```
+
+### Gate with SARIF upload to GitHub Code Scanning
+
+```yaml
+name: Trustify Gate (SARIF)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Generate SBOM
+        run: syft . -o cyclonedx-json=sbom.cdx.json
+
+      - name: Run Trustify Gate
+        id: gate
+        continue-on-error: true
+        working-directory: tools/gate
+        env:
+          TRUSTIFY_URL: ${{ vars.TRUSTIFY_URL }}
+          TRUSTIFY_TOKEN: ${{ secrets.TRUSTIFY_TOKEN }}
+        run: |
+          uv sync
+          uv run python gate.py check \
+            --sbom ${{ github.workspace }}/sbom.cdx.json \
+            --upload \
+            --config examples/builtin-only.json \
+            --format sarif \
+            --output ${{ github.workspace }}/gate-results.sarif
+
+      - name: Upload SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: gate-results.sarif
+
+      - name: Fail if gate failed
+        if: steps.gate.outcome == 'failure'
+        run: exit 1
+```
+
+### Gate with JUnit report and Conforma
+
+```yaml
+name: Trustify Gate (Full Pipeline)
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Install Conforma CLI
+        run: |
+          curl -sL https://github.com/conforma/cli/releases/latest/download/ec_linux_amd64 \
+            -o /usr/local/bin/ec
+          chmod +x /usr/local/bin/ec
+
+      - name: Generate SBOM
+        run: syft . -o cyclonedx-json=sbom.cdx.json
+
+      - name: Run Trustify Gate
+        working-directory: tools/gate
+        env:
+          TRUSTIFY_URL: ${{ vars.TRUSTIFY_URL }}
+          TRUSTIFY_TOKEN: ${{ secrets.TRUSTIFY_TOKEN }}
+        run: |
+          uv sync
+          uv run python gate.py check \
+            --sbom ${{ github.workspace }}/sbom.cdx.json \
+            --upload \
+            --config examples/full-pipeline.json \
+            --format junit \
+            --output ${{ github.workspace }}/gate-results.xml
+
+      - name: Publish JUnit report
+        uses: mikepenz/action-junit-report@v5
+        if: always()
+        with:
+          report_paths: gate-results.xml
+```
+
+### Reusable workflow
+
+Create `.github/workflows/trustify-gate.yml` as a reusable workflow that
+other repos can call:
+
+```yaml
+name: Trustify Gate (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      sbom-path:
+        required: true
+        type: string
+        description: Path to the SBOM file relative to the workspace root
+      config:
+        required: false
+        type: string
+        default: examples/builtin-only.json
+        description: Gate config file (relative to tools/gate/)
+      format:
+        required: false
+        type: string
+        default: table
+      upload:
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      TRUSTIFY_URL:
+        required: true
+      TRUSTIFY_TOKEN:
+        required: true
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Run Trustify Gate
+        working-directory: tools/gate
+        env:
+          TRUSTIFY_URL: ${{ secrets.TRUSTIFY_URL }}
+          TRUSTIFY_TOKEN: ${{ secrets.TRUSTIFY_TOKEN }}
+        run: |
+          uv sync
+          uv run python gate.py check \
+            --sbom ${{ github.workspace }}/${{ inputs.sbom-path }} \
+            ${{ inputs.upload && '--upload' || '' }} \
+            --config ${{ inputs.config }} \
+            --format ${{ inputs.format }}
+```
+
+Callers use it like this:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: syft . -o cyclonedx-json=sbom.cdx.json
+
+  gate:
+    needs: build
+    uses: ./.github/workflows/trustify-gate.yml
+    with:
+      sbom-path: sbom.cdx.json
+    secrets:
+      TRUSTIFY_URL: ${{ vars.TRUSTIFY_URL }}
+      TRUSTIFY_TOKEN: ${{ secrets.TRUSTIFY_TOKEN }}
+```
+
+## File structure
+
+```
+tools/gate/
+  gate.py               Main CLI entrypoint
+  client.py             Synchronous Trustify REST API client
+  config.py             Environment variable configuration
+  policy.py             Data models (Violation, GateResult, config loading)
+  formatters.py         Output formatters (table, JSON, SARIF, JUnit)
+  checkers/
+    __init__.py          Plugin protocol, registry, auto-imports
+    builtin.py           Built-in threshold checker
+    conforma.py          Conforma/EC OPA policy checker
+  examples/
+    builtin-only.json    Builtin checker only
+    conforma-only.json   Conforma checker only
+    full-pipeline.json   Both checkers combined
+    conforma-server.json Conforma in HTTP server mode
+  pyproject.toml
+  Makefile
+  DESIGN.md
+  README.md
+```

--- a/tools/gate/checkers/__init__.py
+++ b/tools/gate/checkers/__init__.py
@@ -1,0 +1,89 @@
+"""Checker plugin system for the Trustify gate.
+
+Each checker is a module in this package that registers itself via
+``register_checker()``. The gate loads checkers by name from the gate
+config file and calls ``check()`` on each one.
+
+To add a new checker:
+
+1. Create ``checkers/mychecker.py``
+2. Implement a class with the ``Checker`` protocol
+3. Call ``register_checker("mychecker", MyChecker)`` at module level
+4. Import the module in this ``__init__.py``
+
+The checker receives a ``CheckContext`` with all the data it needs
+(SBOM info, vulnerabilities, advisories, licenses, raw SBOM path)
+and its own config dict from the gate config file.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from policy import Violation
+
+
+@dataclass
+class CheckContext:
+    """Data available to all checkers.
+
+    Populated by the gate before invoking checkers. Fields may be None
+    if the corresponding data was not fetched (e.g. no SBOM uploaded).
+    """
+
+    sbom_path: Path | None = None
+    sbom_id: str = ""
+    sbom_name: str = ""
+    purls: list[str] = field(default_factory=list)
+    vuln_analysis: Any = None  # response from POST /vulnerability/analyze
+    advisories: dict[str, Any] | None = None  # response from GET /sbom/{id}/advisory
+    license_ids: Any = None  # response from GET /sbom/{id}/all-license-ids
+    sbom_detail: dict[str, Any] | None = None  # response from GET /sbom/{id}
+
+
+class Checker(Protocol):
+    """Protocol that all checker plugins must implement."""
+
+    @property
+    def name(self) -> str:
+        """Short identifier for this checker (e.g. 'builtin', 'conforma')."""
+        ...
+
+    def check(self, ctx: CheckContext, config: dict[str, Any]) -> list[Violation]:
+        """Run the check and return a list of violations.
+
+        An empty list means the check passed. The checker should not
+        raise exceptions for policy failures -- only for infrastructure
+        errors (unreachable services, bad config, etc.).
+        """
+        ...
+
+
+# -- Registry ----------------------------------------------------------------
+
+_registry: dict[str, type[Checker]] = {}
+
+
+def register_checker(name: str, cls: type[Checker]) -> None:
+    """Register a checker class by name."""
+    _registry[name] = cls
+
+
+def get_checker(name: str) -> type[Checker]:
+    """Look up a registered checker by name. Raises KeyError if unknown."""
+    if name not in _registry:
+        available = ", ".join(sorted(_registry)) or "(none)"
+        raise KeyError(
+            f"Unknown checker '{name}'. Available checkers: {available}"
+        )
+    return _registry[name]
+
+
+def available_checkers() -> list[str]:
+    """Return names of all registered checkers."""
+    return sorted(_registry)
+
+
+# Import checker modules so they self-register on import.
+from checkers import builtin as _builtin  # noqa: E402, F401
+from checkers import conforma as _conforma  # noqa: E402, F401

--- a/tools/gate/checkers/builtin.py
+++ b/tools/gate/checkers/builtin.py
@@ -1,0 +1,308 @@
+"""Built-in checker: severity thresholds, CVSS scores, and license policy.
+
+This checker evaluates Trustify vulnerability analysis and advisory data
+against simple declarative rules (max severity, max score, deny/allow
+lists). No external tools required.
+
+Config example (inside gate config ``checkers`` entry)::
+
+    {
+      "name": "builtin",
+      "config": {
+        "vulnerabilities": {
+          "max_severity": "high",
+          "max_score": 9.0,
+          "deny": ["CVE-2024-0001"],
+          "ignore": ["CVE-2024-9999"],
+          "ignore_unfixed": false
+        },
+        "licenses": {
+          "deny": ["GPL-3.0*", "AGPL-*"],
+          "allow": ["MIT", "Apache-2.0", "BSD-*"]
+        }
+      }
+    }
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from checkers import CheckContext, register_checker
+from policy import SEVERITY_RANK, Violation
+
+CHECKER_NAME = "builtin"
+
+
+class BuiltinChecker:
+    """Evaluates vulnerabilities and licenses against declarative thresholds."""
+
+    @property
+    def name(self) -> str:
+        return CHECKER_NAME
+
+    def check(self, ctx: CheckContext, config: dict[str, Any]) -> list[Violation]:
+        violations: list[Violation] = []
+
+        vuln_config = config.get("vulnerabilities", {})
+        lic_config = config.get("licenses", {})
+
+        if ctx.vuln_analysis is not None:
+            violations.extend(_check_vuln_analysis(ctx.vuln_analysis, vuln_config))
+
+        if ctx.advisories is not None:
+            violations.extend(_check_advisories(ctx.advisories, vuln_config))
+
+        if ctx.license_ids is not None:
+            violations.extend(_check_licenses(ctx.license_ids, lic_config))
+
+        for v in violations:
+            v.checker = CHECKER_NAME
+
+        return violations
+
+
+# -- Shared config parsing ---------------------------------------------------
+
+@dataclass
+class _VulnRules:
+    max_sev: str
+    max_sev_rank: int
+    max_score: float
+    deny_cves: list[str]
+    ignore_cves: set[str]
+    ignore_unfixed: bool
+
+
+def _parse_vuln_rules(config: dict[str, Any]) -> _VulnRules:
+    max_sev = config.get("max_severity", "critical").lower()
+    return _VulnRules(
+        max_sev=max_sev,
+        max_sev_rank=SEVERITY_RANK.get(max_sev, 4),
+        max_score=float(config.get("max_score", 10.0)),
+        deny_cves=config.get("deny", []),
+        ignore_cves=set(config.get("ignore", [])),
+        ignore_unfixed=config.get("ignore_unfixed", False),
+    )
+
+
+# -- Vulnerability analysis --------------------------------------------------
+
+def _check_vuln_analysis(
+    analysis: Any,
+    config: dict[str, Any],
+) -> list[Violation]:
+    rules = _parse_vuln_rules(config)
+
+    violations: list[Violation] = []
+
+    items = analysis if isinstance(analysis, list) else []
+    for item in items:
+        purl = item.get("purl", "")
+        for vuln in item.get("vulnerabilities", []):
+            vuln_id = vuln.get("identifier", vuln.get("id", "unknown"))
+
+            if vuln_id in rules.ignore_cves:
+                continue
+
+            if vuln_id in rules.deny_cves:
+                violations.append(Violation(
+                    kind="vulnerability",
+                    severity="critical",
+                    identifier=vuln_id,
+                    message=f"Denied CVE {vuln_id} found in {purl}",
+                    purl=purl,
+                ))
+                continue
+
+            severity = _extract_severity(vuln)
+            score = _extract_score(vuln)
+
+            status = vuln.get("status", "").lower()
+            if rules.ignore_unfixed and status in ("not_affected", "under_investigation"):
+                continue
+
+            sev_rank = SEVERITY_RANK.get(severity, 0)
+            if sev_rank > rules.max_sev_rank:
+                violations.append(Violation(
+                    kind="vulnerability",
+                    severity=severity,
+                    identifier=vuln_id,
+                    message=(
+                        f"{severity.upper()} vulnerability {vuln_id} "
+                        f"(score: {score}) in {purl}"
+                    ),
+                    score=score,
+                    purl=purl,
+                ))
+            elif score > rules.max_score:
+                violations.append(Violation(
+                    kind="vulnerability",
+                    severity=severity,
+                    identifier=vuln_id,
+                    message=(
+                        f"Vulnerability {vuln_id} score {score} exceeds "
+                        f"threshold {rules.max_score} in {purl}"
+                    ),
+                    score=score,
+                    purl=purl,
+                ))
+
+    return violations
+
+
+# -- Advisory checks ---------------------------------------------------------
+
+def _check_advisories(
+    advisories: dict[str, Any],
+    config: dict[str, Any],
+) -> list[Violation]:
+    rules = _parse_vuln_rules(config)
+    violations: list[Violation] = []
+
+    for item in advisories.get("items", []):
+        advisory_id = item.get("identifier", item.get("uuid", "unknown"))
+
+        for vuln in item.get("vulnerabilities", []):
+            vuln_id = vuln.get("identifier", vuln.get("id", "unknown"))
+
+            if vuln_id in rules.ignore_cves:
+                continue
+
+            if vuln_id in rules.deny_cves:
+                violations.append(Violation(
+                    kind="vulnerability",
+                    severity="critical",
+                    identifier=vuln_id,
+                    message=f"Denied CVE {vuln_id} in advisory {advisory_id}",
+                ))
+                continue
+
+            severity = _extract_severity(vuln)
+            score = _extract_score(vuln)
+            sev_rank = SEVERITY_RANK.get(severity, 0)
+
+            if sev_rank > rules.max_sev_rank:
+                violations.append(Violation(
+                    kind="vulnerability",
+                    severity=severity,
+                    identifier=vuln_id,
+                    message=(
+                        f"{severity.upper()} {vuln_id} "
+                        f"(score: {score}) via advisory {advisory_id}"
+                    ),
+                    score=score,
+                ))
+            elif score > rules.max_score:
+                violations.append(Violation(
+                    kind="vulnerability",
+                    severity=severity,
+                    identifier=vuln_id,
+                    message=(
+                        f"{vuln_id} score {score} exceeds "
+                        f"threshold {rules.max_score} via advisory {advisory_id}"
+                    ),
+                    score=score,
+                ))
+
+    return violations
+
+
+# -- License checks ----------------------------------------------------------
+
+def _check_licenses(
+    license_ids: Any,
+    config: dict[str, Any],
+) -> list[Violation]:
+    deny: list[str] = config.get("deny", [])
+    allow: list[str] = config.get("allow", [])
+
+    if not deny and not allow:
+        return []
+
+    violations: list[Violation] = []
+
+    ids: list[str] = []
+    if isinstance(license_ids, list):
+        ids = license_ids
+    elif isinstance(license_ids, dict):
+        ids = license_ids.get("items", license_ids.get("licenses", []))
+
+    for lic in ids:
+        lic_str = str(lic)
+        denied = False
+
+        for pattern in deny:
+            if _glob_match(pattern, lic_str):
+                violations.append(Violation(
+                    kind="license",
+                    severity="high",
+                    identifier=lic_str,
+                    message=f"Denied license '{lic_str}' (matches '{pattern}')",
+                ))
+                denied = True
+                break
+
+        if not denied and allow and not any(_glob_match(p, lic_str) for p in allow):
+            violations.append(Violation(
+                kind="license",
+                severity="medium",
+                identifier=lic_str,
+                message=f"License '{lic_str}' not in allow list",
+            ))
+
+    return violations
+
+
+# -- Helpers -----------------------------------------------------------------
+
+def _extract_severity(vuln: dict[str, Any]) -> str:
+    severity = vuln.get("severity", "")
+    if severity:
+        return severity.lower()
+
+    score = _extract_score(vuln)
+    if score >= 9.0:
+        return "critical"
+    if score >= 7.0:
+        return "high"
+    if score >= 4.0:
+        return "medium"
+    if score > 0.0:
+        return "low"
+    return "unknown"
+
+
+def _extract_score(vuln: dict[str, Any]) -> float:
+    for key in ("score", "base_score"):
+        val = vuln.get(key)
+        if val is not None:
+            return float(val)
+
+    cvss_score = vuln.get("cvss", {}).get("score")
+    if cvss_score is not None:
+        return float(cvss_score)
+
+    scores = vuln.get("scores", vuln.get("cvss3_scores", []))
+    if scores:
+        max_score = 0.0
+        for s in scores:
+            if isinstance(s, dict):
+                for k in ("value", "score", "base_score"):
+                    v = s.get(k)
+                    if v is not None:
+                        max_score = max(max_score, float(v))
+                        break
+            elif isinstance(s, (int, float)):
+                max_score = max(max_score, float(s))
+        return max_score
+
+    return 0.0
+
+
+def _glob_match(pattern: str, value: str) -> bool:
+    regex = re.escape(pattern).replace(r"\*", ".*").replace(r"\?", ".")
+    return bool(re.fullmatch(regex, value, re.IGNORECASE))
+
+
+register_checker(CHECKER_NAME, BuiltinChecker)

--- a/tools/gate/checkers/conforma.py
+++ b/tools/gate/checkers/conforma.py
@@ -1,0 +1,238 @@
+"""Conforma (Enterprise Contract) checker plugin.
+
+Validates SBOM data against OPA/Rego policies using the Conforma ``ec``
+CLI or its HTTP server mode.
+
+Two integration modes:
+
+1. **CLI mode** (default): Shells out to ``ec validate input`` with a
+   JSON file containing Trustify data as the policy input.
+2. **Server mode**: POSTs to a running Conforma server at
+   ``POST /v1/validate/input``.
+
+Config example::
+
+    {
+      "name": "conforma",
+      "config": {
+        "mode": "cli",
+        "ec_binary": "ec",
+        "policy": "git::https://github.com/conforma/policy//policy/release",
+        "policy_file": "./my-policy.yaml",
+        "server_url": "http://localhost:8090",
+        "extra_args": ["--ignore-rekor"]
+      }
+    }
+
+The checker assembles a policy input document from the Trustify data
+(SBOM metadata, PURLs, vulnerability analysis, advisories, licenses)
+and passes it to Conforma for evaluation.
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from checkers import CheckContext, register_checker
+from policy import Violation
+
+CHECKER_NAME = "conforma"
+
+
+class ConformaChecker:
+    """Validates Trustify data against Conforma/EC OPA policies."""
+
+    @property
+    def name(self) -> str:
+        return CHECKER_NAME
+
+    def check(self, ctx: CheckContext, config: dict[str, Any]) -> list[Violation]:
+        mode = config.get("mode", "cli")
+        policy_input = _build_policy_input(ctx)
+
+        if mode == "server":
+            raw_result = _validate_via_server(policy_input, config)
+        else:
+            raw_result = _validate_via_cli(policy_input, config)
+
+        return _parse_conforma_result(raw_result)
+
+
+def _build_policy_input(ctx: CheckContext) -> dict[str, Any]:
+    """Assemble the JSON document that becomes Conforma's policy input.
+
+    This gives Rego rules access to all Trustify-sourced data under
+    a ``trustify`` top-level key, plus standard fields Conforma expects.
+    """
+    doc: dict[str, Any] = {
+        "trustify": {
+            "sbom_id": ctx.sbom_id,
+            "sbom_name": ctx.sbom_name,
+            "purls": ctx.purls,
+        },
+    }
+
+    if ctx.vuln_analysis is not None:
+        doc["trustify"]["vulnerabilities"] = ctx.vuln_analysis
+
+    if ctx.advisories is not None:
+        doc["trustify"]["advisories"] = ctx.advisories
+
+    if ctx.license_ids is not None:
+        licenses = ctx.license_ids
+        if isinstance(licenses, dict):
+            licenses = licenses.get("items", licenses.get("licenses", []))
+        doc["trustify"]["licenses"] = licenses
+
+    if ctx.sbom_detail is not None:
+        doc["trustify"]["sbom"] = ctx.sbom_detail
+
+    return doc
+
+
+def _validate_via_cli(
+    policy_input: dict[str, Any],
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    """Run ``ec validate input`` as a subprocess."""
+    ec_binary = config.get("ec_binary", "ec")
+    policy = config.get("policy", "")
+    policy_file = config.get("policy_file", "")
+    extra_args: list[str] = config.get("extra_args", [])
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False,
+    ) as f:
+        json.dump(policy_input, f)
+        input_path = f.name
+
+    cmd = [ec_binary, "validate", "input"]
+    cmd.extend(["--file", input_path])
+    cmd.extend(["--output", "json"])
+
+    # Policy source: either a policy spec file or inline policy source.
+    if policy_file:
+        cmd.extend(["--policy", policy_file])
+    elif policy:
+        cmd.extend(["--policy", policy])
+
+    # Conforma returns non-zero on policy failure, which is expected.
+    cmd.extend(["--strict=false"])
+    cmd.extend(extra_args)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except FileNotFoundError:
+        print(
+            f"error: conforma binary '{ec_binary}' not found. "
+            "Install it from https://github.com/conforma/cli",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except subprocess.TimeoutExpired:
+        print("error: conforma validation timed out after 120s", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        Path(input_path).unlink(missing_ok=True)
+
+    if result.returncode not in (0, 1):
+        # 0 = pass, 1 = policy failure, anything else = error
+        print(
+            f"error: conforma exited with code {result.returncode}\n"
+            f"stderr: {result.stderr}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        return json.loads(result.stdout) if result.stdout.strip() else {}
+    except json.JSONDecodeError:
+        print(
+            f"error: conforma produced invalid JSON output:\n{result.stdout[:500]}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _validate_via_server(
+    policy_input: dict[str, Any],
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    """POST to a running Conforma HTTP server."""
+    import httpx
+
+    server_url = config.get("server_url", "http://localhost:8090")
+    url = f"{server_url}/v1/validate/input"
+
+    try:
+        with httpx.Client(timeout=120.0) as c:
+            r = c.post(url, json=policy_input)
+            r.raise_for_status()
+            return r.json()
+    except httpx.ConnectError:
+        print(
+            f"error: cannot connect to conforma server at {server_url}. "
+            "Start it with: ec validate input --server --server-port 8090",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except httpx.HTTPStatusError as e:
+        print(f"error: conforma server returned {e.response.status_code}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _parse_conforma_result(raw: dict[str, Any]) -> list[Violation]:
+    """Convert Conforma's JSON output into gate Violations."""
+    violations: list[Violation] = []
+
+    # Conforma output can be a single result or a list of component results.
+    components = raw.get("components", [raw]) if raw else []
+
+    for component in components:
+        # Each component has success, violations (failures), warnings.
+        for failure in component.get("violations", component.get("failures", [])):
+            violations.append(_failure_to_violation(failure))
+
+        # Also check the nested "results" structure used by some output formats.
+        for result_item in component.get("results", []):
+            if not result_item.get("success", True):
+                for failure in result_item.get("violations", result_item.get("failures", [])):
+                    violations.append(_failure_to_violation(failure))
+
+    return violations
+
+
+def _failure_to_violation(failure: dict[str, Any]) -> Violation:
+    """Map a single Conforma failure entry to a Violation."""
+    msg = failure.get("msg", failure.get("message", "Conforma policy violation"))
+    title = failure.get("metadata", {}).get("title", "")
+    code = failure.get("metadata", {}).get("code", failure.get("code", ""))
+    short_name = (
+        failure.get("metadata", {}).get("custom", {}).get("short_name", "")
+    )
+
+    identifier = code or short_name or "conforma-violation"
+    display_msg = f"{title}: {msg}" if title else msg
+
+    # Map Conforma severity to gate severity levels.
+    # Conforma failures are implicitly "high" unless annotated otherwise.
+    severity = failure.get("severity", "high").lower()
+
+    return Violation(
+        kind="conforma",
+        severity=severity,
+        identifier=identifier,
+        message=display_msg,
+        checker=CHECKER_NAME,
+    )
+
+
+register_checker(CHECKER_NAME, ConformaChecker)

--- a/tools/gate/client.py
+++ b/tools/gate/client.py
@@ -1,0 +1,162 @@
+"""Synchronous HTTP client wrapping the Trustify v3 REST API for gate checks."""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from config import TRUSTIFY_TOKEN, TRUSTIFY_URL
+
+TIMEOUT = 60.0
+
+
+def _headers() -> dict[str, str]:
+    h: dict[str, str] = {"Accept": "application/json"}
+    if TRUSTIFY_TOKEN:
+        h["Authorization"] = f"Bearer {TRUSTIFY_TOKEN}"
+    return h
+
+
+def _client() -> httpx.Client:
+    return httpx.Client(base_url=TRUSTIFY_URL, headers=_headers(), timeout=TIMEOUT)
+
+
+def _get(path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    with _client() as c:
+        r = c.get(path, params=params)
+        r.raise_for_status()
+        return r.json()
+
+
+def _post(path: str, json_body: Any) -> dict[str, Any]:
+    with _client() as c:
+        r = c.post(path, json=json_body)
+        r.raise_for_status()
+        return r.json()
+
+
+# -- SBOM upload -------------------------------------------------------------
+
+def upload_sbom(sbom_path: Path) -> dict[str, Any]:
+    """Upload an SBOM document to Trustify. Returns the upload result."""
+    content = sbom_path.read_bytes()
+
+    content_type = "application/json"
+    if sbom_path.suffix.lower() == ".xml":
+        content_type = "application/xml"
+
+    headers = _headers()
+    headers["Content-Type"] = content_type
+
+    with httpx.Client(base_url=TRUSTIFY_URL, headers=headers, timeout=TIMEOUT) as c:
+        r = c.post("/api/v3/sbom", content=content)
+        r.raise_for_status()
+        return r.json()
+
+
+# -- SBOM lookup -------------------------------------------------------------
+
+def find_sbom_by_name(name: str) -> dict[str, Any] | None:
+    """Find an SBOM by name. Returns the first match or None."""
+    result = _get("/api/v3/sbom", {"q": f"name={name}", "limit": 1})
+    items = result.get("items", [])
+    if items:
+        return items[0]
+    return None
+
+
+def find_sbom_by_id(sbom_id: str) -> dict[str, Any]:
+    """Get an SBOM by its ID."""
+    return _get(f"/api/v3/sbom/{sbom_id}")
+
+
+def get_sbom_advisories(sbom_id: str) -> dict[str, Any]:
+    """Get advisories affecting an SBOM."""
+    return _get(f"/api/v3/sbom/{sbom_id}/advisory", {"limit": 1000})
+
+
+def get_sbom_packages(sbom_id: str) -> dict[str, Any]:
+    """Get packages within an SBOM."""
+    return _get(f"/api/v3/sbom/{sbom_id}/packages", {"limit": 10000})
+
+
+def get_sbom_license_ids(sbom_id: str) -> Any:
+    """Get all license IDs for an SBOM."""
+    return _get(f"/api/v3/sbom/{sbom_id}/all-license-ids")
+
+
+# -- Vulnerability analysis --------------------------------------------------
+
+def analyze_purls(purls: list[str]) -> dict[str, Any]:
+    """Batch analyze PURLs for vulnerabilities."""
+    return _post("/api/v3/vulnerability/analyze", {"purls": purls})
+
+
+def get_vulnerability(vuln_id: str) -> dict[str, Any]:
+    """Get vulnerability details."""
+    return _get(f"/api/v3/vulnerability/{vuln_id}")
+
+
+# -- SBOM PURL extraction (for files not yet ingested) -----------------------
+
+def extract_purls_from_sbom(sbom_path: Path) -> list[str]:
+    """Extract PURLs from a local SBOM file without uploading it.
+
+    Parses CycloneDX and SPDX JSON formats locally. Falls back to the
+    Trustify extract endpoint if local parsing cannot identify the format.
+    """
+    content = sbom_path.read_text()
+    try:
+        doc = json.loads(content)
+    except json.JSONDecodeError:
+        print(f"error: {sbom_path} is not valid JSON", file=sys.stderr)
+        sys.exit(1)
+
+    purls: list[str] = []
+
+    # CycloneDX: look for components[].purl
+    if "bomFormat" in doc or "components" in doc:
+        for comp in doc.get("components", []):
+            purl = comp.get("purl")
+            if purl:
+                purls.append(purl)
+        # Also check metadata.component
+        meta_comp = doc.get("metadata", {}).get("component", {})
+        purl = meta_comp.get("purl")
+        if purl:
+            purls.append(purl)
+        return purls
+
+    # SPDX: look for packages[].externalRefs with purl type
+    if "spdxVersion" in doc or "packages" in doc:
+        for pkg in doc.get("packages", []):
+            for ref in pkg.get("externalRefs", []):
+                if ref.get("referenceType") == "purl":
+                    purl = ref.get("referenceLocator")
+                    if purl:
+                        purls.append(purl)
+        return purls
+
+    # Fallback: try Trustify server-side extraction
+    return _extract_purls_via_api(sbom_path)
+
+
+def _extract_purls_via_api(sbom_path: Path) -> list[str]:
+    """Use Trustify's extract-sbom-purls endpoint as a fallback."""
+    content = sbom_path.read_bytes()
+    headers = _headers()
+    headers["Content-Type"] = "application/json"
+
+    with httpx.Client(base_url=TRUSTIFY_URL, headers=headers, timeout=TIMEOUT) as c:
+        r = c.post("/api/v3/ui/extract-sbom-purls", content=content)
+        r.raise_for_status()
+        result = r.json()
+
+    purls = []
+    for item in result if isinstance(result, list) else result.get("items", []):
+        purl = item.get("purl") or item.get("name", "")
+        if purl and purl.startswith("pkg:"):
+            purls.append(purl)
+    return purls

--- a/tools/gate/config.py
+++ b/tools/gate/config.py
@@ -1,0 +1,7 @@
+"""Gate configuration loaded from environment variables."""
+
+import os
+
+
+TRUSTIFY_URL = os.environ.get("TRUSTIFY_URL", "http://localhost:8080")
+TRUSTIFY_TOKEN = os.environ.get("TRUSTIFY_TOKEN", "")

--- a/tools/gate/docs/DESIGN.md
+++ b/tools/gate/docs/DESIGN.md
@@ -1,0 +1,263 @@
+# Trustify Gate
+
+CI/CD policy gate that evaluates SBOMs against configurable security and
+compliance policies using data from a running Trustify instance.
+
+## Purpose
+
+The gate answers: **"Should this build be allowed to ship?"**
+
+It fetches vulnerability, advisory, and license data from Trustify, runs it
+through one or more **checker plugins**, and exits non-zero if any policy
+violations are found. Designed to run in CI/CD pipelines (GitHub Actions,
+GitLab CI, Jenkins, Tekton) as a quality gate before release.
+
+## Architecture
+
+```
+                         gate.py (CLI)
+                            |
+                    +-------+-------+
+                    |               |
+                client.py      checkers/
+                (Trustify API)     |
+                    |         +----+----+----+
+                    |         |         |    |
+                    v      builtin  conforma  ...
+               Trustify     checker  checker
+               REST API
+```
+
+### Plugin system
+
+Policy evaluation is delegated to **checker plugins** in `checkers/`. Each
+checker:
+
+1. Implements the `Checker` protocol (a `name` property and a `check()` method)
+2. Registers itself via `register_checker()` at import time
+3. Receives a `CheckContext` (SBOM data, PURLs, vulnerabilities, advisories,
+   licenses) and its own config dict
+4. Returns a list of `Violation` objects
+
+The gate config file specifies which checkers to run and their individual
+configuration. Multiple checkers run sequentially; all violations are
+aggregated.
+
+### Adding a new checker
+
+1. Create `checkers/mychecker.py`
+2. Implement a class with `name` property and `check(ctx, config)` method
+3. Call `register_checker("mychecker", MyChecker)` at module level
+4. Import the module in `checkers/__init__.py`
+
+## Checkers
+
+### `builtin` -- Threshold-based checker
+
+Evaluates Trustify vulnerability analysis and advisory data against
+declarative rules. No external tools required.
+
+Config:
+
+```json
+{
+  "name": "builtin",
+  "config": {
+    "vulnerabilities": {
+      "max_severity": "high",
+      "max_score": 9.0,
+      "deny": ["CVE-2021-44228"],
+      "ignore": ["CVE-2024-9999"],
+      "ignore_unfixed": false
+    },
+    "licenses": {
+      "deny": ["GPL-3.0*", "AGPL-*"],
+      "allow": ["MIT", "Apache-2.0", "BSD-*"]
+    }
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `max_severity` | Fail if any vuln exceeds this level (none/low/medium/high/critical) |
+| `max_score` | Fail if any CVSS score exceeds this value |
+| `deny` | Always fail on these specific CVE IDs |
+| `ignore` | Skip these CVE IDs entirely |
+| `ignore_unfixed` | Skip vulns with status not_affected/under_investigation |
+| `licenses.deny` | Glob patterns for denied licenses |
+| `licenses.allow` | If set, any license NOT matching is a violation |
+
+### `conforma` -- Conforma/Enterprise Contract checker
+
+Validates Trustify data against OPA/Rego policies using the Conforma `ec`
+CLI or its HTTP server mode.
+
+The checker assembles a policy input document from Trustify data and passes
+it to Conforma. All Trustify data is available under `input.trustify` in
+Rego rules.
+
+**CLI mode** (default):
+
+```json
+{
+  "name": "conforma",
+  "config": {
+    "mode": "cli",
+    "ec_binary": "ec",
+    "policy": "git::https://github.com/conforma/policy//policy/release",
+    "extra_args": ["--ignore-rekor"]
+  }
+}
+```
+
+**Server mode** (Conforma running as HTTP service):
+
+```json
+{
+  "name": "conforma",
+  "config": {
+    "mode": "server",
+    "server_url": "http://localhost:8090"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `mode` | `cli` (subprocess) or `server` (HTTP POST) |
+| `ec_binary` | Path to the `ec` binary (default: `ec` on PATH) |
+| `policy` | Inline Conforma policy source (git URL, OCI ref, or local path) |
+| `policy_file` | Path to an EnterpriseContractPolicy YAML file |
+| `server_url` | URL of a running Conforma HTTP server |
+| `extra_args` | Additional CLI arguments passed to `ec validate input` |
+
+## SBOM input modes
+
+| Mode | Flag | What happens |
+|------|------|--------------|
+| Local file (no upload) | `--sbom ./sbom.json` | PURLs extracted locally, analyzed via Trustify API |
+| Local file (upload) | `--sbom ./sbom.json --upload` | SBOM uploaded to Trustify, then full analysis |
+| By name | `--sbom-name "product-1.0"` | Looks up SBOM in Trustify by name |
+| By ID | `--sbom-id urn:uuid:...` | Fetches SBOM from Trustify by UUID |
+
+## Output formats
+
+| Format | Flag | Use case |
+|--------|------|----------|
+| `table` | `--format table` | Human-readable terminal output (default) |
+| `json` | `--format json` | Machine-readable, CI/CD artifact storage |
+| `sarif` | `--format sarif` | GitHub Code Scanning, IDE integration |
+| `junit` | `--format junit` | Jenkins, GitLab CI, any JUnit-compatible system |
+
+## Trustify API endpoints used
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /api/v3/sbom` | Upload SBOM |
+| `GET /api/v3/sbom` | Find SBOM by name |
+| `GET /api/v3/sbom/{id}` | SBOM detail |
+| `GET /api/v3/sbom/{id}/advisory` | Advisories affecting the SBOM |
+| `GET /api/v3/sbom/{id}/packages` | Packages in the SBOM |
+| `GET /api/v3/sbom/{id}/all-license-ids` | License inventory |
+| `POST /api/v3/vulnerability/analyze` | Batch PURL vulnerability analysis |
+| `GET /api/v3/vulnerability/{id}` | Vulnerability detail |
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRUSTIFY_URL` | `http://localhost:8080` | Trustify server URL |
+| `TRUSTIFY_TOKEN` | (empty) | Bearer token for authentication |
+
+## CI/CD integration examples
+
+### GitHub Actions
+
+```yaml
+- name: Trustify Gate
+  run: |
+    cd tools/gate
+    uv run python gate.py check \
+      --sbom ${{ github.workspace }}/build/sbom.json \
+      --upload \
+      --config examples/builtin-only.json \
+      --format sarif \
+      --output ${{ github.workspace }}/gate-results.sarif
+  env:
+    TRUSTIFY_URL: ${{ vars.TRUSTIFY_URL }}
+    TRUSTIFY_TOKEN: ${{ secrets.TRUSTIFY_TOKEN }}
+
+- name: Upload SARIF
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: gate-results.sarif
+```
+
+### GitLab CI
+
+```yaml
+trustify-gate:
+  stage: test
+  script:
+    - cd tools/gate
+    - uv run python gate.py check
+        --sbom build/sbom.json
+        --upload
+        --format junit
+        --output gate-results.xml
+  artifacts:
+    reports:
+      junit: tools/gate/gate-results.xml
+  variables:
+    TRUSTIFY_URL: $TRUSTIFY_URL
+    TRUSTIFY_TOKEN: $TRUSTIFY_TOKEN
+```
+
+### Tekton
+
+```yaml
+- name: trustify-gate
+  image: python:3.13-slim
+  script: |
+    pip install httpx
+    cd tools/gate
+    python gate.py check \
+      --sbom $(workspaces.source.path)/sbom.json \
+      --upload \
+      --config $(workspaces.source.path)/gate-config.json
+  env:
+    - name: TRUSTIFY_URL
+      valueFrom:
+        secretKeyRef:
+          name: trustify
+          key: url
+    - name: TRUSTIFY_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: trustify
+          key: token
+```
+
+## File structure
+
+```
+tools/gate/
+  gate.py               Main CLI entrypoint
+  client.py             Synchronous Trustify REST API client
+  config.py             Environment variable configuration
+  policy.py             Data models (Violation, GateResult, config loading)
+  formatters.py         Output formatters (table, JSON, SARIF, JUnit)
+  checkers/
+    __init__.py          Plugin protocol, registry, auto-imports
+    builtin.py           Built-in threshold checker
+    conforma.py          Conforma/EC OPA policy checker
+  examples/
+    builtin-only.json    Builtin checker only
+    conforma-only.json   Conforma checker only
+    full-pipeline.json   Both checkers combined
+    conforma-server.json Conforma in HTTP server mode
+  pyproject.toml
+  Makefile
+  DESIGN.md
+```

--- a/tools/gate/examples/builtin-only.json
+++ b/tools/gate/examples/builtin-only.json
@@ -1,0 +1,20 @@
+{
+  "checkers": [
+    {
+      "name": "builtin",
+      "config": {
+        "vulnerabilities": {
+          "max_severity": "high",
+          "max_score": 9.0,
+          "deny": [],
+          "ignore": [],
+          "ignore_unfixed": false
+        },
+        "licenses": {
+          "deny": ["GPL-3.0*", "AGPL-*"],
+          "allow": []
+        }
+      }
+    }
+  ]
+}

--- a/tools/gate/examples/conforma-only.json
+++ b/tools/gate/examples/conforma-only.json
@@ -1,0 +1,13 @@
+{
+  "checkers": [
+    {
+      "name": "conforma",
+      "config": {
+        "mode": "cli",
+        "ec_binary": "ec",
+        "policy": "git::https://github.com/conforma/policy//policy/release?ref=main",
+        "extra_args": ["--ignore-rekor"]
+      }
+    }
+  ]
+}

--- a/tools/gate/examples/conforma-server.json
+++ b/tools/gate/examples/conforma-server.json
@@ -1,0 +1,20 @@
+{
+  "checkers": [
+    {
+      "name": "builtin",
+      "config": {
+        "vulnerabilities": {
+          "max_severity": "high",
+          "max_score": 9.0
+        }
+      }
+    },
+    {
+      "name": "conforma",
+      "config": {
+        "mode": "server",
+        "server_url": "http://localhost:8090"
+      }
+    }
+  ]
+}

--- a/tools/gate/examples/full-pipeline.json
+++ b/tools/gate/examples/full-pipeline.json
@@ -1,0 +1,29 @@
+{
+  "checkers": [
+    {
+      "name": "builtin",
+      "config": {
+        "vulnerabilities": {
+          "max_severity": "high",
+          "max_score": 9.0,
+          "deny": ["CVE-2021-44228"],
+          "ignore": [],
+          "ignore_unfixed": false
+        },
+        "licenses": {
+          "deny": ["GPL-3.0*", "AGPL-*"],
+          "allow": ["MIT", "Apache-2.0", "BSD-*", "ISC", "MPL-2.0"]
+        }
+      }
+    },
+    {
+      "name": "conforma",
+      "config": {
+        "mode": "cli",
+        "ec_binary": "ec",
+        "policy_file": "./my-conforma-policy.yaml",
+        "extra_args": []
+      }
+    }
+  ]
+}

--- a/tools/gate/formatters.py
+++ b/tools/gate/formatters.py
@@ -1,0 +1,238 @@
+"""Output formatters for the Trustify gate."""
+
+import json
+import sys
+from typing import Any, TextIO
+
+from policy import GateResult, Violation
+
+# ANSI color codes for terminal output.
+_RED = "\033[91m"
+_YELLOW = "\033[93m"
+_GREEN = "\033[92m"
+_CYAN = "\033[96m"
+_BOLD = "\033[1m"
+_RESET = "\033[0m"
+
+_SEV_COLORS = {
+    "critical": _RED,
+    "high": _RED,
+    "medium": _YELLOW,
+    "low": _CYAN,
+}
+
+
+def format_result(result: GateResult, fmt: str, out: TextIO = sys.stdout) -> None:
+    """Format and write a GateResult to the given stream."""
+    match fmt:
+        case "json":
+            _format_json(result, out)
+        case "table":
+            _format_table(result, out)
+        case "sarif":
+            _format_sarif(result, out)
+        case "junit":
+            _format_junit(result, out)
+        case _:
+            print(f"error: unknown format '{fmt}'", file=sys.stderr)
+            sys.exit(1)
+
+
+# -- JSON --------------------------------------------------------------------
+
+def _format_json(result: GateResult, out: TextIO) -> None:
+    doc = {
+        "passed": result.passed,
+        "summary": {
+            "critical": result.critical_count,
+            "high": result.high_count,
+            "medium": result.medium_count,
+            "low": result.low_count,
+            "total": len(result.violations),
+        },
+        "checkers": result.checkers_run,
+        "violations": [_violation_dict(v) for v in result.violations],
+    }
+    json.dump(doc, out, indent=2)
+    out.write("\n")
+
+
+def _violation_dict(v: Violation) -> dict[str, Any]:
+    d: dict[str, Any] = {
+        "kind": v.kind,
+        "severity": v.severity,
+        "identifier": v.identifier,
+        "message": v.message,
+        "checker": v.checker,
+    }
+    if v.score > 0:
+        d["score"] = v.score
+    if v.purl:
+        d["purl"] = v.purl
+    return d
+
+
+# -- Table -------------------------------------------------------------------
+
+def _format_table(result: GateResult, out: TextIO) -> None:
+    is_tty = hasattr(out, "isatty") and out.isatty()
+
+    def _c(code: str, text: str) -> str:
+        return f"{code}{text}{_RESET}" if is_tty else text
+
+    status = _c(_GREEN, "PASS") if result.passed else _c(_RED, "FAIL")
+    out.write(f"\n{_c(_BOLD, 'Trustify Gate')}: {status}\n")
+    out.write(f"Checkers: {', '.join(result.checkers_run)}\n\n")
+
+    if not result.violations:
+        out.write("No policy violations found.\n\n")
+        return
+
+    out.write(
+        f"  {_c(_RED, 'Critical')}: {result.critical_count}  "
+        f"{_c(_RED, 'High')}: {result.high_count}  "
+        f"{_c(_YELLOW, 'Medium')}: {result.medium_count}  "
+        f"{_c(_CYAN, 'Low')}: {result.low_count}  "
+        f"Total: {len(result.violations)}\n\n"
+    )
+
+    # Column widths.
+    sev_w = 10
+    id_w = max((len(v.identifier) for v in result.violations), default=12)
+    id_w = max(id_w, 12)
+    chk_w = max((len(v.checker) for v in result.violations), default=8)
+    chk_w = max(chk_w, 8)
+
+    header = f"  {'SEVERITY':<{sev_w}} {'IDENTIFIER':<{id_w}} {'CHECKER':<{chk_w}} MESSAGE"
+    out.write(f"{_c(_BOLD, header)}\n")
+    out.write(f"  {'-' * (sev_w + id_w + chk_w + 20)}\n")
+
+    sorted_violations = sorted(result.violations, key=lambda v: -v.severity_rank)
+    for v in sorted_violations:
+        color = _SEV_COLORS.get(v.severity.lower(), "")
+        sev = _c(color, v.severity.upper().ljust(sev_w))
+        out.write(f"  {sev} {v.identifier:<{id_w}} {v.checker:<{chk_w}} {v.message}\n")
+
+    out.write("\n")
+
+
+# -- SARIF -------------------------------------------------------------------
+
+def _format_sarif(result: GateResult, out: TextIO) -> None:
+    """SARIF v2.1.0 output for GitHub Code Scanning and IDE integration."""
+    rules = []
+    results_list = []
+    rule_index: dict[str, int] = {}
+
+    for v in result.violations:
+        if v.identifier not in rule_index:
+            rule_index[v.identifier] = len(rules)
+            rules.append({
+                "id": v.identifier,
+                "shortDescription": {"text": v.identifier},
+                "defaultConfiguration": {
+                    "level": _sarif_level(v.severity),
+                },
+            })
+
+        results_list.append({
+            "ruleId": v.identifier,
+            "ruleIndex": rule_index[v.identifier],
+            "level": _sarif_level(v.severity),
+            "message": {"text": v.message},
+            "properties": {
+                "checker": v.checker,
+                "kind": v.kind,
+                **({"purl": v.purl} if v.purl else {}),
+                **({"score": v.score} if v.score > 0 else {}),
+            },
+        })
+
+    sarif = {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "trustify-gate",
+                        "version": "0.1.0",
+                        "informationUri": "https://github.com/guacsec/trustify",
+                        "rules": rules,
+                    },
+                },
+                "results": results_list,
+            },
+        ],
+    }
+    json.dump(sarif, out, indent=2)
+    out.write("\n")
+
+
+def _sarif_level(severity: str) -> str:
+    match severity.lower():
+        case "critical" | "high":
+            return "error"
+        case "medium":
+            return "warning"
+        case _:
+            return "note"
+
+
+# -- JUnit -------------------------------------------------------------------
+
+def _format_junit(result: GateResult, out: TextIO) -> None:
+    """JUnit XML output for CI/CD systems."""
+    total = len(result.violations)
+    failures = sum(1 for v in result.violations if v.severity_rank >= 3)
+    errors = 0
+
+    out.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+    out.write(
+        f'<testsuites tests="{total + 1}" failures="{failures}" errors="{errors}">\n'
+    )
+    out.write(
+        f'  <testsuite name="trustify-gate" tests="{total + 1}" '
+        f'failures="{failures}" errors="{errors}">\n'
+    )
+
+    # Overall gate result as a test case.
+    if result.passed:
+        out.write('    <testcase name="gate-policy-check" classname="trustify.gate"/>\n')
+    else:
+        out.write('    <testcase name="gate-policy-check" classname="trustify.gate">\n')
+        out.write(
+            f'      <failure message="Policy check failed with {total} violation(s)">'
+            f"Critical: {result.critical_count}, High: {result.high_count}, "
+            f"Medium: {result.medium_count}, Low: {result.low_count}"
+            f"</failure>\n"
+        )
+        out.write("    </testcase>\n")
+
+    # Each violation as a test case.
+    for v in result.violations:
+        classname = f"trustify.gate.{v.checker}"
+        out.write(f'    <testcase name="{_xml_escape(v.identifier)}" classname="{classname}">\n')
+        if v.severity_rank >= 3:
+            out.write(
+                f'      <failure message="{_xml_escape(v.message)}" '
+                f'type="{v.severity.upper()}">{_xml_escape(v.message)}</failure>\n'
+            )
+        else:
+            out.write(
+                f"      <system-out>{_xml_escape(v.message)}</system-out>\n"
+            )
+        out.write("    </testcase>\n")
+
+    out.write("  </testsuite>\n")
+    out.write("</testsuites>\n")
+
+
+def _xml_escape(s: str) -> str:
+    return (
+        s.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )

--- a/tools/gate/gate.py
+++ b/tools/gate/gate.py
@@ -1,0 +1,305 @@
+"""Trustify Gate -- CI/CD policy gate for the Trustify REST API.
+
+Fetches SBOM, vulnerability, advisory, and license data from a running
+Trustify instance, then evaluates it against configurable policy checkers.
+Exits non-zero when violations are found.
+
+Usage::
+
+    # Check an SBOM already ingested in Trustify (by name)
+    python gate.py check --sbom-name "my-product-1.0"
+
+    # Upload a local SBOM file, then check
+    python gate.py check --sbom ./build/sbom.json --upload
+
+    # Check a local SBOM without uploading (extract PURLs, analyze remotely)
+    python gate.py check --sbom ./build/sbom.json
+
+    # Use a custom gate config (specifies which checkers to run)
+    python gate.py check --sbom ./sbom.json --config gate-config.json
+
+    # Output as JSON / SARIF / JUnit
+    python gate.py check --sbom ./sbom.json --format json
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import client
+from checkers import CheckContext, available_checkers, get_checker
+from formatters import format_result
+from policy import GateResult, Violation, default_gate_config, load_gate_config
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="trustify-gate",
+        description="CI/CD policy gate for the Trustify REST API",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    # -- check ---------------------------------------------------------------
+    check_p = sub.add_parser("check", help="Run policy checks against an SBOM")
+
+    sbom_group = check_p.add_mutually_exclusive_group(required=True)
+    sbom_group.add_argument(
+        "--sbom",
+        type=Path,
+        help="Path to a local SBOM file (CycloneDX or SPDX JSON)",
+    )
+    sbom_group.add_argument(
+        "--sbom-name",
+        help="Name of an SBOM already ingested in Trustify",
+    )
+    sbom_group.add_argument(
+        "--sbom-id",
+        help="UUID of an SBOM already ingested in Trustify",
+    )
+
+    check_p.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload the local SBOM to Trustify before checking",
+    )
+    check_p.add_argument(
+        "--config",
+        type=Path,
+        help="Path to the gate config file (JSON). Default: builtin checker only",
+    )
+    check_p.add_argument(
+        "--format",
+        choices=["table", "json", "sarif", "junit"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    check_p.add_argument(
+        "--output",
+        type=Path,
+        help="Write output to a file instead of stdout",
+    )
+
+    # -- list-checkers -------------------------------------------------------
+    sub.add_parser("list-checkers", help="List available checker plugins")
+
+    return parser.parse_args()
+
+
+def _cmd_list_checkers() -> None:
+    names = available_checkers()
+    print("Available checkers:")
+    for n in names:
+        print(f"  - {n}")
+
+
+def _cmd_check(args: argparse.Namespace) -> None:
+    # Load gate config.
+    if args.config:
+        gate_config = load_gate_config(args.config)
+    else:
+        gate_config = default_gate_config()
+
+    checker_specs: list[dict[str, Any]] = gate_config.get("checkers", [])
+    if not checker_specs:
+        print("error: no checkers configured in gate config", file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve SBOM: upload, look up, or extract PURLs locally.
+    ctx = _build_context(args)
+
+    # Run all configured checkers.
+    all_violations: list[Violation] = []
+    checkers_run: list[str] = []
+
+    for spec in checker_specs:
+        checker_name = spec.get("name", "")
+        checker_config = spec.get("config", {})
+
+        try:
+            checker_cls = get_checker(checker_name)
+        except KeyError as e:
+            print(f"error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        checker = checker_cls()
+        print(f"Running checker: {checker.name}", file=sys.stderr)
+
+        violations = checker.check(ctx, checker_config)
+        all_violations.extend(violations)
+        checkers_run.append(checker.name)
+
+    # Build result.
+    result = GateResult(
+        passed=len(all_violations) == 0,
+        violations=all_violations,
+        checkers_run=checkers_run,
+    )
+
+    # Output.
+    if args.output:
+        with open(args.output, "w") as f:
+            format_result(result, args.format, out=f)
+        print(f"Report written to {args.output}", file=sys.stderr)
+    else:
+        format_result(result, args.format)
+
+    # Exit code: 0 = pass, 1 = violations found.
+    sys.exit(0 if result.passed else 1)
+
+
+def _build_context(args: argparse.Namespace) -> CheckContext:
+    """Build a CheckContext by resolving the SBOM and fetching data."""
+    ctx = CheckContext()
+
+    if args.sbom:
+        ctx.sbom_path = args.sbom
+        if not args.sbom.exists():
+            print(f"error: SBOM file not found: {args.sbom}", file=sys.stderr)
+            sys.exit(1)
+
+        if args.upload:
+            ctx = _context_from_upload(args.sbom)
+        else:
+            ctx = _context_from_local(args.sbom)
+
+    elif args.sbom_name:
+        ctx = _context_from_name(args.sbom_name)
+
+    elif args.sbom_id:
+        ctx = _context_from_id(args.sbom_id)
+
+    return ctx
+
+
+def _context_from_upload(sbom_path: Path) -> CheckContext:
+    """Upload an SBOM to Trustify, then fetch all related data."""
+    print(f"Uploading {sbom_path} to Trustify...", file=sys.stderr)
+
+    try:
+        result = client.upload_sbom(sbom_path)
+    except Exception as e:
+        print(f"error: failed to upload SBOM: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    sbom_id = result.get("id", result.get("document_id", ""))
+    if not sbom_id:
+        print("error: upload succeeded but no SBOM ID returned", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"SBOM ingested: {sbom_id}", file=sys.stderr)
+    return _context_from_id(sbom_id, sbom_path=sbom_path)
+
+
+def _context_from_name(name: str) -> CheckContext:
+    """Look up an SBOM by name and fetch all related data."""
+    print(f"Looking up SBOM: {name}", file=sys.stderr)
+
+    sbom = client.find_sbom_by_name(name)
+    if not sbom:
+        print(f"error: no SBOM found with name '{name}'", file=sys.stderr)
+        sys.exit(1)
+
+    sbom_id = sbom.get("id", "")
+    return _context_from_id(sbom_id)
+
+
+def _context_from_id(
+    sbom_id: str,
+    sbom_path: Path | None = None,
+) -> CheckContext:
+    """Fetch all gate-relevant data for an ingested SBOM."""
+    print(f"Fetching data for SBOM {sbom_id}...", file=sys.stderr)
+
+    ctx = CheckContext(sbom_path=sbom_path, sbom_id=sbom_id)
+
+    # SBOM detail.
+    try:
+        ctx.sbom_detail = client.find_sbom_by_id(sbom_id)
+        ctx.sbom_name = ctx.sbom_detail.get("name", "")
+    except Exception as e:
+        print(f"warning: could not fetch SBOM detail: {e}", file=sys.stderr)
+
+    # Packages and PURLs.
+    try:
+        packages = client.get_sbom_packages(sbom_id)
+        purls = _extract_purls_from_packages(packages)
+        ctx.purls = purls
+    except Exception as e:
+        print(f"warning: could not fetch SBOM packages: {e}", file=sys.stderr)
+
+    # Vulnerability analysis.
+    if ctx.purls:
+        try:
+            print(
+                f"Analyzing {len(ctx.purls)} PURLs for vulnerabilities...",
+                file=sys.stderr,
+            )
+            ctx.vuln_analysis = client.analyze_purls(ctx.purls)
+        except Exception as e:
+            print(f"warning: vulnerability analysis failed: {e}", file=sys.stderr)
+
+    # Advisories.
+    try:
+        ctx.advisories = client.get_sbom_advisories(sbom_id)
+    except Exception as e:
+        print(f"warning: could not fetch advisories: {e}", file=sys.stderr)
+
+    # Licenses.
+    try:
+        ctx.license_ids = client.get_sbom_license_ids(sbom_id)
+    except Exception as e:
+        print(f"warning: could not fetch license IDs: {e}", file=sys.stderr)
+
+    return ctx
+
+
+def _context_from_local(sbom_path: Path) -> CheckContext:
+    """Extract PURLs from a local SBOM and analyze without uploading."""
+    print(f"Extracting PURLs from {sbom_path}...", file=sys.stderr)
+
+    ctx = CheckContext(sbom_path=sbom_path)
+    ctx.purls = client.extract_purls_from_sbom(sbom_path)
+
+    if not ctx.purls:
+        print("warning: no PURLs found in SBOM", file=sys.stderr)
+        return ctx
+
+    print(
+        f"Analyzing {len(ctx.purls)} PURLs for vulnerabilities...",
+        file=sys.stderr,
+    )
+
+    try:
+        ctx.vuln_analysis = client.analyze_purls(ctx.purls)
+    except Exception as e:
+        print(f"warning: vulnerability analysis failed: {e}", file=sys.stderr)
+
+    return ctx
+
+
+def _extract_purls_from_packages(packages: dict[str, Any]) -> list[str]:
+    """Extract PURLs from the Trustify packages response."""
+    purls: list[str] = []
+    for item in packages.get("items", []):
+        for purl in item.get("purl", []):
+            purl_str = purl.get("purl", str(purl)) if isinstance(purl, dict) else str(purl)
+            if purl_str.startswith("pkg:"):
+                purls.append(purl_str)
+    return purls
+
+
+def main() -> None:
+    args = _parse_args()
+
+    if args.command == "list-checkers":
+        _cmd_list_checkers()
+    elif args.command == "check":
+        _cmd_check(args)
+    else:
+        print("error: no command specified. Use 'check' or 'list-checkers'.", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/gate/policy.py
+++ b/tools/gate/policy.py
@@ -1,0 +1,111 @@
+"""Policy data models and loading for the Trustify gate.
+
+This module defines the data structures only. Evaluation logic lives in
+the ``checkers`` package, which implements a plugin architecture.
+"""
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+# Severity ranking (higher = more severe).
+SEVERITY_RANK = {
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+
+
+@dataclass
+class Violation:
+    """A single policy violation produced by any checker."""
+
+    kind: str  # "vulnerability", "license", "conforma", or custom
+    severity: str  # "critical", "high", "medium", "low", "none"
+    identifier: str  # CVE ID, license ID, rule name, etc.
+    message: str
+    checker: str = ""  # which checker produced this
+    score: float = 0.0
+    purl: str = ""
+
+    @property
+    def severity_rank(self) -> int:
+        return SEVERITY_RANK.get(self.severity.lower(), 0)
+
+
+@dataclass
+class GateResult:
+    """Aggregated result from all checkers."""
+
+    passed: bool
+    violations: list[Violation] = field(default_factory=list)
+    warnings: list[Violation] = field(default_factory=list)
+    checkers_run: list[str] = field(default_factory=list)
+
+    @property
+    def critical_count(self) -> int:
+        return sum(1 for v in self.violations if v.severity.lower() == "critical")
+
+    @property
+    def high_count(self) -> int:
+        return sum(1 for v in self.violations if v.severity.lower() == "high")
+
+    @property
+    def medium_count(self) -> int:
+        return sum(1 for v in self.violations if v.severity.lower() == "medium")
+
+    @property
+    def low_count(self) -> int:
+        return sum(1 for v in self.violations if v.severity.lower() == "low")
+
+
+def load_gate_config(path: Path) -> dict[str, Any]:
+    """Load the gate configuration file (JSON).
+
+    The config file specifies which checkers to run and their individual
+    configuration. Structure::
+
+        {
+          "checkers": [
+            {
+              "name": "builtin",
+              "config": { ... builtin-specific config ... }
+            },
+            {
+              "name": "conforma",
+              "config": { ... conforma-specific config ... }
+            }
+          ]
+        }
+    """
+    try:
+        raw = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        print(f"error: invalid gate config JSON in {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError:
+        print(f"error: gate config file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    return raw
+
+
+def default_gate_config() -> dict[str, Any]:
+    """Return a default config that runs only the builtin checker."""
+    return {
+        "checkers": [
+            {
+                "name": "builtin",
+                "config": {
+                    "vulnerabilities": {
+                        "max_severity": "high",
+                        "max_score": 9.0,
+                    },
+                },
+            },
+        ],
+    }

--- a/tools/gate/pyproject.toml
+++ b/tools/gate/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "trustify-gate"
+version = "0.1.0"
+description = "CI/CD policy gate for the Trustify REST API"
+requires-python = ">=3.13"
+dependencies = [
+    "httpx>=0.28",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0",
+]
+
+[project.scripts]
+gate = "gate:main"
+
+[tool.ruff]
+line-length = 100
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tools/gate/tests/conftest.py
+++ b/tools/gate/tests/conftest.py
@@ -1,0 +1,6 @@
+"""Ensure the gate package root is importable from tests."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/tools/gate/tests/test_builtin.py
+++ b/tools/gate/tests/test_builtin.py
@@ -1,0 +1,256 @@
+"""Tests for the builtin checker plugin."""
+
+from checkers import CheckContext
+from checkers.builtin import BuiltinChecker
+
+
+def _make_ctx(
+    vuln_analysis=None,
+    advisories=None,
+    license_ids=None,
+) -> CheckContext:
+    return CheckContext(
+        vuln_analysis=vuln_analysis,
+        advisories=advisories,
+        license_ids=license_ids,
+    )
+
+
+class TestVulnAnalysis:
+    def test_no_vulns_passes(self):
+        ctx = _make_ctx(vuln_analysis=[])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"vulnerabilities": {"max_severity": "low"}})
+        assert result == []
+
+    def test_critical_exceeds_high_threshold(self):
+        ctx = _make_ctx(vuln_analysis=[{
+            "purl": "pkg:npm/foo@1.0",
+            "vulnerabilities": [
+                {"identifier": "CVE-2024-0001", "severity": "critical", "score": 9.8},
+            ],
+        }])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"vulnerabilities": {"max_severity": "high"}})
+        assert len(result) == 1
+        assert result[0].identifier == "CVE-2024-0001"
+        assert result[0].severity == "critical"
+        assert result[0].checker == "builtin"
+
+    def test_high_within_high_threshold_passes(self):
+        ctx = _make_ctx(vuln_analysis=[{
+            "purl": "pkg:npm/foo@1.0",
+            "vulnerabilities": [
+                {"identifier": "CVE-2024-0002", "severity": "high", "score": 7.5},
+            ],
+        }])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"vulnerabilities": {"max_severity": "high"}})
+        assert result == []
+
+    def test_score_exceeds_threshold(self):
+        ctx = _make_ctx(vuln_analysis=[{
+            "purl": "pkg:npm/bar@2.0",
+            "vulnerabilities": [
+                {"identifier": "CVE-2024-0003", "severity": "medium", "score": 9.5},
+            ],
+        }])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"vulnerabilities": {"max_severity": "high", "max_score": 9.0}})
+        assert len(result) == 1
+        assert result[0].score == 9.5
+
+    def test_deny_list(self):
+        ctx = _make_ctx(vuln_analysis=[{
+            "purl": "pkg:npm/baz@3.0",
+            "vulnerabilities": [
+                {"identifier": "CVE-2021-44228", "severity": "low", "score": 1.0},
+            ],
+        }])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"vulnerabilities": {"deny": ["CVE-2021-44228"]}})
+        assert len(result) == 1
+        assert result[0].severity == "critical"
+
+    def test_ignore_list(self):
+        ctx = _make_ctx(vuln_analysis=[{
+            "purl": "pkg:npm/baz@3.0",
+            "vulnerabilities": [
+                {"identifier": "CVE-2024-9999", "severity": "critical", "score": 10.0},
+            ],
+        }])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {
+            "vulnerabilities": {"max_severity": "low", "ignore": ["CVE-2024-9999"]},
+        })
+        assert result == []
+
+    def test_ignore_unfixed(self):
+        ctx = _make_ctx(vuln_analysis=[{
+            "purl": "pkg:npm/baz@3.0",
+            "vulnerabilities": [
+                {
+                    "identifier": "CVE-2024-0010",
+                    "severity": "critical",
+                    "score": 9.8,
+                    "status": "not_affected",
+                },
+            ],
+        }])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {
+            "vulnerabilities": {"max_severity": "low", "ignore_unfixed": True},
+        })
+        assert result == []
+
+    def test_severity_inferred_from_score(self):
+        ctx = _make_ctx(vuln_analysis=[{
+            "purl": "pkg:npm/x@1.0",
+            "vulnerabilities": [
+                {"identifier": "CVE-2024-0020", "score": 9.5},
+            ],
+        }])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"vulnerabilities": {"max_severity": "high"}})
+        assert len(result) == 1
+        assert result[0].severity == "critical"
+
+    def test_score_zero_not_confused_with_missing(self):
+        ctx = _make_ctx(vuln_analysis=[{
+            "purl": "pkg:npm/x@1.0",
+            "vulnerabilities": [
+                {"identifier": "CVE-2024-0030", "score": 0, "severity": "low"},
+            ],
+        }])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"vulnerabilities": {"max_severity": "high"}})
+        assert result == []
+
+    def test_scores_array(self):
+        ctx = _make_ctx(vuln_analysis=[{
+            "purl": "pkg:npm/x@1.0",
+            "vulnerabilities": [
+                {
+                    "identifier": "CVE-2024-0040",
+                    "severity": "medium",
+                    "scores": [{"value": 9.2}, {"value": 7.1}],
+                },
+            ],
+        }])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"vulnerabilities": {"max_severity": "high", "max_score": 9.0}})
+        assert len(result) == 1
+        assert result[0].score == 9.2
+
+    def test_non_list_analysis_handled(self):
+        ctx = _make_ctx(vuln_analysis={"unexpected": "format"})
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"vulnerabilities": {"max_severity": "low"}})
+        assert result == []
+
+
+class TestAdvisories:
+    def test_advisory_critical_vuln(self):
+        ctx = _make_ctx(advisories={
+            "items": [{
+                "identifier": "RHSA-2024:001",
+                "vulnerabilities": [
+                    {"identifier": "CVE-2024-0050", "severity": "critical", "score": 9.8},
+                ],
+            }],
+        })
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"vulnerabilities": {"max_severity": "high"}})
+        assert len(result) == 1
+        assert "RHSA-2024:001" in result[0].message
+
+    def test_advisory_deny_list(self):
+        ctx = _make_ctx(advisories={
+            "items": [{
+                "identifier": "RHSA-2024:002",
+                "vulnerabilities": [
+                    {"identifier": "CVE-2021-44228", "severity": "low"},
+                ],
+            }],
+        })
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"vulnerabilities": {"deny": ["CVE-2021-44228"]}})
+        assert len(result) == 1
+        assert result[0].severity == "critical"
+
+    def test_empty_advisories_passes(self):
+        ctx = _make_ctx(advisories={"items": []})
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"vulnerabilities": {"max_severity": "low"}})
+        assert result == []
+
+
+class TestLicenses:
+    def test_deny_glob(self):
+        ctx = _make_ctx(license_ids=["MIT", "GPL-3.0-only", "Apache-2.0"])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"licenses": {"deny": ["GPL-*"]}})
+        assert len(result) == 1
+        assert result[0].identifier == "GPL-3.0-only"
+
+    def test_allow_list(self):
+        ctx = _make_ctx(license_ids=["MIT", "WTFPL", "Apache-2.0"])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"licenses": {"allow": ["MIT", "Apache-2.0"]}})
+        assert len(result) == 1
+        assert result[0].identifier == "WTFPL"
+
+    def test_deny_and_allow_no_double_violation(self):
+        ctx = _make_ctx(license_ids=["GPL-3.0-only"])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {
+            "licenses": {"deny": ["GPL-*"], "allow": ["MIT"]},
+        })
+        # Should get exactly one violation (deny), not two (deny + not-in-allow).
+        assert len(result) == 1
+        assert result[0].severity == "high"
+
+    def test_no_license_config_passes(self):
+        ctx = _make_ctx(license_ids=["GPL-3.0-only"])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"licenses": {}})
+        assert result == []
+
+    def test_dict_format_licenses(self):
+        ctx = _make_ctx(license_ids={"items": ["MIT", "GPL-3.0-only"]})
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"licenses": {"deny": ["GPL-*"]}})
+        assert len(result) == 1
+
+    def test_empty_licenses_passes(self):
+        ctx = _make_ctx(license_ids=[])
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {"licenses": {"deny": ["GPL-*"]}})
+        assert result == []
+
+
+class TestCombined:
+    def test_vuln_and_license_violations_combined(self):
+        ctx = _make_ctx(
+            vuln_analysis=[{
+                "purl": "pkg:npm/foo@1.0",
+                "vulnerabilities": [
+                    {"identifier": "CVE-2024-0001", "severity": "critical", "score": 9.8},
+                ],
+            }],
+            license_ids=["GPL-3.0-only"],
+        )
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {
+            "vulnerabilities": {"max_severity": "high"},
+            "licenses": {"deny": ["GPL-*"]},
+        })
+        assert len(result) == 2
+        kinds = {v.kind for v in result}
+        assert kinds == {"vulnerability", "license"}
+
+    def test_all_none_context_passes(self):
+        ctx = _make_ctx()
+        checker = BuiltinChecker()
+        result = checker.check(ctx, {})
+        assert result == []

--- a/tools/gate/tests/test_policy.py
+++ b/tools/gate/tests/test_policy.py
@@ -1,0 +1,83 @@
+"""Tests for policy data models and config loading."""
+
+import json
+
+import pytest
+
+from policy import GateResult, Violation, default_gate_config, load_gate_config
+
+
+class TestViolation:
+    def test_severity_rank_critical(self):
+        v = Violation(kind="vulnerability", severity="critical", identifier="CVE-1", message="x")
+        assert v.severity_rank == 4
+
+    def test_severity_rank_high(self):
+        v = Violation(kind="vulnerability", severity="high", identifier="CVE-1", message="x")
+        assert v.severity_rank == 3
+
+    def test_severity_rank_medium(self):
+        v = Violation(kind="vulnerability", severity="medium", identifier="CVE-1", message="x")
+        assert v.severity_rank == 2
+
+    def test_severity_rank_low(self):
+        v = Violation(kind="vulnerability", severity="low", identifier="CVE-1", message="x")
+        assert v.severity_rank == 1
+
+    def test_severity_rank_unknown(self):
+        v = Violation(kind="vulnerability", severity="bogus", identifier="CVE-1", message="x")
+        assert v.severity_rank == 0
+
+    def test_severity_rank_case_insensitive(self):
+        v = Violation(kind="vulnerability", severity="CRITICAL", identifier="CVE-1", message="x")
+        assert v.severity_rank == 4
+
+
+class TestGateResult:
+    def test_passed_no_violations(self):
+        r = GateResult(passed=True, violations=[], checkers_run=["builtin"])
+        assert r.critical_count == 0
+        assert r.high_count == 0
+        assert r.medium_count == 0
+        assert r.low_count == 0
+
+    def test_counts(self):
+        violations = [
+            Violation(kind="v", severity="critical", identifier="a", message=""),
+            Violation(kind="v", severity="critical", identifier="b", message=""),
+            Violation(kind="v", severity="high", identifier="c", message=""),
+            Violation(kind="v", severity="medium", identifier="d", message=""),
+            Violation(kind="v", severity="low", identifier="e", message=""),
+            Violation(kind="v", severity="low", identifier="f", message=""),
+        ]
+        r = GateResult(passed=False, violations=violations, checkers_run=["builtin"])
+        assert r.critical_count == 2
+        assert r.high_count == 1
+        assert r.medium_count == 1
+        assert r.low_count == 2
+
+
+class TestLoadGateConfig:
+    def test_load_valid(self, tmp_path):
+        cfg = {"checkers": [{"name": "builtin", "config": {}}]}
+        p = tmp_path / "gate.json"
+        p.write_text(json.dumps(cfg))
+        result = load_gate_config(p)
+        assert result == cfg
+
+    def test_load_missing_file(self, tmp_path):
+        with pytest.raises(SystemExit):
+            load_gate_config(tmp_path / "nonexistent.json")
+
+    def test_load_invalid_json(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("not json {{{")
+        with pytest.raises(SystemExit):
+            load_gate_config(p)
+
+
+class TestDefaultGateConfig:
+    def test_has_builtin_checker(self):
+        cfg = default_gate_config()
+        assert len(cfg["checkers"]) == 1
+        assert cfg["checkers"][0]["name"] == "builtin"


### PR DESCRIPTION
Illustrates a CLI tool that answers "should this build be allowed to ship?" by evaluating SBOMs against configurable policies using data from a running Trustify instance. This can be used either via the command line or in CI job.

Policy evaluation uses plugin system. Each checker implements a Checker protocol, registers itself at import time, and receives a CheckContext populated with Trustify data (vulnerabilities, advisories, licenses, PURLs). The gate config file specifies which checkers to run.

## Checkers

|Checker |	What it does|
|---|---|
| builtin |	Severity thresholds, CVSS score limits, CVE deny/ignore lists, license allow/deny globs|
| conforma |	OPA/Rego policy evaluation via Conforma (https://conforma.dev) |

Adding a new checker is four steps: create a module, implement the protocol, call register_checker(), add the import.

## SBOM input modes
- --sbom file.json — extract PURLs locally, analyze via Trustify API
- --sbom file.json --upload — upload to Trustify, full advisory + license analysis
- --sbom-name "product-1.0" — look up already-ingested SBOM


## Example command line usage
Local check with default policy (fail on critical vulns)
> uv run python gate.py check --sbom ./sbom.json

Upload + check with custom config, SARIF output
> uv run python gate.py check --sbom ./sbom.json --upload \
   --config examples/builtin-only.json --format sarif --output results.sarif

Local check with conforma policy (needs ec installed).
ensure a local EnterpriseContractPolicy spec exists
```
cat > my-policy.yaml <<'EOF'
sources:
  - name: my-rules
    policy:
      - "git::https://github.com/conforma/policy//policy/release?ref=main"
configuration:
  exclude:
    - friday_policy
    - room_temperature
EOF
```
now run gate with that policy file
```
uv run python gate.py check \
  --sbom ./sbom.cdx.json \
  --config <(cat <<'JSON'
{
  "checkers": [
    {
      "name": "conforma",
      "config": {
        "mode": "cli",
        "policy_file": "./my-policy.yaml",
        "extra_args": ["--ignore-rekor"]
      }
    }
  ]
}
JSON
)
```

## Example CI 

1. Standalone gate check (simplest)
```
name: Trustify Gate

on:
  push:
    branches: [main]
  pull_request:

jobs:
  gate:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - uses: astral-sh/setup-uv@v6

      - name: Generate SBOM
        run: |
          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
          syft . -o cyclonedx-json=sbom.cdx.json

      - name: Run Trustify Gate
        working-directory: tools/gate
        env:
          TRUSTIFY_URL: ${{ vars.TRUSTIFY_URL }}
          TRUSTIFY_TOKEN: ${{ secrets.TRUSTIFY_TOKEN }}
        run: |
          uv sync
          uv run python gate.py check \
            --sbom ${{ github.workspace }}/sbom.cdx.json \
            --upload \
            --config examples/builtin-only.json
```
3. SARIF upload to GitHub Code Scanning
```
name: Trustify Gate (SARIF)

on:
  push:
    branches: [main]
  pull_request:

permissions:
  security-events: write

jobs:
  gate:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - uses: astral-sh/setup-uv@v6

      - name: Generate SBOM
        run: |
          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
          syft . -o cyclonedx-json=sbom.cdx.json

      - name: Run Trustify Gate
        id: gate
        continue-on-error: true
        working-directory: tools/gate
        env:
          TRUSTIFY_URL: ${{ vars.TRUSTIFY_URL }}
          TRUSTIFY_TOKEN: ${{ secrets.TRUSTIFY_TOKEN }}
        run: |
          uv sync
          uv run python gate.py check \
            --sbom ${{ github.workspace }}/sbom.cdx.json \
            --upload \
            --config examples/builtin-only.json \
            --format sarif \
            --output ${{ github.workspace }}/gate-results.sarif

      - name: Upload SARIF
        uses: github/codeql-action/upload-sarif@v3
        if: always()
        with:
          sarif_file: gate-results.sarif

      - name: Fail on violations
        if: steps.gate.outcome == 'failure'
        run: exit 1
```
4. JUnit report (shows in PR checks tab)
```
name: Trustify Gate (JUnit)

on:
  pull_request:

jobs:
  gate:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - uses: astral-sh/setup-uv@v6

      - name: Run Trustify Gate
        id: gate
        continue-on-error: true
        working-directory: tools/gate
        env:
          TRUSTIFY_URL: ${{ vars.TRUSTIFY_URL }}
          TRUSTIFY_TOKEN: ${{ secrets.TRUSTIFY_TOKEN }}
        run: |
          uv sync
          uv run python gate.py check \
            --sbom ${{ github.workspace }}/path/to/sbom.json \
            --upload \
            --format junit \
            --output ${{ github.workspace }}/gate-results.xml

      - name: Publish JUnit report
        uses: mikepenz/action-junit-report@v5
        if: always()
        with:
          report_paths: gate-results.xml
          fail_on_failure: true
```
5. Full pipeline with Conforma
```
name: Trustify Gate (Full Pipeline)

on:
  push:
    branches: [main]

permissions:
  security-events: write

jobs:
  gate:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - uses: astral-sh/setup-uv@v6

      - name: Install Conforma CLI
        run: |
          curl -sL https://github.com/conforma/cli/releases/latest/download/ec_linux_amd64 \
            -o /usr/local/bin/ec
          chmod +x /usr/local/bin/ec

      - name: Generate SBOM
        run: |
          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
          syft . -o cyclonedx-json=sbom.cdx.json

      - name: Run Trustify Gate (builtin + conforma)
        id: gate
        continue-on-error: true
        working-directory: tools/gate
        env:
          TRUSTIFY_URL: ${{ vars.TRUSTIFY_URL }}
          TRUSTIFY_TOKEN: ${{ secrets.TRUSTIFY_TOKEN }}
        run: |
          uv sync
          uv run python gate.py check \
            --sbom ${{ github.workspace }}/sbom.cdx.json \
            --upload \
            --config examples/full-pipeline.json \
            --format sarif \
            --output ${{ github.workspace }}/gate-results.sarif

      - name: Upload SARIF
        uses: github/codeql-action/upload-sarif@v3
        if: always()
        with:
          sarif_file: gate-results.sarif

      - name: Fail on violations
        if: steps.gate.outcome == 'failure'
        run: exit 1
```

## Summary by Sourcery

Introduce a new `tools/gate` CLI-based CI/CD policy gate that evaluates SBOMs against Trustify-backed security and compliance policies and fails builds on violations.

New Features:
- Add a `trustify-gate` CLI with commands to check SBOMs (local, uploaded, or pre-ingested) and list available checker plugins.
- Provide a builtin threshold-based checker for vulnerabilities and licenses, plus a Conforma-based checker integrating OPA/Rego policies via CLI or server modes.
- Support multiple output formats (table, JSON, SARIF, JUnit) and a configurable gate policy that aggregates results from multiple checkers.
- Add a Makefile and example configs to simplify local usage and CI integration of the gate tool.

Enhancements:
- Define shared policy data models and severity ranking, along with pluggable checker and formatter infrastructure.
- Introduce a dedicated Trustify REST API client and environment-driven configuration for connecting to Trustify instances.

Build:
- Add a `pyproject.toml` for the `trustify-gate` project, including dependencies, test extras, scripts entry point, and tooling configuration.

Documentation:
- Add comprehensive README and DESIGN documentation describing Trustify Gate architecture, configuration, usage patterns, and CI/CD workflows.

Tests:
- Add unit tests for the builtin checker and policy models to validate violation handling, severity ranking, and config loading behavior.

Chores:
- Add project scaffolding under `tools/gate` including examples, Makefile, pytest configuration, and .gitignore for the new gate tool.