### PR TITLE
fix(spdx): swap DESCRIBES/DESCRIBED_BY match arms in describing_packages()

### DIFF
--- a/etc/test-data/spdx/described-by-supplier.json
+++ b/etc/test-data/spdx/described-by-supplier.json
@@ -1,0 +1,34 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "described-by-supplier-test",
+  "documentNamespace": "https://example.org/test/described-by-supplier",
+  "creationInfo": {
+    "created": "2024-01-01T00:00:00Z",
+    "creators": [
+      "Tool: test"
+    ],
+    "licenseListVersion": "3.19"
+  },
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Pkg",
+      "name": "described-by-package",
+      "versionInfo": "1.0",
+      "downloadLocation": "https://example.org/described-by-package",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "supplier": "Organization: Test Supplier"
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-Pkg",
+      "relationshipType": "DESCRIBED_BY",
+      "relatedSpdxElement": "SPDXRef-DOCUMENT"
+    }
+  ]
+}

--- a/migration/src/data/document/sbom.rs
+++ b/migration/src/data/document/sbom.rs
@@ -1,7 +1,8 @@
 use super::Document;
 use bytes::Bytes;
-use sea_orm::{FromQueryResult, QuerySelect, prelude::*};
-use trustify_entity::sbom;
+use sea_orm::sea_query::{Expr, extension::postgres::PgExpr};
+use sea_orm::{FromQueryResult, QueryFilter, QuerySelect, prelude::*};
+use trustify_entity::{labels::Labels, sbom};
 use trustify_module_storage::service::StorageBackend;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, FromQueryResult)]
