### PR TITLE
chore: include underlying error when logging failed exploit intelligence job reason

### DIFF
--- a/modules/exploit-intelligence/src/runner/analysis.rs
+++ b/modules/exploit-intelligence/src/runner/analysis.rs
@@ -44,10 +44,7 @@ async fn upload_sbom(
 
     let response = classify_response_error(label, request.send().await)
         .await
-        .map_err(|e| {
-            tracing::warn!(error = %e, label, "EI upload failed");
-            AnalysisError::from(e)
-        })?;
+        .map_err(AnalysisError::from)?;
 
     Ok(response)
 }

--- a/modules/exploit-intelligence/src/runner/mod.rs
+++ b/modules/exploit-intelligence/src/runner/mod.rs
@@ -19,19 +19,6 @@ pub(crate) enum EiRequestError {
     Permanent(anyhow::Error),
 }
 
-impl EiRequestError {
-    /// User-facing error message suitable for storing in the database.
-    /// Transient errors get a generic message; rejected errors surface
-    /// the EI response so users can fix their input.
-    pub(crate) fn user_message(&self) -> String {
-        match self {
-            Self::Transient(_) => "analysis service temporarily unavailable".to_string(),
-            Self::Rejected(msg) => msg.clone(),
-            Self::Permanent(_) => "internal analysis error".to_string(),
-        }
-    }
-}
-
 /// Error from a single analysis tick, classified for retry decisions.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum AnalysisError {
@@ -74,12 +61,10 @@ impl From<crate::Error> for AnalysisError {
 
 impl From<EiRequestError> for AnalysisError {
     fn from(e: EiRequestError) -> Self {
-        let msg = e.user_message();
         match e {
-            EiRequestError::Transient(_) => Self::Retryable(anyhow::anyhow!("{msg}")),
-            EiRequestError::Rejected(_) | EiRequestError::Permanent(_) => {
-                Self::Permanent(anyhow::anyhow!("{msg}"))
-            }
+            EiRequestError::Transient(detail) => Self::Retryable(anyhow::anyhow!("{detail}")),
+            EiRequestError::Rejected(detail) => Self::Permanent(anyhow::anyhow!("{detail}")),
+            EiRequestError::Permanent(err) => Self::Permanent(err),
         }
     }
 }


### PR DESCRIPTION
Previously if an EI request job failed, we would log the following which doesnt give much information:
`failing job: retries exhausted job_id=019ff11e-3217-7473-938a-28743c159835 error=analysis service temporarily unavailable attempt=3 max_retries=3`

With this change, we will log something as such instead:
`failing job: retries exhausted job_id=019ff11d-c2c0-7151-82ff-9bb600403776 error=SPDX upload: HTTP 429 Too Many Requests: {"error": "mock upload failure (HTTP 429)"} attempt=3 max_retries=3`

Fixes [TC-5541](https://redhat.atlassian.net/browse/TC-5541)

[TC-5541]: https://redhat.atlassian.net/browse/TC-5541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Improve exploit intelligence job failure handling to surface detailed underlying errors in logs and error classification.

Enhancements:
- Preserve and propagate detailed EiRequestError information into AnalysisError instead of generic user-facing messages.
- Simplify EI upload error mapping by directly converting EiRequestError into AnalysisError without additional logging.