### PR TITLE
fix(purl): filter purl_statuses by SBOM describing CPEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9034,6 +9034,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "roxmltree",
+ "rstest",
  "sanitize-filename",
  "sea-orm",
  "sea-query",

--- a/etc/test-data/csaf/issues/cpe_edition/advisory-edition-el8.json
+++ b/etc/test-data/csaf/issues/cpe_edition/advisory-edition-el8.json
@@ -1,0 +1,92 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": { "tlp": { "label": "WHITE" } },
+    "publisher": {
+      "category": "vendor",
+      "name": "Test Vendor",
+      "namespace": "https://test.example.com"
+    },
+    "title": "TEST-EDITION-EL8",
+    "tracking": {
+      "current_release_date": "2024-01-01T00:00:00Z",
+      "id": "TEST-EDITION-EL8",
+      "initial_release_date": "2024-01-01T00:00:00Z",
+      "revision_history": [
+        {
+          "date": "2024-01-01T00:00:00Z",
+          "number": "1",
+          "summary": "Initial"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Test Vendor",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "Test Product",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "WidgetOS 9 el8",
+                "product": {
+                  "name": "WidgetOS 9 el8",
+                  "product_id": "widgetos-9-el8",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:acme:widgetos:9::el8"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "category": "architecture",
+            "name": "noarch",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "libwidget-1.0",
+                "product": {
+                  "name": "libwidget-1.0",
+                  "product_id": "libwidget-1.0",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/acme/libwidget@1.0"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libwidget-1.0 as a component of WidgetOS 9 el8",
+          "product_id": "widgetos-9-el8:libwidget-1.0"
+        },
+        "product_reference": "libwidget-1.0",
+        "relates_to_product_reference": "widgetos-9-el8"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-99999",
+      "product_status": {
+        "known_affected": [
+          "widgetos-9-el8:libwidget-1.0"
+        ]
+      }
+    }
+  ]
+}

--- a/etc/test-data/csaf/issues/cpe_edition/advisory-edition-null.json
+++ b/etc/test-data/csaf/issues/cpe_edition/advisory-edition-null.json
@@ -1,0 +1,92 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": { "tlp": { "label": "WHITE" } },
+    "publisher": {
+      "category": "vendor",
+      "name": "Test Vendor",
+      "namespace": "https://test.example.com"
+    },
+    "title": "TEST-EDITION-NULL",
+    "tracking": {
+      "current_release_date": "2024-01-01T00:00:00Z",
+      "id": "TEST-EDITION-NULL",
+      "initial_release_date": "2024-01-01T00:00:00Z",
+      "revision_history": [
+        {
+          "date": "2024-01-01T00:00:00Z",
+          "number": "1",
+          "summary": "Initial"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Test Vendor",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "Test Product",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "WidgetOS 9",
+                "product": {
+                  "name": "WidgetOS 9",
+                  "product_id": "widgetos-9",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:acme:widgetos:9"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "category": "architecture",
+            "name": "noarch",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "libwidget-1.0",
+                "product": {
+                  "name": "libwidget-1.0",
+                  "product_id": "libwidget-1.0",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/acme/libwidget@1.0"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libwidget-1.0 as a component of WidgetOS 9",
+          "product_id": "widgetos-9:libwidget-1.0"
+        },
+        "product_reference": "libwidget-1.0",
+        "relates_to_product_reference": "widgetos-9"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-99999",
+      "product_status": {
+        "known_affected": [
+          "widgetos-9:libwidget-1.0"
+        ]
+      }
+    }
+  ]
+}

--- a/etc/test-data/cyclonedx/issues/cpe_edition/sbom.json
+++ b/etc/test-data/cyclonedx/issues/cpe_edition/sbom.json
@@ -1,0 +1,29 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "timestamp": "1970-01-01T00:00:00Z",
+    "component": {
+      "name": "widgetos",
+      "type": "application",
+      "cpe": "cpe:/a:acme:widgetos:9.2",
+      "bom-ref": "root"
+    }
+  },
+  "components": [
+    {
+      "name": "libwidget",
+      "version": "1.0",
+      "bom-ref": "libwidget",
+      "purl": "pkg:rpm/acme/libwidget@1.0",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root",
+      "dependsOn": ["libwidget"]
+    }
+  ]
+}

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -76,6 +76,7 @@ opentelemetry_sdk = { workspace = true }
 osv = { workspace = true }
 packageurl = { workspace = true }
 regex = { workspace = true }
+rstest = { workspace = true }
 roxmltree = { workspace = true }
 sanitize-filename = { workspace = true }
 semver = { workspace = true }

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -221,6 +221,11 @@ fn cpe_context_subqueries(
             Expr::col((sdc.clone(), sbom_describing_cpe::Column::SbomId))
                 .in_subquery(sbom_ids.clone()),
         )
+        .cond_where(
+            Condition::any()
+                .add(Expr::col((c.clone(), cpe::Column::Edition)).is_null())
+                .add(Expr::col((c.clone(), cpe::Column::Edition)).eq("*")),
+        )
         .to_owned();
 
     let mut allowed_cpe_ids = sbom_describing_cpe::Entity::find()

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -82,6 +82,13 @@ impl PurlDetails {
                 .ok_or(Error::Data("underlying package missing".to_string()))?
         };
 
