### PR TITLE
ci: speed up using cargo-nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,12 @@
+[profile.default]
+# Tests spawn embedded PostgreSQL, which needs time to initialize.
+slow-timeout = { period = "180s", terminate-after = 3 }
+# Fail the run as soon as one test fails.
+fail-fast = true
+
+[profile.ci]
+# CI runners have limited resources; cap parallelism to avoid OOM
+# from too many concurrent embedded PostgreSQL instances.
+test-threads = 4
+slow-timeout = { period = "280s", terminate-after = 3 }
+fail-fast = false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,15 +112,23 @@ jobs:
           sudo mkdir /mnt/trustify
           sudo chmod a+rwx /mnt/trustify
 
+      - uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2
+        with:
+          tool: cargo-nextest
+
       - name: Test
         if: steps.filter.outputs.non_md_changes == 'true'
-        run: cargo test --all-features
+        run: cargo nextest run --all-features -E 'not test(=m0002010::performance)' --profile ci
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" # for embedded postgresql
           RUST_LOG: info,sqlx=error,sea_orm=error
           TRUSTIFY_S3_AWS_REGION: eu-west-1
           TRUSTIFY_S3_AWS_BUCKET: guacsec-migration-dumps
           TMPDIR: /mnt/trustify
+
+      - name: Doc tests
+        if: steps.filter.outputs.non_md_changes == 'true'
+        run: cargo test --doc --all-features
 
       - name: Export and Validate Generated Openapi Spec
         run: |


### PR DESCRIPTION
first in a series of tweaks to speed up our slow CI jobs ... this PR ensures CI uses [cargo-nextest](https://nexte.st/) to run tests.

## Summary by Sourcery

Adopt cargo-nextest for CI test execution with dedicated profiles for local and CI runs.

New Features:
- Introduce cargo-nextest-based test execution in the CI workflow.
- Add a doc-test-only job step to run documentation tests separately in CI.

Enhancements:
- Configure nextest profiles to tune timeouts, parallelism, and fail-fast behavior for local and CI environments.