### PR TITLE
fix(purl): remove VersionMatches from product_status query

### DIFF
--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -174,7 +174,6 @@ impl PurlDetails {
             qualified_package.id,
             &package.name,
             package.namespace.as_deref(),
-            &package_version.version,
         )
         .await?;
 
@@ -226,7 +225,6 @@ async fn get_product_statuses_for_purl<C: ConnectionTrait>(
     qualified_package_id: Uuid,
     purl_name: &str,
     namespace_name: Option<&str>,
-    _version: &str,
 ) -> Result<Vec<ProductStatusCatcher>, Error> {
     // Subquery to get all SBOM IDs for the given purl
     let sbom_ids_query = sbom::Entity::find()

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -226,7 +226,7 @@ async fn get_product_statuses_for_purl<C: ConnectionTrait>(
     qualified_package_id: Uuid,
     purl_name: &str,
     namespace_name: Option<&str>,
-    version: &str,
+    _version: &str,
 ) -> Result<Vec<ProductStatusCatcher>, Error> {
     // Subquery to get all SBOM IDs for the given purl
     let sbom_ids_query = sbom::Entity::find()
@@ -262,11 +262,6 @@ async fn get_product_statuses_for_purl<C: ConnectionTrait>(
             namespace_name.map_or(Expr::value(false), |ns| {
                 Expr::col(product_status::Column::Package).eq(format!("{ns}/{purl_name}"))
             }),
-        ))
-        .filter(SimpleExpr::FunctionCall(
-            Func::cust(VersionMatches)
-                .arg(Expr::value(version.to_string()))
-                .arg(Expr::col((version_range::Entity, Asterisk))),
         ))
         .distinct_on([
             (product_status::Entity, product_status::Column::ContextCpeId),

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -1154,3 +1154,46 @@ async fn product_status_version_filtering(ctx: &TrustifyContext) -> Result<(), a
 
     Ok(())
 }
+
+/// Verifies that product_status entries are returned even when the package version
+/// falls outside the product stream version range — the VersionMatches filter must
+/// not compare package versions against CPE-derived product version ranges.
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn product_status_cross_domain_version(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let service = PurlService::new(PaginationCache::for_test());
+    ctx.ingest_dataset(Dataset::DS1).await?;
+
+    // Given keycloak-core@18.0.6 — its version (18.x) exceeds the Quarkus product
+    // stream range [2.0.0, 3.0.0) derived from CPE cpe:/a:redhat:quarkus:2.
+    let purl = Purl::from_str(
+        "pkg:maven/org.keycloak/keycloak-core@18.0.6.redhat-00001?repository_url=https://maven.repository.redhat.com/ga/&type=jar",
+    )?;
+    let details = service
+        .purl_by_purl(&purl, Default::default(), &ctx.db)
+        .await?
+        .expect("keycloak-core purl must exist after DS1 ingestion");
+
+    // When filtering for product_status entries with CPE context
+    let cpe_statuses: Vec<_> = details
+        .advisories
+        .iter()
+        .flat_map(|a| &a.status)
+        .filter(|s| matches!(&s.context, Some(StatusContext::Cpe(_))))
+        .collect();
+
+    // Then CVE-2023-1664 must appear despite the cross-domain version mismatch
+    assert!(
+        !cpe_statuses.is_empty(),
+        "keycloak-core must have product_status entries with CPE context"
+    );
+
+    assert!(
+        cpe_statuses
+            .iter()
+            .any(|s| s.vulnerability.identifier == "CVE-2023-1664"),
+        "product_statuses must include CVE-2023-1664"
+    );
+
+    Ok(())
+}

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -1133,19 +1133,16 @@ async fn product_status_version_filtering(ctx: &TrustifyContext) -> Result<(), a
         .filter(|s| matches!(&s.context, Some(StatusContext::Cpe(_))))
         .collect();
 
-    assert!(
-        !cpe_statuses.is_empty(),
-        "affected gnutls version must have product_status entries with CPE context"
-    );
-
-    assert!(
-        cpe_statuses
-            .iter()
-            .any(|s| s.vulnerability.identifier == "CVE-2024-28834"),
-        "product_statuses must include CVE-2024-28834"
+    // Then exactly 2 CPE-context entries must exist, both for CVE-2024-28834.
+    assert_eq!(
+        cpe_statuses.len(),
+        2,
+        "expected exactly 2 product_status entries with CPE context"
     );
 
     for s in &cpe_statuses {
+        assert_eq!(s.vulnerability.identifier, "CVE-2024-28834");
+        assert_eq!(s.status, "affected");
         assert!(
             s.version_range.is_some(),
             "every product_status entry must carry a version_range"
@@ -1182,17 +1179,31 @@ async fn product_status_cross_domain_version(ctx: &TrustifyContext) -> Result<()
         .filter(|s| matches!(&s.context, Some(StatusContext::Cpe(_))))
         .collect();
 
-    // Then CVE-2023-1664 must appear despite the cross-domain version mismatch
-    assert!(
-        !cpe_statuses.is_empty(),
-        "keycloak-core must have product_status entries with CPE context"
+    // Then exactly 8 CPE-context entries must be present, including CVE-2023-1664
+    // despite the cross-domain version mismatch.
+    assert_eq!(
+        cpe_statuses.len(),
+        8,
+        "keycloak-core must have 8 product_status entries with CPE context"
     );
 
-    assert!(
-        cpe_statuses
-            .iter()
-            .any(|s| s.vulnerability.identifier == "CVE-2023-1664"),
-        "product_statuses must include CVE-2023-1664"
+    let mut cve_ids: Vec<&str> = cpe_statuses
+        .iter()
+        .map(|s| s.vulnerability.identifier.as_str())
+        .collect();
+    cve_ids.sort();
+    assert_eq!(
+        cve_ids,
+        vec![
+            "CVE-2022-45787",
+            "CVE-2023-0481",
+            "CVE-2023-1584",
+            "CVE-2023-1664",
+            "CVE-2023-28867",
+            "CVE-2023-2974",
+            "CVE-2023-44487",
+            "CVE-2023-4853",
+        ]
     );
 
     Ok(())

--- a/test-context/src/lib.rs
+++ b/test-context/src/lib.rs
@@ -42,12 +42,14 @@ use walkdir::DirEntry;
 use zip::write::FileOptions;
 
 pub enum Dataset {
+    DS1,
     DS3,
 }
 
 impl AsRef<Path> for Dataset {
     fn as_ref(&self) -> &Path {
         match self {
+            Self::DS1 => Path::new("../datasets/ds1"),
             Self::DS3 => Path::new("../datasets/ds3"),
         }
     }


### PR DESCRIPTION
## Summary

- Remove the `VersionMatches` filter from `get_product_statuses_for_purl` — it compared package versions against product stream version ranges (from CPEs), which are incompatible version domains
- Add reproducer test `product_status_cross_domain_version` proving CVE-2023-1664 appears for `keycloak-core@18.0.6` despite the cross-domain version mismatch

## Context

The `VersionMatches` filter was added in commit `2bf72b96` (PR #2521, TC-5170) to reduce false-positive vulnerability matches. While correct on the `purl_statuses` query path (package-version vs package-version-range), it was incorrectly applied to the `product_status` query path where version ranges describe the product stream (e.g., Quarkus `[2.0.0, 3.0.0)` from CPE `cpe:/a:redhat:quarkus:2`), not the component version.

PR #2523 (TC-5171) already removed the same filter from the parallel product_status query in `vulnerability/service/mod.rs`.

## Test plan

- [x] New reproducer test `product_status_cross_domain_version` passes
- [x] Existing `product_status_version_filtering` test passes (no regression)
- [x] `cargo fmt` and `cargo clippy` clean
- [ ] trustify-ui nightly e2e tests pass against this fix

Closes guacsec/trustify#2546
Implements [TC-5406](https://redhat.atlassian.net/browse/TC-5406)

[TC-5406]: https://redhat.atlassian.net/browse/TC-5406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Remove incompatible version filtering from product status lookup for PURLs and add regression coverage for cross-domain version scenarios.

Bug Fixes:
- Stop filtering product_status records by package version against CPE-derived product version ranges in PURL product status queries to avoid dropping valid vulnerabilities.

Tests:
- Add a regression test using dataset DS1 to ensure product_status entries (including CVE-2023-1664) are returned even when package and product stream versions are in different domains.

Chores:
- Extend the shared test dataset enum to expose the DS1 dataset for reuse in tests.