### PR TITLE
feat: enable clippy::absolute_paths lint to enforce import style

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,2 +1,3 @@
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true
+absolute-paths-max-segments = 3

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -36,6 +36,44 @@ use sea_orm::{ConnectionTrait, TransactionTrait};
 This is a manual convention — `rustfmt`'s `imports_granularity = "Crate"` option is not
 available on the stable channel. Reviewers should flag un-nested imports during code review.
 
+### Import Style — Absolute Paths
+
+Fully-qualified paths with 4+ segments are enforced by the `clippy::absolute_paths` lint
+(configured in `.clippy.toml` with `absolute-paths-max-segments = 3`). Paths exceeding the
+threshold must be replaced with `use` imports:
+
+```rust
+// Good — imported
+use crate::graph::db_context::parse_status;
+parse_status(value)?;
+
+// Lint error — 4+ segment absolute path
+crate::graph::db_context::parse_status(value)?;
+```
+
+3-segment paths (e.g. `std::fmt::Result`, `entity::advisory_vulnerability::Model`) are not
+flagged by the lint and are acceptable.
+
+### Import Style — Qualified Names for Common Types
+
+Common or ambiguous names should stay qualified with a 2-segment path, even when there is
+no conflict in the current file. This keeps the code self-documenting and avoids confusion
+when reviewing:
+
+```rust
+// Good — qualified with module prefix
+let model: advisory_vulnerability::Model = ...;
+let result: std::fmt::Result = ...;
+let value = serde_json::from_value(...);
+
+// Avoid — bare name is ambiguous across modules
+let model: Model = ...;
+```
+
+Names that benefit from qualification include `Model`, `Entity`, `Column`, `ActiveModel`,
+`Relation`, `from_value`, `info`, and similar names that appear in many modules. This is a
+reviewer convention, not lint-enforced.
+
 ## Naming Conventions
 
 - Structs: PascalCase (`SbomService`, `AdvisoryService`, `SbomSummary`)

--- a/common/auth/src/authenticator/user.rs
+++ b/common/auth/src/authenticator/user.rs
@@ -1,6 +1,6 @@
 //! Structures to work with users and identities.
 
-use crate::authenticator::error::AuthorizationError;
+use crate::authenticator::error::{AuthenticationError, AuthorizationError};
 
 /// Details of an authenticated user.
 ///
@@ -101,9 +101,7 @@ impl actix_web::FromRequest for UserDetails {
                 log::debug!("Anonymous user, returning failure");
                 core::future::ready(Err(AuthorizationError::Failed.into()))
             }
-            None => core::future::ready(Err(
-                crate::authenticator::error::AuthenticationError::Failed.into(),
-            )),
+            None => core::future::ready(Err(AuthenticationError::Failed.into())),
         }
     }
 }

--- a/common/auth/src/client/provider/mod.rs
+++ b/common/auth/src/client/provider/mod.rs
@@ -106,8 +106,11 @@ impl TokenProvider for String {
 }
 
 #[cfg(feature = "actix")]
+use actix_web_httpauth::extractors::bearer::BearerAuth;
+
+#[cfg(feature = "actix")]
 #[async_trait]
