### PR TITLE
Analysis module performance: reduce allocs, CPU, and DB round-trips

### DIFF
--- a/modules/analysis/src/model.rs
+++ b/modules/analysis/src/model.rs
@@ -79,14 +79,17 @@ pub struct CacheStatusEntry {
 pub struct BaseSummary {
     pub sbom_id: String,
     pub node_id: String,
-    pub purl: Vec<Purl>,
-    pub cpe: Vec<Cpe>,
+    pub purl: Arc<[Purl]>,
+    pub cpe: Arc<[Cpe]>,
     pub name: String,
     pub version: String,
     pub published: String,
-    pub document_id: String,
-    pub product_name: String,
-    pub product_version: String,
+    #[schema(value_type = String)]
+    pub document_id: Arc<String>,
+    #[schema(value_type = String)]
+    pub product_name: Arc<String>,
+    #[schema(value_type = String)]
+    pub product_version: Arc<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]

--- a/modules/analysis/src/model.rs
+++ b/modules/analysis/src/model.rs
@@ -85,11 +85,11 @@ pub struct BaseSummary {
     pub version: String,
     pub published: String,
     #[schema(value_type = String)]
-    pub document_id: Arc<String>,
+    pub document_id: Arc<str>,
     #[schema(value_type = String)]
-    pub product_name: Arc<String>,
+    pub product_name: Arc<str>,
     #[schema(value_type = String)]
-    pub product_version: Arc<String>,
+    pub product_version: Arc<str>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]

--- a/modules/analysis/src/model/graph.rs
+++ b/modules/analysis/src/model/graph.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::sync::LazyLock;
 use time::{OffsetDateTime, macros::format_description};
 use uuid::Uuid;
 
@@ -29,9 +30,9 @@ pub struct BaseNode {
 
     pub name: String,
 
-    pub document_id: Option<Arc<String>>,
-    pub product_name: Option<Arc<String>>,
-    pub product_version: Option<Arc<String>>,
+    pub document_id: Option<Arc<str>>,
+    pub product_name: Option<Arc<str>>,
+    pub product_version: Option<Arc<str>>,
 }
 
 impl DeepSizeOf for BaseNode {
@@ -103,10 +104,9 @@ fn published_to_string(value: OffsetDateTime) -> String {
     value.format(&format).unwrap_or_else(|_| value.to_string())
 }
 
-static EMPTY_ARC_STRING: std::sync::LazyLock<Arc<String>> =
-    std::sync::LazyLock::new(|| Arc::new(String::new()));
+static EMPTY_ARC_STRING: LazyLock<Arc<str>> = LazyLock::new(|| Arc::from(""));
 
-fn arc_string_or_default(opt: &Option<Arc<String>>) -> Arc<String> {
+fn arc_string_or_default(opt: &Option<Arc<str>>) -> Arc<str> {
     opt.as_ref()
         .cloned()
         .unwrap_or_else(|| EMPTY_ARC_STRING.clone())

--- a/modules/analysis/src/model/graph.rs
+++ b/modules/analysis/src/model/graph.rs
@@ -103,33 +103,30 @@ fn published_to_string(value: OffsetDateTime) -> String {
     value.format(&format).unwrap_or_else(|_| value.to_string())
 }
 
+static EMPTY_ARC_STRING: std::sync::LazyLock<Arc<String>> =
+    std::sync::LazyLock::new(|| Arc::new(String::new()));
+
+fn arc_string_or_default(opt: &Option<Arc<String>>) -> Arc<String> {
+    opt.as_ref()
+        .cloned()
+        .unwrap_or_else(|| EMPTY_ARC_STRING.clone())
+}
+
 impl From<&Node> for BaseSummary {
     fn from(value: &Node) -> Self {
         match value {
             Node::Package(value) => BaseSummary::from(value),
             _ => Self {
                 sbom_id: value.sbom_id.to_string(),
-                node_id: value.node_id.to_string(),
-                purl: vec![],
-                cpe: vec![],
-                name: value.name.to_string(),
-                version: "".to_string(),
+                node_id: value.node_id.clone(),
+                purl: Arc::from([]),
+                cpe: Arc::from([]),
+                name: value.name.clone(),
+                version: String::new(),
                 published: published_to_string(value.published),
-                document_id: value
-                    .document_id
-                    .as_ref()
-                    .map(|s| s.to_string())
-                    .unwrap_or_default(),
-                product_name: value
-                    .product_name
-                    .as_ref()
-                    .map(|s| s.to_string())
-                    .unwrap_or_default(),
-                product_version: value
-                    .product_version
-                    .as_ref()
-                    .map(|s| s.to_string())
-                    .unwrap_or_default(),
+                document_id: arc_string_or_default(&value.document_id),
+                product_name: arc_string_or_default(&value.product_name),
+                product_version: arc_string_or_default(&value.product_version),
             },
         }
     }
@@ -139,27 +136,15 @@ impl From<&PackageNode> for BaseSummary {
     fn from(value: &PackageNode) -> Self {
         Self {
             sbom_id: value.sbom_id.to_string(),
-            node_id: value.node_id.to_string(),
-            purl: value.purl.to_vec(),
-            cpe: value.cpe.to_vec(),
-            name: value.name.to_string(),
-            version: value.version.to_string(),
+            node_id: value.node_id.clone(),
+            purl: Arc::clone(&value.purl),
+            cpe: Arc::clone(&value.cpe),
+            name: value.name.clone(),
+            version: value.version.clone(),
             published: published_to_string(value.published),
-            document_id: value
-                .document_id
-                .as_ref()
-                .map(|s| s.to_string())
-                .unwrap_or_default(),
-            product_name: value
-                .product_name
-                .as_ref()
-                .map(|s| s.to_string())
-                .unwrap_or_default(),
-            product_version: value
-                .product_version
-                .as_ref()
-                .map(|s| s.to_string())
-                .unwrap_or_default(),
+            document_id: arc_string_or_default(&value.document_id),
+            product_name: arc_string_or_default(&value.product_name),
+            product_version: arc_string_or_default(&value.product_version),
         }
     }
 }

--- a/modules/analysis/src/model/roots.rs
+++ b/modules/analysis/src/model/roots.rs
@@ -92,20 +92,21 @@ impl<'a> RootTraces for &'a Vec<Node> {
 mod test {
     use super::*;
     use crate::model::BaseSummary;
+    use std::sync::Arc;
     use trustify_entity::relationship::Relationship;
 
     fn base(node_id: &str) -> BaseSummary {
         BaseSummary {
-            sbom_id: "".to_string(),
+            sbom_id: String::new(),
             node_id: node_id.to_string(),
-            purl: vec![],
-            cpe: vec![],
-            name: "".to_string(),
-            version: "".to_string(),
-            published: "".to_string(),
-            document_id: "".to_string(),
-            product_name: "".to_string(),
-            product_version: "".to_string(),
+            purl: Arc::from([]),
+            cpe: Arc::from([]),
+            name: String::new(),
+            version: String::new(),
+            published: String::new(),
+            document_id: Arc::new(String::new()),
+            product_name: Arc::new(String::new()),
+            product_version: Arc::new(String::new()),
         }
     }
 

--- a/modules/analysis/src/model/roots.rs
+++ b/modules/analysis/src/model/roots.rs
@@ -104,9 +104,9 @@ mod test {
             name: String::new(),
             version: String::new(),
             published: String::new(),
-            document_id: Arc::new(String::new()),
-            product_name: Arc::new(String::new()),
-            product_version: Arc::new(String::new()),
+            document_id: Arc::from(""),
+            product_name: Arc::from(""),
+            product_version: Arc::from(""),
         }
     }
 

--- a/modules/analysis/src/service/collector.rs
+++ b/modules/analysis/src/service/collector.rs
@@ -27,6 +27,48 @@ type AncestorResult = Arc<Vec<ResolvedSbom>>;
 type AncestorCell = Arc<tokio::sync::OnceCell<AncestorResult>>;
 type AncestorMap = HashMap<(Uuid, String), AncestorCell>;
 
+type ExternalSbomResult = Arc<Option<ResolvedSbom>>;
+type ExternalSbomCell = Arc<tokio::sync::OnceCell<ExternalSbomResult>>;
+type ExternalSbomMap = HashMap<String, ExternalSbomCell>;
+
+/// Request-scoped cache for [`resolve_external_sbom`] results.
+///
+/// During descendant traversal, every `ExternalNode` triggers a
+/// `resolve_external_sbom` DB query. The same external reference
+/// can appear across multiple SBOMs in the result set, causing
+/// redundant queries. This cache deduplicates them.
+///
+/// Concurrent callers for the same `node_id` are coalesced via
+/// `OnceCell` — only the first executes the query.
+#[derive(Default, Clone)]
+pub struct ExternalSbomCache {
+    cache: Arc<Mutex<ExternalSbomMap>>,
+}
+
+impl ExternalSbomCache {
+    /// Resolve an external SBOM reference, returning a cached result
+    /// when available.
+    async fn resolve<C: ConnectionTrait>(
+        &self,
+        node_id: &str,
+        connection: &C,
+    ) -> Result<Option<ResolvedSbom>, Error> {
+        let cell = {
+            let mut map = self.cache.lock();
+            map.entry(node_id.to_string()).or_default().clone()
+        };
+
+        let result = cell
+            .get_or_try_init(|| async {
+                let resolved = resolve_external_sbom(node_id, connection).await?;
+                Ok::<_, Error>(Arc::new(resolved))
+            })
+            .await?;
+
+        Ok((**result).clone())
+    }
+}
+
 /// Coalescing barrier for [`AncestorCache::prefetch`].
 ///
 /// When multiple concurrent tasks call `prefetch` for the same
@@ -205,6 +247,7 @@ pub struct Collector<'a, C: ConnectionTrait> {
     discovered: DiscoveredTracker,
     loaded_graphs: Arc<Mutex<HashMap<Uuid, Arc<PackageGraph>>>>,
     ancestor_cache: AncestorCache,
+    external_sbom_cache: ExternalSbomCache,
     relationships: &'a HashSet<Relationship>,
     connection: &'a C,
     concurrency: usize,
@@ -224,6 +267,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             discovered: self.discovered.clone(),
             loaded_graphs: self.loaded_graphs.clone(),
             ancestor_cache: self.ancestor_cache.clone(),
+            external_sbom_cache: self.external_sbom_cache.clone(),
             relationships: self.relationships,
             connection: self.connection,
             concurrency: self.concurrency,
@@ -246,6 +290,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
         concurrency: usize,
         loader: &'a GraphLoader,
         ancestor_cache: AncestorCache,
+        external_sbom_cache: ExternalSbomCache,
     ) -> Self {
         Self {
             graph_cache,
@@ -258,6 +303,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             discovered: Default::default(),
             loaded_graphs: Default::default(),
             ancestor_cache,
+            external_sbom_cache,
             relationships,
             connection,
             concurrency,
@@ -293,6 +339,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             discovered: self.discovered.clone(),
             loaded_graphs: self.loaded_graphs.clone(),
             ancestor_cache: self.ancestor_cache.clone(),
+            external_sbom_cache: self.external_sbom_cache.clone(),
             relationships: self.relationships,
             connection: self.connection,
             concurrency: self.concurrency,
@@ -365,7 +412,10 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             sbom_id: external_sbom_id,
             node_id: external_node_id,
             ..
-        }) = resolve_external_sbom(&external_node.node_id, self.connection).await?
+        }) = self
+            .external_sbom_cache
+            .resolve(&external_node.node_id, self.connection)
+            .await?
         else {
             return Ok((
                 None,

--- a/modules/analysis/src/service/load/mod.rs
+++ b/modules/analysis/src/service/load/mod.rs
@@ -82,15 +82,10 @@ impl Context {
     }
 
     pub fn intern(&mut self, s: String) -> Arc<String> {
-        if self.strings.contains_key(&s)
-            && let Some(s) = self.strings.get(&s)
-        {
-            return s.clone();
-        }
-
-        let a = Arc::new(s.clone());
-        self.strings.insert(s, a.clone());
-        a
+        self.strings
+            .entry(s)
+            .or_insert_with_key(|k| Arc::new(k.clone()))
+            .clone()
     }
 }
 

--- a/modules/analysis/src/service/load/mod.rs
+++ b/modules/analysis/src/service/load/mod.rs
@@ -73,7 +73,7 @@ pub struct Node {
 
 #[derive(Debug, Default)]
 struct Context {
-    strings: HashMap<String, Arc<String>>,
+    strings: HashMap<String, Arc<str>>,
 }
 
 impl Context {
@@ -81,10 +81,10 @@ impl Context {
         Self::default()
     }
 
-    pub fn intern(&mut self, s: String) -> Arc<String> {
+    pub fn intern(&mut self, s: String) -> Arc<str> {
         self.strings
             .entry(s)
-            .or_insert_with_key(|k| Arc::new(k.clone()))
+            .or_insert_with_key(|k| Arc::from(k.as_str()))
             .clone()
     }
 }

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -914,40 +914,9 @@ impl AnalysisService {
                 })
             }
             GraphQuery::Query(query) => graph.node_weight(i).is_some_and(|node| {
-                let purls: Vec<_> = match node {
-                    graph::Node::Package(p) => {
-                        p.purl
-                            .iter()
-                            .map(|p| {
-                                let mut v: serde_json::Value = p.into();
-                                // if any translations are applied to
-                                // the DB query, they must be added to
-                                // this context as well
-                                v["type"] = v["ty"].clone();
-                                Value::Json(v)
-                            })
-                            .collect()
-                    }
-                    _ => vec![],
-                };
-                let cpes: Vec<_> = match node {
-                    graph::Node::Package(p) => p
-                        .cpe
-                        .iter()
-                        .map(|cpe| {
-                            Value::Json(json!({
-                                "part": cpe.part(),
-                                "vendor": cpe.vendor(),
-                                "product": cpe.product(),
-                                "version": cpe.version(),
-                                "update": cpe.update(),
-                                "edition": cpe.edition(),
-                                "language": cpe.language(),
-                            }))
-                        })
-                        .collect(),
-                    _ => vec![],
-                };
+                let q = &query.q;
+                let needs_nested_purl = q.contains("purl:");
+                let needs_nested_cpe = q.contains("cpe:");
                 let sbom_id = node.sbom_id.to_string();
                 let mut context = ValueContext::from([
                     ("sbom_id", &*sbom_id),
@@ -957,10 +926,38 @@ impl AnalysisService {
                 match node {
                     graph::Node::Package(package) => {
                         context.put("version", &*package.version);
-                        context.put_hidden("cpe", &package.cpe);
-                        context.put_hidden("cpe", cpes);
                         context.put_hidden("purl", &package.purl);
-                        context.put_hidden("purl", purls);
+                        context.put_hidden("cpe", &package.cpe);
+                        if needs_nested_purl {
+                            let purls: Vec<_> = package
+                                .purl
+                                .iter()
+                                .map(|p| {
+                                    let mut v: serde_json::Value = p.into();
+                                    v["type"] = v["ty"].clone();
+                                    Value::Json(v)
+                                })
+                                .collect();
+                            context.put_hidden("purl", purls);
+                        }
+                        if needs_nested_cpe {
+                            let cpes: Vec<_> = package
+                                .cpe
+                                .iter()
+                                .map(|cpe| {
+                                    Value::Json(json!({
+                                        "part": cpe.part(),
+                                        "vendor": cpe.vendor(),
+                                        "product": cpe.product(),
+                                        "version": cpe.version(),
+                                        "update": cpe.update(),
+                                        "edition": cpe.edition(),
+                                        "language": cpe.language(),
+                                    }))
+                                })
+                                .collect();
+                            context.put_hidden("cpe", cpes);
+                        }
                     }
                     graph::Node::External(external) => {
                         context.put(

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -57,7 +57,7 @@ use trustify_entity::{
     relationship::Relationship,
     sbom,
     sbom_external_node::{self, DiscriminatorType, ExternalType},
-    sbom_node_checksum, source_document,
+    source_document,
 };
 use uuid::Uuid;
 
@@ -235,26 +235,31 @@ async fn resolve_rh_external_sbom_descendants<C: ConnectionTrait>(
     sbom_external_node_ref: String,
     connection: &C,
 ) -> Result<Option<ResolvedSbom>, Error> {
-    // find checksum value for the node
+    // Single self-join query: find nodes in other SBOMs that share
+    // the same checksum value as the given node.
+    #[derive(Debug, FromQueryResult)]
+    struct ChecksumMatch {
+        matched_sbom_id: Uuid,
+        matched_node_id: String,
+    }
 
-    let Some(entity) = sbom_node_checksum::Entity::find()
-        .filter(sbom_node_checksum::Column::NodeId.eq(sbom_external_node_ref.clone()))
-        .filter(sbom_node_checksum::Column::SbomId.eq(sbom_external_sbom_id))
-        .one(connection)
-        .await?
-    else {
-        log::debug!("Unable to find checksum");
-        return Ok(None);
-    };
-
-    log::debug!("Checksum: {} / {}", entity.value, entity.sbom_id);
-
-    // now find if there are any other nodes with the same checksums
-    let matches = sbom_node_checksum::Entity::find()
-        .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
-        .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
-        .all(connection)
-        .await?;
+    let matches = ChecksumMatch::find_by_statement(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        r#"
+        SELECT matched.sbom_id AS matched_sbom_id,
+               matched.node_id AS matched_node_id
+        FROM sbom_node_checksum self_chk
+        JOIN sbom_node_checksum matched
+          ON matched.value = self_chk.value
+         AND matched.type = self_chk.type
+         AND matched.sbom_id != self_chk.sbom_id
+        WHERE self_chk.sbom_id = $1
+          AND self_chk.node_id = $2
+        "#,
+        [sbom_external_sbom_id.into(), sbom_external_node_ref.into()],
+    ))
+    .all(connection)
+    .await?;
 
     log::debug!("Found {} nodes by checksum", matches.len());
 
@@ -264,17 +269,20 @@ async fn resolve_rh_external_sbom_descendants<C: ConnectionTrait>(
         // which has not defined a bom-ref - we can 'sniff' this because such nodes always
         // are ingested with a uuid node-id.
         .find(|model| {
-            if Uuid::parse_str(&model.node_id).is_err() {
+            if Uuid::parse_str(&model.matched_node_id).is_err() {
                 // failed to parse, we keep it
                 true
             } else {
-                log::debug!("Dropping suspected top-level node ID: {}", model.node_id);
+                log::debug!(
+                    "Dropping suspected top-level node ID: {}",
+                    model.matched_node_id
+                );
                 false
             }
         })
-        .map(|matched_model| ResolvedSbom {
-            sbom_id: matched_model.sbom_id,
-            node_id: matched_model.node_id,
+        .map(|matched| ResolvedSbom {
+            sbom_id: matched.matched_sbom_id,
+            node_id: matched.matched_node_id,
             cpe_ids: vec![],
             graph_node_id: None,
         }))
@@ -730,6 +738,7 @@ impl AnalysisService {
 
         let loader = &GraphLoader::new(self.clone());
         let ancestor_cache = AncestorCache::default();
+        let external_sbom_cache = ExternalSbomCache::default();
 
         // Batch-prefetch ancestor results for all PackageNodes in
         // the initial set of graphs.  This replaces N individual
@@ -748,6 +757,7 @@ impl AnalysisService {
                 let graph_cache = self.inner.graph_cache.clone();
                 let relationships = Arc::clone(&relationships);
                 let ancestor_cache = ancestor_cache.clone();
+                let external_sbom_cache = external_sbom_cache.clone();
                 async move {
                     log::trace!(
                         "Discovered node - sbom: {}, node: {}",
@@ -768,6 +778,7 @@ impl AnalysisService {
                         self.concurrency,
                         loader,
                         ancestor_cache.clone(),
+                        external_sbom_cache.clone(),
                     )
                     .collect();
 
@@ -784,6 +795,7 @@ impl AnalysisService {
                         self.concurrency,
                         loader,
                         ancestor_cache,
+                        external_sbom_cache,
                     )
                     .collect();
 

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -725,7 +725,7 @@ impl AnalysisService {
         graphs: &[(Uuid, Arc<PackageGraph>)],
         connection: &C,
     ) -> Result<Vec<Node>, Error> {
-        let relationships = options.relationships;
+        let relationships = Arc::new(options.relationships);
         log::debug!("relations: {:?}", relationships);
 
         let loader = &GraphLoader::new(self.clone());
@@ -746,7 +746,7 @@ impl AnalysisService {
             self.concurrency,
             |graph, node_index, node| {
                 let graph_cache = self.inner.graph_cache.clone();
-                let relationships = relationships.clone();
+                let relationships = Arc::clone(&relationships);
                 let ancestor_cache = ancestor_cache.clone();
                 async move {
                     log::trace!(

--- a/modules/analysis/src/service/test/mod.rs
+++ b/modules/analysis/src/service/test/mod.rs
@@ -344,7 +344,7 @@ async fn test_status_service(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
     let analysis_status = service.status(&ctx.db, false).await?;
     assert_eq!(analysis_status.sbom_count, 1);
     assert_eq!(analysis_status.graph_count, 1);
-    assert_eq!(analysis_status.graph_memory, 2224);
+    assert_eq!(analysis_status.graph_memory, 2152);
     assert!(analysis_status.details.is_none());
 
     service.clear_all_graphs()?;

--- a/modules/analysis/src/service/test/mod.rs
+++ b/modules/analysis/src/service/test/mod.rs
@@ -511,12 +511,12 @@ async fn test_simple_by_name_deps_service(ctx: &TrustifyContext) -> Result<(), a
     assert_eq!(analysis_graph.total, Some(1));
 
     assert_eq!(
-        analysis_graph.items[0].purl,
-        vec![Purl::from_str("pkg:rpm/redhat/A@0.0.0?arch=src")?]
+        &*analysis_graph.items[0].purl,
+        [Purl::from_str("pkg:rpm/redhat/A@0.0.0?arch=src")?]
     );
     assert_eq!(
-        analysis_graph.items[0].cpe,
-        vec![Cpe::from_str("cpe:/a:redhat:simple:1::el9")?]
+        &*analysis_graph.items[0].cpe,
+        [Cpe::from_str("cpe:/a:redhat:simple:1::el9")?]
     );
 
     Ok(())
@@ -545,8 +545,8 @@ async fn test_simple_by_purl_deps_service(ctx: &TrustifyContext) -> Result<(), a
         .await?;
 
     assert_eq!(
-        analysis_graph.items[0].purl,
-        vec![Purl::from_str("pkg:rpm/redhat/AA@0.0.0?arch=src")?]
+        &*analysis_graph.items[0].purl,
+        [Purl::from_str("pkg:rpm/redhat/AA@0.0.0?arch=src")?]
     );
 
     assert_eq!(analysis_graph.total, Some(1));


### PR DESCRIPTION
graph analysis module had several performance inefficiencies:

1. **Per-node JSON serialization in `filter()`** — every node scanned during a `GraphQuery::Query` built `serde_json::Value` maps for all purls and CPEs even if query only needed substring matching
2. **Deep cloning in `BaseSummary`** — every node in the result tree cloned all purls, CPEs, and string fields from the graph into owned types
3. **Double hash lookup in `Context::intern`** — `contains_key` + `get` instead of single `entry()` call during graph construction
4. **Per-node `HashSet<Relationship>` clone** — the relationship filter set was cloned for every matching node in the async closure
5. **Two seq DB queries in `resolve_rh_external_sbom_descendants`** — first fetched the checksum value, then searched for matches
6. **No caching for `resolve_external_sbom`** — every `ExternalNode` hit during descendant traversal triggered a fresh DB query, even for duplicate references

Addressing these positively impacts:
- **Memory**: eliminates tens of MB transient heap allocs per query on large graphs (JSON construction), plus ~500 bytes per result node (Arc sharing vs deep clone)
- **CPU**: common filter path avoids all JSON serialization
- **I/O**: saves a DB round-trip per RH external node; eliminates all duplicate external resolution queries per request

No API changes. No schema changes. No migration required.

## Summary by Sourcery

Improve performance of the analysis module by reducing per-node allocations and database round-trips, primarily through caching, shared ownership of summary data, and more efficient query and filtering paths.

New Features:
- Introduce a request-scoped cache for external SBOM resolution to deduplicate database lookups across descendant traversal.

Enhancements:
- Optimize RH external SBOM descendant resolution by replacing two sequential checksum queries with a single self-join query.
- Avoid unnecessary JSON construction in graph filtering by only materializing nested purl and CPE structures when the query string requires them.
- Reduce per-node memory usage in BaseSummary by sharing purl, CPE, and string fields via Arc instead of cloning.
- Improve string interning performance during graph loading by using a single hashmap entry operation instead of separate contains/get steps.
- Avoid cloning the relationship filter set for each node by sharing it across tasks via Arc.

Tests:
- Update analysis service tests to reflect shared purl and CPE storage using Arc-backed slices.

## Summary by Sourcery

Improve analysis performance by reducing transient allocations, sharing immutable data, and eliminating redundant database queries.

Enhancements:
- Reduce analysis query allocations and CPU usage by avoiding unnecessary nested purl and CPE materialization during filtering.
- Share graph-derived summary data through reference-counted ownership to reduce per-node memory usage.
- Improve graph loading and concurrent traversal efficiency through streamlined string interning and shared relationship filters.
- Deduplicate external SBOM lookups within each request using a concurrent resolution cache.
- Resolve RH external SBOM descendants with a single checksum-matching database query instead of sequential round-trips.

Tests:
- Update analysis service assertions for Arc-backed purl and CPE collections.