### PR TITLE
fix: Reformulation of PR #2582 (TC-5630) for release/0.5.z.

### DIFF
--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -16,7 +16,9 @@ use sea_orm::{
     QueryFilter, QueryOrder, QueryResult, QuerySelect, QueryTrait, RelationTrait, Select,
     SelectColumns,
 };
-use sea_query::{Asterisk, ColumnRef, Expr, Func, IntoIden, JoinType, SimpleExpr};
+use sea_query::{
+    Alias, Asterisk, ColumnRef, Condition, Expr, Func, IntoIden, JoinType, SimpleExpr, UnionType,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, hash_map::Entry};
 use trustify_common::{
@@ -28,8 +30,8 @@ use trustify_common::{
 use trustify_entity::{
     advisory, advisory_vulnerability_score, base_purl, cpe, license, organization, product,
     product_status, product_version, product_version_range, purl_status, qualified_purl, sbom,
-    sbom_license_expanded, sbom_node, sbom_node_purl_ref, sbom_package_license, status,
-    version_range, versioned_purl, vulnerability,
+    sbom_describing_cpe, sbom_license_expanded, sbom_node, sbom_node_purl_ref,
+    sbom_package_license, status, version_range, versioned_purl, vulnerability,
 };
 use trustify_module_ingestor::common::{Deprecation, DeprecationForExt};
 use utoipa::ToSchema;
@@ -152,6 +154,83 @@ impl PurlDetails {
     }
 }
 
+/// Build the two subqueries needed for CPE context filtering:
+/// 1. `allowed_cpe_ids` — CPE IDs from the describing CPEs of SBOMs
+///    containing the given PURL, plus generalized (major-version-only)
+///    variants.
+/// 2. `sbom_has_cpes` — EXISTS subquery that checks whether any SBOM
+///    containing the PURL has describing CPEs at all.
+///
+/// The returned pair is used in a three-way filter:
+///   context_cpe_id IS NULL
+///   OR context_cpe_id IN (allowed_cpe_ids)
+///   OR NOT EXISTS (sbom_has_cpes)
+fn cpe_context_subqueries(
+    qualified_purl_id: Uuid,
+) -> (sea_query::SelectStatement, sea_query::SelectStatement) {
+    let sbom_ids = sbom_node_purl_ref::Entity::find()
+        .select_only()
+        .column(sbom_node_purl_ref::Column::SbomId)
+        .filter(sbom_node_purl_ref::Column::QualifiedPurlId.eq(qualified_purl_id))
+        .into_query();
+
+    let mut allowed_cpe_ids = sbom_describing_cpe::Entity::find()
+        .select_only()
+        .column(sbom_describing_cpe::Column::CpeId)
+        .filter(sbom_describing_cpe::Column::SbomId.in_subquery(sbom_ids.clone()))
+        .into_query();
+
+    let c = Alias::new("c");
+    let sc = Alias::new("sc");
+    let sdc = Alias::new("sdc");
+    let generalized_cpe_ids = sea_query::Query::select()
+        .expr(Expr::col((c.clone(), cpe::Column::Id)))
+        .from_as(cpe::Entity, c.clone())
+        .join_as(
+            JoinType::InnerJoin,
+            cpe::Entity,
+            sc.clone(),
+            Condition::all()
+                .add(
+                    Expr::col((c.clone(), cpe::Column::Vendor))
+                        .equals((sc.clone(), cpe::Column::Vendor)),
+                )
+                .add(
+                    Expr::col((c.clone(), cpe::Column::Product))
+                        .equals((sc.clone(), cpe::Column::Product)),
+                )
+                .add(
+                    Expr::col((c.clone(), cpe::Column::Version)).eq(SimpleExpr::FunctionCall(
+                        Func::cust(Alias::new("split_part"))
+                            .arg(Expr::col((sc.clone(), cpe::Column::Version)))
+                            .arg(Expr::value("."))
+                            .arg(Expr::value(1i32)),
+                    )),
+                ),
+        )
+        .join_as(
+            JoinType::InnerJoin,
+            sbom_describing_cpe::Entity,
+            sdc.clone(),
+            Expr::col((sdc.clone(), sbom_describing_cpe::Column::CpeId))
+                .equals((sc.clone(), cpe::Column::Id)),
+        )
+        .and_where(
+            Expr::col((sdc.clone(), sbom_describing_cpe::Column::SbomId))
+                .in_subquery(sbom_ids.clone()),
+        )
+        .to_owned();
+    allowed_cpe_ids.union(UnionType::Distinct, generalized_cpe_ids);
+
+    let sbom_has_cpes = sea_query::Query::select()
+        .expr(Expr::value(1i32))
+        .from(sbom_describing_cpe::Entity)
+        .and_where(sbom_describing_cpe::Column::SbomId.in_subquery(sbom_ids))
+        .to_owned();
+
+    (allowed_cpe_ids, sbom_has_cpes)
+}
+
 async fn get_product_statuses_for_purl<C: ConnectionTrait>(
     tx: &C,
     qualified_package_id: Uuid,
@@ -167,6 +246,12 @@ async fn get_product_statuses_for_purl<C: ConnectionTrait>(
         .select_only()
         .column(sbom::Column::SbomId)
         .into_query();
+
+    // CPE context filtering — only return product statuses whose
+    // context CPE matches the describing CPEs of SBOMs containing this
+    // PURL.  Mirrors the purl_status CPE context filter in
+    // PurlDetails::from_entity.
+    let (allowed_cpe_ids, sbom_has_cpes) = cpe_context_subqueries(qualified_package_id);
 
     // Main query to get product statuses
     let product_statuses_query = product_status::Entity::find()
@@ -188,6 +273,12 @@ async fn get_product_statuses_for_purl<C: ConnectionTrait>(
             product_status::Relation::Vulnerability.def(),
         )
         .filter(product_version::Column::SbomId.in_subquery(sbom_ids_query))
+        .filter(
+            Condition::any()
+                .add(product_status::Column::ContextCpeId.is_null())
+                .add(product_status::Column::ContextCpeId.in_subquery(allowed_cpe_ids))
+                .add(Expr::exists(sbom_has_cpes).not()),
+        )
         .filter(Expr::col(product_status::Column::Package).eq(purl_name).or(
             namespace_name.map_or(Expr::value(false), |ns| {
                 Expr::col(product_status::Column::Package).eq(format!("{ns}/{purl_name}"))


### PR DESCRIPTION
Constrains product_status matches in get_product_statuses_for_purl to advisories whose context CPE matches the describing CPEs of the SBOMs that actually contain the PURL, preventing wrong-product false positives (e.g. a curl advisory matching an unrelated product sharing a package name). Adds a cpe_context_subqueries() helper building:
  - allowed_cpe_ids: describing CPEs (plus major-version-generalized variants) of SBOMs containing the PURL
  - sbom_has_cpes: whether those SBOMs carry describing CPEs at all applied as: context_cpe_id IS NULL
            OR context_cpe_id IN (allowed_cpe_ids)
            OR NOT EXISTS (sbom_has_cpes)

Adapted to 0.5.z: the helper is taken verbatim from the upstream commit (0.5.z uses sbom_node_purl_ref, matching main), but the from_entity purl_status refactor from the upstream commits is a no-op here as 0.5.z has no inline CPE subqueries to extract.

## Summary by Sourcery

Filter PURL product statuses by the describing CPE context of their containing SBOMs to avoid incorrect advisory matches.

Bug Fixes:
- Restrict product status matches to advisories whose CPE context applies to the SBOMs containing the requested PURL, preventing false positives from unrelated products sharing a package name.

Enhancements:
- Support matching both exact and major-version-generalized describing CPEs, while retaining context-free statuses and fallback behavior for SBOMs without describing CPEs.