### PR TITLE
minor(cargo deny): updated h2 to 0.4.16, removed stale ignore entries, ignore h2 0.3.x which is dev dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.5.0",
  "hyper",
  "hyper-rustls",
@@ -3145,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3504,7 +3504,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
@@ -3579,7 +3579,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5709,7 +5709,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5748,7 +5748,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -6032,7 +6032,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
@@ -9549,7 +9549,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -6,16 +6,12 @@ all-features = true
 # reviewed periodically. Remove entries once the underlying crate is updated.
 ignore = [
     # Pre-existing transitive vulnerabilities — tracked for resolution.
-    # crossbeam-epoch: invalid pointer dereference in fmt::Pointer (transitive)
-    { id = "RUSTSEC-2026-0204", reason = "transitive dep; awaiting upstream update" },
     # proc-macro-error2: unmaintained (transitive via derive macros)
     { id = "RUSTSEC-2026-0173", reason = "transitive dep; no direct replacement yet" },
-    # quick-xml: quadratic attribute-name check (transitive via csaf/spdx parsers)
-    { id = "RUSTSEC-2026-0194", reason = "transitive dep; awaiting upstream update" },
-    # quick-xml: unbounded namespace allocation (transitive via csaf/spdx parsers)
-    { id = "RUSTSEC-2026-0195", reason = "transitive dep; awaiting upstream update" },
     # rsa: Marvin Attack timing side-channel (transitive via sequoia-openpgp)
     { id = "RUSTSEC-2023-0071", reason = "transitive dep via sequoia-openpgp; no fix available" },
+    # h2 0.3.x: unbounded empty DATA frames (dev-only via actix-http; no 0.3.x patch)
+    { id = "RUSTSEC-2026-0258", reason = "dev-dep only via actix-http; h2 0.3.x EOL, no patch available" },
 ]
 
 [licenses]


### PR DESCRIPTION
* Updated h2 0.4.15 → 0.4.16 in Cargo.lock (fixes RUSTSEC-2026-0258 for the 0.4.x line)
* Added ignore for h2 0.3.x in deny.toml — dev-dependency only (via actix-http), no 0.3.x patch exists
* Removed 3 stale ignores (RUSTSEC-2026-0204, -0194, -0195) that no longer match any crate in the dependency tree

## Summary by Sourcery

Refresh dependency vulnerability handling by updating h2 and pruning obsolete security advisories.

Bug Fixes:
- Update h2 0.4.x to 0.4.16 to address its reported security vulnerability.

Enhancements:
- Remove stale vulnerability ignores and document the remaining h2 0.3.x development dependency exception.