### PR TITLE
ci: add grype and cargo-deny ci jobs for security scanning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,15 @@ env:
 
 jobs:
 
+  supply-chain:
+    name: Supply chain audit
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+
   check:
     name: Check
     runs-on: ${{ matrix.os }}
@@ -135,6 +144,9 @@ jobs:
     needs:
       - check
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - uses: actions/checkout@v5
@@ -167,3 +179,53 @@ jobs:
           image_tag: ci
           platforms: linux/amd64
           build_gensbom: 'false'
+
+      - name: Scan trustd container for vulnerabilities
+        uses: anchore/scan-action@v7
+        id: scan-trustd
+        with:
+          image: docker-archive:trustd.tar
+          fail-build: false
+          severity-cutoff: high
+          output-format: sarif
+          output-file: trustd-grype.sarif
+
+      - name: Print trustd vulnerabilities
+        if: always() && steps.scan-trustd.outcome == 'success'
+        run: |
+          jq -r '
+            .runs[].results[] |
+            "\(.level // "warning") \(.locations[0].physicalLocation.artifactLocation.uri // "unknown")  \(.message.text)"
+          ' trustd-grype.sarif | sort | head -100
+
+      - name: Scan xtask container for vulnerabilities
+        uses: anchore/scan-action@v7
+        id: scan-xtask
+        with:
+          image: docker-archive:xtask.tar
+          fail-build: false
+          severity-cutoff: high
+          output-format: sarif
+          output-file: xtask-grype.sarif
+
+      - name: Print xtask vulnerabilities
+        if: always() && steps.scan-xtask.outcome == 'success'
+        run: |
+          jq -r '
+            .runs[].results[] |
+            "\(.level // "warning") \(.locations[0].physicalLocation.artifactLocation.uri // "unknown")  \(.message.text)"
+          ' xtask-grype.sarif | sort | head -100
+
+      - name: Upload trustd scan results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trustd-grype.sarif
+          category: grype-trustd
+
+      - name: Upload xtask scan results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: xtask-grype.sarif
+          category: grype-xtask

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,80 @@
+[graph]
+all-features = true
+
+[advisories]
+# Advisory IDs to ignore. Entries here must include a reason and should be
+# reviewed periodically. Remove entries once the underlying crate is updated.
+ignore = [
+    # Pre-existing transitive vulnerabilities — tracked for resolution.
+    # crossbeam-epoch: invalid pointer dereference in fmt::Pointer (transitive)
+    { id = "RUSTSEC-2026-0204", reason = "transitive dep; awaiting upstream update" },
+    # proc-macro-error2: unmaintained (transitive via derive macros)
+    { id = "RUSTSEC-2026-0173", reason = "transitive dep; no direct replacement yet" },
+    # quick-xml: quadratic attribute-name check (transitive via csaf/spdx parsers)
+    { id = "RUSTSEC-2026-0194", reason = "transitive dep; awaiting upstream update" },
+    # quick-xml: unbounded namespace allocation (transitive via csaf/spdx parsers)
+    { id = "RUSTSEC-2026-0195", reason = "transitive dep; awaiting upstream update" },
+    # rsa: Marvin Attack timing side-channel (transitive via sequoia-openpgp)
+    { id = "RUSTSEC-2023-0071", reason = "transitive dep via sequoia-openpgp; no fix available" },
+]
+
+[licenses]
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "bzip2-1.0.6",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "PostgreSQL",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+exceptions = [
+    # sequoia-openpgp and its dependency; LGPL with Rust static-linking
+    # exception is effectively permissive for our use case
+    { allow = ["LGPL-2.0-or-later"], crate = "buffered-reader" },
+    { allow = ["LGPL-2.0-or-later"], crate = "sequoia-openpgp" },
+    # r-efi is dual-licensed Apache-2.0 OR LGPL-2.1-or-later; cargo-deny
+    # sees both arms so we must explicitly allow the LGPL arm
+    { allow = ["LGPL-2.1-or-later"], crate = "r-efi" },
+    # trustify-ui is Apache-2.0 but its generated crate manifest omits the
+    # license field; tracked upstream at guacsec/trustify-ui
+    { allow = ["Apache-2.0"], crate = "trustify-ui" },
+]
+
+[[licenses.clarify]]
+crate = "trustify-ui"
+expression = "Apache-2.0"
+license-files = []
+
+[licenses.private]
+ignore = true
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+highlight = "all"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = [
+    "https://github.com/scm-rs/csaf-rs",
+    "https://github.com/ctron/spdx-rs",
+    "https://github.com/guacsec/trustify-ui.git",
+]
+
+[sources.allow-org]
+github = []


### PR DESCRIPTION
Introduce two new security checks to the CI pipeline: [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) for Rust dependency auditing and [grype](https://github.com/anchore/grype) for container image vulnerability scanning.

### cargo-deny
cargo-deny configuration (deny.toml) covering four checks:
- **Advisories**: flags crates with known RustSec vulnerabilities (5 pre-existing transitive issues tracked with documented ignore entries)
- **Licenses**: enforces an allowlist of 17 permissive licenses with explicit exceptions for LGPL deps (sequoia-openpgp, r-efi)
- **Bans**:  warns on duplicate crate versions in the dependency tree
- **Sources**:  denies unknown registries/git sources; explicitly allows the 3 known git dependencies

runs cargo-deny check on every PR/push, independent of other jobs (no compilation needed, ~10s)

### Container scanning 
scans trustd and xtask images with **grype** after the existing container build, informational only (we should change that once everything stabilises), uploads SARIF results to GitHub Security tab

## Summary by Sourcery

Add automated Rust dependency and container image security scanning to the CI pipeline.

New Features:
- Introduce a dedicated supply-chain audit CI job that runs cargo-deny checks on every push and pull request.
- Add grype-based vulnerability scanning for the trustd and xtask container images after CI builds, with results uploaded to GitHub Security.

Enhancements:
- Define a centralized cargo-deny configuration (deny.toml) for advisories, license policy, crate bans, and source restrictions.
- Grant minimal security-events permissions to the container build job so vulnerability scan results can be published as SARIF.

CI:
- Extend the main CI workflow with independent supply-chain auditing and post-build container vulnerability scanning stages.