### PR TITLE
chore(ux): set trustify-ui to publish/release0.6.z branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8995,7 +8995,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/guacsec/trustify-ui.git?branch=publish%2Fmain#1deb527367f5bd4933db5e12d0c58270385cf84a"
+source = "git+https://github.com/guacsec/trustify-ui.git?branch=publish%2Frelease%2F0.6.z#54d5abbd9b3d5033037fdfe25ead18c28c6537ea"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ trustify-query = {path = "query" }
 trustify-query-derive = {path = "query/query-derive" }
 trustify-server = { path = "server", default-features = false }
 trustify-test-context = { path = "test-context" }
-trustify-ui = { git = "https://github.com/guacsec/trustify-ui.git", branch = "publish/main" }
+trustify-ui = { git = "https://github.com/guacsec/trustify-ui.git", branch = "publish/release/0.6.z" }
 
 # These dependencies are active during both the build time and the run time. So they are normal dependencies
 # as well as build-dependencies. However, we can't control feature flags for build dependencies the way we do


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update trustify-ui Cargo dependency to track the publish/release/0.6.z branch.