-impl TokenProvider for actix_web_httpauth::extractors::bearer::BearerAuth {
+impl TokenProvider for BearerAuth {
     async fn provide_access_token(&self) -> Result<Option<Credentials>, Error> {
         Ok(Some(Credentials::Bearer(self.token().to_string())))
     }

--- a/common/infrastructure/src/app/mod.rs
+++ b/common/infrastructure/src/app/mod.rs
@@ -13,7 +13,10 @@ use actix_web_httpauth::{extractors::bearer::BearerAuth, middleware::HttpAuthent
 use futures::{FutureExt, future::LocalBoxFuture};
 use opentelemetry_instrumentation_actix_web::{RequestMetrics, RequestTracing};
 use std::sync::Arc;
-use trustify_auth::{authenticator::Authenticator, authorizer::Authorizer};
+use trustify_auth::{
+    authenticator::{Authenticator, actix::openid_validator},
+    authorizer::Authorizer,
+};
 use trustify_common::middleware::StdMiddleware;
 
 #[derive(Default)]
@@ -42,11 +45,7 @@ pub fn new_auth(
     Condition::from_option(auth.map(move |authenticator| {
         HttpAuthentication::bearer(move |req, auth| {
             let authenticator = authenticator.clone();
-            Box::pin(async move {
-                trustify_auth::authenticator::actix::openid_validator(req, auth, authenticator)
-                    .await
-            })
-            .boxed_local()
+            Box::pin(async move { openid_validator(req, auth, authenticator).await }).boxed_local()
         })
     }))
 }

--- a/common/src/decompress.rs
+++ b/common/src/decompress.rs
@@ -1,5 +1,6 @@
 use actix_web::http::header;
 use anyhow::anyhow;
+use async_compression::tokio::bufread::{GzipDecoder, LzmaDecoder};
 use bytes::Bytes;
 use std::{io::Read, path::Path, pin::Pin};
 use tokio::{
@@ -109,8 +110,8 @@ pub async fn decompress_async_read(
     let source = BufReader::new(source);
 
     Ok(match path.extension().and_then(|ext| ext.to_str()) {
-        Some("xz") => Box::pin(async_compression::tokio::bufread::LzmaDecoder::new(source)),
-        Some("gz") => Box::pin(async_compression::tokio::bufread::GzipDecoder::new(source)),
+        Some("xz") => Box::pin(LzmaDecoder::new(source)),
+        Some("gz") => Box::pin(GzipDecoder::new(source)),
         // Anything else could be .sql, .tar, or an unsupported compression format.
         // In that case, the following code would fail to understand the compressed content.
         None | Some(_) => Box::pin(source),

--- a/common/src/uuid.rs
+++ b/common/src/uuid.rs
@@ -4,13 +4,14 @@ pub mod serde {
 
         use serde::{Deserialize, Deserializer, Serializer, de::Error};
         use uuid::Uuid;
+        use uuid::serde::urn::serialize as uuid_urn_serialize;
 
         pub fn serialize<S>(value: &Option<Uuid>, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
             match value {
-                Some(uuid) => uuid::serde::urn::serialize(uuid, serializer),
+                Some(uuid) => uuid_urn_serialize(uuid, serializer),
                 None => serializer.serialize_none(),
             }
         }

--- a/migration/src/data/document/sbom.rs
+++ b/migration/src/data/document/sbom.rs
@@ -5,6 +5,7 @@ use sea_orm::{
     prelude::*,
     sea_query::{Expr, extension::postgres::PgExpr},
 };
+use serde_cyclonedx::cyclonedx::v_1_6::CycloneDx;
 use trustify_entity::{labels::Labels, sbom};
 use trustify_module_storage::service::StorageBackend;
 
@@ -16,7 +17,7 @@ pub struct Id {
 
 #[allow(clippy::large_enum_variant)]
 pub enum Sbom {
-    CycloneDx(serde_cyclonedx::cyclonedx::v_1_6::CycloneDx),
+    CycloneDx(CycloneDx),
     Spdx(spdx_rs::models::SPDX),
     Other(Bytes),
 }

--- a/migration/src/m0002000_add_sbom_properties.rs
+++ b/migration/src/m0002000_add_sbom_properties.rs
@@ -1,4 +1,6 @@
-use crate::data::{MigrationTraitWithData, SchemaDataManager, sbom::Sbom as SbomDoc};
+use crate::data::{
+    MigrationTraitWithData, SchemaDataManager, sbom::Id as SbomId, sbom::Sbom as SbomDoc,
+};
 use sea_orm::{ActiveModelBehavior, ActiveModelTrait, DatabaseTransaction, Set};
 use sea_orm_migration::prelude::*;
 use trustify_common::advisory::cyclonedx::extract_properties_json;
@@ -68,7 +70,7 @@ impl MigrationTraitWithData for Migration {
         manager
             .process(
                 self,
-                async |sbom: SbomDoc, id: crate::data::sbom::Id, tx: &DatabaseTransaction| {
+                async |sbom: SbomDoc, id: SbomId, tx: &DatabaseTransaction| {
                     let mut model = legacy::ActiveModel::new();
                     model.sbom_id = Set(id.sbom);
                     match sbom {

--- a/modules/analysis/src/error.rs
+++ b/modules/analysis/src/error.rs
@@ -5,6 +5,7 @@ use cpe::uri::OwnedUri;
 use sea_orm::DbErr;
 use std::str::FromStr;
 use trustify_auth::authenticator::error::AuthorizationError;
+use trustify_common::db::query::Error as QueryError;
 use trustify_common::db::{DatabaseErrors, DbError};
 use trustify_common::error::ErrorInformation;
 use trustify_common::id::IdError;
@@ -17,7 +18,7 @@ pub enum Error {
     #[error(transparent)]
     Database(DbErr),
     #[error(transparent)]
-    Query(#[from] trustify_common::db::query::Error),
+    Query(#[from] QueryError),
     #[error(transparent)]
     Purl(#[from] PurlErr),
     #[error(transparent)]

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -1,6 +1,9 @@
 use crate::{
     advisory::model::{AdvisoryDetails, AdvisorySummary},
-    test::{caller, caller_with, label::Api},
+    test::{
+        caller, caller_with, label::Api, label::update_labels as do_update_labels,
+        label::update_labels_not_found as do_update_labels_not_found,
+    },
 };
 use actix_http::StatusCode;
 use actix_web::{body::MessageBody, test::TestRequest};
@@ -18,7 +21,10 @@ use trustify_common::{
 };
 use trustify_entity::{advisory_vulnerability_score, labels::Labels};
 use trustify_module_ingestor::{
-    graph::{advisory::AdvisoryInformation, cvss::ScoreCreator},
+    graph::{
+        advisory::AdvisoryInformation,
+        cvss::{ScoreCreator, ScoreInformation},
+    },
     model::IngestResult,
     service::Format,
 };
@@ -56,7 +62,7 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // Use ScoreCreator to write to advisory_vulnerability_score table
     let mut score_creator = ScoreCreator::new(advisory.advisory.id);
-    score_creator.add(trustify_module_ingestor::graph::cvss::ScoreInformation {
+    score_creator.add(ScoreInformation {
         vulnerability_id: "CVE-123".to_string(),
         r#type: advisory_vulnerability_score::ScoreType::V3_0,
         vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N".to_string(),
@@ -180,7 +186,7 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // Use ScoreCreator to write to advisory_vulnerability_score table
     let mut score_creator = ScoreCreator::new(advisory2.advisory.id);
-    score_creator.add(trustify_module_ingestor::graph::cvss::ScoreInformation {
+    score_creator.add(ScoreInformation {
         vulnerability_id: "CVE-123".to_string(),
         r#type: advisory_vulnerability_score::ScoreType::V3_0,
         vector: "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:N/A:N".to_string(),
@@ -286,7 +292,7 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
 
     // Use ScoreCreator to write to advisory_vulnerability_score table
     let mut score_creator = ScoreCreator::new(advisory.advisory.id);
-    score_creator.add(trustify_module_ingestor::graph::cvss::ScoreInformation {
+    score_creator.add(ScoreInformation {
         vulnerability_id: "CVE-123".to_string(),
         r#type: advisory_vulnerability_score::ScoreType::V3_0,
         vector: "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:N/A:N".to_string(),
@@ -595,14 +601,14 @@ async fn download_advisory_by_id(ctx: &TrustifyContext) -> Result<(), anyhow::Er
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn update_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    crate::test::label::update_labels(ctx, Api::Advisory, DOC, "csaf").await
+    do_update_labels(ctx, Api::Advisory, DOC, "csaf").await
 }
 
 /// Test updating labels, for a document that does not exist
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn update_labels_not_found(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    crate::test::label::update_labels_not_found(ctx, Api::Advisory, DOC).await
+    do_update_labels_not_found(ctx, Api::Advisory, DOC).await
 }
 
 /// Test deleing an advisory

--- a/modules/fundamental/src/advisory/service/test.rs
+++ b/modules/fundamental/src/advisory/service/test.rs
@@ -20,9 +20,11 @@ use trustify_module_ingestor::graph::{
     Outcome,
     advisory::{
         AdvisoryContext, AdvisoryInformation,
+        advisory_vulnerability::AdvisoryVulnerabilityContext,
         version::{VersionInfo, VersionSpec},
     },
     cvss::{ScoreCreator, ScoreInformation},
+    error::Error as GraphError,
 };
 use trustify_test_context::TrustifyContext;
 
@@ -30,7 +32,7 @@ pub async fn ingest_sample_advisory<'a>(
     ctx: &'a TrustifyContext,
     id: &'a str,
     title: &'a str,
-) -> Result<AdvisoryContext<'a>, trustify_module_ingestor::graph::error::Error> {
+) -> Result<AdvisoryContext<'a>, GraphError> {
     ctx.graph
         .ingest_advisory(
             title,
@@ -101,8 +103,8 @@ async fn single_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let advisory = ingest_sample_advisory(ctx, "RHSA-1", "RHSA-1").await?;
 
-    let advisory_vuln: trustify_module_ingestor::graph::advisory::advisory_vulnerability::AdvisoryVulnerabilityContext<'_> = advisory
-        .link_to_vulnerability("CVE-123", None,&ctx.db)
+    let advisory_vuln: AdvisoryVulnerabilityContext<'_> = advisory
+        .link_to_vulnerability("CVE-123", None, &ctx.db)
         .await?;
     let mut creator = ScoreCreator::new(advisory_vuln.advisory.advisory.id);
     creator.add(ScoreInformation {

--- a/modules/fundamental/src/endpoints.rs
+++ b/modules/fundamental/src/endpoints.rs
@@ -1,10 +1,16 @@
 use actix_web::web;
 use trustify_common::db::{self, pagination_cache::PaginationCache};
 use trustify_module_analysis::service::AnalysisService;
+use trustify_module_ingestor::common;
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_ingestor::service::IngestorService;
 use trustify_module_storage::service::dispatch::DispatchBackend;
 use utoipa::{IntoParams, ToSchema};
+
+use crate::{
+    advisory, exploit, license, organization, product, purl, sbom, sbom_group, vulnerability,
+    weakness,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct Config {
@@ -27,33 +33,33 @@ pub fn configure(
     let ingestor_service = IngestorService::new(graph, storage, Some(analysis));
     svc.app_data(web::Data::new(ingestor_service.clone()));
 
-    crate::advisory::endpoints::configure(
+    advisory::endpoints::configure(
         svc,
         db_rw.clone(),
         db_ro.clone(),
         config.advisory_upload_limit,
         cache.clone(),
     );
-    crate::exploit::endpoints::configure(svc, db_ro.clone(), cache.clone());
-    crate::license::endpoints::configure(svc, db_ro.clone());
-    crate::organization::endpoints::configure(svc, db_ro.clone(), cache.clone());
-    crate::purl::endpoints::configure(svc, db_ro.clone(), cache.clone());
-    crate::product::endpoints::configure(svc, db_rw.clone(), db_ro.clone(), cache.clone());
-    crate::sbom::endpoints::configure(
+    exploit::endpoints::configure(svc, db_ro.clone(), cache.clone());
+    license::endpoints::configure(svc, db_ro.clone());
+    organization::endpoints::configure(svc, db_ro.clone(), cache.clone());
+    purl::endpoints::configure(svc, db_ro.clone(), cache.clone());
+    product::endpoints::configure(svc, db_rw.clone(), db_ro.clone(), cache.clone());
+    sbom::endpoints::configure(
         svc,
         db_rw.clone(),
         db_ro.clone(),
         config.sbom_upload_limit,
         cache.clone(),
     );
-    crate::vulnerability::endpoints::configure(svc, db_ro.clone(), cache.clone());
-    crate::weakness::endpoints::configure(svc, db_ro.clone(), cache.clone());
-    crate::sbom_group::endpoints::configure(svc, db_rw, db_ro, config.max_group_name_length, cache);
+    vulnerability::endpoints::configure(svc, db_ro.clone(), cache.clone());
+    weakness::endpoints::configure(svc, db_ro.clone(), cache.clone());
+    sbom_group::endpoints::configure(svc, db_rw, db_ro, config.max_group_name_length, cache);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default, ToSchema, serde::Deserialize, IntoParams)]
 pub struct Deprecation {
     #[serde(default)]
     #[param(inline)]
-    pub deprecated: trustify_module_ingestor::common::Deprecation,
+    pub deprecated: common::Deprecation,
 }

--- a/modules/fundamental/src/error.rs
+++ b/modules/fundamental/src/error.rs
@@ -4,7 +4,7 @@ use sea_orm::DbErr;
 use std::borrow::Cow;
 use trustify_auth::authenticator::error::AuthorizationError;
 use trustify_common::{
-    db::{DatabaseErrors, DbError, limiter::LimiterError, pagination_cache::LimitError},
+    db::{DatabaseErrors, DbError, limiter::LimiterError, pagination_cache::LimitError, query},
     decompress,
     error::ErrorInformation,
     id::IdError,
@@ -22,7 +22,7 @@ pub enum Error {
     #[error(transparent)]
     Database(DbErr),
     #[error(transparent)]
-    Query(#[from] trustify_common::db::query::Error),
+    Query(#[from] query::Error),
     #[error(transparent)]
     Ingestor(#[from] trustify_module_ingestor::service::Error),
     #[error(transparent)]

--- a/modules/fundamental/src/organization/endpoints/test.rs
+++ b/modules/fundamental/src/organization/endpoints/test.rs
@@ -1,3 +1,4 @@
+use crate::organization::service::OrganizationService;
 use crate::test::caller;
 use actix_web::{cookie::time::OffsetDateTime, test::TestRequest};
 use jsonpath_rust::JsonPath;
@@ -98,8 +99,7 @@ async fn one_organization(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .link_to_vulnerability("CVE-123", None, &ctx.db)
         .await?;
 
-    let service =
-        crate::organization::service::OrganizationService::new(PaginationCache::for_test());
+    let service = OrganizationService::new(PaginationCache::for_test());
 
     let orgs = service
         .fetch_organizations(

--- a/modules/fundamental/src/organization/service/test.rs
+++ b/modules/fundamental/src/organization/service/test.rs
@@ -1,3 +1,4 @@
+use crate::organization::service::OrganizationService;
 use actix_web::cookie::time::OffsetDateTime;
 use test_context::test_context;
 use test_log::test;
@@ -29,8 +30,7 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let service =
-        crate::organization::service::OrganizationService::new(PaginationCache::for_test());
+    let service = OrganizationService::new(PaginationCache::for_test());
 
     let orgs = service
         .fetch_organizations(

--- a/modules/fundamental/src/product/endpoints/test.rs
+++ b/modules/fundamental/src/product/endpoints/test.rs
@@ -1,3 +1,4 @@
+use crate::product::service::ProductService;
 use crate::test::caller;
 use actix_http::StatusCode;
 use actix_web::{body::MessageBody, test::TestRequest};
@@ -70,7 +71,7 @@ async fn one_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let service = crate::product::service::ProductService::new(PaginationCache::for_test());
+    let service = ProductService::new(PaginationCache::for_test());
 
     let products = service
         .fetch_products(
@@ -117,7 +118,7 @@ async fn delete_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let service = crate::product::service::ProductService::new(PaginationCache::for_test());
+    let service = ProductService::new(PaginationCache::for_test());
 
     let products = service
         .fetch_products(

--- a/modules/fundamental/src/product/service/test.rs
+++ b/modules/fundamental/src/product/service/test.rs
@@ -1,3 +1,4 @@
+use crate::product::service::ProductService;
 use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
@@ -39,7 +40,7 @@ async fn all_products(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .ingest_product_version("1.0.0".to_string(), Some(sbom.sbom.sbom_id), &ctx.db)
         .await?;
 
-    let service = crate::product::service::ProductService::new(PaginationCache::for_test());
+    let service = ProductService::new(PaginationCache::for_test());
 
     let prods = service
         .fetch_products(
@@ -137,7 +138,7 @@ async fn delete_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let service = crate::product::service::ProductService::new(PaginationCache::for_test());
+    let service = ProductService::new(PaginationCache::for_test());
 
     let prods = service
         .fetch_products(

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -5,7 +5,10 @@ use crate::{
     },
     purl::model::summary::purl::PurlSummary,
     sbom::model::{SbomPackage, SbomSummary},
-    test::{caller, label::Api},
+    test::{
+        caller, label::Api, label::update_labels as do_update_labels,
+        label::update_labels_not_found as do_update_labels_not_found,
+    },
 };
 use actix_http::StatusCode;
 use actix_web::{
@@ -1214,7 +1217,7 @@ async fn filter_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn update_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    crate::test::label::update_labels(
+    do_update_labels(
         ctx,
         Api::Sbom,
         "quarkus-bom-2.13.8.Final-redhat-00004.json",
@@ -1227,12 +1230,7 @@ async fn update_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn update_labels_not_found(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    crate::test::label::update_labels_not_found(
-        ctx,
-        Api::Sbom,
-        "quarkus-bom-2.13.8.Final-redhat-00004.json",
-    )
-    .await
+    do_update_labels_not_found(ctx, Api::Sbom, "quarkus-bom-2.13.8.Final-redhat-00004.json").await
 }
 
 /// Test deleting an sbom

--- a/modules/fundamental/src/sbom_group/endpoints/test/list.rs
+++ b/modules/fundamental/src/sbom_group/endpoints/test/list.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::test::{Group, UpdateAssignments, create_groups, locate_id, read_assignments},
-    sbom_group::model::{GroupDetails, GroupListResult},
+    sbom_group::model::{Group as SbomGroupModel, GroupDetails, GroupListResult},
     test::caller,
 };
 use actix_http::body::to_bytes;
@@ -365,7 +365,7 @@ fn into_actual(
             });
 
             GroupDetails {
-                group: crate::sbom_group::model::Group {
+                group: SbomGroupModel {
                     id,
                     parent,
                     name: item.name.to_string(),

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -4,6 +4,7 @@ use rstest::rstest;
 use serde_json::{Value, json};
 use test_context::test_context;
 use time::{OffsetDateTime, macros::datetime};
+use trustify_common::db::pagination_cache::PaginationCache;
 use trustify_common::hashing::Digests;
 use trustify_entity::advisory_vulnerability_score::{ScoreType, Severity};
 use trustify_module_ingestor::graph::{
@@ -565,7 +566,7 @@ async fn cvss_v4_score_after_migration(
             db_ro.clone(),
             storage,
             analysis.clone(),
-            trustify_common::db::pagination_cache::PaginationCache::for_test(),
+            PaginationCache::for_test(),
             trustify_module_ingestor::graph::Graph::new(),
         );
         trustify_module_analysis::endpoints::configure(svc, db_ro, analysis);

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -1,5 +1,8 @@
 use crate::{
-    purl::{model::summary::remediation::RemediationSummary, service::PurlService},
+    purl::{
+        model::{details::purl::StatusContext, summary::remediation::RemediationSummary},
+        service::PurlService,
+    },
     sbom::service::SbomService,
     vulnerability::{model::BaseScore, service::VulnerabilityService},
 };
@@ -1009,8 +1012,8 @@ async fn analyze_purls_product_status(ctx: &TrustifyContext) -> Result<(), anyho
                 .context
                 .clone()
                 .map(|context| match context {
-                    crate::purl::model::details::purl::StatusContext::Purl(_) => false,
-                    crate::purl::model::details::purl::StatusContext::Cpe(cpe) => {
+                    StatusContext::Purl(_) => false,
+                    StatusContext::Cpe(cpe) => {
                         cpe == "cpe:/a:redhat:jboss_fuse_service_works:6:*:*:*"
                     }
                 })
@@ -1076,10 +1079,8 @@ async fn analyze_purls_product_status_0044(ctx: &TrustifyContext) -> Result<(), 
                 .context
                 .clone()
                 .map(|context| match context {
-                    crate::purl::model::details::purl::StatusContext::Purl(_) => false,
-                    crate::purl::model::details::purl::StatusContext::Cpe(cpe) => {
-                        cpe == "cpe:/a:redhat:quarkus:2:*:*:*"
-                    }
+                    StatusContext::Purl(_) => false,
+                    StatusContext::Cpe(cpe) => cpe == "cpe:/a:redhat:quarkus:2:*:*:*",
                 })
                 .unwrap_or(false)
         })
@@ -1182,7 +1183,7 @@ async fn analyze_purls_product_status_version_filtering(
             .context
             .as_ref()
             .map(|ctx| match ctx {
-                crate::purl::model::details::purl::StatusContext::Cpe(cpe) => {
+                StatusContext::Cpe(cpe) => {
                     cpe.contains("maven_product")
                 }
                 _ => false,

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -12,6 +12,7 @@ use trustify_module_fundamental::advisory::model::AdvisoryHead;
 use trustify_module_fundamental::common::model::ScoreType;
 use trustify_module_fundamental::common::model::Severity;
 use trustify_module_fundamental::common::model::{Score, ScoredVector};
+use trustify_module_fundamental::organization::model::{OrganizationHead, OrganizationSummary};
 use trustify_module_fundamental::purl::model::details::version_range::VersionRange;
 use trustify_module_fundamental::{
     purl::{
@@ -209,16 +210,14 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
                 uuid: blank_uuid,
                 identifier: "https://www.redhat.com/#CVE-2023-33201".into(),
                 document_id: "CVE-2023-33201".into(),
-                issuer: Some(
-                    trustify_module_fundamental::organization::model::OrganizationSummary {
-                        head: trustify_module_fundamental::organization::model::OrganizationHead {
-                            id: blank_uuid,
-                            name: "Red Hat Product Security".into(),
-                            cpe_key: None,
-                            website: None
-                        }
+                issuer: Some(OrganizationSummary {
+                    head: OrganizationHead {
+                        id: blank_uuid,
+                        name: "Red Hat Product Security".into(),
+                        cpe_key: None,
+                        website: None
                     }
-                ),
+                }),
                 published: Some(OffsetDateTime::from_unix_timestamp(1686873600)?),
                 modified: Some(OffsetDateTime::from_unix_timestamp(1696623810)?),
                 withdrawn: None,
@@ -369,16 +368,14 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
                 uuid: blank_uuid,
                 identifier: "https://www.redhat.com/#CVE-2023-33201".into(),
                 document_id: "CVE-2023-33201".into(),
-                issuer: Some(
-                    trustify_module_fundamental::organization::model::OrganizationSummary {
-                        head: trustify_module_fundamental::organization::model::OrganizationHead {
-                            id: blank_uuid,
-                            name: "Red Hat Product Security".into(),
-                            cpe_key: None,
-                            website: None
-                        }
+                issuer: Some(OrganizationSummary {
+                    head: OrganizationHead {
+                        id: blank_uuid,
+                        name: "Red Hat Product Security".into(),
+                        cpe_key: None,
+                        website: None
                     }
-                ),
+                }),
                 published: Some(OffsetDateTime::from_unix_timestamp(1686873600)?),
                 modified: Some(OffsetDateTime::from_unix_timestamp(1696537410)?),
                 withdrawn: None,
@@ -436,16 +433,14 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
                 uuid: blank_uuid,
                 identifier: "https://www.redhat.com/#CVE-2023-33201".into(),
                 document_id: "CVE-2023-33201".into(),
-                issuer: Some(
-                    trustify_module_fundamental::organization::model::OrganizationSummary {
-                        head: trustify_module_fundamental::organization::model::OrganizationHead {
-                            id: blank_uuid,
-                            name: "Red Hat Product Security".into(),
-                            cpe_key: None,
-                            website: None
-                        }
+                issuer: Some(OrganizationSummary {
+                    head: OrganizationHead {
+                        id: blank_uuid,
+                        name: "Red Hat Product Security".into(),
+                        cpe_key: None,
+                        website: None
                     }
-                ),
+                }),
                 published: Some(OffsetDateTime::from_unix_timestamp(1686873600)?),
                 modified: Some(OffsetDateTime::from_unix_timestamp(1696623810)?),
                 withdrawn: None,

--- a/modules/fundamental/tests/sbom/cyclonedx/mod.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/mod.rs
@@ -6,6 +6,7 @@ mod purl;
 mod reingest;
 
 use super::*;
+use serde_cyclonedx::cyclonedx::v_1_6::CycloneDx;
 use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
@@ -148,11 +149,7 @@ where
     test_with(
         ctx,
         sbom,
-        |data| {
-            Ok(serde_json::from_slice::<
-                serde_cyclonedx::cyclonedx::v_1_6::CycloneDx,
-            >(data)?)
-        },
+        |data| Ok(serde_json::from_slice::<CycloneDx>(data)?),
         async move |ctx, sbom, tx| {
             Ok(ctx
                 .ingest_cyclonedx(Box::new(sbom.clone()), &Discard, tx)

--- a/modules/importer/src/service.rs
+++ b/modules/importer/src/service.rs
@@ -12,8 +12,8 @@ use trustify_common::{
     db::{
         DatabaseErrors, ReadWrite,
         limiter::{LimitedResult, LimiterTrait},
-        pagination_cache::PaginationCache,
-        query::{Filtering, Query},
+        pagination_cache::{LimitError, PaginationCache},
+        query::{Error as QueryError, Filtering, Query},
     },
     error::ErrorInformation,
     model::{PaginatedResults, Pagination, Revisioned},
@@ -36,11 +36,11 @@ pub enum Error {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
     #[error(transparent)]
-    Query(#[from] trustify_common::db::query::Error),
+    Query(#[from] QueryError),
     #[error(transparent)]
     Label(#[from] labels::Error),
     #[error(transparent)]
-    Limit(#[from] trustify_common::db::pagination_cache::LimitError),
+    Limit(#[from] LimitError),
 }
 
 impl From<sea_orm::DbErr> for Error {

--- a/modules/ingestor/benches/detect.rs
+++ b/modules/ingestor/benches/detect.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::expect_used)]
 
 use criterion::{Criterion, criterion_group, criterion_main};
+use serde_cyclonedx::cyclonedx::v_1_6::CycloneDx;
 use std::hint::black_box;
 use trustify_module_ingestor::service::{DocumentDetector, Format};
 use trustify_test_context::document_bytes;
@@ -23,7 +24,7 @@ fn try_parse_direct(bytes: &[u8]) -> Option<Format> {
     if serde_json::from_slice::<osv::schema::Vulnerability>(bytes).is_ok() {
         return Some(Format::OSV);
     }
-    if serde_json::from_slice::<serde_cyclonedx::cyclonedx::v_1_6::CycloneDx>(bytes).is_ok() {
+    if serde_json::from_slice::<CycloneDx>(bytes).is_ok() {
         return Some(Format::CycloneDX);
     }
     if serde_json::from_slice::<serde_json::Value>(bytes)

--- a/modules/ingestor/src/graph/db_context.rs
+++ b/modules/ingestor/src/graph/db_context.rs
@@ -44,7 +44,7 @@ impl DbContext {
         self.status_cache
             .get(status)
             .cloned()
-            .ok_or_else(|| crate::graph::error::Error::InvalidStatus(status.to_string()))
+            .ok_or_else(|| Error::InvalidStatus(status.to_string()))
     }
 }
 

--- a/modules/ingestor/src/graph/sbom/common/checksum.rs
+++ b/modules/ingestor/src/graph/sbom/common/checksum.rs
@@ -1,4 +1,4 @@
-use serde_cyclonedx::cyclonedx::v_1_6::HashAlg;
+use serde_cyclonedx::cyclonedx::v_1_6::{Hash, HashAlg};
 use spdx_rs::models::Algorithm;
 use std::borrow::Cow;
 
@@ -13,8 +13,8 @@ impl Checksum {
     pub const NONE: [Self; 0] = [];
 }
 
-impl From<serde_cyclonedx::cyclonedx::v_1_6::Hash> for Checksum {
-    fn from(value: serde_cyclonedx::cyclonedx::v_1_6::Hash) -> Self {
+impl From<Hash> for Checksum {
+    fn from(value: Hash) -> Self {
         Self {
             r#type: match value.alg {
                 HashAlg::Md5 => "MD5",

--- a/modules/ingestor/src/graph/sbom/common/relationship.rs
+++ b/modules/ingestor/src/graph/sbom/common/relationship.rs
@@ -3,7 +3,7 @@ use anyhow::bail;
 use sea_orm::{ActiveValue::Set, ConnectionTrait, DbErr, EntityTrait};
 use sea_query::OnConflict;
 use spdx_rs::models::{Algorithm, ExternalDocumentReference};
-use std::collections::HashSet;
+use std::collections::{HashSet, hash_set};
 use tracing::instrument;
 use trustify_common::db::chunk::EntityChunkedIter;
 use trustify_entity::sbom_external_node::{DiscriminatorType, ExternalType};
@@ -219,7 +219,7 @@ pub struct References<'a> {
 
 impl<'a> IntoIterator for References<'a> {
     type Item = &'a str;
-    type IntoIter = std::collections::hash_set::IntoIter<&'a str>;
+    type IntoIter = hash_set::IntoIter<&'a str>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.refs.into_iter()

--- a/modules/ingestor/src/service/advisory/csaf/creator.rs
+++ b/modules/ingestor/src/service/advisory/csaf/creator.rs
@@ -2,7 +2,7 @@ use crate::{
     graph::{
         Graph,
         advisory::{
-            product_status::ProductVersionRange,
+            product_status::{ProductStatus as GraphProductStatus, ProductVersionRange},
             purl_status::PurlStatus,
             version::{Version, VersionInfo, VersionSpec},
         },
@@ -216,7 +216,7 @@ impl<'a> StatusCreator<'a> {
                 let csaf_product_ids = product_to_csaf_ids.get(&product).cloned();
 
                 for package in packages {
-                    let product_status = crate::graph::advisory::product_status::ProductStatus {
+                    let product_status = GraphProductStatus {
                         cpe: product.cpe.clone(),
                         package,
                         status: status_id,

--- a/modules/ingestor/src/service/detect.rs
+++ b/modules/ingestor/src/service/detect.rs
@@ -21,6 +21,7 @@ use cve::Cve;
 use osv::schema::Vulnerability;
 use quick_xml::{Reader, events::Event};
 use sea_orm::{ConnectionTrait, TransactionTrait};
+use serde_cyclonedx::cyclonedx::v_1_6::CycloneDx;
 use std::io::Cursor;
 use tracing::instrument;
 use trustify_common::hashing::Digests;
@@ -53,7 +54,7 @@ pub enum DetectedDocument {
     Osv(Box<Vulnerability>),
     /// SPDX keeps the raw Value because the loader applies license fixups before ingestion.
     Spdx(serde_json::Value),
-    CycloneDx(Box<serde_cyclonedx::cyclonedx::v_1_6::CycloneDx>),
+    CycloneDx(Box<CycloneDx>),
     ClearlyDefined(serde_json::Value),
     ClearlyDefinedCuration(Box<Curation>),
     /// XML kept as raw bytes; the loader parses with roxmltree internally.

--- a/modules/ingestor/src/service/kev/mod.rs
+++ b/modules/ingestor/src/service/kev/mod.rs
@@ -203,6 +203,7 @@ fn parse_date(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::graph::exploit::entry_id;
     use sea_orm::EntityTrait;
     use std::collections::BTreeSet;
     use test_context::test_context;
@@ -261,7 +262,7 @@ mod test {
         assert_eq!(log4shell.remediation_due_date, Some(date!(2021 - 12 - 24)));
         assert_eq!(
             log4shell.id,
-            crate::graph::exploit::entry_id(SOURCE_CISA_KEV, "CVE-2021-44228"),
+            entry_id(SOURCE_CISA_KEV, "CVE-2021-44228"),
             "the id must be derived from source and CVE id"
         );
 
@@ -355,13 +356,10 @@ mod test {
         )
         .await?;
 
-        let revised = exploit::Entity::find_by_id(crate::graph::exploit::entry_id(
-            SOURCE_CISA_KEV,
-            "CVE-2023-35078",
-        ))
-        .one(&ctx.db)
-        .await?
-        .expect("revised entry must exist");
+        let revised = exploit::Entity::find_by_id(entry_id(SOURCE_CISA_KEV, "CVE-2023-35078"))
+            .one(&ctx.db)
+            .await?
+            .expect("revised entry must exist");
 
         // an ON CONFLICT DO NOTHING insert would have kept the old values here
         assert_eq!(revised.remediation_due_date, Some(date!(2026 - 01 - 31)));

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -12,12 +12,14 @@ pub use format::Format;
 pub use json::JsonSource;
 
 use crate::graph::Graph;
+use crate::graph::error::Error as GraphError;
 use crate::{
     model::IngestResult,
     service::dataset::{DatasetIngestResult, DatasetLoader},
 };
 use actix_web::{HttpResponse, ResponseError, body::BoxBody};
 use anyhow::anyhow;
+use jsonpath_rust::parser::errors::JsonPathError;
 use parking_lot::Mutex;
 use sbom_walker::report::ReportSink;
 use sea_orm::error::DbErr;
@@ -42,13 +44,13 @@ pub enum Error {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
     #[error(transparent)]
-    JsonPath(#[from] jsonpath_rust::parser::errors::JsonPathError),
+    JsonPath(#[from] JsonPathError),
     #[error(transparent)]
     Xml(#[from] roxmltree::Error),
     #[error(transparent)]
     Yaml(#[from] serde_yml::Error),
     #[error(transparent)]
-    Graph(#[from] crate::graph::error::Error),
+    Graph(#[from] GraphError),
     #[error(transparent)]
     Db(DbErr),
     #[error("storage error: {0}")]

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -4,7 +4,7 @@ use crate::{
     service::{Error, JsonSource, Warnings},
 };
 use sea_orm::{ConnectionTrait, TransactionTrait};
-use serde_cyclonedx::cyclonedx::v_1_6::Component;
+use serde_cyclonedx::cyclonedx::v_1_6::{Component, CycloneDx};
 use std::str::FromStr;
 use tracing::instrument;
 use trustify_common::hashing::Digests;
@@ -28,7 +28,7 @@ impl<'g> CyclonedxLoader<'g> {
         digests: &Digests,
         tx: &(impl ConnectionTrait + TransactionTrait),
     ) -> Result<IngestResult, Error> {
-        let cdx: Box<serde_cyclonedx::cyclonedx::v_1_6::CycloneDx> = source
+        let cdx: Box<CycloneDx> = source
             .parse_json()
             .map_err(|err| Error::UnsupportedFormat(format!("Failed to parse: {err}")))?;
 
@@ -39,7 +39,7 @@ impl<'g> CyclonedxLoader<'g> {
     pub(crate) async fn ingest(
         &self,
         labels: Labels,
-        cdx: Box<serde_cyclonedx::cyclonedx::v_1_6::CycloneDx>,
+        cdx: Box<CycloneDx>,
         digests: &Digests,
         tx: &(impl ConnectionTrait + TransactionTrait),
     ) -> Result<IngestResult, Error> {

--- a/modules/notification/src/test.rs
+++ b/modules/notification/src/test.rs
@@ -1,6 +1,13 @@
 #![cfg(test)]
 
-use actix_web::{App, HttpRequest, HttpResponse, http::StatusCode, test as actix, web};
+use actix_web::{
+    App, HttpRequest, HttpResponse,
+    http::{
+        StatusCode,
+        header::{HeaderMap, HeaderName},
+    },
+    test as actix, web,
+};
 use sea_orm::ConnectionTrait;
 use std::time::Duration;
 use test_context::test_context;
@@ -71,9 +78,9 @@ fn extract_token_empty_value() {
 
 #[test]
 fn extract_protocol_token_basic() {
-    let mut headers = actix_web::http::header::HeaderMap::new();
+    let mut headers = HeaderMap::new();
     headers.insert(
-        actix_web::http::header::HeaderName::from_static("sec-websocket-protocol"),
+        HeaderName::from_static("sec-websocket-protocol"),
         "access_token, jwt.value".parse().unwrap(),
     );
     assert_eq!(
@@ -84,9 +91,9 @@ fn extract_protocol_token_basic() {
 
 #[test]
 fn extract_protocol_token_missing() {
-    let mut headers = actix_web::http::header::HeaderMap::new();
+    let mut headers = HeaderMap::new();
     headers.insert(
-        actix_web::http::header::HeaderName::from_static("sec-websocket-protocol"),
+        HeaderName::from_static("sec-websocket-protocol"),
         "graphql-ws".parse().unwrap(),
     );
     assert_eq!(crate::inject_token::extract_protocol_token(&headers), None);
@@ -94,9 +101,9 @@ fn extract_protocol_token_missing() {
 
 #[test]
 fn extract_protocol_token_no_token_value() {
-    let mut headers = actix_web::http::header::HeaderMap::new();
+    let mut headers = HeaderMap::new();
     headers.insert(
-        actix_web::http::header::HeaderName::from_static("sec-websocket-protocol"),
+        HeaderName::from_static("sec-websocket-protocol"),
         "access_token".parse().unwrap(),
     );
     assert_eq!(crate::inject_token::extract_protocol_token(&headers), None);
@@ -104,9 +111,9 @@ fn extract_protocol_token_no_token_value() {
 
 #[test]
 fn extract_protocol_token_extra_whitespace() {
-    let mut headers = actix_web::http::header::HeaderMap::new();
+    let mut headers = HeaderMap::new();
     headers.insert(
-        actix_web::http::header::HeaderName::from_static("sec-websocket-protocol"),
+        HeaderName::from_static("sec-websocket-protocol"),
         "access_token ,  jwt.value ".parse().unwrap(),
     );
     assert_eq!(

--- a/modules/storage/src/service/s3.rs
+++ b/modules/storage/src/service/s3.rs
@@ -18,7 +18,7 @@ use aws_sdk_s3::{
     types::{Delete, ObjectIdentifier},
 };
 use aws_smithy_http_client::tls::{Provider, TlsContext, TrustStore, rustls_provider::CryptoMode};
-use aws_smithy_types::endpoint::Endpoint;
+use aws_smithy_types::{byte_stream::error::Error as ByteStreamError, endpoint::Endpoint};
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
 use std::{fmt::Debug, io, str::FromStr};
@@ -274,7 +274,7 @@ pub enum Error {
     #[error(transparent)]
     S3(#[from] aws_sdk_s3::Error),
     #[error(transparent)]
-    Bytes(#[from] aws_smithy_types::byte_stream::error::Error),
+    Bytes(#[from] ByteStreamError),
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error("{0}")]

--- a/modules/ui/src/service.rs
+++ b/modules/ui/src/service.rs
@@ -1,5 +1,5 @@
 use crate::model::ExtractPackage;
-use serde_cyclonedx::cyclonedx::v_1_6::{Component, ComponentEvidenceIdentity};
+use serde_cyclonedx::cyclonedx::v_1_6::{Component, ComponentEvidenceIdentity, CycloneDx};
 use std::collections::BTreeMap;
 use trustify_common::purl::Purl;
 
@@ -30,7 +30,7 @@ pub fn extract_spdx_purls(
 
 /// Extract PURLs from a CycloneDX file
 pub fn extract_cyclonedx_purls(
-    sbom: serde_cyclonedx::cyclonedx::v_1_6::CycloneDx,
+    sbom: CycloneDx,
     warnings: &mut Vec<String>,
 ) -> BTreeMap<String, ExtractPackage> {
     let mut result = BTreeMap::new();

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -3,7 +3,7 @@ use utoipa::{
     IntoParams,
     openapi::{
         ObjectBuilder, Type,
-        path::{Parameter, ParameterIn},
+        path::{Parameter, ParameterBuilder, ParameterIn},
     },
 };
 
@@ -19,13 +19,13 @@ pub struct TrustifyQuery<T: Query> {
 impl<T: Query> IntoParams for TrustifyQuery<T> {
     fn into_params(_parameter_in_provider: impl Fn() -> Option<ParameterIn>) -> Vec<Parameter> {
         vec![
-            utoipa::openapi::path::ParameterBuilder::new()
+            ParameterBuilder::new()
                 .name("q")
                 .parameter_in(ParameterIn::Query)
                 .description(Some(T::generate_query_description()))
                 .schema(Some(ObjectBuilder::new().schema_type(Type::String)))
                 .build(),
-            utoipa::openapi::path::ParameterBuilder::new()
+            ParameterBuilder::new()
                 .name("sort")
                 .parameter_in(ParameterIn::Query)
                 .description(Some(T::generate_sort_description()))

--- a/trustd/src/main.rs
+++ b/trustd/src/main.rs
@@ -9,6 +9,7 @@ use tokio::{
     select,
     task::{LocalSet, spawn_local},
 };
+use trustify_server::profile::{api::Run as ApiRun, importer::Run as ImporterRun};
 
 mod db;
 mod openapi;
@@ -17,9 +18,9 @@ mod openapi;
 #[derive(clap::Subcommand, Debug)]
 pub enum Command {
     /// Run the API server
-    Api(trustify_server::profile::api::Run),
+    Api(ApiRun),
     /// Run the importer server
-    Importer(trustify_server::profile::importer::Run),
+    Importer(ImporterRun),
     /// Manage the database
     Db(db::Run),
     /// Access OpenAPI related information of the API server

--- a/xtask/src/precommit.rs
+++ b/xtask/src/precommit.rs
@@ -28,6 +28,8 @@ impl Precommit {
                 "clippy::unwrap_used",
                 "-D",
                 "clippy::expect_used",
+                "-W",
+                "clippy::absolute_paths",
             ])
             .status()
             .map_err(|_| anyhow!("cargo clippy failed"))?


### PR DESCRIPTION
## Summary

Enable the `clippy::absolute_paths` restriction lint with `absolute-paths-max-segments = 3`
to flag fully-qualified paths with 4+ segments at build time. This enforces import style
deterministically — no reviewer vigilance needed for the common case.

### Why `max-segments = 3` (not 2)?

The lint does not distinguish internal from external crate paths. With `max-segments = 2`,
every 3-segment external crate path (e.g. `std::fmt::Result`, `tokio::sync::Mutex`,
`cpe::component::Component`) would be flagged, requiring a 30+ crate allowlist
(`absolute-paths-allowed-crates`) that must be maintained as dependencies evolve.

Three configurations were tested against the current codebase:

| Configuration | Violations | Files | Allowlist maintenance |
|---|---|---|---|
| `max-segments = 2`, no allowlist | 526 | 165 | N/A — too many false positives |
| `max-segments = 2`, 30-crate allowlist | 196 | 63 | Ongoing — every new dependency with 3-segment paths must be added |
| **`max-segments = 3`, no allowlist** | **70** | **35** | **None** |

`max-segments = 3` was chosen because it:
1. **Catches the original problem** — 4+ segment paths like `crate::graph::db_context::parse_status` are flagged at build time
2. **Requires zero allowlist maintenance** — 3-segment external paths pass automatically
3. **Preserves build safety** — all 70 existing violations are fixed in this PR

**Trade-off:** 3-segment paths (e.g. `std::fmt::Result`, `entity::advisory_vulnerability::Model`)
are not caught. These are covered by a documented reviewer convention (see CONVENTIONS.md changes).

The threshold can be tightened to 2 later if the team decides to take on the allowlist burden —
going from 3 → 2 is additive work, not a breaking change.

### Changes

- `.clippy.toml` — add `absolute-paths-max-segments = 3`
- `xtask/src/precommit.rs` — add `-W clippy::absolute_paths` to clippy invocation
- `CONVENTIONS.md` — document lint (goal 1) and qualified-names convention (goal 2)
- 35 source files — fix existing 4+ segment violations by replacing with `use` imports

Implements [TC-4513](https://redhat.atlassian.net/browse/TC-4513)

[TC-4513]: https://redhat.atlassian.net/browse/TC-4513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enforce consistent Rust import conventions by linting and removing deeply qualified absolute paths throughout the codebase.

Enhancements:
- Enforce a consistent Rust import style by enabling Clippy's absolute-path lint for paths exceeding three segments.
- Replace existing deeply qualified paths across the codebase with imports while preserving qualified naming for common or ambiguous types through documented conventions.

Build:
- Configure the maximum allowed absolute path length in Clippy.

CI:
- Apply the absolute-path lint during the precommit Clippy checks.

Documentation:
- Document the absolute-path lint threshold and conventions for qualified names.