### PR TITLE
chore(release): prep release/0.6.z

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -439,7 +439,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "csaf"
 version = "0.5.0"
-source = "git+https://github.com/scm-rs/csaf-rs?branch=main#63ac9e19d881cbf1808de38b6849635cda19931d"
+source = "git+https://github.com/scm-rs/csaf-rs?branch=main#3b95cd16d78de713a94eb136856b62bcb74617be"
 dependencies = [
  "chrono",
  "cpe",
@@ -2654,7 +2654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3604,7 +3604,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4507,7 +4507,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4597,7 +4597,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.2",
@@ -5038,9 +5038,9 @@ dependencies = [
 
 [[package]]
 name = "packageurl"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35da99768af1ae8830ccf30d295db0e09c24bcfda5a67515191dd4b773f6d82a"
+checksum = "d33fa1a190c3c9024f21b82e6b30f94137d9c1bf25071e2ab2ba13020135fbaf"
 dependencies = [
  "percent-encoding",
  "thiserror 2.0.18",
@@ -6316,7 +6316,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6374,7 +6374,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6799,7 +6799,7 @@ checksum = "e421679c8175ef4674d913af7fdb8ad0078c8a2599db633ad0b4d02a06b2cb3c"
 dependencies = [
  "anyhow",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "buffered-reader",
  "chrono",
  "dyn-clone",
@@ -7185,7 +7185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7706,7 +7706,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7737,7 +7737,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8233,7 +8233,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-auth"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-cli"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8285,7 +8285,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-common"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8342,7 +8342,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-db"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8359,7 +8359,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-entity"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "anyhow",
  "cpe",
@@ -8386,7 +8386,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-infrastructure"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "actix-cors",
  "actix-tls",
@@ -8421,7 +8421,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-migration"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-analysis"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8505,7 +8505,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-exploit-intelligence"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8540,7 +8540,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-fundamental"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8620,7 +8620,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-importer"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8676,7 +8676,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ingestor"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8730,7 +8730,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-storage"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8762,7 +8762,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ui"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "actix-web",
  "actix-web-static-files",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-user"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8806,14 +8806,14 @@ dependencies = [
 
 [[package]]
 name = "trustify-query"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "utoipa",
 ]
 
 [[package]]
 name = "trustify-query-derive"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -8821,7 +8821,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-server"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8861,7 +8861,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-test-context"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8911,7 +8911,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-trustd"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/guacsec/trustify-ui.git?branch=publish%2Fmain#6802f6868f79596d82ef5a0dfc302abed1beccc4"
+source = "git+https://github.com/guacsec/trustify-ui.git?branch=publish%2Fmain#fd5714b72cc733a8b2ca51251df0903c2929a1dd"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9494,7 +9494,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9509,7 +9509,7 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
- "windows-core 0.56.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -9519,23 +9519,10 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
- "windows-implement 0.56.0",
- "windows-interface 0.56.0",
+ "windows-implement",
+ "windows-interface",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -9550,32 +9537,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9919,7 +9884,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/guacsec/trustify-ui.git?branch=publish%2Fmain#fd5714b72cc733a8b2ca51251df0903c2929a1dd"
+source = "git+https://github.com/guacsec/trustify-ui.git?branch=publish%2Frelease%2F0.6.z#54d5abbd9b3d5033037fdfe25ead18c28c6537ea"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ trustify-query = {path = "query" }
 trustify-query-derive = {path = "query/query-derive" }
 trustify-server = { path = "server", default-features = false }
 trustify-test-context = { path = "test-context" }
-trustify-ui = { git = "https://github.com/guacsec/trustify-ui.git", branch = "publish/main" }
+trustify-ui = { git = "https://github.com/guacsec/trustify-ui.git", branch = "publish/release/0.6.z" }
 
 # These dependencies are active during both the build time and the run time. So they are normal dependencies
 # as well as build-dependencies. However, we can't control feature flags for build dependencies the way we do

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0-rc.1"
+version = "0.6.0-rc.1"
 edition = "2024"
 publish = false
 license = "Apache-2.0"
@@ -102,7 +102,7 @@ opentelemetry-otlp = "0.32"
 opentelemetry_sdk = "0.32"
 opentelemetry-instrumentation-actix-web = "0.24.0"
 osv = { version = "0.3.0", default-features = false, features = [] }
-packageurl = "0.6"
+packageurl = "0.7"
 parking_lot = "0.12"
 peak_alloc = "0.3.0"
 pem = "3"

--- a/common/src/purl.rs
+++ b/common/src/purl.rs
@@ -351,7 +351,7 @@ mod tests {
 
         assert_eq!(
             json,
-            r#""pkg:oci/ose-cluster-network-operator@sha256:0170ba5eebd557fd9f477d915bb7e0d4c1ad6cd4c1852d4b1ceed7a2817dd5d2?repository_url=registry.redhat.io/openshift4/ose-cluster-network-operator&tag=v4.11.0-202403090037.p0.g33da9fb.assembly.stream.el8""#
+            r#""pkg:oci/ose-cluster-network-operator@sha256:0170ba5eebd557fd9f477d915bb7e0d4c1ad6cd4c1852d4b1ceed7a2817dd5d2?repository_url=registry.redhat.io%2Fopenshift4%2Fose-cluster-network-operator&tag=v4.11.0-202403090037.p0.g33da9fb.assembly.stream.el8""#
         );
         Ok(())
     }


### PR DESCRIPTION
waiting on #2557

## Summary by Sourcery

Prepare the project for the 0.6.0-rc.1 release line and align dependencies and UI integration with the new release branch.

Build:
- Bump workspace package version to 0.6.0-rc.1.
- Update the packageurl dependency to version 0.7.
- Point the trustify-ui git dependency to the publish/release/0.6.z branch and refresh lockfile entries accordingly.

Tests:
- Adjust a purl JSON serialization test to expect URL-encoded repository paths in OCI package URLs.