@@ -31,6 +32,38 @@ impl Document for Sbom {
 
     async fn all<C: ConnectionTrait>(tx: &C) -> Result<Vec<Self::Id>, DbErr> {
         sbom::Entity::find()
+            .select_only()
+            .column_as(sbom::Column::SourceDocumentId, "source")
+            .column_as(sbom::Column::SbomId, "sbom")
+            .into_model()
+            .all(tx)
+            .await
+    }
+
+    async fn source<S, C>(id: &Self::Id, storage: &S, tx: &C) -> Result<Self, anyhow::Error>
+    where
+        S: StorageBackend + Send + Sync,
+        C: ConnectionTrait,
+    {
+        super::load(id.source, storage, tx).await
+    }
+}
+
+/// SPDX-only Document variant that filters `all()` to SBOMs labeled `type=spdx`.
+pub struct SpdxSbom(pub Sbom);
+
+impl From<Bytes> for SpdxSbom {
+    fn from(value: Bytes) -> Self {
+        SpdxSbom(Sbom::from(value))
+    }
+}
+
+impl Document for SpdxSbom {
+    type Id = Id;
+
+    async fn all<C: ConnectionTrait>(tx: &C) -> Result<Vec<Self::Id>, DbErr> {
+        sbom::Entity::find()
+            .filter(Expr::col(sbom::Column::Labels).contains(Labels::new().add("type", "spdx")))
             .select_only()
             .column_as(sbom::Column::SourceDocumentId, "source")
             .column_as(sbom::Column::SbomId, "sbom")

--- a/migration/src/data/document/sbom.rs
+++ b/migration/src/data/document/sbom.rs
@@ -1,7 +1,10 @@
 use super::Document;
 use bytes::Bytes;
-use sea_orm::sea_query::{Expr, extension::postgres::PgExpr};
-use sea_orm::{FromQueryResult, QueryFilter, QuerySelect, prelude::*};
+use sea_orm::{
+    FromQueryResult, QueryFilter, QuerySelect,
+    prelude::*,
+    sea_query::{Expr, extension::postgres::PgExpr},
+};
 use trustify_entity::{labels::Labels, sbom};
 use trustify_module_storage::service::StorageBackend;
 

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -69,6 +69,7 @@ mod m0002240_product_version_sbom_index;
 mod m0002250_create_cpe_status;
 mod m0002260_cpe_part_vendor_product_index;
 mod m0002270_fix_vulnerability_base_score_type;
+mod m0002280_backfill_sbom_suppliers;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -153,6 +154,7 @@ impl MigratorExt for Migrator {
             .normal(m0002250_create_cpe_status::Migration)
             .normal(m0002260_cpe_part_vendor_product_index::Migration)
             .normal(m0002270_fix_vulnerability_base_score_type::Migration)
+            .data(m0002280_backfill_sbom_suppliers::Migration)
     }
 }
 

--- a/migration/src/m0002280_backfill_sbom_suppliers.rs
+++ b/migration/src/m0002280_backfill_sbom_suppliers.rs
@@ -1,0 +1,99 @@
+/// Data migration that re-processes all SPDX SBOMs to backfill the `suppliers`
+/// column using the corrected `describing_packages()` logic.
+use crate::data::{MigrationTraitWithData, SchemaDataManager, sbom::Sbom as SbomDoc};
+use sea_orm::{ActiveModelBehavior, ActiveModelTrait, DatabaseTransaction, Set};
+use sea_orm_migration::prelude::*;
+use spdx_rs::models::{RelationshipType, SPDX};
+use std::collections::HashSet;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+mod legacy {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "sbom")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub sbom_id: Uuid,
+        pub suppliers: Vec<String>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+fn describing_packages(sbom: &SPDX) -> HashSet<&str> {
+    let mut packages = HashSet::<&str>::new();
+
+    for rel in &sbom.relationships {
+        match rel.relationship_type {
+            RelationshipType::Describes => {
+                packages.insert(&rel.related_spdx_element);
+            }
+            RelationshipType::DescribedBy => {
+                packages.insert(&rel.spdx_element_id);
+            }
+            _ => continue,
+        }
+    }
+
+    packages.extend(
+        sbom.document_creation_information
+            .document_describes
+            .iter()
+            .map(|s| s.as_str()),
+    );
+
+    packages
+}
+
+fn suppliers(sbom: &SPDX) -> Vec<String> {
+    let describing = describing_packages(sbom);
+
+    let mut result = HashSet::new();
+    for p in &sbom.package_information {
+        if !describing.contains(p.package_spdx_identifier.as_str()) {
+            continue;
+        }
+        if let Some(supplier) = &p.package_supplier {
+            result.insert(supplier.clone());
+        }
+    }
+
+    Vec::from_iter(result)
+}
+
+#[async_trait::async_trait]
+impl MigrationTraitWithData for Migration {
+    async fn up(&self, manager: &SchemaDataManager) -> Result<(), DbErr> {
+        manager
+            .process(
+                self,
+                async |sbom: SbomDoc, id: crate::data::sbom::Id, tx: &DatabaseTransaction| {
+                    let SbomDoc::Spdx(spdx) = sbom else {
+                        return Ok(());
+                    };
+
+                    let new_suppliers = suppliers(&spdx);
+
+                    let mut model = legacy::ActiveModel::new();
+                    model.sbom_id = Set(id.sbom);
+                    model.suppliers = Set(new_suppliers);
+                    model.save(tx).await?;
+
+                    Ok(())
+                },
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaDataManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}

--- a/migration/src/m0002280_backfill_sbom_suppliers.rs
+++ b/migration/src/m0002280_backfill_sbom_suppliers.rs
@@ -1,19 +1,12 @@
 /// Data migration that re-processes SPDX SBOMs to backfill the `suppliers`
 /// column using the corrected `describing_packages()` logic.
 use crate::data::{
-    Document, MigrationTraitWithData, SchemaDataManager,
-    sbom::{Id, Sbom},
+    MigrationTraitWithData, SchemaDataManager,
+    sbom::{Id, Sbom, SpdxSbom},
 };
-use bytes::Bytes;
-use sea_orm::{
-    ActiveModelBehavior, ActiveModelTrait, ConnectionTrait, DatabaseTransaction, EntityTrait,
-    QueryFilter, QuerySelect, Set,
-};
+use sea_orm::{ActiveModelBehavior, ActiveModelTrait, DatabaseTransaction, Set};
 use sea_orm_migration::prelude::*;
-use sea_query::{Expr, extension::postgres::PgExpr};
-use trustify_entity::labels::Labels;
 use trustify_module_ingestor::graph::sbom::spdx::suppliers;
-use trustify_module_storage::service::StorageBackend;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -33,40 +26,6 @@ mod legacy {
     pub enum Relation {}
 
     impl ActiveModelBehavior for ActiveModel {}
-}
-
-/// SPDX-only Document wrapper that filters `all()` to SPDX-labeled SBOMs.
-struct SpdxSbom(Sbom);
-
-impl From<Bytes> for SpdxSbom {
-    fn from(value: Bytes) -> Self {
-        SpdxSbom(Sbom::from(value))
-    }
-}
-
-impl Document for SpdxSbom {
-    type Id = Id;
-
-    async fn all<C: ConnectionTrait>(tx: &C) -> Result<Vec<Id>, DbErr> {
-        use trustify_entity::sbom;
-
-        sbom::Entity::find()
-            .filter(Expr::col(sbom::Column::Labels).contains(Labels::new().add("type", "spdx")))
-            .select_only()
-            .column_as(sbom::Column::SourceDocumentId, "source")
-            .column_as(sbom::Column::SbomId, "sbom")
-            .into_model()
-            .all(tx)
-            .await
-    }
-
-    async fn source<S, C>(id: &Id, storage: &S, tx: &C) -> Result<Self, anyhow::Error>
-    where
-        S: StorageBackend + Send + Sync,
-        C: ConnectionTrait,
-    {
-        Sbom::source(id, storage, tx).await.map(SpdxSbom)
-    }
 }
 
 #[async_trait::async_trait]

--- a/migration/src/m0002280_backfill_sbom_suppliers.rs
+++ b/migration/src/m0002280_backfill_sbom_suppliers.rs
@@ -1,9 +1,19 @@
-/// Data migration that re-processes all SPDX SBOMs to backfill the `suppliers`
+/// Data migration that re-processes SPDX SBOMs to backfill the `suppliers`
 /// column using the corrected `describing_packages()` logic.
-use crate::data::{MigrationTraitWithData, SchemaDataManager, sbom::Id, sbom::Sbom as SbomDoc};
-use sea_orm::{ActiveModelBehavior, ActiveModelTrait, DatabaseTransaction, Set};
+use crate::data::{
+    Document, MigrationTraitWithData, SchemaDataManager,
+    sbom::{Id, Sbom},
+};
+use bytes::Bytes;
+use sea_orm::{
+    ActiveModelBehavior, ActiveModelTrait, ConnectionTrait, DatabaseTransaction, EntityTrait,
+    QueryFilter, QuerySelect, Set,
+};
 use sea_orm_migration::prelude::*;
+use sea_query::{Expr, extension::postgres::PgExpr};
+use trustify_entity::labels::Labels;
 use trustify_module_ingestor::graph::sbom::spdx::suppliers;
+use trustify_module_storage::service::StorageBackend;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -25,14 +35,48 @@ mod legacy {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+/// SPDX-only Document wrapper that filters `all()` to SPDX-labeled SBOMs.
+struct SpdxSbom(Sbom);
+
+impl From<Bytes> for SpdxSbom {
+    fn from(value: Bytes) -> Self {
+        SpdxSbom(Sbom::from(value))
+    }
+}
+
+impl Document for SpdxSbom {
+    type Id = Id;
+
+    async fn all<C: ConnectionTrait>(tx: &C) -> Result<Vec<Id>, DbErr> {
+        use trustify_entity::sbom;
+
+        sbom::Entity::find()
+            .filter(Expr::col(sbom::Column::Labels).contains(Labels::new().add("type", "spdx")))
+            .select_only()
+            .column_as(sbom::Column::SourceDocumentId, "source")
+            .column_as(sbom::Column::SbomId, "sbom")
+            .into_model()
+            .all(tx)
+            .await
+    }
+
+    async fn source<S, C>(id: &Id, storage: &S, tx: &C) -> Result<Self, anyhow::Error>
+    where
+        S: StorageBackend + Send + Sync,
+        C: ConnectionTrait,
+    {
+        Sbom::source(id, storage, tx).await.map(SpdxSbom)
+    }
+}
+
 #[async_trait::async_trait]
 impl MigrationTraitWithData for Migration {
     async fn up(&self, manager: &SchemaDataManager) -> Result<(), DbErr> {
         manager
             .process(
                 self,
-                async |sbom: SbomDoc, id: Id, tx: &DatabaseTransaction| {
-                    let SbomDoc::Spdx(spdx) = sbom else {
+                async |sbom: SpdxSbom, id: Id, tx: &DatabaseTransaction| {
+                    let Sbom::Spdx(spdx) = sbom.0 else {
                         return Ok(());
                     };
 

--- a/migration/src/m0002280_backfill_sbom_suppliers.rs
+++ b/migration/src/m0002280_backfill_sbom_suppliers.rs
@@ -3,8 +3,7 @@
 use crate::data::{MigrationTraitWithData, SchemaDataManager, sbom::Id, sbom::Sbom as SbomDoc};
 use sea_orm::{ActiveModelBehavior, ActiveModelTrait, DatabaseTransaction, Set};
 use sea_orm_migration::prelude::*;
-use spdx_rs::models::{RelationshipType, SPDX};
-use std::collections::HashSet;
+use trustify_module_ingestor::graph::sbom::spdx::suppliers;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -24,47 +23,6 @@ mod legacy {
     pub enum Relation {}
 
     impl ActiveModelBehavior for ActiveModel {}
-}
-
-fn describing_packages(sbom: &SPDX) -> HashSet<&str> {
-    let mut packages = HashSet::new();
-
-    for rel in &sbom.relationships {
-        match rel.relationship_type {
-            RelationshipType::Describes => {
-                packages.insert(rel.related_spdx_element.as_str());
-            }
-            RelationshipType::DescribedBy => {
-                packages.insert(rel.spdx_element_id.as_str());
-            }
-            _ => continue,
-        }
-    }
-
-    packages.extend(
-        sbom.document_creation_information
-            .document_describes
-            .iter()
-            .map(|s| s.as_str()),
-    );
-
-    packages
-}
-
-fn suppliers(sbom: &SPDX) -> Vec<String> {
-    let describing = describing_packages(sbom);
-
-    let mut result = HashSet::new();
-    for p in &sbom.package_information {
-        if !describing.contains(p.package_spdx_identifier.as_str()) {
-            continue;
-        }
-        if let Some(supplier) = &p.package_supplier {
-            result.insert(supplier.clone());
-        }
-    }
-
-    Vec::from_iter(result)
 }
 
 #[async_trait::async_trait]

--- a/migration/src/m0002280_backfill_sbom_suppliers.rs
+++ b/migration/src/m0002280_backfill_sbom_suppliers.rs
@@ -1,6 +1,6 @@
 /// Data migration that re-processes all SPDX SBOMs to backfill the `suppliers`
 /// column using the corrected `describing_packages()` logic.
-use crate::data::{MigrationTraitWithData, SchemaDataManager, sbom::Sbom as SbomDoc};
+use crate::data::{MigrationTraitWithData, SchemaDataManager, sbom::Id, sbom::Sbom as SbomDoc};
 use sea_orm::{ActiveModelBehavior, ActiveModelTrait, DatabaseTransaction, Set};
 use sea_orm_migration::prelude::*;
 use spdx_rs::models::{RelationshipType, SPDX};
@@ -27,15 +27,15 @@ mod legacy {
 }
 
 fn describing_packages(sbom: &SPDX) -> HashSet<&str> {
-    let mut packages = HashSet::<&str>::new();
+    let mut packages = HashSet::new();
 
     for rel in &sbom.relationships {
         match rel.relationship_type {
             RelationshipType::Describes => {
-                packages.insert(&rel.related_spdx_element);
+                packages.insert(rel.related_spdx_element.as_str());
             }
             RelationshipType::DescribedBy => {
-                packages.insert(&rel.spdx_element_id);
+                packages.insert(rel.spdx_element_id.as_str());
             }
             _ => continue,
         }
@@ -73,7 +73,7 @@ impl MigrationTraitWithData for Migration {
         manager
             .process(
                 self,
-                async |sbom: SbomDoc, id: crate::data::sbom::Id, tx: &DatabaseTransaction| {
+                async |sbom: SbomDoc, id: Id, tx: &DatabaseTransaction| {
                     let SbomDoc::Spdx(spdx) = sbom else {
                         return Ok(());
                     };

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1719,6 +1719,36 @@ async fn query_sboms_by_array_values(ctx: &TrustifyContext) -> Result<(), anyhow
     Ok(())
 }
 
+/// Verifies that suppliers are correctly extracted for SBOMs using DESCRIBES and DESCRIBED_BY
+/// relationships without a documentDescribes fallback.
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn spdx_describes_suppliers(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    // Given SBOMs with DESCRIBES-only and DESCRIBED_BY-only relationships
+    ctx.ingest_documents([
+        "spdx/license-ref-overlap.json",
+        "spdx/described-by-supplier.json",
+    ])
+    .await?;
+
+    let query = async |expected_count, q| {
+        let app = caller(ctx).await.unwrap();
+        let uri = format!("/api/v3/sbom?total=true&q={}", encode(q));
+        let req = TestRequest::get().uri(&uri).to_request();
+        let response: Value = app.call_and_read_body_json(req).await;
+        tracing::debug!(test = "", "{response:#?}");
+        assert_eq!(expected_count, response["total"], "for {q}");
+    };
+
+    // Then suppliers from DESCRIBES relationships are populated
+    query(1, "suppliers=Organization: Test").await;
+
+    // Then suppliers from DESCRIBED_BY relationships are populated
+    query(1, "suppliers=Organization: Test Supplier").await;
+
+    Ok(())
+}
+
 async fn test_label(
     ctx: &TrustifyContext,
     query: &str,

--- a/modules/ingestor/src/graph/sbom/spdx.rs
+++ b/modules/ingestor/src/graph/sbom/spdx.rs
@@ -34,10 +34,10 @@ fn describing_packages(sbom: &SPDX) -> HashSet<&str> {
     for rel in &sbom.relationships {
         match rel.relationship_type {
             RelationshipType::Describes => {
-                packages.insert(&rel.spdx_element_id);
+                packages.insert(&rel.related_spdx_element);
             }
             RelationshipType::DescribedBy => {
-                packages.insert(&rel.related_spdx_element);
+                packages.insert(&rel.spdx_element_id);
             }
             _ => continue,
         }

--- a/modules/ingestor/src/graph/sbom/spdx.rs
+++ b/modules/ingestor/src/graph/sbom/spdx.rs
@@ -27,8 +27,8 @@ use trustify_entity::{relationship::Relationship, sbom_package_license::LicenseC
 
 pub struct Information<'a>(pub &'a SPDX);
 
-/// get the describing packages
-fn describing_packages(sbom: &SPDX) -> HashSet<&str> {
+/// Get the packages that describe the SBOM document.
+pub fn describing_packages(sbom: &SPDX) -> HashSet<&str> {
     let mut packages = HashSet::<&str>::new();
 
     for rel in &sbom.relationships {
@@ -53,8 +53,8 @@ fn describing_packages(sbom: &SPDX) -> HashSet<&str> {
     packages
 }
 
-/// Extract suppliers for a SPDX SBOM by collecting suppliers of describing packages
-fn suppliers(sbom: &SPDX) -> Vec<String> {
+/// Extract suppliers for a SPDX SBOM by collecting suppliers of describing packages.
+pub fn suppliers(sbom: &SPDX) -> Vec<String> {
     // packages describing the SBOM
     let describing = describing_packages(sbom);
 


### PR DESCRIPTION
## Summary

Fix the swapped SPDX relationship element sides in `describing_packages()` so that
`DESCRIBES` correctly collects the described package (`related_spdx_element`) and
`DESCRIBED_BY` correctly collects the package being described (`spdx_element_id`).

The match arms were swapped, causing `suppliers()` to return an empty list for SBOMs
using `DESCRIBES` or `DESCRIBED_BY` relationships without a `documentDescribes` fallback.

### Changes
- Swap the two match arm bodies in `describing_packages()` (2-line fix)
- Add `spdx_describes_suppliers` endpoint test covering both `DESCRIBES` and `DESCRIBED_BY`
- Add `described-by-supplier.json` minimal test fixture for `DESCRIBED_BY` (no existing fixture uses this relationship type)
- Add `m0002270` data migration to backfill corrected `suppliers` for existing SBOMs (TC-5362)

Implements [TC-5359](https://redhat.atlassian.net/browse/TC-5359)
Implements [TC-5362](https://redhat.atlassian.net/browse/TC-5362)

[TC-5359]: https://redhat.atlassian.net/browse/TC-5359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Fix SPDX package relationship handling for DESCRIBES/DESCRIBED_BY and add coverage for supplier extraction from these relationships.

Bug Fixes:
- Correct SPDX DESCRIBES and DESCRIBED_BY relationship handling so that described packages are associated with the correct element IDs when extracting describing packages.

Tests:
- Add endpoint test verifying suppliers are populated from SPDX DESCRIBES and DESCRIBED_BY relationships without relying on documentDescribes.
- Add a minimal SPDX fixture using DESCRIBED_BY to validate supplier extraction for that relationship type.

[TC-5362]: https://redhat.atlassian.net/browse/TC-5362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