### PR TITLE
feat(notification): add change_log infrastructure and WebSocket endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8815,6 +8815,7 @@ dependencies = [
  "clap",
  "futures",
  "humantime",
+ "sea-orm",
  "serde",
  "serde_json",
  "test-context",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8825,6 +8825,7 @@ dependencies = [
  "trustify-common",
  "trustify-infrastructure",
  "trustify-test-context",
+ "url",
  "utoipa-actix-web",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-ws"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d4f2fbee3ef7a22fa6cb0e416b962237a167ed0419f22d4e451da2d7f082f8"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-web",
+ "bytestring",
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8791,6 +8805,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustify-module-notification"
+version = "0.6.0-rc.1"
+dependencies = [
+ "actix-http",
+ "actix-web",
+ "actix-ws",
+ "anyhow",
+ "clap",
+ "futures",
+ "humantime",
+ "serde",
+ "serde_json",
+ "test-context",
+ "test-log",
+ "tokio",
+ "tracing",
+ "trustify-auth",
+ "trustify-common",
+ "trustify-infrastructure",
+ "trustify-test-context",
+ "utoipa-actix-web",
+ "uuid",
+]
+
+[[package]]
 name = "trustify-module-storage"
 version = "0.6.0-rc.1"
 dependencies = [
@@ -8911,6 +8950,7 @@ dependencies = [
  "trustify-module-fundamental",
  "trustify-module-importer",
  "trustify-module-ingestor",
+ "trustify-module-notification",
  "trustify-module-storage",
  "trustify-module-ui",
  "trustify-module-user",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "modules/fundamental",
     "modules/importer",
     "modules/ingestor",
+    "modules/notification",
     "modules/storage",
     "modules/ui",
     "modules/user",
@@ -37,6 +38,7 @@ actix-cors = "0.7"
 actix-http = "3.3.1"
 actix-tls = "3"
 actix-web = "4.3.1"
+actix-ws = "0.3"
 actix-web-extras = "0.1"
 actix-web-httpauth = "0.8"
 actix-web-static-files = "4.0.1"
@@ -130,7 +132,7 @@ sha2 = "0.11.0"
 spdx = "0.13.3"
 spdx-expression = "0.5.2"
 spdx-rs = "0.5.3"
-sqlx = { version = "0.8", features = ["tls-native-tls"] } # keep aligned with sea-orm
+sqlx = { version = "0.8", features = ["tls-native-tls", "postgres"] } # keep aligned with sea-orm
 strum = "0.28.0"
 tar = "0.4.45"
 temp-env = "0.3"
@@ -172,6 +174,7 @@ trustify-module-exploit-intelligence = { path = "modules/exploit-intelligence" }
 trustify-module-fundamental = { path = "modules/fundamental" }
 trustify-module-importer = { path = "modules/importer" }
 trustify-module-ingestor = { path = "modules/ingestor" }
+trustify-module-notification = { path = "modules/notification" }
 trustify-module-storage = { path = "modules/storage" }
 trustify-module-ui = { path = "modules/ui", default-features = false }
 trustify-module-user = { path = "modules/user" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -52,7 +52,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 urlencoding = { workspace = true }
 utoipa = { workspace = true, features = ["url"] }
-uuid = { workspace = true, features = ["v5", "serde"] }
+uuid = { workspace = true, features = ["v5", "v7", "serde"] }
 walker-common = { workspace = true, features = ["bzip2", "lzma", "flate2"] }
 
 [dev-dependencies]

--- a/common/src/db/change.rs
+++ b/common/src/db/change.rs
@@ -93,6 +93,49 @@ pub async fn record_change(
     Ok(())
 }
 
+async fn fetch_latest_id(pool: &sqlx::PgPool) -> Uuid {
+    let result: Result<Option<(Uuid,)>, _> =
+        sqlx::query_as("SELECT id FROM change_log ORDER BY id DESC LIMIT 1")
+            .fetch_optional(pool)
+            .await;
+    match result {
+        Ok(Some((id,))) => id,
+        Ok(None) => Uuid::nil(),
+        Err(err) => {
+            tracing::warn!(%err, "failed to fetch latest change_log id");
+            Uuid::nil()
+        }
+    }
+}
+
+async fn fetch_entries_after(
+    pool: &sqlx::PgPool,
+    cursor: &Uuid,
+) -> Result<Vec<ChangeEntry>, anyhow::Error> {
+    let rows: Vec<(Uuid, String, Option<Uuid>, String)> = sqlx::query_as(
+        "SELECT id, entity_type, entity_id, operation FROM change_log WHERE id > $1 ORDER BY id",
+    )
+    .bind(cursor)
+    .fetch_all(pool)
+    .await?;
+
+    let entries = rows
+        .into_iter()
+        .filter_map(|(cursor, r#type, id, operation)| {
+            let r#type = ChangeEntity::from_str(&r#type)?;
+            let operation = ChangeOperation::from_str(&operation)?;
+            Some(ChangeEntry {
+                cursor,
+                r#type,
+                id,
+                operation,
+            })
+        })
+        .collect();
+
+    Ok(entries)
+}
+
 /// Watches the change_log table via PostgreSQL LISTEN/NOTIFY with
 /// a periodic polling fallback. All sqlx types are encapsulated —
 /// callers only interact through the public API.
@@ -217,47 +260,12 @@ impl ChangeListener {
         }
     }
 
-    /// Fetches the latest change_log ID for cursor initialization.
     async fn fetch_max_id(&self) -> Uuid {
-        let result: Result<Option<(Uuid,)>, _> =
-            sqlx::query_as("SELECT id FROM change_log ORDER BY id DESC LIMIT 1")
-                .fetch_optional(&self.pool)
-                .await;
-
-        match result {
-            Ok(Some((id,))) => id,
-            Ok(None) => Uuid::nil(),
-            Err(err) => {
-                tracing::warn!(%err, "failed to fetch latest change_log id, starting from zero");
-                Uuid::nil()
-            }
-        }
+        fetch_latest_id(&self.pool).await
     }
 
-    /// Fetches all change_log entries with id > cursor.
     async fn fetch_after(&self, cursor: &Uuid) -> Result<Vec<ChangeEntry>, anyhow::Error> {
-        let rows: Vec<(Uuid, String, Option<Uuid>, String)> = sqlx::query_as(
-            "SELECT id, entity_type, entity_id, operation FROM change_log WHERE id > $1 ORDER BY id",
-        )
-        .bind(cursor)
-        .fetch_all(&self.pool)
-        .await?;
-
-        let entries = rows
-            .into_iter()
-            .filter_map(|(cursor, r#type, id, operation)| {
-                let r#type = ChangeEntity::from_str(&r#type)?;
-                let operation = ChangeOperation::from_str(&operation)?;
-                Some(ChangeEntry {
-                    cursor,
-                    r#type,
-                    id,
-                    operation,
-                })
-            })
-            .collect();
-
-        Ok(entries)
+        fetch_entries_after(&self.pool, cursor).await
     }
 
     /// Deletes change_log entries older than the retention period.
@@ -324,44 +332,11 @@ impl ChangeBroadcaster {
         self.tx.subscribe()
     }
 
-    /// Returns the latest event cursor, or `Uuid::nil()` if the change_log is empty.
     pub async fn fetch_latest_cursor(&self) -> Uuid {
-        let result: Result<Option<(Uuid,)>, _> =
-            sqlx::query_as("SELECT id FROM change_log ORDER BY id DESC LIMIT 1")
-                .fetch_optional(&self.pool)
-                .await;
-        match result {
-            Ok(Some((id,))) => id,
-            Ok(None) => Uuid::nil(),
-            Err(err) => {
-                tracing::warn!(%err, "failed to fetch latest change_log cursor");
-                Uuid::nil()
-            }
-        }
+        fetch_latest_id(&self.pool).await
     }
 
     pub async fn fetch_after(&self, cursor: &Uuid) -> Result<Vec<ChangeEntry>, anyhow::Error> {
-        let rows: Vec<(Uuid, String, Option<Uuid>, String)> = sqlx::query_as(
-            "SELECT id, entity_type, entity_id, operation FROM change_log WHERE id > $1 ORDER BY id",
-        )
-        .bind(cursor)
-        .fetch_all(&self.pool)
-        .await?;
-
-        let entries = rows
-            .into_iter()
-            .filter_map(|(cursor, r#type, id, operation)| {
-                let r#type = ChangeEntity::from_str(&r#type)?;
-                let operation = ChangeOperation::from_str(&operation)?;
-                Some(ChangeEntry {
-                    cursor,
-                    r#type,
-                    id,
-                    operation,
-                })
-            })
-            .collect();
-
-        Ok(entries)
+        fetch_entries_after(&self.pool, cursor).await
     }
 }

--- a/common/src/db/change.rs
+++ b/common/src/db/change.rs
@@ -67,6 +67,28 @@ pub struct ChangeEntry {
     pub operation: ChangeOperation,
 }
 
+/// Raw JSON shape emitted by the `notify_change_log` trigger.
+#[derive(serde::Deserialize)]
+struct NotifyPayload {
+    id: Uuid,
+    entity_type: String,
+    entity_id: Option<Uuid>,
+    operation: String,
+}
+
+impl NotifyPayload {
+    fn into_entry(self) -> Option<ChangeEntry> {
+        let r#type = ChangeEntity::from_str(&self.entity_type)?;
+        let operation = ChangeOperation::from_str(&self.operation)?;
+        Some(ChangeEntry {
+            cursor: self.id,
+            r#type,
+            id: self.entity_id,
+            operation,
+        })
+    }
+}
+
 /// Records a change event in the change_log table.
 ///
 /// Called within the caller's transaction so the event is committed
@@ -228,8 +250,21 @@ impl ChangeListener {
             tokio::select! {
                 notification = listener.recv() => {
                     match notification {
-                        Ok(_) => {
-                            self.sweep(on_change, cursor).await;
+                        Ok(n) => {
+                            match serde_json::from_str::<NotifyPayload>(n.payload())
+                                .ok()
+                                .and_then(|p| p.into_entry())
+                            {
+                                Some(entry) => {
+                                    if entry.cursor > *cursor {
+                                        *cursor = entry.cursor;
+                                    }
+                                    on_change(vec![entry]);
+                                }
+                                None => {
+                                    self.sweep(on_change, cursor).await;
+                                }
+                            }
                         }
                         Err(err) => {
                             return Err(err.into());

--- a/common/src/db/change.rs
+++ b/common/src/db/change.rs
@@ -1,4 +1,4 @@
-use sea_orm::{ConnectionTrait, DbBackend, DbErr, Statement};
+use sea_orm::{ConnectionTrait, DbErr, Statement};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast;
@@ -80,7 +80,7 @@ pub async fn record_change(
 ) -> Result<(), DbErr> {
     let id = Uuid::now_v7();
     conn.execute(Statement::from_sql_and_values(
-        DbBackend::Postgres,
+        conn.get_database_backend(),
         "INSERT INTO change_log (id, entity_type, entity_id, operation) VALUES ($1, $2, $3, $4)",
         vec![
             id.into(),
@@ -142,6 +142,7 @@ async fn fetch_entries_after(
 pub struct ChangeListener {
     pool: sqlx::PgPool,
     poll_interval: Duration,
+    cleanup_interval: Duration,
     retention: Duration,
 }
 
@@ -155,6 +156,7 @@ impl ChangeListener {
         Ok(Self {
             pool,
             poll_interval: DEFAULT_POLL_INTERVAL,
+            cleanup_interval: CLEANUP_INTERVAL,
             retention,
         })
     }
@@ -162,6 +164,12 @@ impl ChangeListener {
     /// Sets the polling interval for the fallback sweep.
     pub fn with_poll_interval(mut self, interval: Duration) -> Self {
         self.poll_interval = interval;
+        self
+    }
+
+    /// Sets the interval between cleanup sweeps of old entries.
+    pub fn with_cleanup_interval(mut self, interval: Duration) -> Self {
+        self.cleanup_interval = interval;
         self
     }
 
@@ -233,7 +241,7 @@ impl ChangeListener {
                 }
             }
 
-            if last_cleanup.elapsed() >= CLEANUP_INTERVAL {
+            if last_cleanup.elapsed() >= self.cleanup_interval {
                 self.cleanup().await;
                 *last_cleanup = tokio::time::Instant::now();
             }
@@ -271,9 +279,10 @@ impl ChangeListener {
     /// Deletes change_log entries older than the retention period.
     async fn cleanup(&self) {
         let retention_secs = self.retention.as_secs() as i64;
-        let result = sqlx::query(&format!(
-            "DELETE FROM change_log WHERE created_at < NOW() - INTERVAL '{retention_secs} seconds'"
-        ))
+        let result = sqlx::query(
+            "DELETE FROM change_log WHERE created_at < NOW() - ($1 * INTERVAL '1 second')",
+        )
+        .bind(retention_secs)
         .execute(&self.pool)
         .await;
 
@@ -305,10 +314,17 @@ pub struct ChangeBroadcaster {
 }
 
 impl ChangeBroadcaster {
-    pub fn new(db_rw: &super::ReadWrite, retention: Duration) -> Result<Self, anyhow::Error> {
+    pub fn new(
+        db_rw: &super::ReadWrite,
+        retention: Duration,
+        poll_interval: Duration,
+        cleanup_interval: Duration,
+    ) -> Result<Self, anyhow::Error> {
         let pool = db_rw.get_postgres_connection_pool().clone();
         let (tx, _) = broadcast::channel(1024);
-        let listener = ChangeListener::new(db_rw, retention)?;
+        let listener = ChangeListener::new(db_rw, retention)?
+            .with_poll_interval(poll_interval)
+            .with_cleanup_interval(cleanup_interval);
         let sender = tx.clone();
 
         let task = tokio::spawn(async move {

--- a/common/src/db/change.rs
+++ b/common/src/db/change.rs
@@ -1,0 +1,367 @@
+use sea_orm::{ConnectionTrait, DbBackend, DbErr, Statement};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+const CHANNEL: &str = "trustify_changes";
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(30);
+const CLEANUP_INTERVAL: Duration = Duration::from_secs(300);
+
+/// The kind of entity that changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeEntity {
+    Advisory,
+    Sbom,
+}
+
+impl ChangeEntity {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Advisory => "advisory",
+            Self::Sbom => "sbom",
+        }
+    }
+
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "advisory" => Some(Self::Advisory),
+            "sbom" => Some(Self::Sbom),
+            _ => None,
+        }
+    }
+}
+
+/// The operation that occurred.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeOperation {
+    Added,
+    Deleted,
+}
+
+impl ChangeOperation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Added => "added",
+            Self::Deleted => "deleted",
+        }
+    }
+
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "added" => Some(Self::Added),
+            "deleted" => Some(Self::Deleted),
+            _ => None,
+        }
+    }
+}
+
+/// A single change log entry read from the database.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ChangeEntry {
+    pub cursor: Uuid,
+    pub r#type: ChangeEntity,
+    pub id: Option<Uuid>,
+    pub operation: ChangeOperation,
+}
+
+/// Records a change event in the change_log table.
+///
+/// Called within the caller's transaction so the event is committed
+/// atomically with the data change. The database trigger fires
+/// `pg_notify` on commit.
+pub async fn record_change(
+    conn: &impl ConnectionTrait,
+    entity_type: ChangeEntity,
+    entity_id: Option<Uuid>,
+    operation: ChangeOperation,
+) -> Result<(), DbErr> {
+    let id = Uuid::now_v7();
+    conn.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO change_log (id, entity_type, entity_id, operation) VALUES ($1, $2, $3, $4)",
+        vec![
+            id.into(),
+            entity_type.as_str().into(),
+            entity_id.into(),
+            operation.as_str().into(),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+/// Watches the change_log table via PostgreSQL LISTEN/NOTIFY with
+/// a periodic polling fallback. All sqlx types are encapsulated —
+/// callers only interact through the public API.
+pub struct ChangeListener {
+    pool: sqlx::PgPool,
+    poll_interval: Duration,
+    retention: Duration,
+}
+
+impl ChangeListener {
+    /// Creates a listener from a ReadWrite connection.
+    ///
+    /// Panics if the database backend is not PostgreSQL (checked at startup).
+    pub fn new(db: &super::ReadWrite, retention: Duration) -> Result<Self, anyhow::Error> {
+        let pool = db.get_postgres_connection_pool().clone();
+
+        Ok(Self {
+            pool,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            retention,
+        })
+    }
+
+    /// Sets the polling interval for the fallback sweep.
+    pub fn with_poll_interval(mut self, interval: Duration) -> Self {
+        self.poll_interval = interval;
+        self
+    }
+
+    /// Sets the retention period for cleaning old entries.
+    pub fn with_retention(mut self, retention: Duration) -> Self {
+        self.retention = retention;
+        self
+    }
+
+    /// Runs forever, calling `on_change` with batches of new entries.
+    ///
+    /// On startup, sets the cursor to the current maximum ID so only
+    /// new events are delivered. Automatically reconnects the LISTEN
+    /// connection on failure.
+    pub async fn run<F>(self, on_change: F)
+    where
+        F: Fn(Vec<ChangeEntry>) + Send + 'static,
+    {
+        let mut cursor = self.fetch_max_id().await;
+        tracing::info!(?cursor, "change listener starting");
+
+        let mut last_cleanup = tokio::time::Instant::now();
+
+        loop {
+            match self
+                .listen_loop(&on_change, &mut cursor, &mut last_cleanup)
+                .await
+            {
+                Ok(()) => break,
+                Err(err) => {
+                    tracing::warn!(%err, "change listener connection lost, reconnecting in 5s");
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                }
+            }
+        }
+    }
+
+    /// Inner loop that creates a PgListener and processes events until an error occurs.
+    async fn listen_loop<F>(
+        &self,
+        on_change: &F,
+        cursor: &mut Uuid,
+        last_cleanup: &mut tokio::time::Instant,
+    ) -> Result<(), anyhow::Error>
+    where
+        F: Fn(Vec<ChangeEntry>) + Send + 'static,
+    {
+        let mut listener = sqlx::postgres::PgListener::connect_with(&self.pool).await?;
+        listener.listen(CHANNEL).await?;
+        tracing::info!("change listener connected and listening on '{CHANNEL}'");
+
+        let mut poll_interval = tokio::time::interval(self.poll_interval);
+        poll_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                notification = listener.recv() => {
+                    match notification {
+                        Ok(_) => {
+                            self.sweep(on_change, cursor).await;
+                        }
+                        Err(err) => {
+                            return Err(err.into());
+                        }
+                    }
+                }
+                _ = poll_interval.tick() => {
+                    self.sweep(on_change, cursor).await;
+                }
+            }
+
+            if last_cleanup.elapsed() >= CLEANUP_INTERVAL {
+                self.cleanup().await;
+                *last_cleanup = tokio::time::Instant::now();
+            }
+        }
+    }
+
+    /// Queries new change_log entries after the cursor and delivers them.
+    async fn sweep<F>(&self, on_change: &F, cursor: &mut Uuid)
+    where
+        F: Fn(Vec<ChangeEntry>),
+    {
+        match self.fetch_after(cursor).await {
+            Ok(entries) if entries.is_empty() => {}
+            Ok(entries) => {
+                if let Some(last) = entries.last() {
+                    *cursor = last.cursor;
+                }
+                tracing::debug!(count = entries.len(), "delivering change events");
+                on_change(entries);
+            }
+            Err(err) => {
+                tracing::warn!(%err, "failed to sweep change_log");
+            }
+        }
+    }
+
+    /// Fetches the latest change_log ID for cursor initialization.
+    async fn fetch_max_id(&self) -> Uuid {
+        let result: Result<Option<(Uuid,)>, _> =
+            sqlx::query_as("SELECT id FROM change_log ORDER BY id DESC LIMIT 1")
+                .fetch_optional(&self.pool)
+                .await;
+
+        match result {
+            Ok(Some((id,))) => id,
+            Ok(None) => Uuid::nil(),
+            Err(err) => {
+                tracing::warn!(%err, "failed to fetch latest change_log id, starting from zero");
+                Uuid::nil()
+            }
+        }
+    }
+
+    /// Fetches all change_log entries with id > cursor.
+    async fn fetch_after(&self, cursor: &Uuid) -> Result<Vec<ChangeEntry>, anyhow::Error> {
+        let rows: Vec<(Uuid, String, Option<Uuid>, String)> = sqlx::query_as(
+            "SELECT id, entity_type, entity_id, operation FROM change_log WHERE id > $1 ORDER BY id",
+        )
+        .bind(cursor)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let entries = rows
+            .into_iter()
+            .filter_map(|(cursor, r#type, id, operation)| {
+                let r#type = ChangeEntity::from_str(&r#type)?;
+                let operation = ChangeOperation::from_str(&operation)?;
+                Some(ChangeEntry {
+                    cursor,
+                    r#type,
+                    id,
+                    operation,
+                })
+            })
+            .collect();
+
+        Ok(entries)
+    }
+
+    /// Deletes change_log entries older than the retention period.
+    async fn cleanup(&self) {
+        let retention_secs = self.retention.as_secs() as i64;
+        let result = sqlx::query(&format!(
+            "DELETE FROM change_log WHERE created_at < NOW() - INTERVAL '{retention_secs} seconds'"
+        ))
+        .execute(&self.pool)
+        .await;
+
+        match result {
+            Ok(r) => {
+                if r.rows_affected() > 0 {
+                    tracing::debug!(
+                        deleted = r.rows_affected(),
+                        "cleaned up old change_log entries"
+                    );
+                }
+            }
+            Err(err) => {
+                tracing::warn!(%err, "failed to clean up change_log");
+            }
+        }
+    }
+}
+
+/// Fan-out broadcaster for change events.
+///
+/// Wraps a single [`ChangeListener`] and distributes events to multiple
+/// subscribers via [`tokio::sync::broadcast`]. Created once at startup.
+#[derive(Clone)]
+pub struct ChangeBroadcaster {
+    tx: broadcast::Sender<ChangeEntry>,
+    pool: sqlx::PgPool,
+    _task: Arc<tokio::task::JoinHandle<()>>,
+}
+
+impl ChangeBroadcaster {
+    pub fn new(db_rw: &super::ReadWrite, retention: Duration) -> Result<Self, anyhow::Error> {
+        let pool = db_rw.get_postgres_connection_pool().clone();
+        let (tx, _) = broadcast::channel(1024);
+        let listener = ChangeListener::new(db_rw, retention)?;
+        let sender = tx.clone();
+
+        let task = tokio::spawn(async move {
+            listener
+                .run(move |entries| {
+                    for entry in entries {
+                        let _ = sender.send(entry);
+                    }
+                })
+                .await;
+        });
+
+        Ok(Self {
+            tx,
+            pool,
+            _task: Arc::new(task),
+        })
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<ChangeEntry> {
+        self.tx.subscribe()
+    }
+
+    /// Returns the latest event cursor, or `Uuid::nil()` if the change_log is empty.
+    pub async fn fetch_latest_cursor(&self) -> Uuid {
+        let result: Result<Option<(Uuid,)>, _> =
+            sqlx::query_as("SELECT id FROM change_log ORDER BY id DESC LIMIT 1")
+                .fetch_optional(&self.pool)
+                .await;
+        match result {
+            Ok(Some((id,))) => id,
+            Ok(None) => Uuid::nil(),
+            Err(err) => {
+                tracing::warn!(%err, "failed to fetch latest change_log cursor");
+                Uuid::nil()
+            }
+        }
+    }
+
+    pub async fn fetch_after(&self, cursor: &Uuid) -> Result<Vec<ChangeEntry>, anyhow::Error> {
+        let rows: Vec<(Uuid, String, Option<Uuid>, String)> = sqlx::query_as(
+            "SELECT id, entity_type, entity_id, operation FROM change_log WHERE id > $1 ORDER BY id",
+        )
+        .bind(cursor)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let entries = rows
+            .into_iter()
+            .filter_map(|(cursor, r#type, id, operation)| {
+                let r#type = ChangeEntity::from_str(&r#type)?;
+                let operation = ChangeOperation::from_str(&operation)?;
+                Some(ChangeEntry {
+                    cursor,
+                    r#type,
+                    id,
+                    operation,
+                })
+            })
+            .collect();
+
+        Ok(entries)
+    }
+}

--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -1,3 +1,4 @@
+pub mod change;
 pub mod chunk;
 pub mod limiter;
 pub mod multi_model;

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -72,6 +72,7 @@ mod m0002270_fix_vulnerability_base_score_type;
 mod m0002280_backfill_sbom_suppliers;
 mod m0002290_create_exploit_intelligence_job;
 mod m0002300_create_exploit;
+mod m0002310_create_change_log;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -159,6 +160,7 @@ impl MigratorExt for Migrator {
             .data(m0002280_backfill_sbom_suppliers::Migration)
             .normal(m0002290_create_exploit_intelligence_job::Migration)
             .normal(m0002300_create_exploit::Migration)
+            .normal(m0002310_create_change_log::Migration)
     }
 }
 

--- a/migration/src/m0002310_create_change_log.rs
+++ b/migration/src/m0002310_create_change_log.rs
@@ -1,0 +1,116 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(ChangeLog::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(ChangeLog::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(ChangeLog::EntityType).text().not_null())
+                    .col(ColumnDef::new(ChangeLog::EntityId).uuid())
+                    .col(ColumnDef::new(ChangeLog::Operation).text().not_null())
+                    .col(
+                        ColumnDef::new(ChangeLog::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(ChangeLog::Table)
+                    .name(Indexes::IdxChangeLogCreatedAt.to_string())
+                    .col(ChangeLog::CreatedAt)
+                    .to_owned(),
+            )
+            .await?;
+
+        // Trigger function that notifies listeners on INSERT
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                CREATE OR REPLACE FUNCTION notify_change_log() RETURNS trigger AS $$
+                BEGIN
+                    PERFORM pg_notify('trustify_changes', NEW.id::text);
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql
+                "#,
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                CREATE TRIGGER change_log_notify
+                    AFTER INSERT ON change_log
+                    FOR EACH ROW
+                    EXECUTE FUNCTION notify_change_log()
+                "#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("DROP TRIGGER IF EXISTS change_log_notify ON change_log")
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared("DROP FUNCTION IF EXISTS notify_change_log()")
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(ChangeLog::Table)
+                    .name(Indexes::IdxChangeLogCreatedAt.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_table(Table::drop().if_exists().table(ChangeLog::Table).to_owned())
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum ChangeLog {
+    Table,
+    Id,
+    EntityType,
+    EntityId,
+    Operation,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum Indexes {
+    IdxChangeLogCreatedAt,
+}

--- a/migration/src/m0002310_create_change_log.rs
+++ b/migration/src/m0002310_create_change_log.rs
@@ -48,7 +48,12 @@ impl MigrationTrait for Migration {
                 r#"
                 CREATE OR REPLACE FUNCTION notify_change_log() RETURNS trigger AS $$
                 BEGIN
-                    PERFORM pg_notify('trustify_changes', NEW.id::text);
+                    PERFORM pg_notify('trustify_changes', json_build_object(
+                        'id', NEW.id,
+                        'entity_type', NEW.entity_type,
+                        'entity_id', NEW.entity_id,
+                        'operation', NEW.operation
+                    )::text);
                     RETURN NEW;
                 END;
                 $$ LANGUAGE plpgsql

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -25,6 +25,7 @@ use sea_orm::{ConnectionTrait, TransactionTrait};
 use std::{fmt::Debug, sync::Arc, time::Instant};
 use tokio::task::JoinError;
 use tracing::instrument;
+use trustify_common::db::change::{ChangeEntity, ChangeOperation, record_change};
 use trustify_common::{db::DatabaseErrors, error::ErrorInformation, id::IdError};
 use trustify_entity::labels::Labels;
 use trustify_module_analysis::service::AnalysisService;
@@ -240,6 +241,22 @@ impl IngestorService {
         let result = detector
             .load(&self.graph, labels.into(), issuer, &result.digests, tx)
             .await?;
+
+        let change_entity = match fmt {
+            Format::CSAF | Format::CVE | Format::OSV => Some(ChangeEntity::Advisory),
+            Format::SPDX | Format::CycloneDX => Some(ChangeEntity::Sbom),
+            _ => None,
+        };
+        if let Some(entity_type) = change_entity {
+            record_change(
+                tx,
+                entity_type,
+                uuid::Uuid::try_parse(&result.id).ok(),
+                ChangeOperation::Added,
+            )
+            .await
+            .map_err(|err| Error::Storage(anyhow!("{err}")))?;
+        }
 
         if let Some(wait) = cache.into() {
             self.load_graph_cache(fmt, &result, wait).await;

--- a/modules/notification/Cargo.toml
+++ b/modules/notification/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
+url = { workspace = true }
 utoipa-actix-web = { workspace = true }
 uuid = { workspace = true }
 

--- a/modules/notification/Cargo.toml
+++ b/modules/notification/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "trustify-module-notification"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+trustify-auth = { workspace = true }
+trustify-common = { workspace = true }
+trustify-infrastructure = { workspace = true }
+
+clap = { workspace = true }
+humantime = { workspace = true }
+
+actix-http = { workspace = true }
+actix-web = { workspace = true }
+actix-ws = { workspace = true }
+anyhow = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
+utoipa-actix-web = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+test-context = { workspace = true }
+test-log = { workspace = true, features = ["log", "trace"] }
+trustify-test-context = { workspace = true }

--- a/modules/notification/Cargo.toml
+++ b/modules/notification/Cargo.toml
@@ -28,6 +28,7 @@ utoipa-actix-web = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+sea-orm = { workspace = true }
 test-context = { workspace = true }
 test-log = { workspace = true, features = ["log", "trace"] }
 trustify-test-context = { workspace = true }

--- a/modules/notification/README.md
+++ b/modules/notification/README.md
@@ -1,0 +1,95 @@
+# Notification Module
+
+WebSocket endpoint that streams `change_log` events (advisory/SBOM additions and deletions) in real time.
+
+## Protocol
+
+- **Endpoint**: `GET /api/v3/notifications?after=<cursor>`
+- **Auth**: Bearer token via `Authorization` header or `?token=<jwt>` query parameter. Requires at least one of `read.sbom` or `read.advisory` — events are filtered per-entity by the caller's permissions
+- **`after`**: last known cursor; omit on first connect (the server sends a `connection` message with the current cursor), provide on reconnect to replay missed events
+- **Heartbeat**: server sends a WebSocket ping every 30 s; clients should respond with pong (most WebSocket libraries do this automatically)
+
+### Connection message
+
+On first connect (no `after` parameter), the server sends a control message:
+
+```json
+{"type":"connection","cursor":"019577ab-..."}
+```
+
+Save this `cursor` value. If you disconnect before any change events arrive, pass it as `?after=` on reconnect for gap-free delivery.
+
+### Change events
+
+Server → client, JSON text frames:
+
+```json
+{"cursor":"019577ab-...","type":"sbom","id":"550e8400-...","operation":"added"}
+```
+
+| Field       | Type                        | Description                                              |
+|-------------|-----------------------------|----------------------------------------------------------|
+| `cursor`    | `string`                    | Monotonically increasing event cursor (pass as `after` on reconnect) |
+| `type`      | `"sbom"` \| `"advisory"`    | What kind of entity changed                              |
+| `id`        | `string` \| `null`          | The entity that changed (null for bulk operations)       |
+| `operation` | `"added"` \| `"deleted"`    | What happened                                            |
+
+Track the `cursor` field from each message and pass it as `?after=` on reconnect for gap-free delivery.
+
+## Example: websocat
+
+```sh
+websocat -H "Authorization: Bearer $TOKEN" \
+  ws://localhost:8080/api/v3/notifications
+```
+
+To resume from a known cursor:
+
+```sh
+websocat -H "Authorization: Bearer $TOKEN" \
+  "ws://localhost:8080/api/v3/notifications?after=019577ab-0000-7000-8000-000000000000"
+```
+
+## Example: HTML
+
+Streams events with reconnect. Enter your access token before connecting.
+
+```html
+<!DOCTYPE html>
+<html>
+<body>
+  <input id="token" placeholder="Access token" style="width:300px">
+  <button onclick="connect()">Connect</button>
+  <pre id="log"></pre>
+  <script>
+    let lastCursor;
+
+    function connect() {
+      const log = document.getElementById('log');
+      const token = document.getElementById('token').value;
+      let url = 'ws://localhost:8080/api/v3/notifications';
+      const params = [];
+      if (lastCursor) params.push('after=' + lastCursor);
+      if (token) params.push('token=' + encodeURIComponent(token));
+      if (params.length) url += '?' + params.join('&');
+
+      const ws = new WebSocket(url);
+      ws.onopen = () => log.textContent += '--- connected ---\n';
+      ws.onmessage = (e) => {
+        const msg = JSON.parse(e.data);
+        lastCursor = msg.cursor;
+        if (msg.type === 'connection') {
+          log.textContent += '--- cursor: ' + msg.cursor + ' ---\n';
+          return;
+        }
+        log.textContent += JSON.stringify(msg) + '\n';
+      };
+      ws.onclose = () => {
+        log.textContent += '--- disconnected, reconnecting in 3s ---\n';
+        setTimeout(connect, 3000);
+      };
+    }
+  </script>
+</body>
+</html>
+```

--- a/modules/notification/src/config.rs
+++ b/modules/notification/src/config.rs
@@ -1,0 +1,11 @@
+/// Configuration for the notification service.
+#[derive(clap::Args, Debug, Clone)]
+pub struct NotificationConfig {
+    /// Retention period for change_log entries (humantime, e.g. "1h", "30m", "1d")
+    #[arg(
+        long,
+        env = "TRUSTD_CHANGE_LOG_RETENTION",
+        default_value = "1d"
+    )]
+    pub change_log_retention: humantime::Duration,
+}

--- a/modules/notification/src/config.rs
+++ b/modules/notification/src/config.rs
@@ -2,10 +2,6 @@
 #[derive(clap::Args, Debug, Clone)]
 pub struct NotificationConfig {
     /// Retention period for change_log entries (humantime, e.g. "1h", "30m", "1d")
-    #[arg(
-        long,
-        env = "TRUSTD_CHANGE_LOG_RETENTION",
-        default_value = "1d"
-    )]
+    #[arg(long, env = "TRUSTD_CHANGE_LOG_RETENTION", default_value = "1d")]
     pub change_log_retention: humantime::Duration,
 }

--- a/modules/notification/src/config.rs
+++ b/modules/notification/src/config.rs
@@ -4,4 +4,12 @@ pub struct NotificationConfig {
     /// Retention period for change_log entries (humantime, e.g. "1h", "30m", "1d")
     #[arg(long, env = "TRUSTD_CHANGE_LOG_RETENTION", default_value = "1d")]
     pub change_log_retention: humantime::Duration,
+
+    /// Polling interval for the change_log fallback sweep
+    #[arg(long, env = "TRUSTD_CHANGE_LOG_POLL_INTERVAL", default_value = "30s")]
+    pub change_log_poll_interval: humantime::Duration,
+
+    /// How often old change_log entries are cleaned up
+    #[arg(long, env = "TRUSTD_CHANGE_LOG_CLEANUP_INTERVAL", default_value = "5m")]
+    pub change_log_cleanup_interval: humantime::Duration,
 }

--- a/modules/notification/src/endpoints.rs
+++ b/modules/notification/src/endpoints.rs
@@ -156,7 +156,7 @@ async fn run_ws_session(
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::warn!(n, "WebSocket notification client lagged");
+                        tracing::warn!(lagged = n, "WebSocket notification client lagged");
                     }
                     Err(broadcast::error::RecvError::Closed) => {
                         break;

--- a/modules/notification/src/endpoints.rs
+++ b/modules/notification/src/endpoints.rs
@@ -1,0 +1,190 @@
+use actix_web::{HttpRequest, HttpResponse, web};
+use futures::StreamExt;
+use serde::Deserialize;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use trustify_auth::{
+    Permission, authenticator::Authenticator, authenticator::user::UserInformation,
+    authorizer::Authorizer,
+};
+use trustify_common::db::change::{ChangeBroadcaster, ChangeEntity, ChangeEntry};
+use trustify_infrastructure::app::new_auth;
+use utoipa_actix_web::service_config::ServiceConfig;
+use uuid::Uuid;
+
+use crate::inject_token::QueryTokenInjector;
+
+#[derive(Debug, Deserialize)]
+pub struct NotificationQuery {
+    pub after: Option<Uuid>,
+    pub token: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Message {
+    Connection,
+}
+
+#[derive(serde::Serialize)]
+struct ConnectionMessage {
+    r#type: Message,
+    cursor: Uuid,
+}
+
+pub fn configure(
+    config: &mut ServiceConfig,
+    broadcaster: ChangeBroadcaster,
+    auth: Option<Arc<Authenticator>>,
+) {
+    config.app_data(web::Data::new(broadcaster)).map(|svc| {
+        svc.service(
+            web::resource("/api/v3/notifications")
+                .wrap(new_auth(auth))
+                .wrap(QueryTokenInjector)
+                .route(web::get().to(ws_handler)),
+        )
+    });
+}
+
+async fn ws_handler(
+    req: HttpRequest,
+    body: web::Payload,
+    query: web::Query<NotificationQuery>,
+    broadcaster: web::Data<ChangeBroadcaster>,
+    user: UserInformation,
+) -> Result<HttpResponse, actix_web::Error> {
+    let authorizer = req
+        .app_data::<web::Data<Authorizer>>()
+        .cloned()
+        .unwrap_or_default();
+
+    let can_read_sbom = authorizer.require(&user, Permission::ReadSbom).is_ok();
+    let can_read_advisory = authorizer.require(&user, Permission::ReadAdvisory).is_ok();
+
+    if !can_read_sbom && !can_read_advisory {
+        return Ok(HttpResponse::Forbidden().finish());
+    }
+
+    let (response, session, msg_stream) = actix_ws::handle(&req, body)?;
+
+    let broadcaster = broadcaster.into_inner();
+    let after = query.into_inner().after;
+
+    actix_web::rt::spawn(async move {
+        if let Err(err) = run_ws_session(
+            session,
+            msg_stream,
+            &broadcaster,
+            after,
+            can_read_sbom,
+            can_read_advisory,
+        )
+        .await
+        {
+            tracing::warn!(%err, "WebSocket notification session error");
+        }
+    });
+
+    Ok(response)
+}
+
+pub(crate) fn is_allowed(
+    entry: &ChangeEntry,
+    can_read_sbom: bool,
+    can_read_advisory: bool,
+) -> bool {
+    match entry.r#type {
+        ChangeEntity::Sbom => can_read_sbom,
+        ChangeEntity::Advisory => can_read_advisory,
+    }
+}
+
+async fn run_ws_session(
+    mut session: actix_ws::Session,
+    mut msg_stream: actix_ws::MessageStream,
+    broadcaster: &ChangeBroadcaster,
+    after: Option<Uuid>,
+    can_read_sbom: bool,
+    can_read_advisory: bool,
+) -> Result<(), anyhow::Error> {
+    // Subscribe before backfill/cursor fetch to avoid gaps.
+    let mut rx = broadcaster.subscribe();
+
+    if let Some(cursor) = after {
+        match broadcaster.fetch_after(&cursor).await {
+            Ok(entries) => {
+                for entry in entries {
+                    if !is_allowed(&entry, can_read_sbom, can_read_advisory) {
+                        continue;
+                    }
+                    let json = serde_json::to_string(&entry)?;
+                    if session.text(json).await.is_err() {
+                        return Ok(());
+                    }
+                }
+            }
+            Err(err) => {
+                tracing::warn!(%err, "notification backfill query failed");
+            }
+        }
+    } else {
+        let cursor = broadcaster.fetch_latest_cursor().await;
+        let msg = ConnectionMessage {
+            r#type: Message::Connection,
+            cursor,
+        };
+        let json = serde_json::to_string(&msg)?;
+        if session.text(json).await.is_err() {
+            return Ok(());
+        }
+    }
+
+    let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(30));
+
+    loop {
+        tokio::select! {
+            event = rx.recv() => {
+                match event {
+                    Ok(entry) => {
+                        if !is_allowed(&entry, can_read_sbom, can_read_advisory) {
+                            continue;
+                        }
+                        let json = serde_json::to_string(&entry)?;
+                        if session.text(json).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(n, "WebSocket notification client lagged");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        break;
+                    }
+                }
+            }
+
+            msg = msg_stream.next() => {
+                match msg {
+                    Some(Ok(actix_ws::Message::Ping(data))) => {
+                        let _ = session.pong(&data).await;
+                    }
+                    Some(Ok(actix_ws::Message::Close(reason))) => {
+                        let _ = session.close(reason).await;
+                        break;
+                    }
+                    Some(Err(_)) | None => break,
+                    _ => {}
+                }
+            }
+
+            _ = heartbeat.tick() => {
+                if session.ping(b"").await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/modules/notification/src/inject_token.rs
+++ b/modules/notification/src/inject_token.rs
@@ -50,7 +50,6 @@ where
 }
 
 pub(crate) fn extract_token(query: &str) -> Option<String> {
-    url::form_urlencoded::parse(query.as_bytes()).find_map(|(key, value)| {
-        (key == "token" && !value.is_empty()).then(|| value.into_owned())
-    })
+    url::form_urlencoded::parse(query.as_bytes())
+        .find_map(|(key, value)| (key == "token" && !value.is_empty()).then(|| value.into_owned()))
 }

--- a/modules/notification/src/inject_token.rs
+++ b/modules/notification/src/inject_token.rs
@@ -49,9 +49,8 @@ where
     }
 }
 
-pub(crate) fn extract_token(query: &str) -> Option<&str> {
-    query.split('&').find_map(|pair| {
-        let (key, value) = pair.split_once('=')?;
-        (key == "token").then_some(value)
+pub(crate) fn extract_token(query: &str) -> Option<String> {
+    url::form_urlencoded::parse(query.as_bytes()).find_map(|(key, value)| {
+        (key == "token" && !value.is_empty()).then(|| value.into_owned())
     })
 }

--- a/modules/notification/src/inject_token.rs
+++ b/modules/notification/src/inject_token.rs
@@ -1,0 +1,57 @@
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
+use actix_web::http::header;
+use futures::future::{LocalBoxFuture, Ready, ok};
+use std::task::{Context, Poll};
+
+pub struct QueryTokenInjector;
+
+impl<S, B> Transform<S, ServiceRequest> for QueryTokenInjector
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error> + 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = actix_web::Error;
+    type Transform = QueryTokenInjectorMiddleware<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ok(QueryTokenInjectorMiddleware { service })
+    }
+}
+
+pub struct QueryTokenInjectorMiddleware<S> {
+    service: S,
+}
+
+impl<S, B> Service<ServiceRequest> for QueryTokenInjectorMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error> + 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = actix_web::Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&self, mut req: ServiceRequest) -> Self::Future {
+        if req.headers().get(header::AUTHORIZATION).is_none()
+            && let Some(token) = extract_token(req.query_string())
+            && let Ok(value) = format!("Bearer {token}").parse()
+        {
+            req.headers_mut().insert(header::AUTHORIZATION, value);
+        }
+
+        let fut = self.service.call(req);
+        Box::pin(fut)
+    }
+}
+
+pub(crate) fn extract_token(query: &str) -> Option<&str> {
+    query.split('&').find_map(|pair| {
+        let (key, value) = pair.split_once('=')?;
+        (key == "token").then_some(value)
+    })
+}

--- a/modules/notification/src/inject_token.rs
+++ b/modules/notification/src/inject_token.rs
@@ -1,5 +1,5 @@
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
-use actix_web::http::header;
+use actix_web::http::header::{self, HeaderMap};
 use futures::future::{LocalBoxFuture, Ready, ok};
 use std::task::{Context, Poll};
 
@@ -38,7 +38,8 @@ where
 
     fn call(&self, mut req: ServiceRequest) -> Self::Future {
         if req.headers().get(header::AUTHORIZATION).is_none()
-            && let Some(token) = extract_token(req.query_string())
+            && let Some(token) =
+                extract_token(req.query_string()).or_else(|| extract_protocol_token(req.headers()))
             && let Ok(value) = format!("Bearer {token}").parse()
         {
             req.headers_mut().insert(header::AUTHORIZATION, value);
@@ -52,4 +53,16 @@ where
 pub(crate) fn extract_token(query: &str) -> Option<String> {
     url::form_urlencoded::parse(query.as_bytes())
         .find_map(|(key, value)| (key == "token" && !value.is_empty()).then(|| value.into_owned()))
+}
+
+/// Extracts a bearer token from the `Sec-WebSocket-Protocol` header.
+///
+/// Browsers' WebSocket API cannot set custom headers but allows setting
+/// subprotocols. The convention is `Sec-WebSocket-Protocol: access_token, <jwt>`.
+pub(crate) fn extract_protocol_token(headers: &HeaderMap) -> Option<String> {
+    let value = headers.get("Sec-WebSocket-Protocol")?.to_str().ok()?;
+    let mut parts = value.splitn(2, ',');
+    let protocol = parts.next()?.trim();
+    let token = parts.next()?.trim();
+    (protocol == "access_token" && !token.is_empty()).then(|| token.to_owned())
 }

--- a/modules/notification/src/lib.rs
+++ b/modules/notification/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, recursion_limit = "256")]
+
 pub mod config;
 pub mod endpoints;
 pub(crate) mod inject_token;

--- a/modules/notification/src/lib.rs
+++ b/modules/notification/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod config;
+pub mod endpoints;
+pub(crate) mod inject_token;
+
+#[cfg(test)]
+mod test;

--- a/modules/notification/src/test.rs
+++ b/modules/notification/src/test.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 #[test]
 fn extract_token_basic() {
     assert_eq!(
-        crate::inject_token::extract_token("token=abc123"),
+        crate::inject_token::extract_token("token=abc123").as_deref(),
         Some("abc123")
     );
 }
@@ -30,7 +30,7 @@ fn extract_token_basic() {
 #[test]
 fn extract_token_with_other_params() {
     assert_eq!(
-        crate::inject_token::extract_token("after=xxx&token=jwt.val&foo=bar"),
+        crate::inject_token::extract_token("after=xxx&token=jwt.val&foo=bar").as_deref(),
         Some("jwt.val")
     );
 }
@@ -46,6 +46,24 @@ fn extract_token_missing() {
 #[test]
 fn extract_token_empty() {
     assert_eq!(crate::inject_token::extract_token(""), None);
+}
+
+#[test]
+fn extract_token_percent_encoded() {
+    assert_eq!(
+        crate::inject_token::extract_token("token=abc%20def").as_deref(),
+        Some("abc def")
+    );
+}
+
+#[test]
+fn extract_token_no_value() {
+    assert_eq!(crate::inject_token::extract_token("token"), None);
+}
+
+#[test]
+fn extract_token_empty_value() {
+    assert_eq!(crate::inject_token::extract_token("token=&foo=bar"), None);
 }
 
 // -- Group B: is_allowed ----------------------------------------------------
@@ -172,6 +190,24 @@ async fn injector_no_token_no_header() {
     let req = actix::TestRequest::get().uri("/test").to_request();
     let resp = actix::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+#[test(actix_web::test)]
+async fn injector_malformed_query_strings() {
+    let app = actix::init_service(
+        App::new().service(
+            web::resource("/test")
+                .wrap(crate::inject_token::QueryTokenInjector)
+                .route(web::get().to(echo_auth)),
+        ),
+    )
+    .await;
+
+    for uri in ["/test?token", "/test?token=&foo=bar"] {
+        let req = actix::TestRequest::get().uri(uri).to_request();
+        let resp = actix::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
 }
 
 // -- Group D: endpoint permission tests -------------------------------------

--- a/modules/notification/src/test.rs
+++ b/modules/notification/src/test.rs
@@ -67,6 +67,54 @@ fn extract_token_empty_value() {
     assert_eq!(crate::inject_token::extract_token("token=&foo=bar"), None);
 }
 
+// -- Group A2: extract_protocol_token ----------------------------------------
+
+#[test]
+fn extract_protocol_token_basic() {
+    let mut headers = actix_web::http::header::HeaderMap::new();
+    headers.insert(
+        actix_web::http::header::HeaderName::from_static("sec-websocket-protocol"),
+        "access_token, jwt.value".parse().unwrap(),
+    );
+    assert_eq!(
+        crate::inject_token::extract_protocol_token(&headers).as_deref(),
+        Some("jwt.value")
+    );
+}
+
+#[test]
+fn extract_protocol_token_missing() {
+    let mut headers = actix_web::http::header::HeaderMap::new();
+    headers.insert(
+        actix_web::http::header::HeaderName::from_static("sec-websocket-protocol"),
+        "graphql-ws".parse().unwrap(),
+    );
+    assert_eq!(crate::inject_token::extract_protocol_token(&headers), None);
+}
+
+#[test]
+fn extract_protocol_token_no_token_value() {
+    let mut headers = actix_web::http::header::HeaderMap::new();
+    headers.insert(
+        actix_web::http::header::HeaderName::from_static("sec-websocket-protocol"),
+        "access_token".parse().unwrap(),
+    );
+    assert_eq!(crate::inject_token::extract_protocol_token(&headers), None);
+}
+
+#[test]
+fn extract_protocol_token_extra_whitespace() {
+    let mut headers = actix_web::http::header::HeaderMap::new();
+    headers.insert(
+        actix_web::http::header::HeaderName::from_static("sec-websocket-protocol"),
+        "access_token ,  jwt.value ".parse().unwrap(),
+    );
+    assert_eq!(
+        crate::inject_token::extract_protocol_token(&headers).as_deref(),
+        Some("jwt.value")
+    );
+}
+
 // -- Group B: is_allowed ----------------------------------------------------
 
 fn dummy_entry(r#type: ChangeEntity) -> ChangeEntry {
@@ -211,6 +259,47 @@ async fn injector_malformed_query_strings() {
     }
 }
 
+#[test(actix_web::test)]
+async fn injector_extracts_from_protocol_header() {
+    let app = actix::init_service(
+        App::new().service(
+            web::resource("/test")
+                .wrap(crate::inject_token::QueryTokenInjector)
+                .route(web::get().to(echo_auth)),
+        ),
+    )
+    .await;
+
+    let req = actix::TestRequest::get()
+        .uri("/test")
+        .append_header(("Sec-WebSocket-Protocol", "access_token, mytoken"))
+        .to_request();
+    let resp = actix::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = actix::read_body(resp).await;
+    assert_eq!(body, "Bearer mytoken");
+}
+
+#[test(actix_web::test)]
+async fn injector_query_token_takes_precedence() {
+    let app = actix::init_service(
+        App::new().service(
+            web::resource("/test")
+                .wrap(crate::inject_token::QueryTokenInjector)
+                .route(web::get().to(echo_auth)),
+        ),
+    )
+    .await;
+
+    let req = actix::TestRequest::get()
+        .uri("/test?token=query")
+        .append_header(("Sec-WebSocket-Protocol", "access_token, proto"))
+        .to_request();
+    let resp = actix::call_service(&app, req).await;
+    let body = actix::read_body(resp).await;
+    assert_eq!(body, "Bearer query");
+}
+
 // -- Group D: endpoint permission tests -------------------------------------
 
 fn user_with_permissions(perms: &[&str]) -> UserDetails {
@@ -224,8 +313,13 @@ fn user_with_permissions(perms: &[&str]) -> UserDetails {
 #[test(actix_web::test)]
 async fn ws_anonymous_forbidden(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
     let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
 
     let app = actix::init_service(
@@ -250,8 +344,13 @@ async fn ws_anonymous_forbidden(ctx: TrustifyContext) {
 #[test(actix_web::test)]
 async fn ws_no_permissions_forbidden(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
     let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
 
     let app = actix::init_service(
@@ -277,8 +376,13 @@ async fn ws_no_permissions_forbidden(ctx: TrustifyContext) {
 #[test(actix_web::test)]
 async fn ws_read_sbom_accepted(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
     let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
 
     let app = actix::init_service(
@@ -305,8 +409,13 @@ async fn ws_read_sbom_accepted(ctx: TrustifyContext) {
 #[test(actix_web::test)]
 async fn ws_read_advisory_accepted(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
     let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
 
     let app = actix::init_service(
@@ -334,8 +443,13 @@ async fn ws_read_advisory_accepted(ctx: TrustifyContext) {
 #[test(tokio::test)]
 async fn fetch_after_returns_newer_entries(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
 
     // Insert 3 entries with small delays so UUIDv7 ordering is preserved
     record_change(
@@ -383,8 +497,13 @@ async fn fetch_after_returns_newer_entries(ctx: TrustifyContext) {
 #[test(tokio::test)]
 async fn record_change_inserts_entry(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
 
     let initial_cursor = broadcaster.fetch_latest_cursor().await;
     let entity_id = Uuid::now_v7();
@@ -410,8 +529,13 @@ async fn record_change_inserts_entry(ctx: TrustifyContext) {
 #[test(tokio::test)]
 async fn record_change_with_none_entity_id(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
 
     let initial_cursor = broadcaster.fetch_latest_cursor().await;
 
@@ -434,8 +558,13 @@ async fn record_change_with_none_entity_id(ctx: TrustifyContext) {
 #[test(tokio::test)]
 async fn fetch_latest_cursor_empty_table(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
 
     let cursor = broadcaster.fetch_latest_cursor().await;
     assert_eq!(cursor, Uuid::nil());
@@ -445,8 +574,13 @@ async fn fetch_latest_cursor_empty_table(ctx: TrustifyContext) {
 #[test(tokio::test)]
 async fn fetch_latest_cursor_returns_newest(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
 
     record_change(
         &ctx.db,
@@ -484,8 +618,13 @@ async fn fetch_latest_cursor_returns_newest(ctx: TrustifyContext) {
 #[test(tokio::test)]
 async fn fetch_after_with_mixed_entity_types(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
 
     let initial_cursor = broadcaster.fetch_latest_cursor().await;
 
@@ -541,8 +680,13 @@ async fn fetch_after_with_mixed_entity_types(ctx: TrustifyContext) {
 #[test(tokio::test)]
 async fn fetch_after_filters_unknown_entity_type(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
 
     let initial_cursor = broadcaster.fetch_latest_cursor().await;
 
@@ -585,8 +729,13 @@ async fn fetch_after_filters_unknown_entity_type(ctx: TrustifyContext) {
 #[test(tokio::test)]
 async fn fetch_after_filters_unknown_operation(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
 
     let initial_cursor = broadcaster.fetch_latest_cursor().await;
 
@@ -705,8 +854,13 @@ fn is_allowed_with_both_permissions() {
 #[test(tokio::test)]
 async fn ingest_sbom_creates_change_log_entry(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
 
     let initial_cursor = broadcaster.fetch_latest_cursor().await;
 
@@ -726,8 +880,13 @@ async fn ingest_sbom_creates_change_log_entry(ctx: TrustifyContext) {
 #[test(tokio::test)]
 async fn ingest_advisory_creates_change_log_entry(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
 
     let initial_cursor = broadcaster.fetch_latest_cursor().await;
 
@@ -751,8 +910,13 @@ async fn ingest_advisory_creates_change_log_entry(ctx: TrustifyContext) {
 #[test(actix_web::test)]
 async fn ws_both_permissions_accepted(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
     let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
 
     let app = actix::init_service(
@@ -780,8 +944,13 @@ async fn ws_both_permissions_accepted(ctx: TrustifyContext) {
 #[test(tokio::test)]
 async fn cleanup_deletes_old_entries(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster =
-        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )
+    .expect("broadcaster");
 
     record_change(
         &ctx.db,

--- a/modules/notification/src/test.rs
+++ b/modules/notification/src/test.rs
@@ -1,0 +1,336 @@
+#![cfg(test)]
+
+use actix_web::{App, HttpRequest, HttpResponse, http::StatusCode, test as actix, web};
+use std::time::Duration;
+use test_context::test_context;
+use test_log::test;
+use trustify_auth::{
+    authenticator::user::UserDetails,
+    authorizer::{Authorizer, AuthorizerConfig},
+};
+use trustify_common::db;
+use trustify_common::db::change::{
+    ChangeBroadcaster, ChangeEntity, ChangeEntry, ChangeOperation, record_change,
+};
+use trustify_test_context::TrustifyContext;
+use trustify_test_context::auth::TestAuthentication;
+use utoipa_actix_web::AppExt;
+use uuid::Uuid;
+
+// -- Group A: extract_token -------------------------------------------------
+
+#[test]
+fn extract_token_basic() {
+    assert_eq!(
+        crate::inject_token::extract_token("token=abc123"),
+        Some("abc123")
+    );
+}
+
+#[test]
+fn extract_token_with_other_params() {
+    assert_eq!(
+        crate::inject_token::extract_token("after=xxx&token=jwt.val&foo=bar"),
+        Some("jwt.val")
+    );
+}
+
+#[test]
+fn extract_token_missing() {
+    assert_eq!(
+        crate::inject_token::extract_token("after=xxx&foo=bar"),
+        None
+    );
+}
+
+#[test]
+fn extract_token_empty() {
+    assert_eq!(crate::inject_token::extract_token(""), None);
+}
+
+// -- Group B: is_allowed ----------------------------------------------------
+
+fn dummy_entry(r#type: ChangeEntity) -> ChangeEntry {
+    ChangeEntry {
+        cursor: Uuid::now_v7(),
+        r#type,
+        id: Some(Uuid::now_v7()),
+        operation: ChangeOperation::Added,
+    }
+}
+
+#[test]
+fn is_allowed_sbom_with_perm() {
+    assert!(crate::endpoints::is_allowed(
+        &dummy_entry(ChangeEntity::Sbom),
+        true,
+        false
+    ));
+}
+
+#[test]
+fn is_allowed_sbom_without_perm() {
+    assert!(!crate::endpoints::is_allowed(
+        &dummy_entry(ChangeEntity::Sbom),
+        false,
+        true
+    ));
+}
+
+#[test]
+fn is_allowed_advisory_with_perm() {
+    assert!(crate::endpoints::is_allowed(
+        &dummy_entry(ChangeEntity::Advisory),
+        false,
+        true
+    ));
+}
+
+#[test]
+fn is_allowed_advisory_without_perm() {
+    assert!(!crate::endpoints::is_allowed(
+        &dummy_entry(ChangeEntity::Advisory),
+        true,
+        false
+    ));
+}
+
+#[test]
+fn is_allowed_no_perms() {
+    assert!(!crate::endpoints::is_allowed(
+        &dummy_entry(ChangeEntity::Sbom),
+        false,
+        false
+    ));
+    assert!(!crate::endpoints::is_allowed(
+        &dummy_entry(ChangeEntity::Advisory),
+        false,
+        false
+    ));
+}
+
+// -- Group C: QueryTokenInjector middleware ----------------------------------
+
+async fn echo_auth(req: HttpRequest) -> HttpResponse {
+    match req.headers().get("Authorization") {
+        Some(val) => HttpResponse::Ok().body(val.to_str().unwrap_or("bad").to_string()),
+        None => HttpResponse::NoContent().finish(),
+    }
+}
+
+#[test(actix_web::test)]
+async fn injector_copies_token() {
+    let app = actix::init_service(
+        App::new().service(
+            web::resource("/test")
+                .wrap(crate::inject_token::QueryTokenInjector)
+                .route(web::get().to(echo_auth)),
+        ),
+    )
+    .await;
+
+    let req = actix::TestRequest::get()
+        .uri("/test?token=mytoken")
+        .to_request();
+    let resp = actix::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = actix::read_body(resp).await;
+    assert_eq!(body, "Bearer mytoken");
+}
+
+#[test(actix_web::test)]
+async fn injector_preserves_existing_header() {
+    let app = actix::init_service(
+        App::new().service(
+            web::resource("/test")
+                .wrap(crate::inject_token::QueryTokenInjector)
+                .route(web::get().to(echo_auth)),
+        ),
+    )
+    .await;
+
+    let req = actix::TestRequest::get()
+        .uri("/test?token=other")
+        .append_header(("Authorization", "Bearer existing"))
+        .to_request();
+    let resp = actix::call_service(&app, req).await;
+    let body = actix::read_body(resp).await;
+    assert_eq!(body, "Bearer existing");
+}
+
+#[test(actix_web::test)]
+async fn injector_no_token_no_header() {
+    let app = actix::init_service(
+        App::new().service(
+            web::resource("/test")
+                .wrap(crate::inject_token::QueryTokenInjector)
+                .route(web::get().to(echo_auth)),
+        ),
+    )
+    .await;
+
+    let req = actix::TestRequest::get().uri("/test").to_request();
+    let resp = actix::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+// -- Group D: endpoint permission tests -------------------------------------
+
+fn user_with_permissions(perms: &[&str]) -> UserDetails {
+    UserDetails {
+        id: "test-user".into(),
+        permissions: perms.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn ws_anonymous_forbidden(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
+
+    let app = actix::init_service(
+        App::new()
+            .into_utoipa_app()
+            .app_data(web::Data::new(authorizer))
+            .configure(|svc| {
+                crate::endpoints::configure(svc, broadcaster, None);
+            })
+            .into_app(),
+    )
+    .await;
+
+    let req = actix::TestRequest::get()
+        .uri("/api/v3/notifications")
+        .to_request();
+    let resp = actix::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn ws_no_permissions_forbidden(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
+
+    let app = actix::init_service(
+        App::new()
+            .into_utoipa_app()
+            .app_data(web::Data::new(authorizer))
+            .configure(|svc| {
+                crate::endpoints::configure(svc, broadcaster, None);
+            })
+            .into_app(),
+    )
+    .await;
+
+    let req = actix::TestRequest::get()
+        .uri("/api/v3/notifications")
+        .to_request()
+        .test_auth_details(user_with_permissions(&[]));
+    let resp = actix::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn ws_read_sbom_accepted(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
+
+    let app = actix::init_service(
+        App::new()
+            .into_utoipa_app()
+            .app_data(web::Data::new(authorizer))
+            .configure(|svc| {
+                crate::endpoints::configure(svc, broadcaster, None);
+            })
+            .into_app(),
+    )
+    .await;
+
+    let req = actix::TestRequest::get()
+        .uri("/api/v3/notifications")
+        .to_request()
+        .test_auth_details(user_with_permissions(&["read.sbom"]));
+    let resp = actix::call_service(&app, req).await;
+    // Not 403 — passed the permission gate (will fail at WS upgrade since no upgrade headers)
+    assert_ne!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn ws_read_advisory_accepted(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
+
+    let app = actix::init_service(
+        App::new()
+            .into_utoipa_app()
+            .app_data(web::Data::new(authorizer))
+            .configure(|svc| {
+                crate::endpoints::configure(svc, broadcaster, None);
+            })
+            .into_app(),
+    )
+    .await;
+
+    let req = actix::TestRequest::get()
+        .uri("/api/v3/notifications")
+        .to_request()
+        .test_auth_details(user_with_permissions(&["read.advisory"]));
+    let resp = actix::call_service(&app, req).await;
+    assert_ne!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// -- Group E: ChangeBroadcaster::fetch_after DB test ------------------------
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn fetch_after_returns_newer_entries(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+
+    // Insert 3 entries with small delays so UUIDv7 ordering is preserved
+    record_change(
+        &ctx.db,
+        ChangeEntity::Sbom,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    record_change(
+        &ctx.db,
+        ChangeEntity::Advisory,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    record_change(
+        &ctx.db,
+        ChangeEntity::Sbom,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Deleted,
+    )
+    .await
+    .unwrap();
+
+    let all = broadcaster.fetch_after(&Uuid::nil()).await.unwrap();
+    assert!(all.len() >= 3);
+
+    let first_cursor = all[all.len() - 3].cursor;
+    let after_first = broadcaster.fetch_after(&first_cursor).await.unwrap();
+    assert_eq!(after_first.len(), 2);
+
+    let last_cursor = all.last().unwrap().cursor;
+    let after_last = broadcaster.fetch_after(&last_cursor).await.unwrap();
+    assert!(after_last.is_empty());
+}

--- a/modules/notification/src/test.rs
+++ b/modules/notification/src/test.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use actix_web::{App, HttpRequest, HttpResponse, http::StatusCode, test as actix, web};
+use sea_orm::ConnectionTrait;
 use std::time::Duration;
 use test_context::test_context;
 use test_log::test;
@@ -223,7 +224,8 @@ fn user_with_permissions(perms: &[&str]) -> UserDetails {
 #[test(actix_web::test)]
 async fn ws_anonymous_forbidden(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
     let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
 
     let app = actix::init_service(
@@ -248,7 +250,8 @@ async fn ws_anonymous_forbidden(ctx: TrustifyContext) {
 #[test(actix_web::test)]
 async fn ws_no_permissions_forbidden(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
     let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
 
     let app = actix::init_service(
@@ -274,7 +277,8 @@ async fn ws_no_permissions_forbidden(ctx: TrustifyContext) {
 #[test(actix_web::test)]
 async fn ws_read_sbom_accepted(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
     let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
 
     let app = actix::init_service(
@@ -301,7 +305,8 @@ async fn ws_read_sbom_accepted(ctx: TrustifyContext) {
 #[test(actix_web::test)]
 async fn ws_read_advisory_accepted(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
     let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
 
     let app = actix::init_service(
@@ -329,7 +334,8 @@ async fn ws_read_advisory_accepted(ctx: TrustifyContext) {
 #[test(tokio::test)]
 async fn fetch_after_returns_newer_entries(ctx: TrustifyContext) {
     let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
 
     // Insert 3 entries with small delays so UUIDv7 ordering is preserved
     record_change(
@@ -369,4 +375,451 @@ async fn fetch_after_returns_newer_entries(ctx: TrustifyContext) {
     let last_cursor = all.last().unwrap().cursor;
     let after_last = broadcaster.fetch_after(&last_cursor).await.unwrap();
     assert!(after_last.is_empty());
+}
+
+// -- Group F: record_change and fetch_* DB tests -----------------------------
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn record_change_inserts_entry(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+
+    let initial_cursor = broadcaster.fetch_latest_cursor().await;
+    let entity_id = Uuid::now_v7();
+
+    record_change(
+        &ctx.db,
+        ChangeEntity::Sbom,
+        Some(entity_id),
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+
+    let entries = broadcaster.fetch_after(&initial_cursor).await.unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].r#type, ChangeEntity::Sbom);
+    assert_eq!(entries[0].id, Some(entity_id));
+    assert_eq!(entries[0].operation, ChangeOperation::Added);
+    assert_ne!(entries[0].cursor, Uuid::nil());
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn record_change_with_none_entity_id(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+
+    let initial_cursor = broadcaster.fetch_latest_cursor().await;
+
+    record_change(
+        &ctx.db,
+        ChangeEntity::Advisory,
+        None,
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+
+    let entries = broadcaster.fetch_after(&initial_cursor).await.unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].r#type, ChangeEntity::Advisory);
+    assert_eq!(entries[0].id, None);
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn fetch_latest_cursor_empty_table(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+
+    let cursor = broadcaster.fetch_latest_cursor().await;
+    assert_eq!(cursor, Uuid::nil());
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn fetch_latest_cursor_returns_newest(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+
+    record_change(
+        &ctx.db,
+        ChangeEntity::Sbom,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    record_change(
+        &ctx.db,
+        ChangeEntity::Advisory,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    record_change(
+        &ctx.db,
+        ChangeEntity::Sbom,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Deleted,
+    )
+    .await
+    .unwrap();
+
+    let all = broadcaster.fetch_after(&Uuid::nil()).await.unwrap();
+    let latest = broadcaster.fetch_latest_cursor().await;
+    assert_eq!(latest, all.last().unwrap().cursor);
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn fetch_after_with_mixed_entity_types(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+
+    let initial_cursor = broadcaster.fetch_latest_cursor().await;
+
+    record_change(
+        &ctx.db,
+        ChangeEntity::Sbom,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    record_change(
+        &ctx.db,
+        ChangeEntity::Advisory,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    record_change(
+        &ctx.db,
+        ChangeEntity::Sbom,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Deleted,
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    record_change(
+        &ctx.db,
+        ChangeEntity::Advisory,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Deleted,
+    )
+    .await
+    .unwrap();
+
+    let entries = broadcaster.fetch_after(&initial_cursor).await.unwrap();
+    assert_eq!(entries.len(), 4);
+    assert_eq!(entries[0].r#type, ChangeEntity::Sbom);
+    assert_eq!(entries[0].operation, ChangeOperation::Added);
+    assert_eq!(entries[1].r#type, ChangeEntity::Advisory);
+    assert_eq!(entries[1].operation, ChangeOperation::Added);
+    assert_eq!(entries[2].r#type, ChangeEntity::Sbom);
+    assert_eq!(entries[2].operation, ChangeOperation::Deleted);
+    assert_eq!(entries[3].r#type, ChangeEntity::Advisory);
+    assert_eq!(entries[3].operation, ChangeOperation::Deleted);
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn fetch_after_filters_unknown_entity_type(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+
+    let initial_cursor = broadcaster.fetch_latest_cursor().await;
+
+    record_change(
+        &ctx.db,
+        ChangeEntity::Sbom,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(2)).await;
+
+    let corrupt_id = Uuid::now_v7();
+    ctx.db
+        .execute_unprepared(&format!(
+            "INSERT INTO change_log (id, entity_type, entity_id, operation) \
+             VALUES ('{corrupt_id}', 'dataset', NULL, 'added')"
+        ))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(2)).await;
+
+    record_change(
+        &ctx.db,
+        ChangeEntity::Advisory,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+
+    let entries = broadcaster.fetch_after(&initial_cursor).await.unwrap();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].r#type, ChangeEntity::Sbom);
+    assert_eq!(entries[1].r#type, ChangeEntity::Advisory);
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn fetch_after_filters_unknown_operation(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+
+    let initial_cursor = broadcaster.fetch_latest_cursor().await;
+
+    record_change(
+        &ctx.db,
+        ChangeEntity::Sbom,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(2)).await;
+
+    let corrupt_id = Uuid::now_v7();
+    ctx.db
+        .execute_unprepared(&format!(
+            "INSERT INTO change_log (id, entity_type, entity_id, operation) \
+             VALUES ('{corrupt_id}', 'sbom', NULL, 'modified')"
+        ))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(2)).await;
+
+    record_change(
+        &ctx.db,
+        ChangeEntity::Advisory,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Deleted,
+    )
+    .await
+    .unwrap();
+
+    let entries = broadcaster.fetch_after(&initial_cursor).await.unwrap();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].r#type, ChangeEntity::Sbom);
+    assert_eq!(entries[1].r#type, ChangeEntity::Advisory);
+}
+
+// -- Group G: Serialization format tests --------------------------------------
+
+#[test]
+fn change_entry_serialization_format() {
+    let cursor = Uuid::parse_str("01234567-89ab-cdef-0123-456789abcdef").unwrap();
+    let id = Uuid::parse_str("fedcba98-7654-3210-fedc-ba9876543210").unwrap();
+    let entry = ChangeEntry {
+        cursor,
+        r#type: ChangeEntity::Sbom,
+        id: Some(id),
+        operation: ChangeOperation::Added,
+    };
+    let json: serde_json::Value = serde_json::to_value(&entry).unwrap();
+    assert_eq!(json["type"], "sbom");
+    assert_eq!(json["operation"], "added");
+    assert_eq!(json["cursor"], "01234567-89ab-cdef-0123-456789abcdef");
+    assert_eq!(json["id"], "fedcba98-7654-3210-fedc-ba9876543210");
+    assert_eq!(json.as_object().unwrap().len(), 4);
+}
+
+#[test]
+fn change_entry_serialization_none_id() {
+    let entry = ChangeEntry {
+        cursor: Uuid::now_v7(),
+        r#type: ChangeEntity::Advisory,
+        id: None,
+        operation: ChangeOperation::Deleted,
+    };
+    let json: serde_json::Value = serde_json::to_value(&entry).unwrap();
+    assert!(json["id"].is_null());
+    assert_eq!(json["type"], "advisory");
+    assert_eq!(json["operation"], "deleted");
+}
+
+#[test]
+fn change_entity_serialization_variants() {
+    assert_eq!(
+        serde_json::to_value(ChangeEntity::Advisory).unwrap(),
+        serde_json::Value::String("advisory".into())
+    );
+    assert_eq!(
+        serde_json::to_value(ChangeEntity::Sbom).unwrap(),
+        serde_json::Value::String("sbom".into())
+    );
+}
+
+#[test]
+fn change_operation_serialization_variants() {
+    assert_eq!(
+        serde_json::to_value(ChangeOperation::Added).unwrap(),
+        serde_json::Value::String("added".into())
+    );
+    assert_eq!(
+        serde_json::to_value(ChangeOperation::Deleted).unwrap(),
+        serde_json::Value::String("deleted".into())
+    );
+}
+
+// -- Group H: is_allowed extended coverage ------------------------------------
+
+#[test]
+fn is_allowed_with_both_permissions() {
+    assert!(crate::endpoints::is_allowed(
+        &dummy_entry(ChangeEntity::Sbom),
+        true,
+        true
+    ));
+    assert!(crate::endpoints::is_allowed(
+        &dummy_entry(ChangeEntity::Advisory),
+        true,
+        true
+    ));
+}
+
+// -- Group I: Ingestor side-effect tests --------------------------------------
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn ingest_sbom_creates_change_log_entry(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+
+    let initial_cursor = broadcaster.fetch_latest_cursor().await;
+
+    ctx.ingest_document("spdx/TC-1817-1.json").await.unwrap();
+
+    let entries = broadcaster.fetch_after(&initial_cursor).await.unwrap();
+    let sbom_entries: Vec<_> = entries
+        .iter()
+        .filter(|e| e.r#type == ChangeEntity::Sbom)
+        .collect();
+    assert_eq!(sbom_entries.len(), 1);
+    assert_eq!(sbom_entries[0].operation, ChangeOperation::Added);
+    assert!(sbom_entries[0].id.is_some());
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn ingest_advisory_creates_change_log_entry(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+
+    let initial_cursor = broadcaster.fetch_latest_cursor().await;
+
+    ctx.ingest_document("csaf/CVE-2023-20862.json")
+        .await
+        .unwrap();
+
+    let entries = broadcaster.fetch_after(&initial_cursor).await.unwrap();
+    let advisory_entries: Vec<_> = entries
+        .iter()
+        .filter(|e| e.r#type == ChangeEntity::Advisory)
+        .collect();
+    assert_eq!(advisory_entries.len(), 1);
+    assert_eq!(advisory_entries[0].operation, ChangeOperation::Added);
+    assert!(advisory_entries[0].id.is_some());
+}
+
+// -- Group J: Endpoint permission extended coverage ---------------------------
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn ws_both_permissions_accepted(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+    let authorizer = Authorizer::new(Some(AuthorizerConfig {}));
+
+    let app = actix::init_service(
+        App::new()
+            .into_utoipa_app()
+            .app_data(web::Data::new(authorizer))
+            .configure(|svc| {
+                crate::endpoints::configure(svc, broadcaster, None);
+            })
+            .into_app(),
+    )
+    .await;
+
+    let req = actix::TestRequest::get()
+        .uri("/api/v3/notifications")
+        .to_request()
+        .test_auth_details(user_with_permissions(&["read.sbom", "read.advisory"]));
+    let resp = actix::call_service(&app, req).await;
+    assert_ne!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// -- Group K: Cleanup behavior ------------------------------------------------
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn cleanup_deletes_old_entries(ctx: TrustifyContext) {
+    let db_rw = db::ReadWrite::new(ctx.db.clone());
+    let broadcaster =
+        ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400)).expect("broadcaster");
+
+    record_change(
+        &ctx.db,
+        ChangeEntity::Sbom,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    record_change(
+        &ctx.db,
+        ChangeEntity::Advisory,
+        Some(Uuid::now_v7()),
+        ChangeOperation::Added,
+    )
+    .await
+    .unwrap();
+
+    let all = broadcaster.fetch_after(&Uuid::nil()).await.unwrap();
+    assert_eq!(all.len(), 2);
+
+    let old_cursor = all[0].cursor;
+    ctx.db
+        .execute_unprepared(&format!(
+            "UPDATE change_log SET created_at = NOW() - INTERVAL '2 days' WHERE id = '{old_cursor}'"
+        ))
+        .await
+        .unwrap();
+
+    ctx.db
+        .execute_unprepared(
+            "DELETE FROM change_log WHERE created_at < NOW() - INTERVAL '60 seconds'",
+        )
+        .await
+        .unwrap();
+
+    let remaining = broadcaster.fetch_after(&Uuid::nil()).await.unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].r#type, ChangeEntity::Advisory);
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,6 +16,7 @@ trustify-module-exploit-intelligence = { workspace = true }
 trustify-module-fundamental = { workspace = true }
 trustify-module-importer = { workspace = true }
 trustify-module-ingestor = { workspace = true }
+trustify-module-notification = { workspace = true }
 trustify-module-storage = { workspace = true }
 trustify-module-ui = { workspace = true }
 trustify-module-user = { workspace = true }

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -14,7 +14,12 @@ pub async fn create_openapi() -> anyhow::Result<utoipa::openapi::OpenApi> {
     let db_rw = db::ReadWrite::new(db.clone());
     let db_ro = db::ReadOnly::new(db.clone());
     let analysis = AnalysisService::new(AnalysisConfig::default(), db_ro.clone());
-    let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400))?;
+    let broadcaster = ChangeBroadcaster::new(
+        &db_rw,
+        Duration::from_secs(86400),
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    )?;
 
     let ei_service = ExploitIntelligenceService::new(None)?;
     let (_, mut openapi) = App::new()

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -1,6 +1,7 @@
 use crate::profile::api::{Config, ModuleConfig, configure, default_openapi_info};
 use actix_web::App;
-use trustify_common::db::{self, pagination_cache::PaginationCache};
+use std::time::Duration;
+use trustify_common::db::{self, change::ChangeBroadcaster, pagination_cache::PaginationCache};
 use trustify_module_analysis::{config::AnalysisConfig, service::AnalysisService};
 use trustify_module_exploit_intelligence::service::ExploitIntelligenceService;
 use trustify_module_ingestor::graph::Graph;
@@ -13,6 +14,7 @@ pub async fn create_openapi() -> anyhow::Result<utoipa::openapi::OpenApi> {
     let db_rw = db::ReadWrite::new(db.clone());
     let db_ro = db::ReadOnly::new(db.clone());
     let analysis = AnalysisService::new(AnalysisConfig::default(), db_ro.clone());
+    let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400))?;
 
     let ei_service = ExploitIntelligenceService::new(None)?;
     let (_, mut openapi) = App::new()
@@ -28,6 +30,7 @@ pub async fn create_openapi() -> anyhow::Result<utoipa::openapi::OpenApi> {
                     storage: storage.into(),
                     auth: None,
                     analysis,
+                    broadcaster,
                     read_only: false,
                     ei_service,
                     graph: Graph::new(),

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -39,8 +39,8 @@ use trustify_module_exploit_intelligence::{
     runner::worker::start_worker,
     service::{ExploitIntelligenceConfig, ExploitIntelligenceService},
 };
-use trustify_module_notification::config::NotificationConfig;
 use trustify_module_ingestor::graph::Graph;
+use trustify_module_notification::config::NotificationConfig;
 use trustify_module_storage::{config::StorageConfig, service::dispatch::DispatchBackend};
 use trustify_module_ui::{UI, endpoints::UiResources};
 use utoipa::openapi::{Info, License};
@@ -469,7 +469,12 @@ impl InitData {
 
         let ei_config = run.exploit_intelligence.into_config().await?;
 
-        let broadcaster = ChangeBroadcaster::new(&db_rw, *run.notification.change_log_retention)?;
+        let broadcaster = ChangeBroadcaster::new(
+            &db_rw,
+            *run.notification.change_log_retention,
+            *run.notification.change_log_poll_interval,
+            *run.notification.change_log_cleanup_interval,
+        )?;
 
         Ok(InitData {
             analysis: AnalysisService::new(run.analysis, db_ro.clone()),
@@ -643,6 +648,9 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
     svc.app_data(graph.clone());
 
     let ei_enabled = ei_service.runtime().is_some();
+    // Notification endpoint lives outside the `/api` scope because it uses
+    // QueryTokenInjector middleware — browsers' WebSocket API does not support
+    // custom headers, so the auth token is passed via query string instead.
     svc.configure(|svc| {
         endpoints::configure(svc, auth.clone(), read_only, ei_enabled);
         trustify_module_notification::endpoints::configure(svc, broadcaster, auth.clone());
@@ -741,7 +749,12 @@ mod test {
         let db_rw = db::ReadWrite::new(ctx.db.clone());
         let analysis =
             AnalysisService::new(AnalysisConfig::default(), db::ReadOnly::new(ctx.db.clone()));
-        let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400))?;
+        let broadcaster = ChangeBroadcaster::new(
+            &db_rw,
+            Duration::from_secs(86400),
+            Duration::from_secs(30),
+            Duration::from_secs(300),
+        )?;
         let app = actix_web::test::init_service(
             App::new()
                 .into_utoipa_app()
@@ -826,8 +839,13 @@ mod test {
             AnalysisService::new(AnalysisConfig::default(), db::ReadOnly::new(ctx.db.clone()));
         let ei_service = ExploitIntelligenceService::new(None).expect("disabled EI service");
         let graph = Graph::new();
-        let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400))
-            .expect("failed to create change broadcaster");
+        let broadcaster = ChangeBroadcaster::new(
+            &db_rw,
+            Duration::from_secs(86400),
+            Duration::from_secs(30),
+            Duration::from_secs(300),
+        )
+        .expect("failed to create change broadcaster");
         call::caller_app(move |svc| {
             configure(
                 svc,
@@ -1052,6 +1070,8 @@ mod test {
             broadcaster: ChangeBroadcaster::new(
                 &db::ReadWrite::new(ctx.db.clone()),
                 Duration::from_secs(86400),
+                Duration::from_secs(30),
+                Duration::from_secs(300),
             )
             .expect("failed to create change broadcaster"),
             #[cfg(feature = "garage-door")]
@@ -1097,6 +1117,8 @@ mod test {
         let broadcaster = ChangeBroadcaster::new(
             &db::ReadWrite::new(ctx.db.clone()),
             Duration::from_secs(86400),
+            Duration::from_secs(30),
+            Duration::from_secs(300),
         )
         .expect("failed to create change broadcaster");
         let app = call::caller_app(move |svc| {

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -18,6 +18,7 @@ use trustify_common::{
     config::{Database, DatabaseReadOnly},
     db::{
         self,
+        change::ChangeBroadcaster,
         pagination_cache::{PaginationCache, PaginationConfig},
     },
     middleware::ReadOnlyState,
@@ -38,6 +39,7 @@ use trustify_module_exploit_intelligence::{
     runner::worker::start_worker,
     service::{ExploitIntelligenceConfig, ExploitIntelligenceService},
 };
+use trustify_module_notification::config::NotificationConfig;
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_storage::{config::StorageConfig, service::dispatch::DispatchBackend};
 use trustify_module_ui::{UI, endpoints::UiResources};
@@ -103,6 +105,10 @@ pub struct Run {
     /// Analysis configuration
     #[command(flatten)]
     pub analysis: AnalysisConfig,
+
+    /// Notification configuration
+    #[command(flatten)]
+    pub notification: NotificationConfig,
 
     /// Database configuration
     #[command(flatten)]
@@ -354,6 +360,7 @@ struct InitData {
     ui: UI,
     config: ModuleConfig,
     analysis: AnalysisService,
+    broadcaster: ChangeBroadcaster,
     read_only: bool,
     ei_config: Option<ExploitIntelligenceConfig>,
 }
@@ -462,8 +469,11 @@ impl InitData {
 
         let ei_config = run.exploit_intelligence.into_config().await?;
 
+        let broadcaster = ChangeBroadcaster::new(&db_rw, *run.notification.change_log_retention)?;
+
         Ok(InitData {
             analysis: AnalysisService::new(run.analysis, db_ro.clone()),
+            broadcaster,
             authenticator,
             authorizer,
             db_rw,
@@ -513,6 +523,7 @@ impl InitData {
                             storage: self.storage.clone(),
                             auth: self.authenticator.clone(),
                             analysis: self.analysis.clone(),
+                            broadcaster: self.broadcaster.clone(),
                             read_only: self.read_only,
                             ei_service: ei_service.clone(),
                             graph: graph.clone(),
@@ -598,6 +609,7 @@ pub(crate) struct Config {
     pub(crate) cache: PaginationCache,
     pub(crate) storage: DispatchBackend,
     pub(crate) analysis: AnalysisService,
+    pub(crate) broadcaster: ChangeBroadcaster,
     pub(crate) auth: Option<Arc<Authenticator>>,
     pub(crate) read_only: bool,
     pub(crate) ei_service: ExploitIntelligenceService,
@@ -618,6 +630,7 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
         storage,
         auth,
         analysis,
+        broadcaster,
         read_only,
         ei_service,
         graph,
@@ -632,6 +645,7 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
     let ei_enabled = ei_service.runtime().is_some();
     svc.configure(|svc| {
         endpoints::configure(svc, auth.clone(), read_only, ei_enabled);
+        trustify_module_notification::endpoints::configure(svc, broadcaster, auth.clone());
     });
 
     svc.service(
@@ -695,9 +709,10 @@ mod test {
     };
     use clap::{Args, Command, FromArgMatches};
     use rstest::rstest;
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
     use test_context::test_context;
     use test_log::test;
+    use trustify_common::db::change::ChangeBroadcaster;
     use trustify_infrastructure::app::http::ApplyOpenApi;
     use trustify_module_ui::{UI, endpoints::UiResources};
     use trustify_test_context::{TrustifyContext, app::TestApp, call, call::CallService};
@@ -723,8 +738,10 @@ mod test {
     #[test(actix_web::test)]
     async fn routing(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         let ui = Arc::new(UiResources::new(&UI::default())?);
+        let db_rw = db::ReadWrite::new(ctx.db.clone());
         let analysis =
             AnalysisService::new(AnalysisConfig::default(), db::ReadOnly::new(ctx.db.clone()));
+        let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400))?;
         let app = actix_web::test::init_service(
             App::new()
                 .into_utoipa_app()
@@ -734,12 +751,13 @@ mod test {
                         svc,
                         Config {
                             config: ModuleConfig::default(),
-                            db_rw: db::ReadWrite::new(ctx.db.clone()),
+                            db_rw,
                             db_ro: db::ReadOnly::new(ctx.db.clone()),
                             cache: PaginationCache::for_test(),
                             storage: ctx.storage.clone().into(),
                             auth: None,
                             analysis,
+                            broadcaster,
                             read_only: false,
                             ei_service: ExploitIntelligenceService::new(None)
                                 .expect("disabled EI service"),
@@ -803,21 +821,25 @@ mod test {
 
     /// Creates a fully configured test app with all server endpoints and standard middleware.
     async fn caller(ctx: &TrustifyContext, read_only: bool) -> impl CallService {
+        let db_rw = db::ReadWrite::new(ctx.db.clone());
         let analysis =
             AnalysisService::new(AnalysisConfig::default(), db::ReadOnly::new(ctx.db.clone()));
         let ei_service = ExploitIntelligenceService::new(None).expect("disabled EI service");
         let graph = Graph::new();
+        let broadcaster = ChangeBroadcaster::new(&db_rw, Duration::from_secs(86400))
+            .expect("failed to create change broadcaster");
         call::caller_app(move |svc| {
             configure(
                 svc,
                 Config {
                     config: ModuleConfig::default(),
-                    db_rw: db::ReadWrite::new(ctx.db.clone()),
+                    db_rw,
                     db_ro: db::ReadOnly::new(ctx.db.clone()),
                     storage: ctx.storage.clone().into(),
                     cache: PaginationCache::for_test(),
                     auth: None,
                     analysis,
+                    broadcaster,
                     read_only,
                     ei_service,
                     graph,
@@ -1027,6 +1049,11 @@ mod test {
             ),
             read_only: false,
             ei_config: None,
+            broadcaster: ChangeBroadcaster::new(
+                &db::ReadWrite::new(ctx.db.clone()),
+                Duration::from_secs(86400),
+            )
+            .expect("failed to create change broadcaster"),
             #[cfg(feature = "garage-door")]
             embedded_oidc: None,
             ui: Default::default(),
@@ -1067,6 +1094,11 @@ mod test {
         }))
         .expect("enabled EI service");
         let graph = Graph::new();
+        let broadcaster = ChangeBroadcaster::new(
+            &db::ReadWrite::new(ctx.db.clone()),
+            Duration::from_secs(86400),
+        )
+        .expect("failed to create change broadcaster");
         let app = call::caller_app(move |svc| {
             configure(
                 svc,
@@ -1081,6 +1113,7 @@ mod test {
                     read_only: false,
                     ei_service,
                     graph,
+                    broadcaster,
                 },
             );
         })


### PR DESCRIPTION
## Summary

- Add `change_log` table with PostgreSQL `LISTEN/NOTIFY` trigger for real-time change event streaming
- Introduce `ChangeListener` (single-consumer, poll+notify) and `ChangeBroadcaster` (fan-out via `tokio::sync::broadcast`) in `common/src/db/change.rs`
- Add WebSocket endpoint at `GET /api/v3/notifications` with:
  - Cursor-based gap-free reconnection (`?after=<cursor>`)
  - `?token=` query parameter auth for browser clients
  - Per-entity permission filtering (`read.sbom` / `read.advisory`)
  - Connection message with current cursor on first connect
  - 30s heartbeat ping
- Record change events in the ingestor on advisory/SBOM ingestion
- Configurable retention via `--change-log-retention` / `TRUSTD_CHANGE_LOG_RETENTION` (humantime, default `1d`)

## Test plan

- [ ] `cargo check` — workspace compiles
- [ ] `cargo clippy --workspace` — no warnings
- [ ] `cargo test -p trustify-module-notification` — 17 tests (12 unit, 5 integration)
- [ ] Manual: connect via `websocat`, ingest a document, verify event arrives
- [ ] Manual: reconnect with `?after=<cursor>`, verify backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable gap-free real-time advisory and SBOM change notifications over WebSockets.

New Features:
- Add a WebSocket notifications endpoint that streams advisory and SBOM change events with authentication, permission filtering, cursor-based replay, and heartbeat support.

Enhancements:
- Introduce shared change event listening and broadcasting infrastructure with PostgreSQL notification and polling support.
- Record advisory and SBOM ingestion events for real-time notification delivery.
- Support configurable change-log retention and listener timing through command-line and environment settings.

Build:
- Add the notification module and required WebSocket/PostgreSQL dependencies to the workspace.

Documentation:
- Document the notification WebSocket protocol, authentication options, reconnection behavior, and client examples.

Tests:
- Add unit and integration coverage for token handling, permission filtering, change-log operations, event serialization, ingestion events, and retention behavior.

Chores:
- Add the change-log database migration, trigger, and cleanup support.