### PR TITLE
docs: add turbofish convention for collection constructors

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -229,12 +229,9 @@ The turbofish is acceptable when the compiler cannot infer the type. Common case
 - **Assertion macros** — `assert_eq!` does not propagate type constraints between its arguments
 
 ```rust
-// Good — return type provides inference
-fn make_set() -> HashSet<String> {
-    let mut s = HashSet::new();
-    s.insert("a".to_string());
-    s
-}
+// Good — compiler infers HashSet<&str> from the insert call
+let mut names = HashSet::new();
+names.insert("alice");
 
 // Good — turbofish needed because .or_default() requires type resolution
 let mut map = BTreeMap::<String, Vec<Item>>::new();

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -213,6 +213,38 @@ let base_purl_map: HashMap<PurlKey, BasePurl> = base_purls.into_iter().map(|b| (
 This also applies to SeaORM `.all()` calls (which already return `Vec<Model>`) and `push()` calls
 where the collection type is already known.
 
+#### Turbofish on collection constructors
+
+Prefer plain constructors (`HashMap::new()`, `Vec::new()`) over turbofish-annotated ones
+(`HashMap::<K, V>::new()`) when the compiler can infer the type from context — for example,
+from the function's return type or from a subsequent assignment.
+
+The turbofish is acceptable when the compiler cannot infer the type. Common cases:
+
+- **`.entry().or_default()`** — the compiler needs the value type to resolve `Default::default()`
+- **Type coercion** — the turbofish drives `&String` → `&str` coercion that inference alone
+  would not produce
+- **Generic function parameters** — e.g., `impl IntoIterator<Item = impl AsRef<str>>` does
+  not constrain the concrete collection type
+- **Assertion macros** — `assert_eq!` does not propagate type constraints between its arguments
+
+```rust
+// Good — return type provides inference
+fn make_set() -> HashSet<String> {
+    let mut s = HashSet::new();
+    s.insert("a".to_string());
+    s
+}
+
+// Good — turbofish needed because .or_default() requires type resolution
+let mut map = BTreeMap::<String, Vec<Item>>::new();
+map.entry(key).or_default().push(item);
+
+// Good — turbofish drives &String → &str coercion
+let mut packages = HashSet::<&str>::new();
+packages.insert(&some_string); // &String coerced to &str
+```
+
 ### Iterator ownership
 
 Prefer consuming the collection (`for item in items`, which calls `IntoIterator`) over


### PR DESCRIPTION
## Summary

- Add "Turbofish on collection constructors" convention to CONVENTIONS.md under Rust Idioms > Type inference
- Documents preference for plain constructors (`HashMap::new()`) over turbofish-annotated ones (`HashMap::<K, V>::new()`) when the compiler can infer the type
- Lists the cases where turbofish is acceptable: `.entry().or_default()`, type coercion, generic function parameters, and assertion macros

### Turbofish verification results

All 8 existing turbofish instances in the codebase were individually verified against the compiler — **none are removable**:

| File | Pattern | Reason turbofish is required |
|------|---------|------------------------------|
| `modules/ui/src/service.rs` | `BTreeMap::<K,V>::new()` | `.entry().or_default()` needs value type |
| `modules/ingestor/src/graph/sbom/spdx.rs` | `HashSet::<&str>::new()` | Drives `&String` → `&str` coercion |
| `modules/ingestor/src/service/advisory/csaf/util.rs` | `HashMap::<&'a str, Vec<&'a Branch>>::new()` | Lifetime annotations + type coercion |
| `modules/fundamental/tests/sbom/cyclonedx/cpe.rs` | `Vec::<String>::new()` | `assert_eq!` doesn't propagate type constraints |
| `modules/fundamental/src/vulnerability/service/mod.rs` | `BTreeMap::<K,V>::new()` | `.entry().or_default()` needs value type |
| `modules/fundamental/src/vulnerability/service/test.rs` (×2) | `Vec::<&str>::new()` | `impl IntoIterator<Item = impl AsRef<str>>` too generic |
| `modules/analysis/src/service/mod.rs` | `HashMap::<K,V>::with_capacity()` | `.entry().or_default()` needs value type |

Implements [TC-5390](https://redhat.atlassian.net/browse/TC-5390)

[TC-5390]: https://redhat.atlassian.net/browse/TC-5390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Document Rust turbofish usage guidelines for collection constructors in the conventions guide.

Documentation:
- Add a Rust idiom convention preferring plain collection constructors over turbofish-annotated ones when type inference is sufficient.
- Document specific scenarios where turbofish on collection constructors is acceptable, including .entry().or_default(), type coercion, generic parameters, and assertion macros.