### PR TITLE
fix: resolve clippy warnings from Rust 1.98

### DIFF
--- a/modules/fundamental/src/common/test.rs
+++ b/modules/fundamental/src/common/test.rs
@@ -227,7 +227,7 @@ impl UpdateAssignments {
         let initial_etag = self.etag.clone();
 
         let request = TestRequest::put()
-            .uri(&format!("/api/v3/group/sbom-assignment/{}", &self.sbom_id))
+            .uri(&format!("/api/v3/group/sbom-assignment/{}", self.sbom_id))
             .set_json(&self.group_ids);
 
         let request = match self.etag {

--- a/modules/fundamental/src/sbom_group/endpoints/test/mod.rs
+++ b/modules/fundamental/src/sbom_group/endpoints/test/mod.rs
@@ -76,7 +76,7 @@ impl Update {
         }
 
         let request = TestRequest::put()
-            .uri(&format!("/api/v3/group/sbom/{}", &self.id))
+            .uri(&format!("/api/v3/group/sbom/{}", self.id))
             .set_json(update_body);
 
         let request = add_if_match(request, self.if_match_type, &self.etag);

--- a/modules/importer/src/runner/clearly_defined/mod.rs
+++ b/modules/importer/src/runner/clearly_defined/mod.rs
@@ -54,10 +54,10 @@ impl super::ImportRunner {
             }
             Err(err) => Err(ScannerError::Normal {
                 err: err.into(),
-                output: RunOutput {
+                output: Box::new(RunOutput {
                     report: report.lock().await.clone().build(),
                     continuation: None,
-                },
+                }),
             }),
         }
     }

--- a/modules/importer/src/runner/clearly_defined_curation/mod.rs
+++ b/modules/importer/src/runner/clearly_defined_curation/mod.rs
@@ -135,10 +135,10 @@ impl super::ImportRunner {
         }
         .map_err(|err| ScannerError::Normal {
             err: err.into(),
-            output: RunOutput {
+            output: Box::new(RunOutput {
                 report: report.lock().clone().build(),
                 continuation: None,
-            },
+            }),
         })?;
 
         // extract the report

--- a/modules/importer/src/runner/csaf/mod.rs
+++ b/modules/importer/src/runner/csaf/mod.rs
@@ -107,10 +107,10 @@ impl super::ImportRunner {
             // further processing, like storing the marker
             .map_err(|err| ScannerError::Normal {
                 err: err.into(),
-                output: RunOutput {
+                output: Box::new(RunOutput {
                     report: report.lock().clone().build(),
                     continuation: None,
-                },
+                }),
             })?;
 
         Ok(match Arc::try_unwrap(report) {

--- a/modules/importer/src/runner/cve/mod.rs
+++ b/modules/importer/src/runner/cve/mod.rs
@@ -131,10 +131,10 @@ impl super::ImportRunner {
         }
         .map_err(|err| ScannerError::Normal {
             err: err.into(),
-            output: RunOutput {
+            output: Box::new(RunOutput {
                 report: report.lock().clone().build(),
                 continuation: None,
-            },
+            }),
         })?;
 
         // extract the report

--- a/modules/importer/src/runner/cwe/mod.rs
+++ b/modules/importer/src/runner/cwe/mod.rs
@@ -55,10 +55,10 @@ impl super::ImportRunner {
             }
             Err(err) => Err(ScannerError::Normal {
                 err: err.into(),
-                output: RunOutput {
+                output: Box::new(RunOutput {
                     report: report.lock().await.clone().build(),
                     continuation: None,
-                },
+                }),
             }),
         }
     }

--- a/modules/importer/src/runner/kev/mod.rs
+++ b/modules/importer/src/runner/kev/mod.rs
@@ -52,10 +52,10 @@ impl super::ImportRunner {
             }
             Err(err) => Err(ScannerError::Normal {
                 err: err.into(),
-                output: RunOutput {
+                output: Box::new(RunOutput {
                     report: report.lock().await.clone().build(),
                     continuation: None,
-                },
+                }),
             }),
         }
     }

--- a/modules/importer/src/runner/quay/mod.rs
+++ b/modules/importer/src/runner/quay/mod.rs
@@ -52,10 +52,10 @@ impl super::ImportRunner {
             }
             Err(err) => Err(ScannerError::Normal {
                 err: err.into(),
-                output: RunOutput {
+                output: Box::new(RunOutput {
                     report: report.lock().await.clone().build(),
                     continuation: None,
-                },
+                }),
             }),
         }
     }

--- a/modules/importer/src/runner/report.rs
+++ b/modules/importer/src/runner/report.rs
@@ -194,7 +194,7 @@ pub enum ScannerError {
     Normal {
         #[source]
         err: anyhow::Error,
-        output: RunOutput,
+        output: Box<RunOutput>,
     },
 }
 
@@ -207,7 +207,7 @@ impl SplitScannerError for Result<RunOutput, ScannerError> {
     fn split(self) -> anyhow::Result<(RunOutput, anyhow::Result<()>)> {
         match self {
             Ok(output) => Ok((output, Ok(()))),
-            Err(ScannerError::Normal { err, output }) => Ok((output, Err(err))),
+            Err(ScannerError::Normal { err, output }) => Ok((*output, Err(err))),
             Err(ScannerError::Critical(err)) => Err(err),
         }
     }

--- a/modules/importer/src/runner/sbom/mod.rs
+++ b/modules/importer/src/runner/sbom/mod.rs
@@ -111,10 +111,10 @@ impl super::ImportRunner {
             // further processing, like storing the marker
             .map_err(|err| ScannerError::Normal {
                 err: err.into(),
-                output: RunOutput {
+                output: Box::new(RunOutput {
                     report: report.lock().clone().build(),
                     continuation: None,
-                },
+                }),
             })?;
 
         Ok(match Arc::try_unwrap(report) {

--- a/modules/importer/src/server/mod.rs
+++ b/modules/importer/src/server/mod.rs
@@ -167,13 +167,13 @@ async fn import(
             report,
             continuation,
         }) => (None, Some(report), continuation),
-        Err(ScannerError::Normal {
-            err,
-            output: RunOutput {
+        Err(ScannerError::Normal { err, output }) => {
+            let RunOutput {
                 report,
                 continuation,
-            },
-        }) => (Some(err.to_string()), Some(report), continuation),
+            } = *output;
+            (Some(err.to_string()), Some(report), continuation)
+        }
         Err(ScannerError::Critical(err)) => (Some(err.to_string()), None, None),
     };
 

--- a/xtask/src/openapi.rs
+++ b/xtask/src/openapi.rs
@@ -57,7 +57,7 @@ pub async fn generate_openapi(base: Option<&Path>) -> anyhow::Result<()> {
 
     // write
 
-    println!("Writing openapi to {:?}", &path);
+    println!("Writing openapi to {:?}", path);
 
     fs::write(path, doc).context("Failed to write openapi spec")?;
 


### PR DESCRIPTION
## Summary

* Box `RunOutput` inside `ScannerError::Normal` to fix `result_large_err` lint (the `Normal` variant was ~144 bytes, triggering the new clippy check)
* Remove redundant `&` references in `format!`/`println!` macro arguments to fix `useless_borrows_in_formatting` lint

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` passes clean
- [x] `cargo fmt` produces no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve Rust 1.98 Clippy warnings across scanner error handling and formatting calls.

Enhancements:
- Reduce scanner error size by boxing import run output and update error handling to accommodate the change.
- Remove redundant references from formatting and request-building calls.