### PR TITLE
docs: document import nesting convention

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -19,6 +19,23 @@
 - Use `?` operator for error propagation, not `.unwrap()`
 - All CI checks are run via `cargo xtask precommit` (see [Pre-commit Workflow](#pre-commit-workflow))
 
+### Import Nesting
+
+Merge multiple `use` statements from the same crate into a single `use` block with nested
+paths. This reduces visual clutter and groups related imports.
+
+```rust
+// Good — single nested use block
+use sea_orm::{error::DbErr, ConnectionTrait, TransactionTrait};
+
+// Avoid — separate use statements from the same crate
+use sea_orm::error::DbErr;
+use sea_orm::{ConnectionTrait, TransactionTrait};
+```
+
+This is a manual convention — `rustfmt`'s `imports_granularity = "Crate"` option is not
+available on the stable channel. Reviewers should flag un-nested imports during code review.
+
 ## Naming Conventions
 
 - Structs: PascalCase (`SbomService`, `AdvisoryService`, `SbomSummary`)


### PR DESCRIPTION
## Summary

- Add Import Nesting convention to CONVENTIONS.md under Code Style
- Requires merging multiple `use` statements from the same crate into a single nested `use` block
- Documents that `rustfmt`'s `imports_granularity = "Crate"` is not available on stable, so enforcement is via code review

Implements [TC-5419](https://redhat.atlassian.net/browse/TC-5419)

[TC-5419]: https://redhat.atlassian.net/browse/TC-5419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Documentation:
- Add a Code Style section describing the convention of merging multiple `use` statements from the same crate into a single nested `use` block and noting its manual enforcement via review.