### PR TITLE
chore(deps): update deps for 0.6.0-rc.1 (and main)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -439,7 +439,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "csaf"
 version = "0.5.0"
-source = "git+https://github.com/scm-rs/csaf-rs?branch=main#63ac9e19d881cbf1808de38b6849635cda19931d"
+source = "git+https://github.com/scm-rs/csaf-rs?branch=main#3b95cd16d78de713a94eb136856b62bcb74617be"
 dependencies = [
  "chrono",
  "cpe",
@@ -2654,7 +2654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3604,7 +3604,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4507,7 +4507,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4597,7 +4597,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.2",
@@ -5038,9 +5038,9 @@ dependencies = [
 
 [[package]]
 name = "packageurl"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35da99768af1ae8830ccf30d295db0e09c24bcfda5a67515191dd4b773f6d82a"
+checksum = "d33fa1a190c3c9024f21b82e6b30f94137d9c1bf25071e2ab2ba13020135fbaf"
 dependencies = [
  "percent-encoding",
  "thiserror 2.0.18",
@@ -6316,7 +6316,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6374,7 +6374,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6799,7 +6799,7 @@ checksum = "e421679c8175ef4674d913af7fdb8ad0078c8a2599db633ad0b4d02a06b2cb3c"
 dependencies = [
  "anyhow",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "buffered-reader",
  "chrono",
  "dyn-clone",
@@ -7185,7 +7185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7706,7 +7706,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7737,7 +7737,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/guacsec/trustify-ui.git?branch=publish%2Fmain#6802f6868f79596d82ef5a0dfc302abed1beccc4"
+source = "git+https://github.com/guacsec/trustify-ui.git?branch=publish%2Fmain#fd5714b72cc733a8b2ca51251df0903c2929a1dd"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9494,7 +9494,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9509,7 +9509,7 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
- "windows-core 0.56.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -9519,23 +9519,10 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
- "windows-implement 0.56.0",
- "windows-interface 0.56.0",
+ "windows-implement",
+ "windows-interface",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -9550,32 +9537,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ opentelemetry-otlp = "0.32"
 opentelemetry_sdk = "0.32"
 opentelemetry-instrumentation-actix-web = "0.24.0"
 osv = { version = "0.3.0", default-features = false, features = [] }
-packageurl = "0.6"
+packageurl = "0.7"
 parking_lot = "0.12"
 peak_alloc = "0.3.0"
 pem = "3"

--- a/common/src/purl.rs
+++ b/common/src/purl.rs
@@ -40,7 +40,13 @@ pub struct Purl {
 impl Valuable for Purl {
     fn like(&self, pat: &str) -> bool {
         match urlencoding::decode(pat) {
-            Ok(s) => self.to_string().contains(&s.into_owned()),
+            Ok(decoded_pat) => {
+                let self_str = self.to_string();
+                match urlencoding::decode(&self_str) {
+                    Ok(decoded_self) => decoded_self.contains(decoded_pat.as_ref()),
+                    _ => self_str.contains(decoded_pat.as_ref()),
+                }
+            }
             _ => false,
         }
     }
@@ -351,7 +357,7 @@ mod tests {
 
         assert_eq!(
             json,
-            r#""pkg:oci/ose-cluster-network-operator@sha256:0170ba5eebd557fd9f477d915bb7e0d4c1ad6cd4c1852d4b1ceed7a2817dd5d2?repository_url=registry.redhat.io/openshift4/ose-cluster-network-operator&tag=v4.11.0-202403090037.p0.g33da9fb.assembly.stream.el8""#
+            r#""pkg:oci/ose-cluster-network-operator@sha256:0170ba5eebd557fd9f477d915bb7e0d4c1ad6cd4c1852d4b1ceed7a2817dd5d2?repository_url=registry.redhat.io%2Fopenshift4%2Fose-cluster-network-operator&tag=v4.11.0-202403090037.p0.g33da9fb.assembly.stream.el8""#
         );
         Ok(())
     }

--- a/modules/analysis/src/endpoints/tests/cyclonedx.rs
+++ b/modules/analysis/src/endpoints/tests/cyclonedx.rs
@@ -112,13 +112,14 @@ async fn cdx_ancestor_of(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["cyclonedx/openssl-3.0.7-18.el9_2.cdx_1.6.sbom.json"])
         .await?;
 
-    let parent = "pkg:generic/openssl@3.0.7?checksum=SHA-512:1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e&download_url=https://pkgs.devel.redhat.com/repo/openssl/openssl-3.0.7-hobbled.tar.gz/sha512/1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e/openssl-3.0.7-hobbled.tar.gz";
+    let parent_query = "pkg:generic/openssl@3.0.7?checksum=SHA-512:1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e&download_url=https://pkgs.devel.redhat.com/repo/openssl/openssl-3.0.7-hobbled.tar.gz/sha512/1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e/openssl-3.0.7-hobbled.tar.gz";
+    let parent_expected = "pkg:generic/openssl@3.0.7?checksum=SHA-512:1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e&download_url=https:%2F%2Fpkgs.devel.redhat.com%2Frepo%2Fopenssl%2Fopenssl-3.0.7-hobbled.tar.gz%2Fsha512%2F1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e%2Fopenssl-3.0.7-hobbled.tar.gz";
     let child = "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src";
 
     // Ensure parent has ancestors that include the child
     let response: Value = app
         .req(Req {
-            what: What::Id(parent),
+            what: What::Id(parent_query),
             descendants: Some(10),
             ..Req::default()
         })
@@ -127,7 +128,7 @@ async fn cdx_ancestor_of(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     assert!(response.contains_subset(json!({
         "items": [{
-            "purl": [ parent ],
+            "purl": [ parent_expected ],
             "descendants": [{
                 "relationship": "ancestor_of",
                 "purl": [ child ]
@@ -150,7 +151,7 @@ async fn cdx_ancestor_of(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             "purl": [ child ],
             "ancestors": [{
                 "relationship": "ancestor_of",
-                "purl": [ parent ]
+                "purl": [ parent_expected ]
             }]
         }]
     })));

--- a/modules/analysis/src/endpoints/tests/latest_filters.rs
+++ b/modules/analysis/src/endpoints/tests/latest_filters.rs
@@ -401,11 +401,11 @@ async fn test_tc2677(
         {
           "node_id": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87",
           "purl": [
-            "pkg:oci/authorino-rhel9@sha256:a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com/3scale-tech-preview/authorino-rhel9&tag=3scale2.15.0",
-            "pkg:oci/authorino-rhel9@sha256:a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com/3scale-tech-preview/authorino-rhel9&tag=1.1.3",
-            "pkg:oci/authorino-rhel9@sha256:a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com/3scale-tech-preview/authorino-rhel9&tag=1.1.3-1",
+            "pkg:oci/authorino-rhel9@sha256:a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15.0",
+            "pkg:oci/authorino-rhel9@sha256:a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=1.1.3",
+            "pkg:oci/authorino-rhel9@sha256:a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=1.1.3-1",
             "pkg:oci/authorino-rhel9@sha256:a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87",
-            "pkg:oci/authorino-rhel9@sha256:a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com/3scale-tech-preview/authorino-rhel9&tag=3scale2.15"
+            "pkg:oci/authorino-rhel9@sha256:a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15"
           ],
           "name": "3scale-tech-preview/authorino-rhel9",
           "version": "sha256:a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87",

--- a/modules/analysis/src/endpoints/tests/mod.rs
+++ b/modules/analysis/src/endpoints/tests/mod.rs
@@ -152,14 +152,14 @@ async fn test_quarkus_retrieve_analysis_endpoint(
                 "purl": [ purl ],
                 "document_id": "https://access.redhat.com/security/data/sbom/spdx/quarkus-bom-3.2.11.Final-redhat-00001",
                 "ancestors": [{
-                    "purl": [ "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.11.Final-redhat-00001?repository_url=https://maven.repository.redhat.com/ga/&type=pom" ]
+                    "purl": [ "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.11.Final-redhat-00001?repository_url=https:%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=pom" ]
                 }]
             },
             {
                 "purl": [ purl ],
                 "document_id": "https://access.redhat.com/security/data/sbom/spdx/quarkus-bom-3.2.12.Final-redhat-00002",
                 "ancestors": [{
-                    "purl": [ "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.12.Final-redhat-00002?repository_url=https://maven.repository.redhat.com/ga/&type=pom" ]
+                    "purl": [ "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.12.Final-redhat-00002?repository_url=https:%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=pom" ]
                 }]
             }
         ]
@@ -368,10 +368,11 @@ async fn quarkus_component_by_purl(ctx: &TrustifyContext) -> Result<(), anyhow::
     ])
     .await?;
 
-    let purl = "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.11.Final-redhat-00001?repository_url=https://maven.repository.redhat.com/ga/&type=pom";
+    let purl_query = "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.11.Final-redhat-00001?repository_url=https://maven.repository.redhat.com/ga/&type=pom";
+    let purl_expected = "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.11.Final-redhat-00001?repository_url=https:%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=pom";
     let response: Value = app
         .req(Req {
-            what: What::Id(purl),
+            what: What::Id(purl_query),
             total: true,
             ..Req::default()
         })
@@ -379,7 +380,7 @@ async fn quarkus_component_by_purl(ctx: &TrustifyContext) -> Result<(), anyhow::
     tracing::debug!(test = "", "{response:#?}");
     assert!(response.contains_subset(json!({
         "items": [{
-            "purl": [ purl ],
+            "purl": [ purl_expected ],
             "cpe": ["cpe:/a:redhat:quarkus:3.2:*:el8:*"]
         }]
     })));
@@ -411,11 +412,11 @@ async fn quarkus_component_by_cpe(ctx: &TrustifyContext) -> Result<(), anyhow::E
     assert!(response.contains_subset(json!({
         "items": [
             {
-                "purl": [ "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.11.Final-redhat-00001?repository_url=https://maven.repository.redhat.com/ga/&type=pom" ],
+                "purl": [ "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.11.Final-redhat-00001?repository_url=https:%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=pom" ],
                 "cpe": [ cpe ]
             },
             {
-                "purl": [ "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.12.Final-redhat-00002?repository_url=https://maven.repository.redhat.com/ga/&type=pom" ],
+                "purl": [ "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.12.Final-redhat-00002?repository_url=https:%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=pom" ],
                 "cpe": [ cpe ]
             }
         ]
@@ -468,7 +469,7 @@ async fn find_component_by_query(
     ctx.ingest_documents(["spdx/quarkus-bom-3.2.11.Final-redhat-00001.json"])
         .await?;
 
-    const PURL: &str = "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.11.Final-redhat-00001?repository_url=https://maven.repository.redhat.com/ga/&type=pom";
+    const PURL: &str = "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.11.Final-redhat-00001?repository_url=https:%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=pom";
 
     assert!(
         query(ctx, query_str).await.contains_subset(json!({

--- a/modules/analysis/src/endpoints/tests/spdx.rs
+++ b/modules/analysis/src/endpoints/tests/spdx.rs
@@ -64,12 +64,12 @@ async fn spdx_variant_of(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await?;
 
     let parents = [
-        "pkg:oci/ubi9-container@sha256:d4c5d9c980678267b81c3c197a4a0dd206382111c912875a6cdffc6ca319b769?arch=aarch64&repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012",
-        "pkg:oci/ubi9-container@sha256:204383c3d96c0e6c7154c91d07764f92035738dd67aa8896679f7feb73f66bfd?arch=x86_64&repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012",
-        "pkg:oci/ubi9-container@sha256:721ca837c80c8b98752010a17ffccbdf17a0d260ddd916b7097f04187f6aa3a8?arch=s390x&repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012",
-        "pkg:oci/ubi9-container@sha256:9a6092cdd8e7f4361ea3f508ae6d6d3d9dbb9458a921ab09e4cc006c0a7f0a61?arch=ppc64le&repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012",
+        "pkg:oci/ubi9-container@sha256:d4c5d9c980678267b81c3c197a4a0dd206382111c912875a6cdffc6ca319b769?arch=aarch64&repository_url=registry.redhat.io%2Fubi9&tag=9.2-755.1697625012",
+        "pkg:oci/ubi9-container@sha256:204383c3d96c0e6c7154c91d07764f92035738dd67aa8896679f7feb73f66bfd?arch=x86_64&repository_url=registry.redhat.io%2Fubi9&tag=9.2-755.1697625012",
+        "pkg:oci/ubi9-container@sha256:721ca837c80c8b98752010a17ffccbdf17a0d260ddd916b7097f04187f6aa3a8?arch=s390x&repository_url=registry.redhat.io%2Fubi9&tag=9.2-755.1697625012",
+        "pkg:oci/ubi9-container@sha256:9a6092cdd8e7f4361ea3f508ae6d6d3d9dbb9458a921ab09e4cc006c0a7f0a61?arch=ppc64le&repository_url=registry.redhat.io%2Fubi9&tag=9.2-755.1697625012",
     ];
-    let child = "pkg:oci/ubi9-container@sha256:2f168398c538b287fd705519b83cd5b604dc277ef3d9f479c28a2adb4d830a49?repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012";
+    let child = "pkg:oci/ubi9-container@sha256:2f168398c538b287fd705519b83cd5b604dc277ef3d9f479c28a2adb4d830a49?repository_url=registry.redhat.io%2Fubi9&tag=9.2-755.1697625012";
 
     // Ensure variant relationships
     for parent in parents {

--- a/modules/analysis/src/service/test/mod.rs
+++ b/modules/analysis/src/service/test/mod.rs
@@ -311,7 +311,7 @@ async fn test_quarkus_analysis_service(ctx: &TrustifyContext) -> Result<(), anyh
                             version: "3.2.12.Final-redhat-00002",
                             cpes: &["cpe:/a:redhat:quarkus:3.2:*:el8:*",],
                             purls: &[
-                                "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.12.Final-redhat-00002?repository_url=https://maven.repository.redhat.com/ga/&type=pom"
+                                "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.12.Final-redhat-00002?repository_url=https:%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=pom"
                             ],
                         },
                         Node {

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -238,7 +238,7 @@ async fn purl_filter_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
     ctx.ingest_documents(["spdx/quarkus-bom-3.2.11.Final-redhat-00001.json"])
         .await?;
 
-    const PURL: &str = "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.11.Final-redhat-00001?repository_url=https://maven.repository.redhat.com/ga/&type=pom";
+    const PURL: &str = "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.11.Final-redhat-00001?repository_url=https:%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=pom";
 
     let query = async |query| {
         let app = caller(ctx).await.unwrap();

--- a/modules/fundamental/tests/sbom/cyclonedx/purl.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/purl.rs
@@ -80,8 +80,8 @@ async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         to_strings(&relation.package.purl),
         // we must find two purls here, one from the main section, the other from the evidence
         vec![
-            "pkg:generic/openssl@3.0.7?checksum=SHA-512:1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e&download_url=https://pkgs.devel.redhat.com/repo/openssl/openssl-3.0.7-hobbled.tar.gz/sha512/1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e/openssl-3.0.7-hobbled.tar.gz",
-            "pkg:generic/openssl@3.0.7?checksum=SHA-512:1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e&download_url=https://pkgs.devel.redhat.com/repo/openssl/openssl-3.0.7-hobbled.tar.gz/sha512/1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e/openssl-3.0.7-hobbled.tar.gz&foo=bar"
+            "pkg:generic/openssl@3.0.7?checksum=SHA-512:1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e&download_url=https:%2F%2Fpkgs.devel.redhat.com%2Frepo%2Fopenssl%2Fopenssl-3.0.7-hobbled.tar.gz%2Fsha512%2F1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e%2Fopenssl-3.0.7-hobbled.tar.gz",
+            "pkg:generic/openssl@3.0.7?checksum=SHA-512:1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e&download_url=https:%2F%2Fpkgs.devel.redhat.com%2Frepo%2Fopenssl%2Fopenssl-3.0.7-hobbled.tar.gz%2Fsha512%2F1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e%2Fopenssl-3.0.7-hobbled.tar.gz&foo=bar"
         ]
     );
 

--- a/modules/fundamental/tests/sbom/spdx/reingest.rs
+++ b/modules/fundamental/tests/sbom/spdx/reingest.rs
@@ -57,7 +57,7 @@ async fn reingest(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                     .map(|purl| purl.head.purl.to_string())
                     .collect())
                 .collect::<Vec<Vec<_>>>(),
-            vec![vec!["pkg:maven/com.redhat.quarkus.platform/quarkus-bom@2.13.8.Final-redhat-00004?repository_url=https://maven.repository.redhat.com/ga/&type=pom".to_string()]]
+            vec![vec!["pkg:maven/com.redhat.quarkus.platform/quarkus-bom@2.13.8.Final-redhat-00004?repository_url=https:%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=pom".to_string()]]
         );
 
         // get product

--- a/modules/ingestor/src/service/advisory/osv/translate.rs
+++ b/modules/ingestor/src/service/advisory/osv/translate.rs
@@ -83,7 +83,7 @@ mod test {
     #[case(
         Ecosystem::Maven("http://other/repo".to_string()),
         "groupid:artifactid",
-        Some("pkg:maven/groupid/artifactid?repository_url=http://other/repo")
+        Some("pkg:maven/groupid/artifactid?repository_url=http:%2F%2Fother%2Frepo")
     )]
     #[case(Ecosystem::PyPI, "aiohttp", Some("pkg:pypi/aiohttp"))]
     #[case(Ecosystem::Go, "tailscale.com", Some("pkg:golang/tailscale.com"))]


### PR DESCRIPTION
Updated `packageurl` crate from 0.6 to 0.7. 

This is a far reaching change which corrects usage of pURL throughout trustify.

The largest impact was that many tests had to be corrected for percent encoding ... for example `/` should be percent encoded in `repository_url` qualifier **urlparam** value now should be `https:%2F%2Fmaven.repository.redhat.com%2Fga%2F` instead of `https://maven.repository.redhat.com/ga/`. The same idiom applies to other **urlparam** (like `download_url`).

Also in tests:
*  `:` should NOT be %3A encoded -- packageurl 0.7 only encodes / and , in qualifier values, not :. Fixed all %3A%2F%2F back to :%2F%2F.
* Split dual-use purl variables in tests -- Where the same purl string was used as both a query input AND output assertion (quarkus_component_by_purl, cdx_ancestor_of), split into _query (unencoded) and _expected (encoded) variables.

Lastly, had to fix `Purl::like()` (common/src/purl.rs:41-46) -- The in-memory filter was decoding the search pattern but comparing against self.to_string() which now (due to updated `packageurl`) produces %2F-encoded output, this was a latent minor bug that has been around for a long time. Fixed by decoding both sides before comparison.

## Summary by Sourcery

Build:
- Update the packageurl crate dependency from 0.6 to 0.7 in Cargo.toml and refresh Cargo.lock.

## Summary by Sourcery

Update package URL handling across the codebase to be compatible with packageurl 0.7, including fixing purl matching and adjusting tests for new encoding behavior.

Bug Fixes:
- Fix Purl::like() to compare decoded values consistently after packageurl encoding changes.

Enhancements:
- Align in-memory purl filtering and matching behavior with updated packageurl encoding semantics.

Build:
- Update packageurl crate dependency to 0.7 and refresh Cargo.lock.

Tests:
- Update analysis, fundamental, and ingestor tests to expect percent-encoded URL qualifiers and separate query vs expected purl values where needed.