### PR TITLE
chore: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -27,7 +27,7 @@ runs:
 
     - name: Build Image (trustd)
       id: build-image-trustd
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@v3
       with:
         image: trustd
         tags: ${{ inputs.image_tag }}
@@ -41,7 +41,7 @@ runs:
 
     - name: Build Image (xtask)
       id: build-image-xtask
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@v3
       with:
         image: xtask
         tags: ${{ inputs.image_tag }}
@@ -56,7 +56,7 @@ runs:
     - name: Build Image (gensbom)
       if: inputs.build_gensbom == 'true'
       id: build-image-gensbom
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@v3
       with:
         image: gensbom
         tags: ${{ inputs.image_tag }}

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -46,7 +46,7 @@ jobs:
           sudo rm -Rf ${RUBY_PATH}
           df -h
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-rust
 
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-rust
 
@@ -90,7 +90,7 @@ jobs:
           shared-key: ${{ matrix.target }}-${{ matrix.edition }}
 
       - name: Export GitHub Actions cache environment variables for vcpkg
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         if: runner.os == 'Windows'
         with:
           script: |
@@ -130,7 +130,7 @@ jobs:
       # Visual Studio bug tracker https://developercommunity.visualstudio.com/t/Regression-from-1943:-linkexe-crashes/10912960
       - name: Setup RUSTFLAGS (Windows)
         if: runner.os == 'Windows'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             core.exportVariable('RUSTFLAGS', '-Csymbol-mangling-version=v0');

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,14 +38,14 @@ jobs:
               vcpkg install openssl:x64-windows-static-md
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-rust
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
 
       - name: Cache Theseus Postgresql Installation
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.theseus/postgresql
           key: ${{ runner.os }}-theseus-postgresql-${{ hashFiles('**/Cargo.lock') }}
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/maximize-build-space
 
       - uses: ./.github/actions/setup-rust
@@ -84,7 +84,7 @@ jobs:
               - '!**/*.md'
 
       - name: Cache Theseus Postgresql Installation
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.theseus/postgresql
           key: ${{ runner.os }}-theseus-postgresql-${{ hashFiles('**/Cargo.lock') }}
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/maximize-build-space
       - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -46,7 +46,7 @@ jobs:
             microsoft-edge-stable
           df -h
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
@@ -55,7 +55,7 @@ jobs:
           key: tarpaulin
 
       - name: Cache Theseus Postgresql Installation
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.theseus/postgresql
           key: ${{ runner.os }}-theseus-postgresql-${{ hashFiles('**/Cargo.lock') }}
@@ -78,7 +78,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" # for embedded postgresql
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         if: github.repository_owner == 'guacsec'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - run: |
           cd docs/book

--- a/.github/workflows/latest-release.yaml
+++ b/.github/workflows/latest-release.yaml
@@ -76,7 +76,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - uses: actions/download-artifact@v8
         with:
@@ -132,7 +132,7 @@ jobs:
     steps:
 
       - name: Log in and set context
-        uses: redhat-actions/oc-login@v1
+        uses: redhat-actions/oc-login@v2
         with:
           openshift_server_url: ${{ env.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}

--- a/.github/workflows/migration-upload.yaml
+++ b/.github/workflows/migration-upload.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: Swatinem/rust-cache@v2
       - run: |
           cargo xtask generate-dump --input .github/scripts/migration-dump/config.yaml --storage-output dump.tar

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'guacsec' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           path: trustify
       - name: Checkout trustify-ui
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: guacsec/trustify-ui
           path: trustify-ui

--- a/.github/workflows/perf-test.yaml
+++ b/.github/workflows/perf-test.yaml
@@ -59,7 +59,7 @@ jobs:
           echo "sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
           echo "ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ steps.pr.outputs.sha }}
 
@@ -90,7 +90,7 @@ jobs:
           python -m pip install httpie
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v9
 
       - name: Build
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
       - init
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Setup cargo-binstall
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -96,7 +96,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -125,7 +125,7 @@ jobs:
       - name: Display staging area
         run: ls -R staging
 
-      - uses: actions/attest-build-provenance@v1
+      - uses: actions/attest-build-provenance@v4
         with:
           subject-path: 'staging/*'
 

--- a/.github/workflows/rita-request-review.yaml
+++ b/.github/workflows/rita-request-review.yaml
@@ -18,12 +18,12 @@ jobs:
 
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - run: npm ci
         working-directory: .github/scripts/map-users
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         id: message
         with:
           script: |
@@ -32,7 +32,7 @@ jobs:
             return msg || "";
           result-encoding: string
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         id: directMessages
         with:
           script: |

--- a/.github/workflows/scale-test.yaml
+++ b/.github/workflows/scale-test.yaml
@@ -48,7 +48,7 @@ jobs:
           sudo rm -Rf ${RUBY_PATH}
           df -h
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           repository: "guacsec/trustify-scale-test-runs"
 


### PR DESCRIPTION
## Summary
- Update all GitHub Actions from Node.js 20 to their latest Node.js 24 compatible versions

### Action version bumps
| Action | From | To |
|--------|------|----|
| `actions/github-script` | v7 | **v9** |
| `actions/checkout` | v5 | **v7** |
| `actions/cache` | v5 | **v6** |
| `actions/attest-build-provenance` | v1 | **v4** |
| `astral-sh/setup-uv` | v6 | **v9** |
| `codecov/codecov-action` | v5 | **v7** |
| `redhat-actions/buildah-build` | v2 | **v3** |
| `redhat-actions/oc-login` | v1 | **v2** |

## Test plan
- [ ] CI workflows run without Node.js 20 deprecation warnings
- [ ] Windows binary builds still work with `github-script` v9
- [ ] Release workflow attestation still works with `attest-build-provenance` v4
- [ ] Container builds work with `buildah-build` v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: TC-4283