### PR TITLE
fix: request 'openid' scope in client_credentials token requests

### DIFF
--- a/common/auth/src/client/provider/openid.rs
+++ b/common/auth/src/client/provider/openid.rs
@@ -262,7 +262,7 @@ impl OpenIdTokenProvider {
     async fn initial_token(&self) -> Result<openid::TemporalBearerGuard, openid::error::Error> {
         Ok(self
             .client
-            .request_token_using_client_credentials(None)
+            .request_token_using_client_credentials(Some("openid"))
             .await?
             .into())
     }


### PR DESCRIPTION
When Trustify acquires tokens via OIDC `client_credentials` flow (e.g. for calling the Exploit Intelligence service), the `openid` scope was not being requested. This caused token validation failures (401) on services that require the `openid` scope in the token, such as the EI client running with Quarkus OIDC.

The fix passes `"openid"` as the scope parameter to `request_token_using_client_credentials`. This is standard OIDC behavior, `openid` is the baseline scope that distinguishes an OIDC request from a plain OAuth2 request, and is supported by all OIDC-compliant providers.


## Summary by Sourcery

Bug Fixes:
- Include the 'openid' scope in client_credentials token requests to comply with OpenID Connect requirements.