### PR TITLE
fix: cargo audit quick-xml finding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5689,9 +5689,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ parking_lot = "0.12"
 peak_alloc = "0.3.0"
 pem = "3"
 petgraph = { version = "0.8.0", features = ["serde-1"] }
-quick-xml = "0.40.1"
+quick-xml = "0.41.0"
 rand = "0.10.0"
 regex = "1.10.3"
 reqwest = "0.13"


### PR DESCRIPTION
### Summary ###

Ran cargo audit on the code base, came across two [1] [2] quick-xml findings as below, both rated as high.

```
$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1216 security advisories (from /root/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (879 crate dependencies)
Crate:     quick-xml
Version:   0.40.1
Title:     Quadratic run time when checking a start tag for duplicate attribute names
Date:      2026-06-29
ID:        RUSTSEC-2026-0194
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0194
Severity:  7.5 (high)
Solution:  Upgrade to >=0.41.0

Crate:     quick-xml
Version:   0.40.1
Title:     Unbounded namespace-declaration allocation in `NsReader` enables memory-exhaustion denial of service
Date:      2026-06-29
ID:        RUSTSEC-2026-0195
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0195
Severity:  7.5 (high)
Solution:  Upgrade to >=0.41.0

<< snip >>

$
```

### Fix ####

Bumping up the version of quick-xml to >=0.41.0 as mentioned on the advisory pages [1][2]

```
$ git diff
diff --git a/Cargo.toml b/Cargo.toml
index 67d54a5c..e0b94fb4 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ parking_lot = "0.12"
 peak_alloc = "0.3.0"
 pem = "3"
 petgraph = { version = "0.8.0", features = ["serde-1"] }
-quick-xml = "0.40.1"
+quick-xml = "0.41.0"
 rand = "0.10.0"
 regex = "1.10.3"
 reqwest = "0.13"
$
```


### Verification ###

Ran build which worked as expected, no failure

```
$ cargo build --workspace
   Compiling proc-macro2 v1.0.107
   Compiling quote v1.0.47
   Compiling unicode-ident v1.0.24
   Compiling libc v0.2.189
   Compiling syn v2.0.119
   Compiling serde_core v1.0.229

<< snip >>

   Compiling trustify-module-ui v0.6.0-rc.1 (/root/Y/trustify/modules/ui)
   Compiling garage-door v0.2.0
   Compiling trustify-module-exploit-intelligence v0.6.0-rc.1 (/root/Y/trustify/modules/exploit-intelligence)
   Compiling trustify-module-user v0.6.0-rc.1 (/root/Y/trustify/modules/user)
   Compiling procfs v0.18.0
   Compiling procfs-core v0.18.0
   Compiling test-context-macros v0.5.8
   Compiling test-context v0.5.8
   Compiling tracing-flame v0.2.0
   Compiling async-tar v0.6.1
   Compiling which v8.0.5
   Compiling base16ct v1.0.0
   Compiling peak_alloc v0.3.0
   Compiling trustify-test-context v0.6.0-rc.1 (/root/Y/trustify/test-context)
   Compiling xtask v0.6.0-rc.1 (/root/Y/trustify/xtask)
   Compiling trustify-trustd v0.6.0-rc.1 (/root/Y/trustify/trustd)
   Compiling trustify-cli v0.6.0-rc.1 (/root/Y/trustify/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19m 22s
warning: the following packages contain code that will be rejected by a future version of Rust: proc-macro-error2 v2.0.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
$
$ ./target/debug/trustify --version
trustify 0.6.0-rc.1
$
```

Running cargo audit post this does not show those quick-xml findings anymore.


[1] https://rustsec.org/advisories/RUSTSEC-2026-0194
[2] https://rustsec.org/advisories/RUSTSEC-2026-0195