+        // CPE context filtering — only return purl statuses whose context
+        // CPE matches the describing CPEs of SBOMs containing this PURL.
+        // Prevents cross-product false positives (e.g. a hummingbird/RHEL
+        // advisory context attaching to an unrelated el8 package by name).
+        // Mirrors the product_status filter in get_product_statuses_for_purl.
+        let (allowed_cpe_ids, sbom_has_cpes) = cpe_context_subqueries(qualified_package.id);
+
         let purl_statuses = purl_status::Entity::find()
             .filter(purl_status::Column::BasePurlId.eq(package.id))
             .left_join(version_range::Entity)
@@ -92,6 +99,12 @@ impl PurlDetails {
                     .arg(Expr::value(package_version.version.clone()))
                     .arg(Expr::col((version_range::Entity, Asterisk))),
             ))
+            .filter(
+                Condition::any()
+                    .add(purl_status::Column::ContextCpeId.is_null())
+                    .add(purl_status::Column::ContextCpeId.in_subquery(allowed_cpe_ids))
+                    .add(Expr::exists(sbom_has_cpes).not()),
+            )
             .distinct_on([ColumnRef::TableColumn(
                 purl_status::Entity.into_iden(),
                 purl_status::Column::Id.into_iden(),

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -1,4 +1,5 @@
 use crate::purl::{model::details::purl::StatusContext, service::PurlService};
+use rstest::rstest;
 use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
@@ -930,6 +931,54 @@ async fn versioned_base_purl_by_purl(ctx: &TrustifyContext) -> Result<(), anyhow
         .await?;
 
     assert!(!results.unwrap().purls.is_empty());
+
+    Ok(())
+}
+
+/// Test that CPE context filtering on purl_statuses correctly handles
+/// the `edition` field when using generalized (major-version) matching.
+///
+/// Setup (all via document ingestion):
+/// - A CycloneDX SBOM with describing CPE `cpe:/a:acme:widgetos:9.2`
+///   (version 9.2, no edition) containing `pkg:rpm/acme/libwidget@1.0`
+/// - A CSAF advisory creating a purl_status for the same base purl,
+///   with a context CPE that varies in `edition` per test case
+///
+/// The generalized CPE match expands version 9.2 to major "9", but should
+/// only admit CPEs whose edition is NULL or `*`.  A CPE with a specific
+/// edition (e.g. "el8") must NOT pass the filter.
+#[test_context(TrustifyContext)]
+#[rstest]
+#[case::edition_null("csaf/issues/cpe_edition/advisory-edition-null.json", true)]
+#[case::edition_specific("csaf/issues/cpe_edition/advisory-edition-el8.json", false)]
+#[test_log::test(actix_web::test)]
+async fn cpe_context_edition_filtering(
+    ctx: &TrustifyContext,
+    #[case] advisory_path: &str,
+    #[case] expect_status_visible: bool,
+) -> Result<(), anyhow::Error> {
+    let service = PurlService::new();
+
+    ctx.ingest_document("cyclonedx/issues/cpe_edition/sbom.json")
+        .await?;
+    ctx.ingest_document(advisory_path).await?;
+
+    let purl: Purl = "pkg:rpm/acme/libwidget@1.0".try_into()?;
+    let details = service
+        .purl_by_purl(&purl, Default::default(), &ctx.db)
+        .await?
+        .expect("purl should exist");
+
+    let has_status = details
+        .advisories
+        .iter()
+        .flat_map(|a| &a.status)
+        .any(|s| s.vulnerability.identifier == "CVE-2024-99999");
+
+    assert_eq!(
+        has_status, expect_status_visible,
+        "advisory {advisory_path}: expected status visible={expect_status_visible}, got {has_status}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Backport of f322d188 to `release/0.4.z`.

The `purl_status` query in `PurlDetails::from_entity` returned entries whose
`context_cpe_id` came from unrelated products (e.g. a hummingbird/RHEL advisory
context attaching to an el8 package by name), because the context CPE was never
validated against the SBOM's own describing CPEs.

This applies the same three-way CPE-context filter already used by
`get_product_statuses_for_purl`, reusing the existing `cpe_context_subqueries`
helper:

```
context_cpe_id IS NULL
OR context_cpe_id IN (SBOM's generalized describing CPEs)
OR the SBOM has no describing CPEs
```

Scope: `/purl` endpoint only (matches upstream `f322d188`). The generalized-CPE
and edition-constraint refinements (`c2fd9ffe`, `76b2732b`) are already present in
0.4.z's `cpe_context_subqueries` helper. TC-5630 CPE-only-node parity is a separate,
larger change (requires the `cpe_status` table).

Verified: `cargo check` clean; `advisory::csaf::reingest` (4/4) and `vuln` regression
tests pass.

## Summary by Sourcery

Restrict PURL advisory statuses to CPE contexts supported by the associated SBOMs.

Bug Fixes:
- Filter `/purl` advisory statuses so context CPEs are limited to CPEs describing the SBOM, preventing unrelated cross-product status matches.

Enhancements:
- Apply generalized CPE edition matching consistently when determining valid PURL status contexts.

Build:
- Add the rstest test dependency and supporting CPE edition test fixtures.

Tests:
- Add regression coverage for accepting null or wildcard editions while rejecting specific editions in PURL CPE-context matching.