### PR TITLE
ci: optimize CI pipeline for faster PR feedback

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci
 
       - name: Cache Theseus Postgresql Installation
         uses: actions/cache@v6
@@ -83,6 +85,8 @@ jobs:
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci
       - uses: dorny/paths-filter@v4
         id: filter
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,10 @@ on:
       - release/**
       - feature/**
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,10 +67,6 @@ jobs:
         if: matrix.install != ''
         run: ${{ matrix.install }}
 
-      - name: Check
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" # for embedded postgresql
-        run: cargo check
       - name: Clippy
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" # for embedded postgresql

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,8 +73,6 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
 
   ci:
-    needs:
-      - check
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -7,13 +7,6 @@ on:
       - 'etc/**'
     branches:
       - main
-  pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - 'etc/**'
-    branches:
-      - main
-      - feature/**
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
On every PR, 4 workflows trigger with 12 separate Rust compilation invokes across 6 runners:

**ci.yaml**:
  supply-chain ──────────────────────── (47s, independent)

  check [ubuntu] ──┐
  check [windows]  ─┼──► ci (tests, fmt, xtask, docs)     ~2h 10m
  check [macos]  ──┤
                   └──► container (release build, scan)   ~10m

**codecov.yaml**:  ──────────────────────── (independent, ~1h+)
**benchmark.yaml**: ─────────────────────── (independent, ~30m+)

This PR mitigates some of the simpler stuff to reduce PR feedback time and avoid avoid wasted runner resources. Further (more complicated) PRs are needed to fully optimise.

## Cancel stale runs
Adds concurrency: `cancel-in-progress` to ci.yaml. When new push arrives on same branch, any in-progress CI run is cancelled instead of running to completion.
## Remove redundant cargo check
The check job was running both cargo check & cargo clippy --all-targets --all-features. Clippy already performs all type-checking that cargo check does, so separate check step was pure overhead (~1-3 min per OS, across 3 OS runners).
## Run tests in parallel with checks
Previously the ci (test) job had `needs: [check]` blocking until all 3 OS check jobs finished. The slowest runner (eg. Windows /w vcpkg/MSVC) would gate entire test suite. Tests now start immediately in parallel with checks. The container job still depends on check.

## Move codecov to push-only
The codecov workflow re-compiles the entire workspace with coverage instrumentation and re-runs all tests single-threaded (--jobs 1). This duplicated the full test suite at ~1h+ per run. Coverage is now collected only on merge to main, not on every PR push. This is a trade off ... obvs we want code coverage information to gate off things ... perhaps we can think of precommit time ways of helping send a signal to a developer ?

## Share build cache between jobs
The check (ubuntu) and ci jobs both run on ubuntu-24.04 but previously maintained separate Rust build caches. They now share a cache via `shared-key: ci`, so compilation artifacts from whichever job runs first benefit the other.

## Summary by Sourcery

Optimize CI workflows to reduce redundant work and speed up PR feedback.

CI:
- Add concurrency configuration to cancel in-progress CI runs when new commits are pushed to the same branch.
- Remove the standalone cargo check step in favor of relying on clippy checks only.
- Allow the main CI test job to run without waiting on the check job, while sharing a Rust build cache between check and CI jobs.
- Restrict the Codecov workflow to run only on pushes to main instead of on every pull request.