### PR TITLE
fix: correctly serialize RFC3339 datetimes in EI API types

### DIFF
--- a/modules/exploit-intelligence/src/endpoints/test.rs
+++ b/modules/exploit-intelligence/src/endpoints/test.rs
@@ -11,9 +11,10 @@ use actix_web::{
     web,
 };
 use sea_orm::{ActiveModelTrait, Set, TransactionTrait};
+use serde_json::Value;
 use test_context::test_context;
 use test_log::test;
-use time::OffsetDateTime;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use trustify_common::{db, error::ErrorInformation, model::PaginatedResults};
 use trustify_entity::{
     exploit_intelligence_job::{self, ExploitIntelligenceFinding, ExploitIntelligenceJobStatus},
@@ -149,15 +150,20 @@ async fn get_job_completed(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // Then the response contains the completed job details
     assert_eq!(resp.status(), 200);
-    let body: ExploitIntelligenceJobDetails = test::read_body_json(resp).await;
-    assert_eq!(body.id, job_id);
-    assert_eq!(body.status, ExploitIntelligenceJobStatus::Completed);
-    assert_eq!(body.vulnerability_id, "CVE-2024-1234");
-    assert_eq!(
-        body.finding,
-        Some(ExploitIntelligenceFinding::NotVulnerable)
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["id"], job_id.to_string());
+    assert_eq!(body["status"], "completed");
+    assert_eq!(body["vulnerability_id"], "CVE-2024-1234");
+    assert_eq!(body["finding"], "not_vulnerable");
+    assert!(
+        OffsetDateTime::parse(body["created"].as_str().unwrap(), &Rfc3339).is_ok(),
+        "created should be valid RFC3339"
     );
-    assert_eq!(body.total_components, Some(1));
+    assert!(
+        OffsetDateTime::parse(body["updated"].as_str().unwrap(), &Rfc3339).is_ok(),
+        "created should be valid RFC3339"
+    );
+    assert_eq!(body["total_components"], 1);
 
     Ok(())
 }

--- a/modules/exploit-intelligence/src/model/mod.rs
+++ b/modules/exploit-intelligence/src/model/mod.rs
@@ -57,9 +57,11 @@ pub struct ExploitIntelligenceJobSummary {
     /// Number of completed components with Uncertain finding (computed at query time).
     pub uncertain_components: Option<i32>,
     /// Timestamp when the job was created.
+    #[serde(with = "time::serde::rfc3339")]
     #[schema(value_type = String)]
     pub created: OffsetDateTime,
     /// Timestamp when the job was last updated.
+    #[serde(with = "time::serde::rfc3339")]
     #[schema(value_type = String)]
     pub updated: OffsetDateTime,
 }
@@ -98,9 +100,11 @@ pub struct ExploitIntelligenceJobDetails {
     /// Per-component analysis results (populated for multi-component jobs).
     pub components: Vec<ComponentResult>,
     /// Timestamp when the job was created.
+    #[serde(with = "time::serde::rfc3339")]
     #[schema(value_type = String)]
     pub created: OffsetDateTime,
     /// Timestamp when the job was last updated.
+    #[serde(with = "time::serde::rfc3339")]
     #[schema(value_type = String)]
     pub updated: OffsetDateTime,
 }
@@ -169,9 +173,11 @@ pub struct ComponentResult {
     /// unsupported ecosystem) rather than genuinely failing.
     pub excluded: bool,
     /// Timestamp when the component record was created.
+    #[serde(with = "time::serde::rfc3339")]
     #[schema(value_type = String)]
     pub created: OffsetDateTime,
     /// Timestamp when the component record was last updated.
+    #[serde(with = "time::serde::rfc3339")]
     #[schema(value_type = String)]
     pub updated: OffsetDateTime,
 }


### PR DESCRIPTION
OpenAPI spec currently states that these date fields should be strings, but the implementation didnt match. Not currently used anywhere so the issue wasn't caught. 

Fixes [TC-5538](https://redhat.atlassian.net/browse/TC-5538)

[TC-5538]: https://redhat.atlassian.net/browse/TC-5538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure exploit intelligence API timestamps are serialized as RFC3339 strings and update tests accordingly.

Bug Fixes:
- Correct RFC3339 serialization of created and updated timestamp fields in exploit intelligence job and component responses.

Tests:
- Adjust exploit intelligence job completion test to assert string-based RFC3339 timestamps and other serialized fields via generic JSON inspection.