### PR TITLE
experiment(correlation): add in-memory correlation engine with graph cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8503,6 +8503,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustify-module-correlation"
+version = "0.5.0-rc.1"
+dependencies = [
+ "actix-web",
+ "anyhow",
+ "arc-swap",
+ "cpe",
+ "petgraph",
+ "sea-orm",
+ "sea-query",
+ "serde",
+ "serde_json",
+ "test-context",
+ "test-log",
+ "time",
+ "tokio",
+ "tracing",
+ "trustify-common",
+ "trustify-entity",
+ "trustify-module-analysis",
+ "trustify-module-fundamental",
+ "trustify-test-context",
+ "utoipa",
+ "utoipa-actix-web",
+ "uuid",
+]
+
+[[package]]
 name = "trustify-module-fundamental"
 version = "0.5.0-rc.1"
 dependencies = [
@@ -8805,6 +8833,7 @@ dependencies = [
  "trustify-db",
  "trustify-infrastructure",
  "trustify-module-analysis",
+ "trustify-module-correlation",
  "trustify-module-fundamental",
  "trustify-module-importer",
  "trustify-module-ingestor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "entity",
     "migration",
     "modules/analysis",
+    "modules/correlation",
     "modules/fundamental",
     "modules/importer",
     "modules/ingestor",
@@ -39,6 +40,7 @@ actix-web = "4.3.1"
 actix-web-extras = "0.1"
 actix-web-httpauth = "0.8"
 actix-web-static-files = "4.0.1"
+arc-swap = "1"
 anyhow = "1.0.72"
 async-compression = "0.4.13"
 async-recursion = "1"
@@ -167,6 +169,7 @@ trustify-entity = { path = "entity" }
 trustify-infrastructure = { path = "common/infrastructure" }
 trustify-migration = { path = "migration" }
 trustify-module-analysis = { path = "modules/analysis" }
+trustify-module-correlation = { path = "modules/correlation" }
 trustify-module-fundamental = { path = "modules/fundamental" }
 trustify-module-importer = { path = "modules/importer" }
 trustify-module-ingestor = { path = "modules/ingestor" }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -22,3 +22,4 @@ pub mod service;
 pub mod time;
 pub mod tls;
 pub mod uuid;
+pub mod version;

--- a/common/src/version/maven.rs
+++ b/common/src/version/maven.rs
@@ -1,0 +1,131 @@
+/// Maven version comparison, ported from the PL/pgSQL `mavenver_cmp`.
+///
+/// Splits on the first `-` to separate the numeric release
+/// (`major.minor.revision`) from a qualifier/build suffix. Versions
+/// without a qualifier are greater than versions with one (opposite of
+/// semver pre-release). Qualifiers are compared case-insensitively.
+///
+/// Note: the original PL/pgSQL had a bug (`right_numeric` checked
+/// `left_qualifier_or_build` instead of `right_qualifier_or_build`).
+/// This port fixes that bug.
+use std::cmp::Ordering;
+
+/// Compare two Maven version strings.
+///
+/// Returns `None` if either string cannot be parsed.
+pub fn mavenver_cmp(left: &str, right: &str) -> Option<Ordering> {
+    let (left_release, left_qual) = parse_maven(left)?;
+    let (right_release, right_qual) = parse_maven(right)?;
+
+    // Compare major.minor.revision
+    for (l, r) in left_release.iter().zip(right_release.iter()) {
+        match l.cmp(r) {
+            Ordering::Equal => continue,
+            other => return Some(other),
+        }
+    }
+
+    // Compare cardinality
+    match left_release.len().cmp(&right_release.len()) {
+        Ordering::Equal => {}
+        other => return Some(other),
+    }
+
+    // Qualifier comparison: no qualifier > has qualifier
+    match (&left_qual, &right_qual) {
+        (None, None) => Some(Ordering::Equal),
+        (None, Some(_)) => Some(Ordering::Greater),
+        (Some(_), None) => Some(Ordering::Less),
+        (Some(l), Some(r)) => {
+            // If both are purely numeric, compare as integers
+            if let (Ok(ln), Ok(rn)) = (l.parse::<u64>(), r.parse::<u64>()) {
+                return Some(ln.cmp(&rn));
+            }
+            // Case-insensitive lexicographic comparison
+            let l_lower = l.to_lowercase();
+            let r_lower = r.to_lowercase();
+            Some(l_lower.cmp(&r_lower))
+        }
+    }
+}
+
+/// Parse a Maven version string into (release parts, optional qualifier).
+///
+/// The qualifier is everything after the first `-` (including the `-`).
+fn parse_maven(s: &str) -> Option<(Vec<u64>, Option<String>)> {
+    let (release_str, qualifier) = match s.find('-') {
+        Some(idx) => (&s[..idx], Some(s[idx + 1..].to_string())),
+        None => (s, None),
+    };
+
+    let parts: Vec<u64> = release_str
+        .split('.')
+        .map(|p| p.parse::<u64>().ok())
+        .collect::<Option<Vec<_>>>()?;
+
+    if parts.is_empty() {
+        return None;
+    }
+
+    // Pad to at least 3 parts (major.minor.revision)
+    let mut padded = parts;
+    while padded.len() < 3 {
+        padded.push(0);
+    }
+
+    Some((padded, qualifier))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_ordering() {
+        assert_eq!(mavenver_cmp("1.0.0", "1.0.0"), Some(Ordering::Equal));
+        assert_eq!(mavenver_cmp("1.0.1", "1.0.0"), Some(Ordering::Greater));
+        assert_eq!(mavenver_cmp("2.0.0", "1.9.9"), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn qualifier_less_than_no_qualifier() {
+        // In Maven, 1.0.0-SNAPSHOT < 1.0.0 (no qualifier wins)
+        assert_eq!(
+            mavenver_cmp("1.0.0-SNAPSHOT", "1.0.0"),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            mavenver_cmp("1.0.0", "1.0.0-SNAPSHOT"),
+            Some(Ordering::Greater)
+        );
+    }
+
+    #[test]
+    fn qualifier_ordering() {
+        assert_eq!(
+            mavenver_cmp("1.0.0-alpha", "1.0.0-beta"),
+            Some(Ordering::Less)
+        );
+    }
+
+    #[test]
+    fn numeric_qualifier() {
+        assert_eq!(
+            mavenver_cmp("1.0.0-1", "1.0.0-2"),
+            Some(Ordering::Less)
+        );
+    }
+
+    #[test]
+    fn case_insensitive_qualifier() {
+        assert_eq!(
+            mavenver_cmp("1.0.0-ALPHA", "1.0.0-alpha"),
+            Some(Ordering::Equal)
+        );
+    }
+
+    #[test]
+    fn lenient_parsing() {
+        assert_eq!(mavenver_cmp("1.0", "1.0.0"), Some(Ordering::Equal));
+    }
+}

--- a/common/src/version/mod.rs
+++ b/common/src/version/mod.rs
@@ -1,0 +1,297 @@
+/// Rust-native version comparison functions, ported from the PL/pgSQL
+/// implementations in the migration SQL. These enable in-memory version
+/// matching without round-tripping to PostgreSQL.
+///
+/// Each scheme has a `*_cmp` function returning `Option<Ordering>` and
+/// a `*_version_matches` function that checks range membership. The
+/// range-checking logic is factored into [`range_matches`] and reused
+/// by all schemes that support ordering.
+mod maven;
+mod python;
+mod rpm;
+mod semver;
+
+use std::cmp::Ordering;
+
+pub use self::semver::semver_cmp;
+
+/// A version range with optional lower and upper bounds.
+///
+/// Mirrors the `version_range` database table. Each bound is optional;
+/// when present, the `*_inclusive` flag controls whether the boundary
+/// value itself is included (`[`/`]`) or excluded (`(`/`)`).
+#[derive(Debug, Clone)]
+pub struct VersionRange {
+    pub scheme: VersionScheme,
+    pub low_version: Option<String>,
+    pub low_inclusive: bool,
+    pub high_version: Option<String>,
+    pub high_inclusive: bool,
+}
+
+/// Version scheme identifier, matching the `version_scheme_id` column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VersionScheme {
+    Semver,
+    Rpm,
+    Maven,
+    Python,
+    Golang,
+    Generic,
+    Git,
+    Npm,
+    NuGet,
+    Gem,
+    Hex,
+    Swift,
+    Pub,
+    Packagist,
+    Cargo,
+}
+
+impl VersionScheme {
+    /// Parse a scheme string (as stored in the database) into the enum.
+    pub fn from_db_str(s: &str) -> Option<Self> {
+        match s {
+            "semver" => Some(Self::Semver),
+            "rpm" => Some(Self::Rpm),
+            "maven" => Some(Self::Maven),
+            "python" => Some(Self::Python),
+            "golang" => Some(Self::Golang),
+            "generic" => Some(Self::Generic),
+            "git" => Some(Self::Git),
+            "npm" => Some(Self::Npm),
+            "nuget" => Some(Self::NuGet),
+            "gem" => Some(Self::Gem),
+            "hex" => Some(Self::Hex),
+            "swift" => Some(Self::Swift),
+            "pub" => Some(Self::Pub),
+            "packagist" => Some(Self::Packagist),
+            "cargo" => Some(Self::Cargo),
+            _ => None,
+        }
+    }
+}
+
+/// Check whether `version` falls within the given `range` using the
+/// range's version scheme for ordering.
+///
+/// This is the Rust equivalent of the PL/pgSQL `version_matches()`
+/// dispatcher.
+pub fn version_matches(version: &str, range: &VersionRange) -> bool {
+    match range.scheme {
+        VersionScheme::Generic | VersionScheme::Git => {
+            exact_version_matches(version, range)
+        }
+        VersionScheme::Golang => {
+            let normalized = version.strip_prefix('v').unwrap_or(version);
+            range_matches(normalized, range, semver::semver_cmp)
+        }
+        VersionScheme::Semver
+        | VersionScheme::Npm
+        | VersionScheme::NuGet
+        | VersionScheme::Gem
+        | VersionScheme::Hex
+        | VersionScheme::Swift
+        | VersionScheme::Pub
+        | VersionScheme::Packagist
+        | VersionScheme::Cargo => {
+            range_matches(version, range, semver::semver_cmp)
+        }
+        VersionScheme::Rpm => {
+            range_matches(version, range, rpm::rpmver_cmp)
+        }
+        VersionScheme::Maven => {
+            range_matches(version, range, maven::mavenver_cmp)
+        }
+        VersionScheme::Python => {
+            range_matches(version, range, python::pythonver_cmp)
+        }
+    }
+}
+
+/// Range-checking template shared by all orderable schemes.
+///
+/// Mirrors the PL/pgSQL `semver_version_matches` logic exactly:
+/// - If `cmp_fn` returns `None` (parse error), that bound is skipped.
+/// - If both bounds are unset or unparseable, returns `false`.
+fn range_matches(
+    version: &str,
+    range: &VersionRange,
+    cmp_fn: fn(&str, &str) -> Option<Ordering>,
+) -> bool {
+    let low_cmp = range
+        .low_version
+        .as_deref()
+        .and_then(|low| cmp_fn(version, low));
+
+    if let Some(ord) = low_cmp {
+        if range.low_inclusive {
+            if ord == Ordering::Less {
+                return false;
+            }
+        } else if ord != Ordering::Greater {
+            return false;
+        }
+    }
+
+    let high_cmp = range
+        .high_version
+        .as_deref()
+        .and_then(|high| cmp_fn(version, high));
+
+    if let Some(ord) = high_cmp {
+        if range.high_inclusive {
+            if ord == Ordering::Greater {
+                return false;
+            }
+        } else if ord != Ordering::Less {
+            return false;
+        }
+    }
+
+    // Both bounds unset or unparseable → no match.
+    if low_cmp.is_none() && high_cmp.is_none() {
+        return false;
+    }
+
+    true
+}
+
+/// Exact-equality matching for schemes without ordering (generic, git).
+///
+/// Only matches if the version string exactly equals an inclusive bound.
+fn exact_version_matches(version: &str, range: &VersionRange) -> bool {
+    if range.low_inclusive
+        && range.low_version.as_deref() == Some(version)
+    {
+        return true;
+    }
+    if range.high_inclusive
+        && range.high_version.as_deref() == Some(version)
+    {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn range(
+        scheme: VersionScheme,
+        low: Option<&str>,
+        low_incl: bool,
+        high: Option<&str>,
+        high_incl: bool,
+    ) -> VersionRange {
+        VersionRange {
+            scheme,
+            low_version: low.map(String::from),
+            low_inclusive: low_incl,
+            high_version: high.map(String::from),
+            high_inclusive: high_incl,
+        }
+    }
+
+    #[test]
+    fn semver_inclusive_range() {
+        let r = range(VersionScheme::Semver, Some("1.0.0"), true, Some("2.0.0"), true);
+        assert!(version_matches("1.0.0", &r));
+        assert!(version_matches("1.5.0", &r));
+        assert!(version_matches("2.0.0", &r));
+        assert!(!version_matches("0.9.0", &r));
+        assert!(!version_matches("2.0.1", &r));
+    }
+
+    #[test]
+    fn semver_exclusive_range() {
+        let r = range(VersionScheme::Semver, Some("1.0.0"), false, Some("2.0.0"), false);
+        assert!(!version_matches("1.0.0", &r));
+        assert!(version_matches("1.5.0", &r));
+        assert!(!version_matches("2.0.0", &r));
+    }
+
+    #[test]
+    fn semver_half_open_low() {
+        let r = range(VersionScheme::Semver, Some("1.0.0"), true, None, false);
+        assert!(version_matches("1.0.0", &r));
+        assert!(version_matches("99.0.0", &r));
+        assert!(!version_matches("0.9.0", &r));
+    }
+
+    #[test]
+    fn semver_half_open_high() {
+        let r = range(VersionScheme::Semver, None, false, Some("2.0.0"), false);
+        assert!(version_matches("1.0.0", &r));
+        assert!(!version_matches("2.0.0", &r));
+    }
+
+    #[test]
+    fn semver_both_null_returns_false() {
+        let r = range(VersionScheme::Semver, None, false, None, false);
+        assert!(!version_matches("1.0.0", &r));
+    }
+
+    #[test]
+    fn generic_exact_match() {
+        let r = range(VersionScheme::Generic, Some("1.2.3"), true, None, false);
+        assert!(version_matches("1.2.3", &r));
+        assert!(!version_matches("1.2.4", &r));
+    }
+
+    #[test]
+    fn generic_non_inclusive_never_matches() {
+        let r = range(VersionScheme::Generic, Some("1.2.3"), false, None, false);
+        assert!(!version_matches("1.2.3", &r));
+    }
+
+    #[test]
+    fn golang_strips_v_prefix() {
+        let r = range(VersionScheme::Golang, Some("1.0.0"), true, Some("2.0.0"), false);
+        assert!(version_matches("v1.5.0", &r));
+        assert!(version_matches("1.5.0", &r));
+        assert!(!version_matches("v2.0.0", &r));
+    }
+
+    #[test]
+    fn semver_prerelease_less_than_release() {
+        let r = range(VersionScheme::Semver, Some("1.0.0"), true, None, false);
+        // 1.0.0-alpha < 1.0.0 per semver spec, so it should NOT match >= 1.0.0
+        assert!(!version_matches("1.0.0-alpha", &r));
+    }
+
+    #[test]
+    fn rpm_basic_range() {
+        let r = range(VersionScheme::Rpm, Some("1.0"), true, Some("2.0"), false);
+        assert!(version_matches("1.0", &r));
+        assert!(version_matches("1.5", &r));
+        assert!(!version_matches("2.0", &r));
+    }
+
+    #[test]
+    fn maven_basic_range() {
+        let r = range(VersionScheme::Maven, Some("1.0.0"), true, Some("2.0.0"), false);
+        assert!(version_matches("1.0.0", &r));
+        assert!(version_matches("1.5.0", &r));
+        assert!(!version_matches("2.0.0", &r));
+    }
+
+    #[test]
+    fn python_basic_range() {
+        let r = range(VersionScheme::Python, Some("1.0.0"), true, Some("2.0.0"), false);
+        assert!(version_matches("1.0.0", &r));
+        assert!(version_matches("1.5.0", &r));
+        assert!(!version_matches("2.0.0", &r));
+    }
+
+    #[test]
+    fn python_prerelease_ordering() {
+        let r = range(VersionScheme::Python, Some("1.0.0"), true, None, false);
+        // 1.0.0a1 < 1.0.0 in PEP 440
+        assert!(!version_matches("1.0.0a1", &r));
+        assert!(version_matches("1.0.0", &r));
+        assert!(version_matches("1.0.0post1", &r));
+    }
+}

--- a/common/src/version/python.rs
+++ b/common/src/version/python.rs
@@ -1,0 +1,231 @@
+/// Python (PEP 440) version comparison, ported from PL/pgSQL `pythonver_cmp`.
+///
+/// Ordering: `major.minor.patch`, then pre-release (`a` < `b` < `rc`,
+/// pre-release < release), then post-release (`post` > release), then
+/// dev-release (`dev` < release).
+use std::cmp::Ordering;
+
+/// Compare two PEP 440 version strings.
+///
+/// Returns `None` if either string cannot be parsed.
+pub fn pythonver_cmp(left: &str, right: &str) -> Option<Ordering> {
+    let lv = parse_python(left)?;
+    let rv = parse_python(right)?;
+
+    // Compare major.minor.patch
+    for (l, r) in lv.release.iter().zip(rv.release.iter()) {
+        match l.cmp(r) {
+            Ordering::Equal => continue,
+            other => return Some(other),
+        }
+    }
+
+    // Pre-release: has pre < no pre
+    match (&lv.pre, &rv.pre) {
+        (Some(_), None) => return Some(Ordering::Less),
+        (None, Some(_)) => return Some(Ordering::Greater),
+        (Some(l), Some(r)) => {
+            let ord = compare_pre_tag(&l.tag, &r.tag);
+            if ord != Ordering::Equal {
+                return Some(ord);
+            }
+            match l.num.cmp(&r.num) {
+                Ordering::Equal => {}
+                other => return Some(other),
+            }
+        }
+        (None, None) => {}
+    }
+
+    // Post-release: has post > no post
+    match (lv.post, rv.post) {
+        (Some(_), None) => return Some(Ordering::Greater),
+        (None, Some(_)) => return Some(Ordering::Less),
+        (Some(l), Some(r)) => {
+            match l.cmp(&r) {
+                Ordering::Equal => {}
+                other => return Some(other),
+            }
+        }
+        (None, None) => {}
+    }
+
+    // Dev-release: has dev < no dev
+    match (lv.dev, rv.dev) {
+        (Some(_), None) => return Some(Ordering::Less),
+        (None, Some(_)) => return Some(Ordering::Greater),
+        (Some(l), Some(r)) => {
+            match l.cmp(&r) {
+                Ordering::Equal => {}
+                other => return Some(other),
+            }
+        }
+        (None, None) => {}
+    }
+
+    Some(Ordering::Equal)
+}
+
+/// Pre-release tag: `a` (alpha), `b` (beta), `rc` (release candidate).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PreTag {
+    Alpha,
+    Beta,
+    Rc,
+}
+
+fn compare_pre_tag(left: &PreTag, right: &PreTag) -> Ordering {
+    fn tag_ord(t: &PreTag) -> u8 {
+        match t {
+            PreTag::Alpha => 0,
+            PreTag::Beta => 1,
+            PreTag::Rc => 2,
+        }
+    }
+    tag_ord(left).cmp(&tag_ord(right))
+}
+
+#[derive(Debug, Clone)]
+struct PreRelease {
+    tag: PreTag,
+    num: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+struct PythonVersion {
+    release: Vec<u64>,
+    pre: Option<PreRelease>,
+    post: Option<u64>,
+    dev: Option<u64>,
+}
+
+/// Parse a PEP 440 version string.
+fn parse_python(s: &str) -> Option<PythonVersion> {
+    // Extract the numeric release prefix (everything before first alpha char)
+    let release_end = s
+        .find(|c: char| c.is_ascii_alphabetic())
+        .unwrap_or(s.len());
+    let release_str = &s[..release_end];
+    let release_str = release_str.trim_end_matches('.');
+
+    let parts: Vec<u64> = if release_str.is_empty() {
+        return None;
+    } else {
+        release_str
+            .split('.')
+            .map(|p| p.parse::<u64>().ok())
+            .collect::<Option<Vec<_>>>()?
+    };
+
+    if parts.is_empty() {
+        return None;
+    }
+
+    // Pad to 3 parts
+    let mut release = parts;
+    while release.len() < 3 {
+        release.push(0);
+    }
+
+    // Pre-release: a|b|rc followed by optional digits
+    let pre = extract_pre(s);
+
+    // Post-release: postN
+    let post = extract_tagged_num(s, "post");
+
+    // Dev-release: devN
+    let dev = extract_tagged_num(s, "dev");
+
+    Some(PythonVersion {
+        release,
+        pre,
+        post,
+        dev,
+    })
+}
+
+/// Extract a pre-release tag (a, b, rc) and optional number.
+fn extract_pre(s: &str) -> Option<PreRelease> {
+    // Try rc first (longer match), then b, then a
+    for (pattern, tag) in [("rc", PreTag::Rc), ("beta", PreTag::Beta), ("b", PreTag::Beta), ("alpha", PreTag::Alpha), ("a", PreTag::Alpha)] {
+        if let Some(idx) = s.find(pattern) {
+            // Ensure it's not part of another word (like "post" containing no pre-tags)
+            let after = &s[idx + pattern.len()..];
+            let num_str: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+            let num = if num_str.is_empty() {
+                None
+            } else {
+                num_str.parse::<u64>().ok()
+            };
+
+            // Verify it's preceded by a digit or start-of-string (not mid-word)
+            if idx == 0 || s.as_bytes().get(idx - 1).is_some_and(|b| b.is_ascii_digit() || *b == b'.') {
+                return Some(PreRelease { tag, num });
+            }
+        }
+    }
+    None
+}
+
+/// Extract a tagged numeric suffix like `postN` or `devN`.
+fn extract_tagged_num(s: &str, tag: &str) -> Option<u64> {
+    let idx = s.find(tag)?;
+    let after = &s[idx + tag.len()..];
+    let num_str: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if num_str.is_empty() {
+        None
+    } else {
+        num_str.parse::<u64>().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_ordering() {
+        assert_eq!(pythonver_cmp("1.0.0", "1.0.0"), Some(Ordering::Equal));
+        assert_eq!(pythonver_cmp("1.0.1", "1.0.0"), Some(Ordering::Greater));
+        assert_eq!(pythonver_cmp("2.0.0", "1.9.9"), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn prerelease_ordering() {
+        // a < b < rc < release
+        assert_eq!(pythonver_cmp("1.0.0a1", "1.0.0b1"), Some(Ordering::Less));
+        assert_eq!(pythonver_cmp("1.0.0b1", "1.0.0rc1"), Some(Ordering::Less));
+        assert_eq!(pythonver_cmp("1.0.0rc1", "1.0.0"), Some(Ordering::Less));
+    }
+
+    #[test]
+    fn prerelease_numbering() {
+        assert_eq!(pythonver_cmp("1.0.0a1", "1.0.0a2"), Some(Ordering::Less));
+    }
+
+    #[test]
+    fn post_release() {
+        assert_eq!(
+            pythonver_cmp("1.0.0post1", "1.0.0"),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            pythonver_cmp("1.0.0post1", "1.0.0post2"),
+            Some(Ordering::Less)
+        );
+    }
+
+    #[test]
+    fn dev_release() {
+        assert_eq!(pythonver_cmp("1.0.0dev1", "1.0.0"), Some(Ordering::Less));
+        assert_eq!(
+            pythonver_cmp("1.0.0dev1", "1.0.0dev2"),
+            Some(Ordering::Less)
+        );
+    }
+
+    #[test]
+    fn lenient_parsing() {
+        assert_eq!(pythonver_cmp("1.0", "1.0.0"), Some(Ordering::Equal));
+    }
+}

--- a/common/src/version/rpm.rs
+++ b/common/src/version/rpm.rs
@@ -1,0 +1,187 @@
+/// RPM version comparison, ported from the PL/pgSQL `rpmver_cmp`.
+///
+/// Tokenizes into segments: runs of digits, runs of alpha characters,
+/// or special characters `~` and `^`. Segments are compared pairwise:
+/// - `~` sorts before everything (pre-release indicator)
+/// - `^` sorts after everything (snapshot indicator)
+/// - Numeric segments are compared by magnitude (strip leading zeros)
+/// - Alpha segments are compared lexicographically
+/// - Numeric > alpha when types differ
+use std::cmp::Ordering;
+
+/// Compare two RPM version strings.
+///
+/// Returns `None` only if inputs are truly degenerate (empty after
+/// tokenization). The PL/pgSQL version never returns NULL for RPM.
+pub fn rpmver_cmp(left: &str, right: &str) -> Option<Ordering> {
+    if left == right {
+        return Some(Ordering::Equal);
+    }
+
+    let left_segs = tokenize(left);
+    let right_segs = tokenize(right);
+
+    let min_len = left_segs.len().min(right_segs.len());
+
+    for i in 0..min_len {
+        let l = &left_segs[i];
+        let r = &right_segs[i];
+
+        if let Some(ord) = compare_segments(l, r)
+            && ord != Ordering::Equal
+        {
+            return Some(ord);
+        }
+    }
+
+    // Handle trailing segments
+    if let Some(seg) = right_segs.get(left_segs.len()) {
+        if seg == "~" {
+            return Some(Ordering::Greater);
+        }
+        if seg == "^" {
+            return Some(Ordering::Less);
+        }
+    }
+    if let Some(seg) = left_segs.get(right_segs.len()) {
+        if seg == "~" {
+            return Some(Ordering::Less);
+        }
+        if seg == "^" {
+            return Some(Ordering::Greater);
+        }
+    }
+
+    Some(left_segs.len().cmp(&right_segs.len()))
+}
+
+/// Tokenize an RPM version string into segments.
+///
+/// Each segment is either a run of digits, a run of alphabetic
+/// characters, or a single `~` or `^` character. All other characters
+/// (`.`, `-`, `_`) are separators and discarded.
+fn tokenize(s: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut chars = s.chars().peekable();
+
+    while let Some(&c) = chars.peek() {
+        if c == '~' || c == '^' {
+            segments.push(c.to_string());
+            chars.next();
+        } else if c.is_ascii_digit() {
+            let mut seg = String::new();
+            while let Some(&d) = chars.peek() {
+                if d.is_ascii_digit() {
+                    seg.push(d);
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            segments.push(seg);
+        } else if c.is_ascii_alphabetic() {
+            let mut seg = String::new();
+            while let Some(&d) = chars.peek() {
+                if d.is_ascii_alphabetic() {
+                    seg.push(d);
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            segments.push(seg);
+        } else {
+            // Separator character — skip
+            chars.next();
+        }
+    }
+
+    segments
+}
+
+/// Compare two RPM segments.
+fn compare_segments(left: &str, right: &str) -> Option<Ordering> {
+    let l_is_digit = left.starts_with(|c: char| c.is_ascii_digit());
+    let r_is_digit = right.starts_with(|c: char| c.is_ascii_digit());
+
+    // Handle tilde (sorts before everything)
+    if left == "~" && right != "~" {
+        return Some(Ordering::Less);
+    }
+    if right == "~" && left != "~" {
+        return Some(Ordering::Greater);
+    }
+    if left == "~" && right == "~" {
+        return Some(Ordering::Equal);
+    }
+
+    // Handle caret (sorts after everything except when comparing to ~)
+    if left == "^" && right != "^" {
+        return Some(Ordering::Greater);
+    }
+    if right == "^" && left != "^" {
+        return Some(Ordering::Less);
+    }
+    if left == "^" && right == "^" {
+        return Some(Ordering::Equal);
+    }
+
+    if l_is_digit && r_is_digit {
+        // Numeric comparison: strip leading zeros, compare by length then value
+        let l_trimmed = left.trim_start_matches('0');
+        let r_trimmed = right.trim_start_matches('0');
+        match l_trimmed.len().cmp(&r_trimmed.len()) {
+            Ordering::Equal => Some(l_trimmed.cmp(r_trimmed)),
+            other => Some(other),
+        }
+    } else if l_is_digit {
+        // Numeric > alpha
+        Some(Ordering::Greater)
+    } else if r_is_digit {
+        Some(Ordering::Less)
+    } else {
+        // Alpha comparison: lexicographic
+        Some(left.cmp(right))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_ordering() {
+        assert_eq!(rpmver_cmp("1.0", "1.0"), Some(Ordering::Equal));
+        assert_eq!(rpmver_cmp("1.1", "1.0"), Some(Ordering::Greater));
+        assert_eq!(rpmver_cmp("1.0", "1.1"), Some(Ordering::Less));
+    }
+
+    #[test]
+    fn numeric_vs_alpha() {
+        assert_eq!(rpmver_cmp("1.0.1", "1.0.a"), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn tilde_sorts_before() {
+        assert_eq!(rpmver_cmp("1.0~rc1", "1.0"), Some(Ordering::Less));
+    }
+
+    #[test]
+    fn caret_sorts_after() {
+        assert_eq!(rpmver_cmp("1.0^git1", "1.0"), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn leading_zeros() {
+        assert_eq!(rpmver_cmp("01", "1"), Some(Ordering::Equal));
+        assert_eq!(rpmver_cmp("001", "1"), Some(Ordering::Equal));
+    }
+
+    #[test]
+    fn complex_rpm_version() {
+        assert_eq!(
+            rpmver_cmp("1.0.0-1.el8", "1.0.0-2.el8"),
+            Some(Ordering::Less)
+        );
+    }
+}

--- a/common/src/version/semver.rs
+++ b/common/src/version/semver.rs
@@ -1,0 +1,155 @@
+/// Semver comparison, ported from the PL/pgSQL `semver_cmp` function.
+///
+/// Splits on `+` (build metadata, ignored), then `-` (pre-release),
+/// then `.` (major.minor.patch). Pre-release identifiers are compared
+/// segment-by-segment: numeric segments numerically, string segments
+/// lexicographically. A version without pre-release is greater than
+/// one with pre-release (e.g., `1.0.0 > 1.0.0-alpha`).
+use std::cmp::Ordering;
+
+/// Compare two semver-ish version strings.
+///
+/// Returns `None` if either string cannot be parsed (matches the
+/// PL/pgSQL `EXCEPTION WHEN OTHERS THEN RETURN NULL` behavior).
+pub fn semver_cmp(left: &str, right: &str) -> Option<Ordering> {
+    let (left_release, left_pre) = parse_semver(left)?;
+    let (right_release, right_pre) = parse_semver(right)?;
+
+    // Compare major.minor.patch
+    for (l, r) in left_release.iter().zip(right_release.iter()) {
+        match l.cmp(r) {
+            Ordering::Equal => continue,
+            other => return Some(other),
+        }
+    }
+
+    // Compare cardinality (more parts = greater, matching PL/pgSQL)
+    match left_release.len().cmp(&right_release.len()) {
+        Ordering::Equal => {}
+        other => return Some(other),
+    }
+
+    // Pre-release comparison
+    match (&left_pre, &right_pre) {
+        (None, None) => Some(Ordering::Equal),
+        (Some(_), None) => Some(Ordering::Less),
+        (None, Some(_)) => Some(Ordering::Greater),
+        (Some(l), Some(r)) => Some(compare_pre_release(l, r)),
+    }
+}
+
+/// Parse a semver string into (release parts, optional pre-release string).
+///
+/// Handles: `major.minor.patch-pre+build` and lenient variants like
+/// `major.minor` (patch defaults to 0).
+fn parse_semver(s: &str) -> Option<(Vec<u64>, Option<String>)> {
+    // Strip build metadata (everything after +)
+    let without_build = s.split('+').next().unwrap_or(s);
+
+    // Split release from pre-release (first -)
+    let (release_str, pre) = match without_build.find('-') {
+        Some(idx) => (&without_build[..idx], Some(without_build[idx + 1..].to_string())),
+        None => (without_build, None),
+    };
+
+    // Parse release segments
+    let parts: Vec<u64> = release_str
+        .split('.')
+        .map(|p| p.parse::<u64>().ok())
+        .collect::<Option<Vec<_>>>()?;
+
+    if parts.is_empty() {
+        return None;
+    }
+
+    // Pad to at least 3 parts (major.minor.patch)
+    let mut padded = parts;
+    while padded.len() < 3 {
+        padded.push(0);
+    }
+
+    Some((padded, pre))
+}
+
+/// Compare pre-release identifiers segment-by-segment.
+///
+/// Per semver spec: numeric identifiers are compared as integers;
+/// alphanumeric identifiers are compared lexicographically; numeric
+/// has lower precedence than alphanumeric; fewer fields is less than
+/// more fields when all preceding fields are equal.
+fn compare_pre_release(left: &str, right: &str) -> Ordering {
+    let left_parts: Vec<&str> = left.split('.').collect();
+    let right_parts: Vec<&str> = right.split('.').collect();
+
+    for (l, r) in left_parts.iter().zip(right_parts.iter()) {
+        let l_num = l.parse::<u64>().ok();
+        let r_num = r.parse::<u64>().ok();
+
+        let ord = match (l_num, r_num) {
+            (Some(ln), Some(rn)) => ln.cmp(&rn),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => l.cmp(r),
+        };
+
+        if ord != Ordering::Equal {
+            return ord;
+        }
+    }
+
+    left_parts.len().cmp(&right_parts.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_ordering() {
+        assert_eq!(semver_cmp("1.0.0", "1.0.0"), Some(Ordering::Equal));
+        assert_eq!(semver_cmp("1.0.1", "1.0.0"), Some(Ordering::Greater));
+        assert_eq!(semver_cmp("1.0.0", "1.0.1"), Some(Ordering::Less));
+        assert_eq!(semver_cmp("2.0.0", "1.9.9"), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn prerelease_less_than_release() {
+        assert_eq!(semver_cmp("1.0.0-alpha", "1.0.0"), Some(Ordering::Less));
+        assert_eq!(semver_cmp("1.0.0", "1.0.0-alpha"), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn prerelease_ordering() {
+        assert_eq!(
+            semver_cmp("1.0.0-alpha", "1.0.0-beta"),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            semver_cmp("1.0.0-alpha.1", "1.0.0-alpha.2"),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            semver_cmp("1.0.0-1", "1.0.0-2"),
+            Some(Ordering::Less)
+        );
+    }
+
+    #[test]
+    fn build_metadata_ignored() {
+        assert_eq!(
+            semver_cmp("1.0.0+build1", "1.0.0+build2"),
+            Some(Ordering::Equal)
+        );
+    }
+
+    #[test]
+    fn lenient_parsing() {
+        assert_eq!(semver_cmp("1.0", "1.0.0"), Some(Ordering::Equal));
+        assert_eq!(semver_cmp("1", "1.0.0"), Some(Ordering::Equal));
+    }
+
+    #[test]
+    fn invalid_returns_none() {
+        assert_eq!(semver_cmp("not-a-version", "1.0.0"), None);
+    }
+}

--- a/docs/adrs/00021-correlation-engine-refactor.md
+++ b/docs/adrs/00021-correlation-engine-refactor.md
@@ -1,0 +1,321 @@
+# 00021. Vulnerability Correlation Engine Refactor
+
+Date: 2026-07-24
+
+## Status
+
+DRAFT
+
+## Context
+
+[ADR 00020](00020-vulnerability-correlation-engine.md) documents the status quo of the
+vulnerability correlation engine: six independent SQL queries (A1–A3 for Direction A,
+B1–B3 for Direction B) that are not guaranteed to agree, have different scoping semantics,
+and suffer from performance problems on large datasets.
+
+[PR #2528](https://github.com/guacsec/trustify/pull/2528) attempted to fix this by building
+a parallel in-memory correlation module (`modules/correlation/`) with its own advisory and
+SBOM indexes loaded into `HashMap`s at startup. While it achieved 4–24x speedups, it had
+fundamental problems:
+
+- **Startup penalty**: loading all advisory and SBOM indexes into memory takes minutes on
+  large datasets (270k SBOMs), making the server unusable during warmup.
+- **Duplicate data model**: built its own `AdvisoryIndex` and `SbomIndex` rather than
+  reusing the existing graph cache (`modules/analysis/`), which already stores
+  `PackageNode` data (PURLs, CPEs, versions) per SBOM in a bounded moka cache.
+- **Scope creep**: bundled WebSocket notifications, change_log tables, and a
+  `ChangeBroadcaster` into the same PR.
+- **Incomplete coverage**: `correlate_purls` only queried `purl_status` initially; CPE
+  matching (`cpe_status`) was absent entirely.
+
+This ADR proposes a refactor that reuses the existing graph cache infrastructure and
+addresses the directional asymmetries documented in ADR 00020, without building a parallel
+data model.
+
+## Decision
+
+### Principle: one matching layer, two entry points
+
+Instead of six independent queries, implement a single `CorrelationService` that expresses
+identity matching, version matching, and context scoping once. Direction A and Direction B
+become two entry points into the same matching logic, parameterized by anchor side.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                  CorrelationService                     │
+│                                                         │
+│  ┌─────────────────┐     ┌──────────────────────────┐  │
+│  │  AdvisoryIndex   │     │  Graph Cache (existing)  │  │
+│  │  (in-memory)     │     │  modules/analysis/       │  │
+│  │                  │     │  PackageGraph per SBOM   │  │
+│  │  by_purl:        │     │  - PackageNode.purl      │  │
+│  │    HashMap<      │     │  - PackageNode.cpe       │  │
+│  │      BasePurlKey,│     │  - PackageNode.version   │  │
+│  │      Vec<Status>>│     │  moka LRU, 200 MiB      │  │
+│  │  by_cpe:         │     │  eager load after ingest │  │
+│  │    HashMap<      │     └──────────────────────────┘  │
+│  │      CpeKey,     │                                   │
+│  │      Vec<Status>>│                                   │
+│  │  by_product_name:│                                   │
+│  │    HashMap<      │                                   │
+│  │      String,     │                                   │
+│  │      Vec<Status>>│                                   │
+│  └─────────────────┘                                    │
+│                                                         │
+│  correlate_sbom(sbom_id) → Vec<CorrelationMatch>        │
+│  correlate_vuln(vuln_id) → Vec<CorrelationMatch>        │
+│  correlate_purls(purls)  → Vec<CorrelationMatch>        │
+└─────────────────────────────────────────────────────────┘
+          │                          │
+          ▼                          ▼
+┌──────────────────┐    ┌─────────────────────────┐
+│  Hydration Layer │    │  Existing Endpoints      │
+│  (DB lookups)    │    │  GET /v3/sbom/{id}/adv   │
+│  advisory, vuln, │    │  GET /v3/vulnerability/  │
+│  scores, orgs    │    │      {id}                │
+└──────────────────┘    └─────────────────────────┘
+```
+
+### Component 1: AdvisoryIndex (new, in-memory)
+
+A read-optimized index over the advisory side of the correlation pivot. Loaded at startup
+from `purl_status`, `cpe_status`, and `product_status` tables. Incrementally updated on
+advisory ingest/delete via `change_log` events or direct notification.
+
+```rust
+struct AdvisoryIndex {
+    /// PURL identity → status entries (with version ranges).
+    /// Key: (purl_type, namespace, name) — same as base_purl identity.
+    by_purl: HashMap<BasePurlKey, Vec<PurlStatusEntry>>,
+
+    /// CPE identity → status entries (with version ranges).
+    /// Key: (vendor, product) where part = 'a'.
+    by_cpe: HashMap<CpeKey, Vec<CpeStatusEntry>>,
+
+    /// Product name → status entries (with version ranges).
+    /// Key: package name (both bare and namespace/name forms).
+    by_product_name: HashMap<String, Vec<ProductStatusEntry>>,
+}
+```
+
+Each `*StatusEntry` contains: `advisory_id`, `vulnerability_id`, `status_id`,
+`version_range`, `context_cpe_id`, and the version scheme. This is the advisory's
+*assertion* — it does not know about SBOMs.
+
+**Why a separate index instead of querying the DB?** The advisory side is the smaller,
+more stable half of the correlation. Status tables are write-once (at ingest time) and
+change only when advisories are ingested or deleted. Keeping them in memory eliminates
+the multi-join SQL queries that are the primary bottleneck. On the DS3 dataset, this
+index is ~50–100 MB — well within server memory budgets.
+
+**Why not reuse the graph cache for advisories?** The graph cache stores *SBOM dependency
+trees* as petgraphs. Advisories are not graphs — they are flat assertion sets. Forcing
+them into the graph model would be a poor fit. The advisory index is a simple HashMap
+lookup structure.
+
+### Component 2: reuse the existing graph cache for SBOM data
+
+PR #2528's `SbomIndex` duplicated what the existing `GraphMap` already stores. Each
+`PackageNode` in the graph cache already contains:
+
+- `purl: Arc<[Purl]>` — all qualified PURLs for the package
+- `cpe: Arc<[Cpe]>` — all CPEs for the package
+- `version: String` — the package version
+- `name: String` — the package name
+- `sbom_id: Uuid` — which SBOM this belongs to
+
+For Direction A (`correlate_sbom`), the flow is:
+
+1. Load the SBOM's `PackageGraph` from the graph cache (cache hit or DB load).
+2. Iterate over all `PackageNode`s in the graph.
+3. For each node, look up its PURLs in `AdvisoryIndex.by_purl`, its CPEs in
+   `AdvisoryIndex.by_cpe`, and its name in `AdvisoryIndex.by_product_name`.
+4. For each matching status entry, run `version_matches()` in Rust (not PL/pgSQL).
+5. Apply context CPE scoping using the SBOM's describing CPEs (from the graph's
+   root/DESCRIBES node).
+6. Collect and deduplicate matches.
+
+For Direction B (`correlate_vuln`), the flow is:
+
+1. Query `AdvisoryIndex` for all status entries mentioning the given `vulnerability_id`.
+   This requires a secondary index: `by_vuln: HashMap<String, Vec<StatusEntryRef>>`.
+2. For each status entry, determine which SBOMs could match:
+   - For PURL entries: query DB for SBOMs containing a matching `base_purl` (this is
+     a simple indexed lookup, not the full multi-join).
+   - For CPE entries: query DB for SBOMs with matching `sbom_node_cpe_ref`.
+   - For product name entries: query DB for SBOMs with matching package names.
+3. For each candidate SBOM, load its graph from the cache and verify the version match
+   and context scoping (same logic as Direction A step 4–5).
+4. Collect and deduplicate.
+
+This ensures both directions execute the **same matching logic** — eliminating the
+directional asymmetries documented in ADR 00020 (L11–L15).
+
+### Component 3: Rust version matching (port from PL/pgSQL)
+
+PR #2528 already ported the version comparison functions to Rust. This work should be
+extracted and reused:
+
+- `semver_version_matches` — covers npm, NuGet, Cargo, Gem, Hex, Swift, Pub, Packagist
+- `rpm_version_matches` — RPM epoch:version-release
+- `maven_version_matches` — Maven ordering
+- `python_version_matches` — PEP 440
+- `golang_version_matches` — Go module versioning
+- `generic_version_matches` — exact string equality
+
+These replace the `version_matches()` PL/pgSQL function for the in-memory path. The SQL
+function remains for direct DB queries outside the correlation engine.
+
+### Component 4: context CPE scoping (unified)
+
+Both directions currently apply context CPE scoping differently (or not at all — see
+L5, L13, L14 in ADR 00020). The refactored engine applies a single scoping rule:
+
+1. Extract the SBOM's describing CPEs from its graph (the root node's CPEs, or
+   `sbom_describing_cpe` as fallback).
+2. Generalize to `(vendor, product, major_version)` triples.
+3. A status entry matches if:
+   - Its `context_cpe_id` is NULL (universal), OR
+   - Its context CPE matches one of the generalized describing CPEs, OR
+   - The SBOM has no describing CPEs (unscoped SBOMs match everything).
+
+This is Direction A's current rule (which is the more correct one), applied uniformly
+to both directions and all three matching strategies.
+
+### Component 5: hydration layer
+
+The correlation engine produces `Vec<CorrelationMatch>` — lightweight structs containing
+only IDs (`advisory_id`, `vulnerability_id`, `status_id`, `sbom_id`, `purl_id`, etc.).
+A hydration layer performs batched DB lookups to inflate these into the full API response
+models (`SbomAdvisory`, `VulnerabilityDetails`, etc.).
+
+This is the same approach PR #2528 took, and it is sound: the hot path (identity matching +
+version comparison) runs in memory, and the cold path (entity metadata) is a small number
+of batched `WHERE id IN (...)` queries.
+
+### Component 6: status filter unification (F10)
+
+Both directions use the same status filter, configurable per request:
+
+- Direction A default: `["affected"]` (current behavior, backward compatible)
+- Direction B default: `["affected", "fixed", "under_investigation", "recommended"]`
+  (current `!= 'not_affected'` behavior, made explicit)
+
+The caller can override with a `status` query parameter on both endpoints.
+
+### Incremental update strategy
+
+The `AdvisoryIndex` is rebuilt on advisory ingest/delete. Two options:
+
+**Option A — full rebuild on change.** The advisory index is small enough (~50–100 MB)
+that a full rebuild from DB takes 2–5 seconds. Use `ArcSwap` for lock-free reads during
+rebuild. Triggered by `change_log` events or a periodic poll.
+
+**Option B — incremental delta.** On advisory ingest, query only the new/changed
+`purl_status`/`cpe_status`/`product_status` rows and merge them into the index. On
+advisory delete, remove entries by `advisory_id`. More complex but avoids the rebuild
+pause.
+
+Recommend starting with **Option A** for simplicity, with Option B as an optimization
+if the rebuild pause proves problematic.
+
+### What this does NOT change
+
+- **Ingestion paths** — loaders, creators, status tables, version scheme assignment.
+  These are separate concerns (L1, L2, L3, L8, L9, L10 in ADR 00020).
+- **The analysis module** — graph cache, cross-SBOM traversal, `/v3/analysis/` endpoints.
+  The correlation service *consumes* the graph cache but does not modify it.
+- **Database schema** — no new tables or migrations. The `purl_status`, `cpe_status`,
+  `product_status`, and `version_range` tables remain the source of truth.
+
+### Limitations addressed
+
+| ADR 00020 ID | Status | How |
+|---|---|---|
+| L5 | Fixed | Context CPE scoping applied uniformly to all matching strategies |
+| L11 | Fixed | Single status filter definition, configurable per request |
+| L12 | Fixed | Product name matching uses `=` in both directions (no `LIKE`) |
+| L13 | Fixed | Context CPE scoping applied to PURL matches in Direction B |
+| L14 | Fixed | Single scoping mechanism for product name matches |
+| L15 | Enabled | Cross-direction consistency tests become trivial (same code path) |
+| L16 | Fixed | DESCRIBES spine used for projection only, not filtering |
+| L7, L19 | Fixed | N+1 queries eliminated by batched hydration |
+
+### Limitations NOT addressed (out of scope)
+
+| ADR 00020 ID | Why |
+|---|---|
+| L1 | CVE PURL divination — ingestion concern |
+| L2 | Generic version scheme — ingestion concern (L10 is the root cause) |
+| L3 | Product name normalization — ingestion concern |
+| L4 | Context CPE major-version-only — deliberate design choice, revisit separately |
+| L6 | Cross-advisory dedup — separate feature (F8) |
+| L8 | Red Hat CSAF heuristic — ingestion concern |
+| L10 | Version scheme assignment — ingestion concern (F9) |
+| L17 | CPE-only nodes — data model artifact, requires entity changes |
+| L18 | Legacy `purls` field — API deprecation decision (F15) |
+| L20 | Non-deterministic version — fixed as side effect (graph iteration is stable) |
+
+## Migration plan
+
+### Phase 1: extract and test the matching layer
+
+1. Port version comparison functions from PR #2528 into `common/src/version/`.
+2. Build `AdvisoryIndex` with `by_purl`, `by_cpe`, `by_product_name` indexes.
+3. Implement `correlate_sbom()` — Direction A only.
+4. Add correctness tests comparing in-memory results against SQL baseline.
+5. Wire up behind a feature flag (`--correlation-enabled`).
+
+### Phase 2: Direction B and hydration
+
+1. Add `by_vuln` secondary index to `AdvisoryIndex`.
+2. Implement `correlate_vuln()` — Direction B.
+3. Build hydration layer for `VulnerabilityDetails` response format.
+4. Add cross-direction consistency tests (F12 from ADR 00020).
+
+### Phase 3: replace the SQL paths
+
+1. Make the correlation service the default for `/v3/sbom/{id}/advisory` and
+   `/v3/vulnerability/{id}`.
+2. Keep the SQL paths available under `/v3a/` for comparison during validation.
+3. Remove the SQL paths once correctness is confirmed at scale.
+
+### Phase 4: cleanup
+
+1. Remove `raw_sql.rs` query functions (`product_advisory_info_sql`,
+   `cpe_advisory_info_sql`, `batch_severity_counts_sql`).
+2. Remove the A1 SeaORM query chain in `details.rs`.
+3. Remove B1/B2/B3 queries in `vulnerability_advisory.rs`.
+4. Remove the legacy `purls` field (F15) or keep it explicitly documented.
+
+## Consequences
+
+- **Performance**: in-memory matching eliminates the multi-join SQL queries. PR #2528
+  demonstrated 4–24x speedups; this design should achieve similar results without the
+  startup penalty (the graph cache warms lazily).
+- **Correctness**: a single matching layer guarantees directional consistency.
+  The asymmetries documented in ADR 00020 (L11–L15) are eliminated by construction.
+- **Memory**: the `AdvisoryIndex` adds ~50–100 MB of resident memory (advisory status
+  entries). The existing graph cache (200 MiB default) is reused, not duplicated.
+- **Startup**: unlike PR #2528, no upfront SBOM loading. The advisory index loads in
+  2–5 seconds. SBOM graphs are loaded on demand via the existing graph cache.
+- **Complexity**: replaces six SQL query implementations with one Rust matching
+  function. The hydration layer adds new code, but it is straightforward batched
+  DB lookups.
+- **Risk**: version matching in Rust must produce identical results to the PL/pgSQL
+  functions. Correctness tests against the SQL baseline mitigate this.
+
+## References
+
+- [ADR 00020](00020-vulnerability-correlation-engine.md) — status quo documentation
+- [ADR 00001](00001-graph-analytics.md) — graph analytics design (petgraph + moka cache)
+- [ADR 00002](00002-analysis-graph.md) — analysis graph model
+- [PR #2528](https://github.com/guacsec/trustify/pull/2528) — prior in-memory
+  correlation attempt (draft, not merged)
+- `modules/analysis/src/model.rs` — `GraphMap`, `PackageGraph`, `PackageNode`
+- `modules/analysis/src/service/mod.rs` — `AnalysisService`, graph cache loading
+- `modules/fundamental/src/sbom/model/details.rs` — current Direction A queries
+- `modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs` —
+  current Direction B queries

--- a/modules/correlation/Cargo.toml
+++ b/modules/correlation/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "trustify-module-correlation"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+trustify-common = { workspace = true }
+trustify-entity = { workspace = true }
+trustify-module-analysis = { workspace = true }
+trustify-module-fundamental = { workspace = true }
+
+actix-web = { workspace = true }
+anyhow = { workspace = true }
+cpe = { workspace = true }
+arc-swap = { workspace = true }
+petgraph = { workspace = true }
+sea-orm = { workspace = true }
+sea-query = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+time = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
+utoipa = { workspace = true, features = ["actix_extras", "uuid"] }
+utoipa-actix-web = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+test-context = { workspace = true }
+test-log = { workspace = true, features = ["log", "trace"] }
+trustify-test-context = { workspace = true }

--- a/modules/correlation/src/advisory_index.rs
+++ b/modules/correlation/src/advisory_index.rs
@@ -1,0 +1,431 @@
+/// In-memory read-optimized index over advisory status assertions.
+///
+/// Loaded from `purl_status`, `cpe_status`, and `product_status` tables.
+/// Provides O(1) lookup by PURL identity, CPE identity, product name,
+/// and vulnerability ID. Used by the correlation engine to avoid the
+/// multi-join SQL queries that are the primary performance bottleneck.
+use std::collections::HashMap;
+use tracing::{info, instrument};
+use trustify_common::version::{VersionRange, VersionScheme};
+use uuid::Uuid;
+
+/// A single advisory status assertion about a vulnerability affecting
+/// packages matching a specific identity and version range.
+#[derive(Debug, Clone)]
+pub struct StatusEntry {
+    /// FK to the advisory that made this assertion.
+    pub advisory_id: Uuid,
+    /// The vulnerability identifier (e.g., "CVE-2024-1234").
+    pub vulnerability_id: String,
+    /// FK to the status value (affected, fixed, not_affected, etc.).
+    pub status_id: Uuid,
+    /// The status slug for fast filtering without a DB lookup.
+    pub status_slug: String,
+    /// Version range this assertion applies to.
+    pub version_range: VersionRange,
+    /// Optional context CPE scoping (NULL = universally applicable).
+    pub context_cpe: Option<ContextCpe>,
+}
+
+/// Context CPE data for scoping, extracted from the `cpe` table.
+#[derive(Debug, Clone)]
+pub struct ContextCpe {
+    pub cpe_id: Uuid,
+    pub vendor: String,
+    pub product: String,
+    pub version: String,
+}
+
+/// Key for PURL-based lookups: (type, namespace, name) — matches `base_purl`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BasePurlKey {
+    pub ty: String,
+    pub namespace: Option<String>,
+    pub name: String,
+}
+
+/// Key for CPE-based lookups: (vendor, product) where part = 'a'.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CpeKey {
+    pub vendor: String,
+    pub product: String,
+}
+
+/// The in-memory advisory index.
+///
+/// Each map contains all non-deprecated status assertions from the
+/// database, keyed by the identity dimension used for lookup.
+#[derive(Debug, Clone)]
+pub struct AdvisoryIndex {
+    /// PURL identity → status entries (from `purl_status` table).
+    pub by_purl: HashMap<BasePurlKey, Vec<StatusEntry>>,
+
+    /// CPE identity → status entries (from `cpe_status` table).
+    pub by_cpe: HashMap<CpeKey, Vec<StatusEntry>>,
+
+    /// Product name → status entries (from `product_status` table).
+    /// Both bare name and `namespace/name` forms are indexed.
+    pub by_product_name: HashMap<String, Vec<StatusEntry>>,
+
+    /// Vulnerability ID → indices into the other maps.
+    /// Used for Direction B (given a vuln, find candidate SBOMs).
+    pub by_vuln: HashMap<String, Vec<VulnEntry>>,
+}
+
+/// A reference from a vulnerability to a status entry, recording
+/// which index map and key the entry lives under.
+#[derive(Debug, Clone)]
+pub struct VulnEntry {
+    pub advisory_id: Uuid,
+    pub status_id: Uuid,
+    pub status_slug: String,
+    pub match_source: MatchSource,
+}
+
+/// Which index map a status entry came from.
+#[derive(Debug, Clone)]
+pub enum MatchSource {
+    Purl(BasePurlKey),
+    Cpe(CpeKey),
+    ProductName(String),
+}
+
+impl AdvisoryIndex {
+    /// Build an empty index.
+    pub fn empty() -> Self {
+        Self {
+            by_purl: HashMap::new(),
+            by_cpe: HashMap::new(),
+            by_product_name: HashMap::new(),
+            by_vuln: HashMap::new(),
+        }
+    }
+
+    /// Load the advisory index from the database.
+    ///
+    /// Queries `purl_status`, `cpe_status`, and `product_status` tables
+    /// with their associated `version_range`, `status`, `advisory`, and
+    /// `cpe` data. Only non-deprecated advisories are included.
+    #[instrument(skip_all, err(level = tracing::Level::INFO))]
+    pub async fn load<C: sea_orm::ConnectionTrait>(
+        connection: &C,
+    ) -> Result<Self, anyhow::Error> {
+        let mut index = Self::empty();
+
+        let purl_count = load_purl_statuses(&mut index, connection).await?;
+        let cpe_count = load_cpe_statuses(&mut index, connection).await?;
+        let product_count = load_product_statuses(&mut index, connection).await?;
+
+        info!(
+            purl_entries = purl_count,
+            cpe_entries = cpe_count,
+            product_entries = product_count,
+            vuln_entries = index.by_vuln.len(),
+            "advisory index loaded"
+        );
+
+        Ok(index)
+    }
+
+    /// Register a status entry in the `by_vuln` secondary index.
+    fn index_by_vuln(&mut self, entry: &StatusEntry, source: MatchSource) {
+        self.by_vuln
+            .entry(entry.vulnerability_id.clone())
+            .or_default()
+            .push(VulnEntry {
+                advisory_id: entry.advisory_id,
+                status_id: entry.status_id,
+                status_slug: entry.status_slug.clone(),
+                match_source: source,
+            });
+    }
+}
+
+/// Load `purl_status` entries into the index.
+async fn load_purl_statuses<C: sea_orm::ConnectionTrait>(
+    index: &mut AdvisoryIndex,
+    connection: &C,
+) -> Result<usize, anyhow::Error> {
+    use sea_orm::{FromQueryResult, Statement};
+
+    #[derive(Debug, FromQueryResult)]
+    struct Row {
+        advisory_id: Uuid,
+        vulnerability_id: String,
+        status_id: Uuid,
+        status_slug: String,
+        purl_type: String,
+        purl_namespace: Option<String>,
+        purl_name: String,
+        version_scheme_id: String,
+        low_version: Option<String>,
+        low_inclusive: Option<bool>,
+        high_version: Option<String>,
+        high_inclusive: Option<bool>,
+        context_cpe_id: Option<Uuid>,
+        cpe_vendor: Option<String>,
+        cpe_product: Option<String>,
+        cpe_version: Option<String>,
+    }
+
+    let rows: Vec<Row> = Row::find_by_statement(Statement::from_string(
+        sea_orm::DatabaseBackend::Postgres,
+        r#"
+        SELECT
+            ps.advisory_id,
+            ps.vulnerability_id,
+            ps.status_id,
+            s.slug AS status_slug,
+            bp.type AS purl_type,
+            bp.namespace AS purl_namespace,
+            bp.name AS purl_name,
+            vr.version_scheme_id,
+            vr.low_version,
+            vr.low_inclusive,
+            vr.high_version,
+            vr.high_inclusive,
+            ps.context_cpe_id,
+            c.vendor AS cpe_vendor,
+            c.product AS cpe_product,
+            c.version AS cpe_version
+        FROM purl_status ps
+        JOIN status s ON ps.status_id = s.id
+        JOIN base_purl bp ON ps.base_purl_id = bp.id
+        JOIN version_range vr ON ps.version_range_id = vr.id
+        JOIN advisory a ON ps.advisory_id = a.id AND a.deprecated = false
+        LEFT JOIN cpe c ON ps.context_cpe_id = c.id
+        "#
+        .to_string(),
+    ))
+    .all(connection)
+    .await?;
+
+    let count = rows.len();
+
+    for row in rows {
+        let scheme = match VersionScheme::from_db_str(&row.version_scheme_id) {
+            Some(s) => s,
+            None => continue,
+        };
+
+        let context_cpe = match (row.context_cpe_id, row.cpe_vendor, row.cpe_product) {
+            (Some(id), Some(vendor), Some(product)) => Some(ContextCpe {
+                cpe_id: id,
+                vendor,
+                product,
+                version: row.cpe_version.unwrap_or_default(),
+            }),
+            _ => None,
+        };
+
+        let entry = StatusEntry {
+            advisory_id: row.advisory_id,
+            vulnerability_id: row.vulnerability_id.clone(),
+            status_id: row.status_id,
+            status_slug: row.status_slug,
+            version_range: VersionRange {
+                scheme,
+                low_version: row.low_version,
+                low_inclusive: row.low_inclusive.unwrap_or(false),
+                high_version: row.high_version,
+                high_inclusive: row.high_inclusive.unwrap_or(false),
+            },
+            context_cpe,
+        };
+
+        let key = BasePurlKey {
+            ty: row.purl_type,
+            namespace: row.purl_namespace,
+            name: row.purl_name,
+        };
+
+        index.index_by_vuln(&entry, MatchSource::Purl(key.clone()));
+        index.by_purl.entry(key).or_default().push(entry);
+    }
+
+    Ok(count)
+}
+
+/// Load `cpe_status` entries into the index.
+async fn load_cpe_statuses<C: sea_orm::ConnectionTrait>(
+    index: &mut AdvisoryIndex,
+    connection: &C,
+) -> Result<usize, anyhow::Error> {
+    use sea_orm::{FromQueryResult, Statement};
+
+    #[derive(Debug, FromQueryResult)]
+    struct Row {
+        advisory_id: Uuid,
+        vulnerability_id: String,
+        status_id: Uuid,
+        status_slug: String,
+        cpe_vendor: String,
+        cpe_product: String,
+        version_scheme_id: String,
+        low_version: Option<String>,
+        low_inclusive: Option<bool>,
+        high_version: Option<String>,
+        high_inclusive: Option<bool>,
+    }
+
+    let rows: Vec<Row> = Row::find_by_statement(Statement::from_string(
+        sea_orm::DatabaseBackend::Postgres,
+        r#"
+        SELECT
+            cs.advisory_id,
+            cs.vulnerability_id,
+            cs.status_id,
+            s.slug AS status_slug,
+            c.vendor AS cpe_vendor,
+            c.product AS cpe_product,
+            vr.version_scheme_id,
+            vr.low_version,
+            vr.low_inclusive,
+            vr.high_version,
+            vr.high_inclusive
+        FROM cpe_status cs
+        JOIN status s ON cs.status_id = s.id
+        JOIN cpe c ON cs.cpe_id = c.id AND c.part = 'a'
+        JOIN version_range vr ON cs.version_range_id = vr.id
+        JOIN advisory a ON cs.advisory_id = a.id AND a.deprecated = false
+        "#
+        .to_string(),
+    ))
+    .all(connection)
+    .await?;
+
+    let count = rows.len();
+
+    for row in rows {
+        let scheme = match VersionScheme::from_db_str(&row.version_scheme_id) {
+            Some(s) => s,
+            None => continue,
+        };
+
+        let entry = StatusEntry {
+            advisory_id: row.advisory_id,
+            vulnerability_id: row.vulnerability_id.clone(),
+            status_id: row.status_id,
+            status_slug: row.status_slug,
+            version_range: VersionRange {
+                scheme,
+                low_version: row.low_version,
+                low_inclusive: row.low_inclusive.unwrap_or(false),
+                high_version: row.high_version,
+                high_inclusive: row.high_inclusive.unwrap_or(false),
+            },
+            context_cpe: None,
+        };
+
+        let key = CpeKey {
+            vendor: row.cpe_vendor,
+            product: row.cpe_product,
+        };
+
+        index.index_by_vuln(&entry, MatchSource::Cpe(key.clone()));
+        index.by_cpe.entry(key).or_default().push(entry);
+    }
+
+    Ok(count)
+}
+
+/// Load `product_status` entries into the index.
+async fn load_product_statuses<C: sea_orm::ConnectionTrait>(
+    index: &mut AdvisoryIndex,
+    connection: &C,
+) -> Result<usize, anyhow::Error> {
+    use sea_orm::{FromQueryResult, Statement};
+
+    #[derive(Debug, FromQueryResult)]
+    struct Row {
+        advisory_id: Uuid,
+        vulnerability_id: String,
+        status_id: Uuid,
+        status_slug: String,
+        package: String,
+        version_scheme_id: String,
+        low_version: Option<String>,
+        low_inclusive: Option<bool>,
+        high_version: Option<String>,
+        high_inclusive: Option<bool>,
+        context_cpe_id: Option<Uuid>,
+        cpe_vendor: Option<String>,
+        cpe_product: Option<String>,
+        cpe_version: Option<String>,
+    }
+
+    let rows: Vec<Row> = Row::find_by_statement(Statement::from_string(
+        sea_orm::DatabaseBackend::Postgres,
+        r#"
+        SELECT
+            ps.advisory_id,
+            ps.vulnerability_id,
+            ps.status_id,
+            s.slug AS status_slug,
+            ps.package,
+            vr.version_scheme_id,
+            vr.low_version,
+            vr.low_inclusive,
+            vr.high_version,
+            vr.high_inclusive,
+            ps.context_cpe_id,
+            c.vendor AS cpe_vendor,
+            c.product AS cpe_product,
+            c.version AS cpe_version
+        FROM product_status ps
+        JOIN status s ON ps.status_id = s.id
+        JOIN product_version_range pvr ON ps.product_version_range_id = pvr.id
+        JOIN version_range vr ON pvr.version_range_id = vr.id
+        JOIN advisory a ON ps.advisory_id = a.id AND a.deprecated = false
+        LEFT JOIN cpe c ON ps.context_cpe_id = c.id
+        WHERE ps.package IS NOT NULL
+        "#
+        .to_string(),
+    ))
+    .all(connection)
+    .await?;
+
+    let count = rows.len();
+
+    for row in rows {
+        let scheme = match VersionScheme::from_db_str(&row.version_scheme_id) {
+            Some(s) => s,
+            None => continue,
+        };
+
+        let context_cpe = match (row.context_cpe_id, row.cpe_vendor, row.cpe_product) {
+            (Some(id), Some(vendor), Some(product)) => Some(ContextCpe {
+                cpe_id: id,
+                vendor,
+                product,
+                version: row.cpe_version.unwrap_or_default(),
+            }),
+            _ => None,
+        };
+
+        let entry = StatusEntry {
+            advisory_id: row.advisory_id,
+            vulnerability_id: row.vulnerability_id.clone(),
+            status_id: row.status_id,
+            status_slug: row.status_slug,
+            version_range: VersionRange {
+                scheme,
+                low_version: row.low_version,
+                low_inclusive: row.low_inclusive.unwrap_or(false),
+                high_version: row.high_version,
+                high_inclusive: row.high_inclusive.unwrap_or(false),
+            },
+            context_cpe,
+        };
+
+        let name = row.package;
+        index.index_by_vuln(&entry, MatchSource::ProductName(name.clone()));
+        index
+            .by_product_name
+            .entry(name)
+            .or_default()
+            .push(entry);
+    }
+
+    Ok(count)
+}

--- a/modules/correlation/src/endpoints/mod.rs
+++ b/modules/correlation/src/endpoints/mod.rs
@@ -1,0 +1,268 @@
+#[cfg(test)]
+mod test;
+
+use crate::{hydrate, service::CorrelationService};
+use actix_web::{HttpResponse, Responder, get, web};
+use serde::Serialize;
+use trustify_common::db;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+/// Register correlation endpoints.
+pub fn configure(
+    config: &mut utoipa_actix_web::service_config::ServiceConfig,
+    db_ro: db::ReadOnly,
+    correlation: CorrelationService,
+) {
+    config
+        .app_data(web::Data::new(db_ro))
+        .app_data(web::Data::new(correlation))
+        .service(correlation_status)
+        .service(correlate_sbom)
+        .service(correlate_sbom_advisory)
+        .service(correlate_vuln);
+}
+
+/// Status of the correlation service.
+#[derive(Debug, Clone, Serialize, serde::Deserialize, ToSchema)]
+pub struct CorrelationStatus {
+    /// Whether the advisory index is loaded.
+    pub index_loaded: bool,
+    /// Number of PURL status entries in the index.
+    pub purl_entries: usize,
+    /// Number of CPE status entries in the index.
+    pub cpe_entries: usize,
+    /// Number of product name entries in the index.
+    pub product_entries: usize,
+    /// Number of distinct vulnerabilities indexed.
+    pub vulnerability_count: usize,
+}
+
+/// Get the status of the correlation engine.
+#[utoipa::path(
+    tag = "correlation",
+    operation_id = "correlationStatus",
+    responses(
+        (status = 200, description = "Correlation engine status", body = CorrelationStatus),
+    ),
+)]
+#[get("/v3/correlation/status")]
+pub async fn correlation_status(
+    correlation: web::Data<CorrelationService>,
+) -> actix_web::Result<impl Responder> {
+    let index = correlation.index();
+    Ok(HttpResponse::Ok().json(CorrelationStatus {
+        index_loaded: !index.by_purl.is_empty()
+            || !index.by_cpe.is_empty()
+            || !index.by_product_name.is_empty(),
+        purl_entries: index.by_purl.values().map(|v| v.len()).sum(),
+        cpe_entries: index.by_cpe.values().map(|v| v.len()).sum(),
+        product_entries: index.by_product_name.values().map(|v| v.len()).sum(),
+        vulnerability_count: index.by_vuln.len(),
+    }))
+}
+
+/// Query parameters for the correlate endpoint.
+#[derive(Debug, Clone, serde::Deserialize, utoipa::IntoParams)]
+pub struct CorrelateParams {
+    /// Status filter (e.g., "affected"). If empty, defaults to ["affected"].
+    #[serde(default)]
+    pub status: Vec<String>,
+}
+
+/// Lightweight correlation result for a single SBOM.
+#[derive(Debug, Clone, Serialize, serde::Deserialize, ToSchema)]
+pub struct CorrelationResult {
+    /// Total number of matches.
+    pub total_matches: usize,
+    /// Distinct advisories matched.
+    pub advisory_count: usize,
+    /// Distinct vulnerabilities matched.
+    pub vulnerability_count: usize,
+    /// Matches grouped by status slug.
+    pub by_status: std::collections::HashMap<String, usize>,
+}
+
+/// Correlate an SBOM against advisory status assertions.
+///
+/// Uses the in-memory advisory index and the graph cache for matching.
+/// Returns a lightweight summary; full hydrated results will be available
+/// at the existing `/v3/sbom/{id}/advisory` endpoint once the correlation
+/// engine replaces the SQL path.
+#[utoipa::path(
+    tag = "correlation",
+    operation_id = "correlateSbom",
+    params(
+        ("id" = Uuid, Path, description = "SBOM identifier"),
+        CorrelateParams,
+    ),
+    responses(
+        (status = 200, description = "Correlation results", body = CorrelationResult),
+        (status = 404, description = "SBOM not found"),
+    ),
+)]
+#[get("/v3/correlation/sbom/{id}")]
+pub async fn correlate_sbom(
+    correlation: web::Data<CorrelationService>,
+    db: web::Data<db::ReadOnly>,
+    id: web::Path<Uuid>,
+    web::Query(params): web::Query<CorrelateParams>,
+) -> actix_web::Result<impl Responder> {
+    let status_filter: Vec<&str> = if params.status.is_empty() {
+        vec!["affected"]
+    } else {
+        params.status.iter().map(|s| s.as_str()).collect()
+    };
+
+    let tx = db.begin().await.map_err(actix_web::error::ErrorInternalServerError)?;
+    let matches = correlation
+        .correlate_sbom(*id, &status_filter, &tx)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let advisory_count = matches
+        .iter()
+        .map(|m| m.advisory_id)
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+    let vulnerability_count = matches
+        .iter()
+        .map(|m| &m.vulnerability_id)
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+
+    let mut by_status: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for m in &matches {
+        *by_status.entry(m.status_slug.clone()).or_default() += 1;
+    }
+
+    Ok(HttpResponse::Ok().json(CorrelationResult {
+        total_matches: matches.len(),
+        advisory_count,
+        vulnerability_count,
+        by_status,
+    }))
+}
+
+/// Correlate a vulnerability against all SBOMs.
+///
+/// Uses the in-memory advisory index to find candidate SBOMs, then
+/// verifies each candidate using the graph cache. Returns a lightweight
+/// summary with matched SBOM count.
+#[utoipa::path(
+    tag = "correlation",
+    operation_id = "correlateVulnerability",
+    params(
+        ("id" = String, Path, description = "Vulnerability identifier (e.g., CVE-2024-1234)"),
+        CorrelateParams,
+    ),
+    responses(
+        (status = 200, description = "Correlation results", body = VulnCorrelationResult),
+    ),
+)]
+#[get("/v3/correlation/vulnerability/{id}")]
+pub async fn correlate_vuln(
+    correlation: web::Data<CorrelationService>,
+    db: web::Data<db::ReadOnly>,
+    id: web::Path<String>,
+    web::Query(params): web::Query<CorrelateParams>,
+) -> actix_web::Result<impl Responder> {
+    let status_filter: Vec<&str> = if params.status.is_empty() {
+        vec!["affected", "fixed", "under_investigation", "recommended"]
+    } else {
+        params.status.iter().map(|s| s.as_str()).collect()
+    };
+
+    let tx = db.begin().await.map_err(actix_web::error::ErrorInternalServerError)?;
+    let matches = correlation
+        .correlate_vuln(&id, &status_filter, &tx)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let sbom_count = matches
+        .iter()
+        .map(|m| m.sbom_id)
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+    let advisory_count = matches
+        .iter()
+        .map(|m| m.advisory_id)
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+
+    let mut by_status: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for m in &matches {
+        *by_status.entry(m.status_slug.clone()).or_default() += 1;
+    }
+
+    Ok(HttpResponse::Ok().json(VulnCorrelationResult {
+        total_matches: matches.len(),
+        sbom_count,
+        advisory_count,
+        by_status,
+    }))
+}
+
+/// Lightweight vulnerability correlation result.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct VulnCorrelationResult {
+    /// Total number of matches across all SBOMs.
+    pub total_matches: usize,
+    /// Number of distinct SBOMs matched.
+    pub sbom_count: usize,
+    /// Number of distinct advisories matched.
+    pub advisory_count: usize,
+    /// Matches grouped by status slug.
+    pub by_status: std::collections::HashMap<String, usize>,
+}
+
+/// Hydrated advisory result for an SBOM.
+///
+/// Returns the same `Vec<SbomAdvisory>` format as
+/// `GET /v3/sbom/{id}/advisory`, enabling direct comparison between
+/// the SQL-based and correlation-based paths.
+#[utoipa::path(
+    tag = "correlation",
+    operation_id = "correlateSbomAdvisory",
+    params(
+        ("id" = Uuid, Path, description = "SBOM identifier"),
+        CorrelateParams,
+    ),
+    responses(
+        (status = 200, description = "Advisory matches (same format as /v3/sbom/{id}/advisory)"),
+        (status = 404, description = "SBOM not found"),
+    ),
+)]
+#[get("/v3/correlation/sbom/{id}/advisory")]
+pub async fn correlate_sbom_advisory(
+    correlation: web::Data<CorrelationService>,
+    db: web::Data<db::ReadOnly>,
+    id: web::Path<Uuid>,
+    web::Query(params): web::Query<CorrelateParams>,
+) -> actix_web::Result<impl Responder> {
+    let status_filter: Vec<&str> = if params.status.is_empty() {
+        vec!["affected"]
+    } else {
+        params.status.iter().map(|s| s.as_str()).collect()
+    };
+
+    let tx = db
+        .begin()
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let matches = correlation
+        .correlate_sbom(*id, &status_filter, &tx)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let hydrated = hydrate::hydrate_sbom_matches(&matches, &tx)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let advisories = hydrate::to_sbom_advisories(hydrated);
+
+    Ok(HttpResponse::Ok().json(advisories))
+}

--- a/modules/correlation/src/endpoints/test.rs
+++ b/modules/correlation/src/endpoints/test.rs
@@ -1,0 +1,157 @@
+use crate::service::CorrelationService;
+use actix_web::{App, test as actix_test, web};
+use test_context::test_context;
+use test_log::test;
+use trustify_common::db;
+use trustify_module_analysis::{config::AnalysisConfig, service::AnalysisService};
+use trustify_test_context::{TrustifyContext, app::TestApp};
+
+/// Build a correlation service for testing, pre-loaded with the advisory index.
+async fn test_correlation(ctx: &TrustifyContext) -> CorrelationService {
+    let analysis =
+        AnalysisService::new(AnalysisConfig::default(), db::ReadOnly::new(ctx.db.clone()));
+    let svc = CorrelationService::new(analysis);
+    let tx = db::ReadOnly::new(ctx.db.clone())
+        .begin()
+        .await
+        .expect("begin tx");
+    svc.load_index(&tx).await.expect("load advisory index");
+    svc
+}
+
+/// Ingest a document and return its ID (stripped of urn:uuid: prefix).
+async fn ingest_and_get_id(ctx: &TrustifyContext, path: &str) -> String {
+    let result = ctx.ingest_document(path).await.expect("ingest document");
+    result
+        .id
+        .strip_prefix("urn:uuid:")
+        .unwrap_or(&result.id)
+        .to_string()
+}
+
+/// Verify the correlation status endpoint works.
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn correlation_status_empty(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    let correlation = test_correlation(ctx).await;
+    let db_ro = db::ReadOnly::new(ctx.db.clone());
+
+    let app = actix_test::init_service(
+        App::new()
+            .add_test_authorizer()
+            .app_data(web::Data::new(db_ro))
+            .app_data(web::Data::new(correlation))
+            .service(super::correlation_status),
+    )
+    .await;
+
+    let req = actix_test::TestRequest::get()
+        .uri("/v3/correlation/status")
+        .to_request();
+
+    let resp = actix_test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: super::CorrelationStatus = actix_test::read_body_json(resp).await;
+    // Empty DB, no advisories loaded
+    assert_eq!(body.purl_entries, 0);
+    assert_eq!(body.cpe_entries, 0);
+    assert_eq!(body.vulnerability_count, 0);
+
+    Ok(())
+}
+
+/// Verify that correlating an SBOM with a matching advisory produces results.
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn correlate_sbom_with_advisory(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    // Ingest an SBOM and a matching advisory.
+    let sbom_id_str = ingest_and_get_id(ctx, "cyclonedx/application.cdx.json").await;
+    let _advisory_id = ingest_and_get_id(ctx, "csaf/cve-2023-0044.json").await;
+
+    // Reload the index after ingesting the advisory.
+    let correlation = test_correlation(ctx).await;
+    let db_ro = db::ReadOnly::new(ctx.db.clone());
+
+    let app = actix_test::init_service(
+        App::new()
+            .add_test_authorizer()
+            .app_data(web::Data::new(db_ro.clone()))
+            .app_data(web::Data::new(correlation.clone()))
+            .service(super::correlate_sbom)
+            .service(super::correlation_status),
+    )
+    .await;
+
+    // Check that the index loaded something
+    let req = actix_test::TestRequest::get()
+        .uri("/v3/correlation/status")
+        .to_request();
+    let resp = actix_test::call_service(&app, req).await;
+    let status: super::CorrelationStatus = actix_test::read_body_json(resp).await;
+    assert!(
+        status.purl_entries > 0 || status.product_entries > 0,
+        "advisory index should have entries after advisory ingest"
+    );
+
+    // Correlate the SBOM.
+    let req = actix_test::TestRequest::get()
+        .uri(&format!("/v3/correlation/sbom/{sbom_id_str}"))
+        .to_request();
+    let resp = actix_test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: super::CorrelationResult = actix_test::read_body_json(resp).await;
+    // We expect at least some matches if the advisory covers the SBOM's packages.
+    // The exact count depends on test fixtures, but this verifies the pipeline works.
+    tracing::info!(
+        total_matches = body.total_matches,
+        advisory_count = body.advisory_count,
+        vulnerability_count = body.vulnerability_count,
+        "correlation result"
+    );
+
+    Ok(())
+}
+
+/// Verify the hydrated advisory endpoint returns Vec<SbomAdvisory>.
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn correlate_sbom_advisory_hydrated(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    let sbom_id_str = ingest_and_get_id(ctx, "cyclonedx/application.cdx.json").await;
+    let _advisory_id = ingest_and_get_id(ctx, "csaf/cve-2023-0044.json").await;
+
+    let correlation = test_correlation(ctx).await;
+    let db_ro = db::ReadOnly::new(ctx.db.clone());
+
+    let app = actix_test::init_service(
+        App::new()
+            .add_test_authorizer()
+            .app_data(web::Data::new(db_ro))
+            .app_data(web::Data::new(correlation))
+            .service(super::correlate_sbom_advisory),
+    )
+    .await;
+
+    let req = actix_test::TestRequest::get()
+        .uri(&format!("/v3/correlation/sbom/{sbom_id_str}/advisory"))
+        .to_request();
+    let resp = actix_test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    // Parse as the same SbomAdvisory type the existing endpoint returns.
+    let body: Vec<trustify_module_fundamental::sbom::model::details::SbomAdvisory> =
+        actix_test::read_body_json(resp).await;
+    tracing::info!(advisory_count = body.len(), "hydrated advisory result");
+
+    // Verify structure: each advisory has statuses with vulnerabilities
+    for advisory in &body {
+        assert!(!advisory.head.identifier.is_empty());
+        for status in &advisory.status {
+            assert!(!status.vulnerability.identifier.is_empty());
+            assert!(!status.status.is_empty());
+        }
+    }
+
+    Ok(())
+}

--- a/modules/correlation/src/hydrate.rs
+++ b/modules/correlation/src/hydrate.rs
@@ -1,0 +1,503 @@
+/// Hydration layer: converts lightweight `CorrelationMatch` results into
+/// the full `SbomAdvisory` API response by batch-loading entity data
+/// from the database.
+///
+/// The hot path (identity + version matching) runs in memory. This module
+/// handles the cold path: loading advisory, vulnerability, score, CPE,
+/// PURL, and package metadata for the matched entities.
+use crate::service::CorrelationMatch;
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use tracing::{Instrument, info_span, instrument};
+
+use trustify_entity::{
+    advisory, advisory_vulnerability, advisory_vulnerability_score, cpe, organization,
+    qualified_purl, sbom_node, sbom_package, status, vulnerability,
+};
+use trustify_module_fundamental::{
+    advisory::model::AdvisoryHead,
+    purl::model::{details::purl::StatusContext, summary::purl::PurlSummary},
+    sbom::model::{SbomPackage, details::{SbomAdvisory, SbomStatus}},
+    vulnerability::model::VulnerabilityHead,
+};
+use uuid::Uuid;
+
+/// A fully hydrated advisory with its vulnerability statuses and
+/// matched packages, ready for API serialization.
+///
+/// This mirrors `SbomAdvisory` from the fundamental module but is
+/// constructed from correlation matches rather than SQL query results.
+#[derive(Debug, Clone)]
+pub struct HydratedAdvisory {
+    /// Advisory identity and metadata.
+    pub advisory: advisory::Model,
+    /// Optional issuing organization.
+    pub organization: Option<organization::Model>,
+    /// Vulnerability statuses within this advisory.
+    pub statuses: Vec<HydratedStatus>,
+}
+
+/// A vulnerability status within an advisory, with matched packages.
+#[derive(Debug, Clone)]
+pub struct HydratedStatus {
+    /// The advisory-vulnerability link.
+    pub advisory_vulnerability: advisory_vulnerability::Model,
+    /// The vulnerability entity.
+    pub vulnerability: vulnerability::Model,
+    /// The status slug (affected, fixed, etc.).
+    pub status_slug: String,
+    /// Optional context CPE.
+    pub context_cpe: Option<cpe::Model>,
+    /// CVSS scores for this advisory-vulnerability pair.
+    pub scores: Vec<advisory_vulnerability_score::Model>,
+    /// Matched SBOM packages.
+    pub packages: Vec<HydratedPackage>,
+}
+
+/// A matched SBOM package with its PURL and node metadata.
+#[derive(Debug, Clone)]
+pub struct HydratedPackage {
+    /// SBOM package metadata (version, etc.).
+    pub sbom_package: sbom_package::Model,
+    /// SBOM node metadata (name, etc.).
+    pub sbom_node: sbom_node::Model,
+    /// Qualified PURLs for this package.
+    pub purls: Vec<qualified_purl::Model>,
+}
+
+/// Hydrate a set of correlation matches into structured advisory data.
+///
+/// Extracts unique entity IDs, batch-fetches from the database, and
+/// assembles into the grouped advisory → status → package hierarchy.
+#[instrument(skip_all, err(level = tracing::Level::INFO))]
+pub async fn hydrate_sbom_matches<C: ConnectionTrait>(
+    matches: &[CorrelationMatch],
+    connection: &C,
+) -> Result<Vec<HydratedAdvisory>, anyhow::Error> {
+    if matches.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Collect unique entity IDs.
+    let mut advisory_ids = BTreeSet::new();
+    let mut vulnerability_ids = BTreeSet::new();
+    let mut status_ids = BTreeSet::new();
+    let mut sbom_node_keys: BTreeSet<(Uuid, String)> = BTreeSet::new();
+
+    for m in matches {
+        advisory_ids.insert(m.advisory_id);
+        vulnerability_ids.insert(m.vulnerability_id.clone());
+        status_ids.insert(m.status_id);
+        sbom_node_keys.insert((m.sbom_id, m.node_id.clone()));
+    }
+
+    // Batch-fetch all entities in parallel.
+    let (advisories, vulns, av_models, _statuses, sbom_packages, sbom_nodes, scores, orgs) =
+        tokio::try_join!(
+            fetch_advisories(&advisory_ids, connection),
+            fetch_vulnerabilities(&vulnerability_ids, connection),
+            fetch_advisory_vulnerabilities(&advisory_ids, &vulnerability_ids, connection),
+            fetch_statuses(&status_ids, connection),
+            fetch_sbom_packages(&sbom_node_keys, connection),
+            fetch_sbom_nodes(&sbom_node_keys, connection),
+            fetch_scores(&advisory_ids, &vulnerability_ids, connection),
+            fetch_organizations(&advisory_ids, connection),
+        )?;
+
+    // Fetch qualified PURLs for matched nodes.
+    let purls = fetch_purls_for_nodes(&sbom_node_keys, connection).await?;
+
+    // Assemble into the grouped hierarchy.
+    let mut advisory_map: BTreeMap<Uuid, HydratedAdvisory> = BTreeMap::new();
+
+    for m in matches {
+        let advisory = match advisories.get(&m.advisory_id) {
+            Some(a) => a,
+            None => continue,
+        };
+
+        let hydrated = advisory_map.entry(m.advisory_id).or_insert_with(|| {
+            let org = advisory
+                .issuer_id
+                .and_then(|oid| orgs.get(&oid).cloned());
+            HydratedAdvisory {
+                advisory: advisory.clone(),
+                organization: org,
+                statuses: Vec::new(),
+            }
+        });
+
+        // Find or create the status entry.
+        let status_idx = hydrated
+            .statuses
+            .iter()
+            .position(|s| {
+                s.advisory_vulnerability.vulnerability_id == m.vulnerability_id
+                    && s.status_slug == m.status_slug
+            });
+
+        let status_entry = if let Some(idx) = status_idx {
+            &mut hydrated.statuses[idx]
+        } else {
+            let av_key = (m.advisory_id, m.vulnerability_id.clone());
+            let av = match av_models.get(&av_key) {
+                Some(av) => av.clone(),
+                None => continue, // Skip if we can't find the advisory-vulnerability link
+            };
+
+            let vuln = match vulns.get(&m.vulnerability_id) {
+                Some(v) => v.clone(),
+                None => continue, // Skip if we can't find the vulnerability
+            };
+
+            let score_key = (m.advisory_id, m.vulnerability_id.clone());
+            let match_scores = scores
+                .get(&score_key)
+                .cloned()
+                .unwrap_or_default();
+
+            hydrated.statuses.push(HydratedStatus {
+                advisory_vulnerability: av,
+                vulnerability: vuln,
+                status_slug: m.status_slug.clone(),
+                context_cpe: None,
+                scores: match_scores,
+                packages: Vec::new(),
+            });
+            let Some(entry) = hydrated.statuses.last_mut() else {
+                continue;
+            };
+            entry
+        };
+
+        // Add the matched package.
+        let node_key = (m.sbom_id, m.node_id.clone());
+        let pkg = sbom_packages.get(&node_key);
+        let node = sbom_nodes.get(&node_key);
+
+        if let (Some(pkg), Some(node)) = (pkg, node) {
+            // Avoid duplicate packages in the same status entry.
+            let already_present = status_entry.packages.iter().any(|p| {
+                p.sbom_package.sbom_id == pkg.sbom_id
+                    && p.sbom_package.node_id == pkg.node_id
+            });
+
+            if !already_present {
+                let node_purls = purls
+                    .get(&node_key)
+                    .cloned()
+                    .unwrap_or_default();
+
+                status_entry.packages.push(HydratedPackage {
+                    sbom_package: pkg.clone(),
+                    sbom_node: node.clone(),
+                    purls: node_purls,
+                });
+            }
+        }
+    }
+
+    Ok(advisory_map.into_values().collect())
+}
+
+async fn fetch_advisories<C: ConnectionTrait>(
+    ids: &BTreeSet<Uuid>,
+    connection: &C,
+) -> Result<BTreeMap<Uuid, advisory::Model>, anyhow::Error> {
+    let rows = advisory::Entity::find()
+        .filter(advisory::Column::Id.is_in(ids.iter().copied()))
+        .all(connection)
+        .instrument(info_span!("fetch advisories"))
+        .await?;
+    Ok(rows.into_iter().map(|r| (r.id, r)).collect())
+}
+
+async fn fetch_advisory_vulnerabilities<C: ConnectionTrait>(
+    advisory_ids: &BTreeSet<Uuid>,
+    vulnerability_ids: &BTreeSet<String>,
+    connection: &C,
+) -> Result<BTreeMap<(Uuid, String), advisory_vulnerability::Model>, anyhow::Error> {
+    let rows = advisory_vulnerability::Entity::find()
+        .filter(
+            advisory_vulnerability::Column::AdvisoryId.is_in(advisory_ids.iter().copied()),
+        )
+        .filter(
+            advisory_vulnerability::Column::VulnerabilityId
+                .is_in(vulnerability_ids.iter().cloned()),
+        )
+        .all(connection)
+        .instrument(info_span!("fetch advisory vulnerabilities"))
+        .await?;
+    Ok(rows
+        .into_iter()
+        .map(|r| ((r.advisory_id, r.vulnerability_id.clone()), r))
+        .collect())
+}
+
+async fn fetch_vulnerabilities<C: ConnectionTrait>(
+    ids: &BTreeSet<String>,
+    connection: &C,
+) -> Result<BTreeMap<String, vulnerability::Model>, anyhow::Error> {
+    let rows = vulnerability::Entity::find()
+        .filter(vulnerability::Column::Id.is_in(ids.iter().cloned()))
+        .all(connection)
+        .instrument(info_span!("fetch vulnerabilities"))
+        .await?;
+    Ok(rows.into_iter().map(|r| (r.id.clone(), r)).collect())
+}
+
+async fn fetch_statuses<C: ConnectionTrait>(
+    ids: &BTreeSet<Uuid>,
+    connection: &C,
+) -> Result<BTreeMap<Uuid, status::Model>, anyhow::Error> {
+    let rows = status::Entity::find()
+        .filter(status::Column::Id.is_in(ids.iter().copied()))
+        .all(connection)
+        .instrument(info_span!("fetch statuses"))
+        .await?;
+    Ok(rows.into_iter().map(|r| (r.id, r)).collect())
+}
+
+async fn fetch_sbom_packages<C: ConnectionTrait>(
+    keys: &BTreeSet<(Uuid, String)>,
+    connection: &C,
+) -> Result<BTreeMap<(Uuid, String), sbom_package::Model>, anyhow::Error> {
+    if keys.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    // Query by sbom_id IN (...) and filter in memory by node_id.
+    let sbom_ids: BTreeSet<Uuid> = keys.iter().map(|(s, _)| *s).collect();
+    let rows = sbom_package::Entity::find()
+        .filter(sbom_package::Column::SbomId.is_in(sbom_ids.iter().copied()))
+        .all(connection)
+        .instrument(info_span!("fetch sbom packages"))
+        .await?;
+    let mut map = BTreeMap::new();
+    for r in rows {
+        let key = (r.sbom_id, r.node_id.clone());
+        if keys.contains(&key) {
+            map.insert(key, r);
+        }
+    }
+    Ok(map)
+}
+
+async fn fetch_sbom_nodes<C: ConnectionTrait>(
+    keys: &BTreeSet<(Uuid, String)>,
+    connection: &C,
+) -> Result<BTreeMap<(Uuid, String), sbom_node::Model>, anyhow::Error> {
+    if keys.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let sbom_ids: BTreeSet<Uuid> = keys.iter().map(|(s, _)| *s).collect();
+    let rows = sbom_node::Entity::find()
+        .filter(sbom_node::Column::SbomId.is_in(sbom_ids.iter().copied()))
+        .all(connection)
+        .instrument(info_span!("fetch sbom nodes"))
+        .await?;
+    let mut map = BTreeMap::new();
+    for r in rows {
+        let key = (r.sbom_id, r.node_id.clone());
+        if keys.contains(&key) {
+            map.insert(key, r);
+        }
+    }
+    Ok(map)
+}
+
+async fn fetch_scores<C: ConnectionTrait>(
+    advisory_ids: &BTreeSet<Uuid>,
+    vulnerability_ids: &BTreeSet<String>,
+    connection: &C,
+) -> Result<HashMap<(Uuid, String), Vec<advisory_vulnerability_score::Model>>, anyhow::Error> {
+    let rows = advisory_vulnerability_score::Entity::find()
+        .filter(
+            advisory_vulnerability_score::Column::AdvisoryId
+                .is_in(advisory_ids.iter().copied()),
+        )
+        .filter(
+            advisory_vulnerability_score::Column::VulnerabilityId
+                .is_in(vulnerability_ids.iter().cloned()),
+        )
+        .all(connection)
+        .instrument(info_span!("fetch scores"))
+        .await?;
+    let mut map: HashMap<(Uuid, String), Vec<_>> = HashMap::new();
+    for r in rows {
+        map.entry((r.advisory_id, r.vulnerability_id.clone()))
+            .or_default()
+            .push(r);
+    }
+    Ok(map)
+}
+
+async fn fetch_organizations<C: ConnectionTrait>(
+    advisory_ids: &BTreeSet<Uuid>,
+    connection: &C,
+) -> Result<BTreeMap<Uuid, organization::Model>, anyhow::Error> {
+    // First get issuer_ids from advisories, then fetch orgs.
+    let advisories = advisory::Entity::find()
+        .filter(advisory::Column::Id.is_in(advisory_ids.iter().copied()))
+        .all(connection)
+        .instrument(info_span!("fetch advisory issuers"))
+        .await?;
+    let org_ids: BTreeSet<Uuid> = advisories
+        .iter()
+        .filter_map(|a| a.issuer_id)
+        .collect();
+    if org_ids.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let rows = organization::Entity::find()
+        .filter(organization::Column::Id.is_in(org_ids.iter().copied()))
+        .all(connection)
+        .instrument(info_span!("fetch organizations"))
+        .await?;
+    Ok(rows.into_iter().map(|r| (r.id, r)).collect())
+}
+
+async fn fetch_purls_for_nodes<C: ConnectionTrait>(
+    keys: &BTreeSet<(Uuid, String)>,
+    connection: &C,
+) -> Result<BTreeMap<(Uuid, String), Vec<qualified_purl::Model>>, anyhow::Error> {
+    use sea_orm::{FromQueryResult, Statement};
+
+    if keys.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let sbom_ids: Vec<Uuid> = keys.iter().map(|(s, _)| *s).collect();
+
+    #[derive(Debug, FromQueryResult)]
+    struct PurlRow {
+        sbom_id: Uuid,
+        node_id: String,
+        purl_id: Uuid,
+    }
+
+    let rows: Vec<PurlRow> = PurlRow::find_by_statement(
+        Statement::from_sql_and_values(
+            sea_orm::DatabaseBackend::Postgres,
+            r#"
+            SELECT snpr.sbom_id, snpr.node_id, snpr.qualified_purl_id AS purl_id
+            FROM sbom_node_purl_ref snpr
+            WHERE snpr.sbom_id = ANY($1)
+            "#,
+            [sbom_ids.into()],
+        ),
+    )
+    .all(connection)
+    .instrument(info_span!("fetch purl refs"))
+    .await?;
+
+    // Filter to only requested nodes and collect purl IDs.
+    let mut node_to_purl_ids: BTreeMap<(Uuid, String), Vec<Uuid>> = BTreeMap::new();
+    let mut all_purl_ids = BTreeSet::new();
+    for r in &rows {
+        let key = (r.sbom_id, r.node_id.clone());
+        if keys.contains(&key) {
+            node_to_purl_ids.entry(key).or_default().push(r.purl_id);
+            all_purl_ids.insert(r.purl_id);
+        }
+    }
+
+    // Fetch qualified_purl models.
+    let purl_models = qualified_purl::Entity::find()
+        .filter(qualified_purl::Column::Id.is_in(all_purl_ids.iter().copied()))
+        .all(connection)
+        .instrument(info_span!("fetch qualified purls"))
+        .await?;
+    let purl_map: BTreeMap<Uuid, qualified_purl::Model> =
+        purl_models.into_iter().map(|p| (p.id, p)).collect();
+
+    // Assemble per-node PURL lists.
+    let mut result = BTreeMap::new();
+    for (key, purl_ids) in node_to_purl_ids {
+        let purls: Vec<qualified_purl::Model> = purl_ids
+            .iter()
+            .filter_map(|id| purl_map.get(id).cloned())
+            .collect();
+        result.insert(key, purls);
+    }
+
+    Ok(result)
+}
+
+/// Convert hydrated advisory data into the existing `SbomAdvisory` API
+/// response format.
+///
+/// This enables the correlation engine to produce the same response type
+/// as the SQL-based `GET /v3/sbom/{id}/advisory` endpoint, making it a
+/// drop-in replacement.
+#[allow(deprecated)]
+pub fn to_sbom_advisories(hydrated: Vec<HydratedAdvisory>) -> Vec<SbomAdvisory> {
+    hydrated
+        .into_iter()
+        .map(|ha| {
+            let issuer = ha.organization.as_ref().map(|org| {
+                trustify_module_fundamental::organization::model::OrganizationSummary::from_entity(
+                    org,
+                )
+            });
+
+            let head = AdvisoryHead {
+                uuid: ha.advisory.id,
+                identifier: ha.advisory.identifier.clone(),
+                document_id: ha.advisory.document_id.clone(),
+                issuer,
+                published: ha.advisory.published,
+                modified: ha.advisory.modified,
+                withdrawn: ha.advisory.withdrawn,
+                title: ha.advisory.title.clone(),
+                labels: ha.advisory.labels.clone(),
+            };
+
+            let status = ha
+                .statuses
+                .into_iter()
+                .map(|hs| {
+                    let vuln_head = VulnerabilityHead::from_advisory_vulnerability_entity(
+                        &hs.advisory_vulnerability,
+                        &hs.vulnerability,
+                    );
+
+                    let context = hs.context_cpe.as_ref().and_then(|cpe_model| {
+                        let uri: Result<::cpe::uri::OwnedUri, _> = cpe_model.try_into();
+                        uri.ok().map(|u| StatusContext::Cpe(u.to_string()))
+                    });
+
+                    let scores = hs
+                        .scores
+                        .into_iter()
+                        .map(trustify_module_fundamental::common::model::ScoredVector::from)
+                        .collect();
+
+                    let packages = hs
+                        .packages
+                        .into_iter()
+                        .map(|hp| SbomPackage {
+                            id: hp.sbom_package.node_id.clone(),
+                            name: hp.sbom_node.name.clone(),
+                            group: hp.sbom_package.group.clone(),
+                            version: hp.sbom_package.version.clone(),
+                            purl: PurlSummary::from_entities(&hp.purls),
+                            cpe: vec![],
+                            licenses: vec![],
+                            licenses_ref_mapping: vec![],
+                        })
+                        .collect();
+
+                    SbomStatus {
+                        vulnerability: vuln_head,
+                        status: hs.status_slug,
+                        context,
+                        packages,
+                        scores,
+                    }
+                })
+                .collect();
+
+            SbomAdvisory { head, status }
+        })
+        .collect()
+}

--- a/modules/correlation/src/lib.rs
+++ b/modules/correlation/src/lib.rs
@@ -1,0 +1,6 @@
+#![recursion_limit = "512"]
+
+pub mod advisory_index;
+pub mod endpoints;
+pub mod hydrate;
+pub mod service;

--- a/modules/correlation/src/service.rs
+++ b/modules/correlation/src/service.rs
@@ -1,0 +1,560 @@
+/// Correlation service: matches SBOM packages against advisory status
+/// assertions using the in-memory advisory index and the existing
+/// graph cache for SBOM data.
+use crate::advisory_index::{AdvisoryIndex, BasePurlKey, CpeKey, ContextCpe, StatusEntry};
+use arc_swap::ArcSwap;
+use petgraph::visit::EdgeRef;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tracing::{info, instrument};
+use trustify_common::version;
+use trustify_module_analysis::model::graph;
+use trustify_module_analysis::service::AnalysisService;
+use uuid::Uuid;
+
+/// A single correlation match: a package in an SBOM matched an advisory
+/// status assertion via a specific matching strategy.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CorrelationMatch {
+    /// The SBOM that contains the matched package.
+    pub sbom_id: Uuid,
+    /// The node ID of the matched package within the SBOM.
+    pub node_id: String,
+    /// The advisory that asserted this status.
+    pub advisory_id: Uuid,
+    /// The vulnerability identifier.
+    pub vulnerability_id: String,
+    /// The status assertion ID.
+    pub status_id: Uuid,
+    /// The status slug (affected, fixed, not_affected, etc.).
+    pub status_slug: String,
+    /// Which matching strategy produced this match.
+    pub match_kind: MatchKind,
+}
+
+/// How a match was established.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MatchKind {
+    /// Matched via PURL identity + version range.
+    Purl,
+    /// Matched via CPE identity (vendor/product) + version range.
+    Cpe,
+    /// Matched via product name + version range.
+    ProductName,
+}
+
+/// Generalized describing CPE for context scoping.
+///
+/// Extracted from the SBOM's root node and expanded to
+/// `(vendor, product, major_version)` triples.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DescribingCpe {
+    vendor: String,
+    product: String,
+    major_version: String,
+}
+
+/// The correlation service orchestrates in-memory matching.
+#[derive(Clone)]
+pub struct CorrelationService {
+    /// The advisory index, atomically swappable for live reloads.
+    index: Arc<ArcSwap<AdvisoryIndex>>,
+    /// The existing graph cache for SBOM package data.
+    analysis: AnalysisService,
+}
+
+impl CorrelationService {
+    /// Create a new correlation service with an empty index.
+    ///
+    /// Call [`load_index`] to populate from the database.
+    pub fn new(analysis: AnalysisService) -> Self {
+        Self {
+            index: Arc::new(ArcSwap::from_pointee(AdvisoryIndex::empty())),
+            analysis,
+        }
+    }
+
+    /// Get a snapshot of the current advisory index.
+    pub fn index(&self) -> arc_swap::Guard<Arc<AdvisoryIndex>> {
+        self.index.load()
+    }
+
+    /// Load (or reload) the advisory index from the database.
+    #[instrument(skip_all, err(level = tracing::Level::INFO))]
+    pub async fn load_index<C: sea_orm::ConnectionTrait>(
+        &self,
+        connection: &C,
+    ) -> Result<(), anyhow::Error> {
+        let index = AdvisoryIndex::load(connection).await?;
+        self.index.store(Arc::new(index));
+        info!("advisory index reloaded");
+        Ok(())
+    }
+
+    /// Direction A: given an SBOM, find all matching advisory status assertions.
+    ///
+    /// Loads the SBOM's graph from the cache, iterates its packages, and
+    /// matches each against the advisory index using PURL identity, CPE
+    /// identity, and product name strategies. Applies context CPE scoping.
+    #[instrument(skip(self, connection), err(level = tracing::Level::INFO))]
+    pub async fn correlate_sbom<C: sea_orm::ConnectionTrait>(
+        &self,
+        sbom_id: Uuid,
+        status_filter: &[&str],
+        connection: &C,
+    ) -> Result<Vec<CorrelationMatch>, anyhow::Error> {
+        // Load the SBOM graph from the analysis cache.
+        let graph = self
+            .analysis
+            .load_graph(connection, sbom_id)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to load SBOM graph {sbom_id}: {e}"))?;
+
+        let index = self.index.load();
+
+        // Extract describing CPEs from the graph's root node for context scoping.
+        let describing_cpes = extract_describing_cpes(&graph);
+
+        let mut matches = Vec::new();
+        let mut seen = HashSet::new();
+
+        // Iterate all package nodes in the graph.
+        for node_idx in graph.node_indices() {
+            let node = &graph[node_idx];
+            let graph::Node::Package(pkg) = node else {
+                continue;
+            };
+
+            let version = &pkg.version;
+            let name = &pkg.name;
+
+            // Strategy 1: PURL identity + version range
+            for purl in pkg.purl.iter() {
+                let key = BasePurlKey {
+                    ty: purl.ty.clone(),
+                    namespace: purl.namespace.clone(),
+                    name: purl.name.clone(),
+                };
+
+                if let Some(entries) = index.by_purl.get(&key) {
+                    collect_matches(
+                        entries,
+                        version,
+                        &describing_cpes,
+                        status_filter,
+                        sbom_id,
+                        &pkg.base.node_id,
+                        MatchKind::Purl,
+                        &mut matches,
+                        &mut seen,
+                    );
+                }
+            }
+
+            // Strategy 2: CPE identity + version range
+            for cpe in pkg.cpe.iter() {
+                let key = CpeKey {
+                    vendor: cpe.vendor().to_string(),
+                    product: cpe.product().to_string(),
+                };
+
+                if let Some(entries) = index.by_cpe.get(&key) {
+                    // For CPE matches, use the CPE's version if not wildcard,
+                    // otherwise fall back to the package version.
+                    let cpe_version = cpe.version().to_string();
+                    let effective_version = if cpe_version == "*" || cpe_version.is_empty() {
+                        version.as_str()
+                    } else {
+                        &cpe_version
+                    };
+
+                    collect_matches_no_context(
+                        entries,
+                        effective_version,
+                        status_filter,
+                        sbom_id,
+                        &pkg.base.node_id,
+                        MatchKind::Cpe,
+                        &mut matches,
+                        &mut seen,
+                    );
+                }
+            }
+
+            // Strategy 3: Product name matching
+            // Try both bare name and namespace/name forms.
+            let name_keys: Vec<String> = {
+                let mut keys = vec![name.clone()];
+                // Also try namespace/name for each PURL
+                for purl in pkg.purl.iter() {
+                    if let Some(ref ns) = purl.namespace {
+                        keys.push(format!("{ns}/{}", purl.name));
+                    }
+                }
+                keys
+            };
+
+            for name_key in &name_keys {
+                if let Some(entries) = index.by_product_name.get(name_key) {
+                    collect_matches(
+                        entries,
+                        version,
+                        &describing_cpes,
+                        status_filter,
+                        sbom_id,
+                        &pkg.base.node_id,
+                        MatchKind::ProductName,
+                        &mut matches,
+                        &mut seen,
+                    );
+                }
+            }
+        }
+
+        Ok(matches)
+    }
+
+    /// Direction B: given a vulnerability ID, find all SBOMs that match.
+    ///
+    /// Looks up the advisory index for all status entries mentioning the
+    /// vulnerability, queries the DB for candidate SBOMs, then verifies
+    /// each candidate against the graph cache using the same matching
+    /// logic as Direction A.
+    #[instrument(skip(self, connection), err(level = tracing::Level::INFO))]
+    pub async fn correlate_vuln<C: sea_orm::ConnectionTrait>(
+        &self,
+        vulnerability_id: &str,
+        status_filter: &[&str],
+        connection: &C,
+    ) -> Result<Vec<CorrelationMatch>, anyhow::Error> {
+        use sea_orm::{FromQueryResult, Statement};
+
+        let index = self.index.load();
+
+        let vuln_entries = match index.by_vuln.get(vulnerability_id) {
+            Some(entries) => entries,
+            None => return Ok(Vec::new()),
+        };
+
+        // Collect all unique purl keys, cpe keys, and product names
+        // from the vulnerability's status entries to find candidate SBOMs.
+        let mut purl_keys: Vec<&BasePurlKey> = Vec::new();
+        let mut cpe_keys: Vec<&CpeKey> = Vec::new();
+        let mut product_names: Vec<&str> = Vec::new();
+
+        for entry in vuln_entries {
+            if !status_filter.is_empty() && !status_filter.contains(&entry.status_slug.as_str()) {
+                continue;
+            }
+            match &entry.match_source {
+                crate::advisory_index::MatchSource::Purl(key) => purl_keys.push(key),
+                crate::advisory_index::MatchSource::Cpe(key) => cpe_keys.push(key),
+                crate::advisory_index::MatchSource::ProductName(name) => {
+                    product_names.push(name.as_str())
+                }
+            }
+        }
+
+        // Query candidate SBOM IDs from the database.
+        // This is a set of indexed lookups, not the full multi-join.
+        let mut candidate_sbom_ids: HashSet<Uuid> = HashSet::new();
+
+        // Find SBOMs containing matching PURLs.
+        if !purl_keys.is_empty() {
+            let types: Vec<String> = purl_keys.iter().map(|k| k.ty.clone()).collect();
+            let names: Vec<String> = purl_keys.iter().map(|k| k.name.clone()).collect();
+
+            #[derive(Debug, FromQueryResult)]
+            struct SbomId {
+                sbom_id: Uuid,
+            }
+
+            let rows: Vec<SbomId> = SbomId::find_by_statement(
+                Statement::from_sql_and_values(
+                    sea_orm::DatabaseBackend::Postgres,
+                    r#"
+                    SELECT DISTINCT snpr.sbom_id
+                    FROM sbom_node_purl_ref snpr
+                    JOIN qualified_purl qp ON snpr.qualified_purl_id = qp.id
+                    JOIN versioned_purl vp ON qp.versioned_purl_id = vp.id
+                    JOIN base_purl bp ON vp.base_purl_id = bp.id
+                    WHERE bp.type = ANY($1) AND bp.name = ANY($2)
+                    "#,
+                    [types.into(), names.into()],
+                ),
+            )
+            .all(connection)
+            .await?;
+
+            for row in rows {
+                candidate_sbom_ids.insert(row.sbom_id);
+            }
+        }
+
+        // Find SBOMs containing matching CPEs.
+        if !cpe_keys.is_empty() {
+            let vendors: Vec<String> = cpe_keys.iter().map(|k| k.vendor.clone()).collect();
+            let products: Vec<String> = cpe_keys.iter().map(|k| k.product.clone()).collect();
+
+            #[derive(Debug, FromQueryResult)]
+            struct SbomId {
+                sbom_id: Uuid,
+            }
+
+            let rows: Vec<SbomId> = SbomId::find_by_statement(
+                Statement::from_sql_and_values(
+                    sea_orm::DatabaseBackend::Postgres,
+                    r#"
+                    SELECT DISTINCT sncr.sbom_id
+                    FROM sbom_node_cpe_ref sncr
+                    JOIN cpe c ON sncr.cpe_id = c.id
+                    WHERE c.vendor = ANY($1) AND c.product = ANY($2) AND c.part = 'a'
+                    "#,
+                    [vendors.into(), products.into()],
+                ),
+            )
+            .all(connection)
+            .await?;
+
+            for row in rows {
+                candidate_sbom_ids.insert(row.sbom_id);
+            }
+        }
+
+        // Find SBOMs containing matching product names.
+        if !product_names.is_empty() {
+            let names: Vec<String> = product_names.iter().map(|s| s.to_string()).collect();
+
+            #[derive(Debug, FromQueryResult)]
+            struct SbomId {
+                sbom_id: Uuid,
+            }
+
+            let rows: Vec<SbomId> = SbomId::find_by_statement(
+                Statement::from_sql_and_values(
+                    sea_orm::DatabaseBackend::Postgres,
+                    r#"
+                    SELECT DISTINCT sp.sbom_id
+                    FROM sbom_package sp
+                    JOIN sbom_node sn ON sp.sbom_id = sn.sbom_id AND sp.node_id = sn.node_id
+                    WHERE sn.name = ANY($1)
+                    "#,
+                    [names.into()],
+                ),
+            )
+            .all(connection)
+            .await?;
+
+            for row in rows {
+                candidate_sbom_ids.insert(row.sbom_id);
+            }
+        }
+
+        // For each candidate SBOM, run the same matching logic as Direction A.
+        let mut all_matches = Vec::new();
+        for sbom_id in candidate_sbom_ids {
+            match self
+                .correlate_sbom(sbom_id, status_filter, connection)
+                .await
+            {
+                Ok(mut sbom_matches) => {
+                    // Filter to only matches for this vulnerability.
+                    sbom_matches.retain(|m| m.vulnerability_id == vulnerability_id);
+                    all_matches.append(&mut sbom_matches);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        sbom_id = %sbom_id,
+                        error = %e,
+                        "failed to correlate candidate SBOM, skipping"
+                    );
+                }
+            }
+        }
+
+        Ok(all_matches)
+    }
+}
+
+/// Extract describing CPEs from the SBOM graph's root node.
+///
+/// The root node is identified by DESCRIBES relationships. Its CPEs
+/// are generalized to `(vendor, product, major_version)` triples.
+fn extract_describing_cpes(
+    graph: &trustify_module_analysis::model::PackageGraph,
+) -> Vec<DescribingCpe> {
+    use trustify_entity::relationship::Relationship;
+
+    let mut cpes = Vec::new();
+
+    for edge in graph.edge_references() {
+        if *edge.weight() != Relationship::Describes {
+            continue;
+        }
+        let source_node = &graph[edge.source()];
+        if let graph::Node::Package(pkg) = source_node {
+            for cpe in pkg.cpe.iter() {
+                let version_str = cpe.version().to_string();
+                let major = version_str
+                    .split('.')
+                    .next()
+                    .unwrap_or(&version_str)
+                    .to_string();
+                cpes.push(DescribingCpe {
+                    vendor: cpe.vendor().to_string(),
+                    product: cpe.product().to_string(),
+                    major_version: major,
+                });
+            }
+        }
+
+        // Also check the target node (the described package may have CPEs)
+        let target_node = &graph[edge.target()];
+        if let graph::Node::Package(pkg) = target_node {
+            for cpe in pkg.cpe.iter() {
+                let version_str = cpe.version().to_string();
+                let major = version_str
+                    .split('.')
+                    .next()
+                    .unwrap_or(&version_str)
+                    .to_string();
+                cpes.push(DescribingCpe {
+                    vendor: cpe.vendor().to_string(),
+                    product: cpe.product().to_string(),
+                    major_version: major,
+                });
+            }
+        }
+    }
+
+    cpes
+}
+
+/// Check if a status entry's context CPE matches the SBOM's describing CPEs.
+///
+/// Implements the unified scoping rule from ADR 00021:
+/// - NULL context → universal (always matches)
+/// - Matches if vendor/product/major_version align with any describing CPE
+/// - SBOM with no describing CPEs → matches everything (unscoped)
+fn context_cpe_matches(
+    context: &Option<ContextCpe>,
+    describing: &[DescribingCpe],
+) -> bool {
+    let Some(ctx) = context else {
+        // NULL context = universally applicable
+        return true;
+    };
+
+    if describing.is_empty() {
+        // Unscoped SBOM = matches everything
+        return true;
+    }
+
+    let ctx_major = ctx
+        .version
+        .split('.')
+        .next()
+        .unwrap_or(&ctx.version);
+
+    describing.iter().any(|d| {
+        d.vendor == ctx.vendor && d.product == ctx.product && d.major_version == ctx_major
+    })
+}
+
+/// Collect matches from status entries, applying version matching,
+/// context CPE scoping, and status filtering.
+#[allow(clippy::too_many_arguments)]
+fn collect_matches(
+    entries: &[StatusEntry],
+    version: &str,
+    describing_cpes: &[DescribingCpe],
+    status_filter: &[&str],
+    sbom_id: Uuid,
+    node_id: &str,
+    match_kind: MatchKind,
+    matches: &mut Vec<CorrelationMatch>,
+    seen: &mut HashSet<(Uuid, String, Uuid, String)>,
+) {
+    for entry in entries {
+        // Status filter
+        if !status_filter.is_empty() && !status_filter.contains(&entry.status_slug.as_str()) {
+            continue;
+        }
+
+        // Context CPE scoping
+        if !context_cpe_matches(&entry.context_cpe, describing_cpes) {
+            continue;
+        }
+
+        // Version matching
+        if !version::version_matches(version, &entry.version_range) {
+            continue;
+        }
+
+        // Dedup key: (advisory_id, vulnerability_id, status_id, node_id)
+        let dedup_key = (
+            entry.advisory_id,
+            entry.vulnerability_id.clone(),
+            entry.status_id,
+            node_id.to_string(),
+        );
+        if !seen.insert(dedup_key) {
+            continue;
+        }
+
+        matches.push(CorrelationMatch {
+            sbom_id,
+            node_id: node_id.to_string(),
+            advisory_id: entry.advisory_id,
+            vulnerability_id: entry.vulnerability_id.clone(),
+            status_id: entry.status_id,
+            status_slug: entry.status_slug.clone(),
+            match_kind: match_kind.clone(),
+        });
+    }
+}
+
+/// Collect matches without context CPE scoping (used for CPE identity
+/// matches, where context scoping is deliberately omitted — see L5 in
+/// ADR 00020).
+#[allow(clippy::too_many_arguments)]
+fn collect_matches_no_context(
+    entries: &[StatusEntry],
+    version: &str,
+    status_filter: &[&str],
+    sbom_id: Uuid,
+    node_id: &str,
+    match_kind: MatchKind,
+    matches: &mut Vec<CorrelationMatch>,
+    seen: &mut HashSet<(Uuid, String, Uuid, String)>,
+) {
+    for entry in entries {
+        if !status_filter.is_empty() && !status_filter.contains(&entry.status_slug.as_str()) {
+            continue;
+        }
+
+        if !version::version_matches(version, &entry.version_range) {
+            continue;
+        }
+
+        let dedup_key = (
+            entry.advisory_id,
+            entry.vulnerability_id.clone(),
+            entry.status_id,
+            node_id.to_string(),
+        );
+        if !seen.insert(dedup_key) {
+            continue;
+        }
+
+        matches.push(CorrelationMatch {
+            sbom_id,
+            node_id: node_id.to_string(),
+            advisory_id: entry.advisory_id,
+            vulnerability_id: entry.vulnerability_id.clone(),
+            status_id: entry.status_id,
+            status_slug: entry.status_slug.clone(),
+            match_kind: match_kind.clone(),
+        });
+    }
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,6 +12,7 @@ trustify-common = { workspace = true }
 trustify-db = { workspace = true }
 trustify-infrastructure = { workspace = true }
 trustify-module-analysis = { workspace = true }
+trustify-module-correlation = { workspace = true }
 trustify-module-fundamental = { workspace = true }
 trustify-module-importer = { workspace = true }
 trustify-module-ingestor = { workspace = true }

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -25,6 +25,7 @@ pub async fn create_openapi() -> anyhow::Result<utoipa::openapi::OpenApi> {
                     storage: storage.into(),
                     auth: None,
                     analysis,
+                    correlation: None,
                     read_only: false,
                 },
             );

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -32,6 +32,7 @@ use trustify_infrastructure::{
     otel::{Metrics as OtelMetrics, Tracing},
 };
 use trustify_module_analysis::{config::AnalysisConfig, service::AnalysisService};
+use trustify_module_correlation::service::CorrelationService;
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_storage::{config::StorageConfig, service::dispatch::DispatchBackend};
 use trustify_module_ui::{UI, endpoints::UiResources};
@@ -94,6 +95,10 @@ pub struct Run {
 
     // flattened commands must go last
     //
+    /// Enable the in-memory correlation engine (experimental).
+    #[arg(long, env = "TRUSTD_CORRELATION_ENABLED")]
+    pub correlation_enabled: bool,
+
     /// Analysis configuration
     #[command(flatten)]
     pub analysis: AnalysisConfig,
@@ -193,6 +198,7 @@ struct InitData {
     ui: UI,
     config: ModuleConfig,
     analysis: AnalysisService,
+    correlation: Option<CorrelationService>,
     read_only: bool,
 }
 
@@ -298,8 +304,28 @@ impl InitData {
             },
         };
 
+        let analysis = AnalysisService::new(run.analysis, db_ro.clone());
+
+        let correlation = if run.correlation_enabled {
+            let svc = CorrelationService::new(analysis.clone());
+            match db_ro.begin().await {
+                Ok(tx) => {
+                    if let Err(e) = svc.load_index(&tx).await {
+                        log::error!("Failed to load correlation advisory index: {e}");
+                    }
+                }
+                Err(e) => {
+                    log::error!("Failed to begin transaction for correlation index load: {e}");
+                }
+            }
+            Some(svc)
+        } else {
+            None
+        };
+
         Ok(InitData {
-            analysis: AnalysisService::new(run.analysis, db_ro.clone()),
+            analysis,
+            correlation,
             authenticator,
             authorizer,
             db_rw,
@@ -340,6 +366,7 @@ impl InitData {
                             storage: self.storage.clone(),
                             auth: self.authenticator.clone(),
                             analysis: self.analysis.clone(),
+                            correlation: self.correlation.clone(),
                             read_only: self.read_only,
                         },
                     );
@@ -389,6 +416,7 @@ pub(crate) struct Config {
     pub(crate) cache: PaginationCache,
     pub(crate) storage: DispatchBackend,
     pub(crate) analysis: AnalysisService,
+    pub(crate) correlation: Option<CorrelationService>,
     pub(crate) auth: Option<Arc<Authenticator>>,
     pub(crate) read_only: bool,
 }
@@ -407,6 +435,7 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
         storage,
         auth,
         analysis,
+        correlation,
         read_only,
     } = config;
 
@@ -443,6 +472,13 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
                     cache,
                 );
                 trustify_module_analysis::endpoints::configure(svc, db_ro.clone(), analysis);
+                if let Some(correlation) = correlation {
+                    trustify_module_correlation::endpoints::configure(
+                        svc,
+                        db_ro.clone(),
+                        correlation,
+                    );
+                }
                 trustify_module_user::endpoints::configure(svc);
                 trustify_module_ui::endpoints::configure(svc, ui)
             }),
@@ -520,6 +556,7 @@ mod test {
                             storage: ctx.storage.clone().into(),
                             auth: None,
                             analysis,
+                            correlation: None,
                             read_only: false,
                         },
                     );
@@ -593,6 +630,7 @@ mod test {
                     cache: PaginationCache::for_test(),
                     auth: None,
                     analysis,
+                    correlation: None,
                     read_only,
                 },
             );


### PR DESCRIPTION
New in-memory correlation engine that replaces the six independent SQL queries for vulnerability-SBOM matching with a single shared matching layer, reusing the existing graph cache for SBOM data.

Addresses: ADR 00020 (docs/adrs/00020-vulnerability-correlation-engine.md) (status quo), implements ADR 00021 (docs/adrs/00021-correlation-engine-refactor.md) (refactor design).

Learns from: #2528 (prior attempt) — reuses graph cache instead of building a duplicate SBOM index, avoids startup penalty, fixes the Maven version comparison bug.

# Compare SQL vs correlation:
```
curl localhost:8080/api/v3/sbom/{id}/advisory          # SQL path
curl localhost:8080/api/v3/correlation/sbom/{id}/advisory  # correlation path
curl localhost:8080/api/v3/correlation/status           # index stats
```

What remains
- Batch severity counts for GET /v3/sbom?advisories=true via correlation
- Integration correctness tests (ingest fixtures, compare SQL vs correlation results)
- Replace SQL path as default once validated at scale
- Remove dead SQL query code (raw_sql.rs, details.rs A1-A3, vulnerability_advisory.rs B1-B3)

## Summary by Sourcery

Introduce an experimental in-memory vulnerability correlation engine that reuses the existing SBOM graph cache and exposes new correlation APIs, while wiring it into the server behind a feature flag.

New Features:
- Add a correlation module providing an in-memory advisory index and correlation service for SBOMs and vulnerabilities.
- Expose new HTTP endpoints for correlation status, SBOM correlation summaries, hydrated SBOM advisories, and vulnerability-to-SBOM correlation results.
- Introduce Rust-native version comparison utilities to support in-memory version range matching across multiple schemes.

Enhancements:
- Wire the correlation service into the server startup and routing pipeline, gated by a configuration flag and environment variable, and integrate it with OpenAPI generation.
- Leverage the existing analysis graph cache instead of building a separate SBOM index for correlation, and provide a hydration layer to reuse existing advisory response models.
- Document the refactored correlation engine design and architecture in a new ADR describing the unified matching layer and scoping semantics.

Build:
- Add the correlation module as a new workspace member and dependency, along with the arc-swap crate for managing hot-swappable in-memory indexes.

Documentation:
- Add an ADR describing the new correlation engine refactor, unified matching logic, and migration plan away from the legacy SQL-based implementation.

Tests:
- Add integration-style tests for the correlation endpoints to validate status reporting, SBOM correlation behavior, and hydrated advisory responses based on ingested fixtures.