### PR TITLE
feat: backport CPE-identity vulnerability correlation (cpe_status) to release/0.4.z

### DIFF
--- a/common/src/cpe.rs
+++ b/common/src/cpe.rs
@@ -427,7 +427,21 @@ fn unescape_cpe23(s: &str) -> String {
     out
 }
 
-/// Percent-encode a decoded component value using CPE 2.2 URI syntax,
+/// Percent-encode a single literal character into CPE 2.2 URI syntax.
+/// Never emits the `%01`/`%02` wildcard encodings — a literal `*`/`?` is
+/// percent-encoded as its ordinary byte (`%2a`/`%3f`).
+fn push_literal(out: &mut String, c: char) {
+    if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') {
+        out.push(c);
+    } else {
+        let mut buf = [0u8; 4];
+        for b in c.encode_utf8(&mut buf).as_bytes() {
+            out.push_str(&format!("%{b:02x}"));
+        }
+    }
+}
+
+/// Percent-encode an already-decoded component value using CPE 2.2 URI syntax,
 /// mapping the `?`/`*` wildcards to their `%01`/`%02` special encodings.
 fn encode_uri_component(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
@@ -435,13 +449,30 @@ fn encode_uri_component(value: &str) -> String {
         match c {
             '?' => out.push_str("%01"),
             '*' => out.push_str("%02"),
-            c if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') => out.push(c),
-            c => {
-                let mut buf = [0u8; 4];
-                for b in c.encode_utf8(&mut buf).as_bytes() {
-                    out.push_str(&format!("%{b:02x}"));
+            other => push_literal(&mut out, other),
+        }
+    }
+    out
+}
+
+/// Percent-encode a raw (still `\`-escaped) CPE 2.3 component into CPE 2.2 URI
+/// syntax in a single pass. An **unescaped** `*`/`?` is a wildcard (`%02`/`%01`);
+/// an **escaped** `\*`/`\?` (or any other `\x`) is a literal character and is
+/// percent-encoded as such, so it can never be mistaken for a wildcard.
+fn encode_cpe23_component(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => {
+                // escaped: the next char is a literal, even if it is `*` or `?`
+                if let Some(next) = chars.next() {
+                    push_literal(&mut out, next);
                 }
             }
+            '?' => out.push_str("%01"),
+            '*' => out.push_str("%02"),
+            other => push_literal(&mut out, other),
         }
     }
     out
@@ -453,7 +484,7 @@ fn cpe23_component_to_uri(raw: &str) -> String {
         // ANY is the empty component in URI syntax
         "*" => String::new(),
         "-" => "-".to_string(),
-        _ => encode_uri_component(&unescape_cpe23(raw)),
+        _ => encode_cpe23_component(raw),
     }
 }
 
@@ -833,6 +864,21 @@ mod test {
             Cpe::from_str("cpe:2.3:a:libfoo.a(bar.o): in function `baz':1.0:-:*:*:*:*:*:*:*")
                 .is_err()
         );
+    }
+
+    #[test]
+    fn cpe23_escaped_wildcard_is_literal() {
+        // An escaped `\*` is a LITERAL asterisk and must remain distinct from
+        // the `*` wildcard. If the escape is dropped before wildcard encoding,
+        // a literal character is silently turned into a wildcard, corrupting
+        // the CPE identity and producing incorrect vulnerability matches.
+        // Escaped `\*` mid-component: pre-fix this was unescaped to `*` then
+        // encoded as the wildcard `%02`, yielding `pro%02duct` — which the
+        // CPE-2.2 URI parser rejects, so the whole CPE was silently dropped.
+        // It must now parse and keep the literal asterisk.
+        let cpe = Cpe::from_str(r"cpe:2.3:a:acme:pro\*duct:1.0:*:*:*:*:*:*:*")
+            .expect("escaped literal '\\*' must parse, not be turned into a wildcard");
+        assert_eq!(cpe.product().as_ref(), "pro*duct");
     }
 
     #[test]

--- a/common/src/cpe.rs
+++ b/common/src/cpe.rs
@@ -310,6 +310,64 @@ impl Cpe {
     pub fn language(&self) -> Language {
         self.uri.language().clone().into()
     }
+
+    /// Return a copy of this CPE with the version component normalized to ANY.
+    ///
+    /// Useful for deriving a vendor/product identity key when the concrete
+    /// version is carried separately (e.g. via a `version_range`).
+    ///
+    /// Known limitation: the extended attributes packed into the URI edition
+    /// component (`sw_edition`/`target_sw`/`target_hw`/`other`) are not
+    /// exposed by this wrapper's accessors and are therefore dropped by this
+    /// normalization. In practice CVE `affected[].cpes` entries are plain
+    /// `part:vendor:product:version` tuples, so this does not affect the
+    /// CVE-loader use case this method was added for.
+    pub fn with_any_version(&self) -> Self {
+        fn field(component: &Component) -> String {
+            match component {
+                Component::Any => String::new(),
+                Component::NotApplicable => "-".to_string(),
+                Component::Value(value) => encode_uri_component(value),
+            }
+        }
+
+        let part = match self.part().as_ref() {
+            "*" => String::new(),
+            other => other.to_string(),
+        };
+        let vendor = field(&self.vendor());
+        let product = field(&self.product());
+        let update = field(&self.update());
+        let edition = field(&self.edition());
+        let language = match self.language() {
+            Language::Any => String::new(),
+            Language::Language(value) => value,
+        };
+
+        let mut components = vec![
+            part,
+            vendor,
+            product,
+            String::new(),
+            update,
+            edition,
+            language,
+        ];
+        // trailing empty (ANY) components must be dropped: the URI parser
+        // treats empty components in the middle as ANY, but rejects a
+        // trailing empty language component.
+        while components.last().is_some_and(|c| c.is_empty()) {
+            components.pop();
+        }
+
+        // Reconstructed from an already-valid CPE with only the version blanked,
+        // so re-parsing cannot fail; keep the original on the unreachable error
+        // path rather than propagate an impossible failure through the signature.
+        match OwnedUri::from_str(&format!("cpe:/{}", components.join(":"))) {
+            Ok(uri) => Self { uri },
+            Err(_) => self.clone(),
+        }
+    }
 }
 
 impl Debug for Cpe {
@@ -332,22 +390,144 @@ impl From<OwnedUri> for Cpe {
     }
 }
 
+/// Split a CPE 2.3 formatted string body into its components, honoring `\`-escapes.
+fn split_cpe23(s: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut cur = String::new();
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => {
+                cur.push(c);
+                if let Some(next) = chars.next() {
+                    cur.push(next);
+                }
+            }
+            ':' => parts.push(std::mem::take(&mut cur)),
+            _ => cur.push(c),
+        }
+    }
+    parts.push(cur);
+    parts
+}
+
+/// Remove `\`-escapes from a CPE 2.3 formatted string component.
+fn unescape_cpe23(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if let Some(next) = chars.next() {
+                out.push(next);
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Percent-encode a decoded component value using CPE 2.2 URI syntax,
+/// mapping the `?`/`*` wildcards to their `%01`/`%02` special encodings.
+fn encode_uri_component(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '?' => out.push_str("%01"),
+            '*' => out.push_str("%02"),
+            c if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') => out.push(c),
+            c => {
+                let mut buf = [0u8; 4];
+                for b in c.encode_utf8(&mut buf).as_bytes() {
+                    out.push_str(&format!("%{b:02x}"));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Turn a raw (still escaped) CPE 2.3 component into its CPE 2.2 URI form.
+fn cpe23_component_to_uri(raw: &str) -> String {
+    match raw {
+        // ANY is the empty component in URI syntax
+        "*" => String::new(),
+        "-" => "-".to_string(),
+        _ => encode_uri_component(&unescape_cpe23(raw)),
+    }
+}
+
+/// Convert a CPE 2.3 formatted string (`cpe:2.3:part:vendor:...`, 11 attribute
+/// components) into a CPE 2.2 URI, packing the extended attributes
+/// (sw_edition, target_sw, target_hw, other) into the edition component.
+fn cpe23_to_uri(value: &str, body: &str) -> Result<OwnedUri, cpe::error::CpeError> {
+    let invalid = || cpe::error::CpeError::InvalidUri {
+        value: value.to_owned(),
+    };
+
+    let raw = split_cpe23(body);
+    if raw.len() != 11 {
+        return Err(invalid());
+    }
+
+    let part = match raw[0].as_str() {
+        "*" | "-" => "",
+        part => part,
+    };
+
+    let [vendor, product, version, update, edition] =
+        [&raw[1], &raw[2], &raw[3], &raw[4], &raw[5]].map(|c| cpe23_component_to_uri(c));
+    let [sw_edition, target_sw, target_hw, other] =
+        [&raw[7], &raw[8], &raw[9], &raw[10]].map(|c| cpe23_component_to_uri(c));
+
+    let edition = if [&sw_edition, &target_sw, &target_hw, &other]
+        .iter()
+        .all(|c| c.is_empty())
+    {
+        edition
+    } else {
+        format!("~{edition}~{sw_edition}~{target_sw}~{target_hw}~{other}")
+    };
+
+    let language = match raw[6].as_str() {
+        "*" | "-" => String::new(),
+        lang => unescape_cpe23(lang),
+    };
+
+    let mut components = vec![
+        part.to_string(),
+        vendor,
+        product,
+        version,
+        update,
+        edition,
+        language,
+    ];
+    // the URI parser treats empty components in the middle as ANY, but fails on
+    // an empty trailing language component
+    while components.last().is_some_and(|c| c.is_empty()) {
+        components.pop();
+    }
+
+    OwnedUri::from_str(&format!("cpe:/{}", components.join(":")))
+}
+
 impl FromStr for Cpe {
     type Err = <OwnedUri as FromStr>::Err;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self {
-            uri: OwnedUri::from_str(s)?,
-        })
+        let uri = match s.strip_prefix("cpe:2.3:") {
+            Some(body) => cpe23_to_uri(s, body)?,
+            None => OwnedUri::from_str(s)?,
+        };
+        Ok(Self { uri })
     }
 }
 
 impl TryFrom<&str> for Cpe {
     type Error = <OwnedUri as FromStr>::Err;
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Ok(Self {
-            uri: OwnedUri::from_str(value)?,
-        })
+        Self::from_str(value)
     }
 }
 
@@ -571,5 +751,134 @@ mod test {
             cpe.uuid().to_string(),
             "61bca16a-febc-5d79-8b4d-f51fa37c876d"
         );
+    }
+
+    #[test]
+    fn cpe23_simple() {
+        let cpe =
+            Cpe::from_str("cpe:2.3:a:openssl:openssl:0.9.8w:*:*:*:*:*:*:*").expect("must parse");
+        assert!(matches!(cpe.part(), CpeType::Application));
+        assert_eq!(cpe.vendor().as_ref(), "openssl");
+        assert_eq!(cpe.product().as_ref(), "openssl");
+        assert_eq!(cpe.version().as_ref(), "0.9.8w");
+        assert!(matches!(cpe.update(), Component::Any));
+        assert!(matches!(cpe.edition(), Component::Any));
+        assert!(matches!(cpe.language(), Language::Any));
+    }
+
+    #[test]
+    fn cpe23_same_uuid_as_cpe22() {
+        let cpe23 = Cpe::from_str("cpe:2.3:a:redhat:enterprise_linux:9:*:crb:*:*:*:*:*")
+            .expect("must parse");
+        assert_eq!(
+            cpe23.uuid().to_string(),
+            "61bca16a-febc-5d79-8b4d-f51fa37c876d"
+        );
+    }
+
+    #[test]
+    fn cpe23_not_applicable() {
+        let cpe = Cpe::from_str("cpe:2.3:a:busybox:busybox:-:*:*:*:*:*:*:*").expect("must parse");
+        assert!(matches!(cpe.version(), Component::NotApplicable));
+    }
+
+    #[test]
+    fn cpe23_escaped_characters() {
+        let cpe = Cpe::from_str(r"cpe:2.3:a:foo\:bar:some\+product:1.0:*:*:*:*:*:*:*")
+            .expect("must parse");
+        assert_eq!(cpe.vendor().as_ref(), "foo:bar");
+        assert_eq!(cpe.product().as_ref(), "some+product");
+        assert_eq!(cpe.version().as_ref(), "1.0");
+    }
+
+    #[test]
+    fn cpe23_embedded_wildcard() {
+        let cpe =
+            Cpe::from_str("cpe:2.3:a:openssl:openssl:0.9.8*:*:*:*:*:*:*:*").expect("must parse");
+        assert_eq!(cpe.version().as_ref(), "0.9.8*");
+    }
+
+    #[test]
+    fn cpe23_extended_attributes() {
+        let cpe = Cpe::from_str("cpe:2.3:o:microsoft:windows_10:1607:*:*:*:*:*:x64:*")
+            .expect("must parse");
+        assert!(matches!(cpe.part(), CpeType::OperatingSystem));
+        assert_eq!(cpe.vendor().as_ref(), "microsoft");
+        assert_eq!(cpe.product().as_ref(), "windows_10");
+        assert_eq!(cpe.version().as_ref(), "1607");
+        // extended attributes end up in the packed edition component of the URI
+        assert_eq!(
+            cpe.to_string(),
+            "cpe:/o:microsoft:windows_10:1607:*~*~*~*~x64~*:*"
+        );
+    }
+
+    #[test]
+    fn cpe23_language() {
+        let cpe =
+            Cpe::from_str("cpe:2.3:a:vendor:product:1.0:*:*:en-us:*:*:*:*").expect("must parse");
+        assert_eq!(cpe.language().as_ref(), "en-US");
+    }
+
+    #[test]
+    fn cpe23_wrong_component_count() {
+        assert!(Cpe::from_str("cpe:2.3:a:openssl:openssl:0.9.8w").is_err());
+        assert!(Cpe::from_str("cpe:2.3:a:openssl:openssl:0.9.8w:*:*:*:*:*:*:*:*").is_err());
+    }
+
+    #[test]
+    fn cpe23_garbage_rejected() {
+        // unescapable garbage (spaces are not valid in any CPE component)
+        assert!(
+            Cpe::from_str("cpe:2.3:a:libfoo.a(bar.o): in function `baz':1.0:-:*:*:*:*:*:*:*")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn with_any_version_normalizes_concrete_version() {
+        let cpe =
+            Cpe::from_str("cpe:2.3:a:openssl:openssl:0.9.8w:*:*:*:*:*:*:*").expect("must parse");
+        let normalized = cpe.with_any_version();
+
+        assert!(matches!(normalized.part(), CpeType::Application));
+        assert_eq!(normalized.vendor().as_ref(), "openssl");
+        assert_eq!(normalized.product().as_ref(), "openssl");
+        assert!(matches!(normalized.version(), Component::Any));
+
+        // vendor/product identity is unchanged, only the version differs
+        assert_ne!(cpe.uuid(), normalized.uuid());
+    }
+
+    #[test]
+    fn with_any_version_is_idempotent_for_already_any_version() {
+        let cpe = Cpe::from_str("cpe:2.3:a:busybox:busybox:*:*:*:*:*:*:*:*").expect("must parse");
+        let normalized = cpe.with_any_version();
+        assert_eq!(cpe.uuid(), normalized.uuid());
+    }
+
+    #[test]
+    fn with_any_version_preserves_special_characters() {
+        let cpe = Cpe::from_str(r"cpe:2.3:a:foo\:bar:some\+product:1.0:*:*:*:*:*:*:*")
+            .expect("must parse");
+        let normalized = cpe.with_any_version();
+        assert_eq!(normalized.vendor().as_ref(), "foo:bar");
+        assert_eq!(normalized.product().as_ref(), "some+product");
+        assert!(matches!(normalized.version(), Component::Any));
+    }
+
+    #[test]
+    fn with_any_version_drops_unexposed_extended_attributes() {
+        // known limitation: sw_edition/target_sw/target_hw/other are packed
+        // into the URI edition component and aren't reachable through this
+        // wrapper's accessors, so with_any_version can't round-trip them.
+        // CVE affected[].cpes entries never carry these, so this doesn't
+        // affect the CVE-loader use case.
+        let cpe = Cpe::from_str("cpe:2.3:o:microsoft:windows_10:1607:*:*:*:*:*:x64:*")
+            .expect("must parse");
+        let normalized = cpe.with_any_version();
+        assert!(matches!(normalized.version(), Component::Any));
+        assert_eq!(normalized.vendor().as_ref(), "microsoft");
+        assert_eq!(normalized.product().as_ref(), "windows_10");
     }
 }

--- a/entity/src/cpe_status.rs
+++ b/entity/src/cpe_status.rs
@@ -1,0 +1,97 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "cpe_status")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    pub advisory_id: Uuid,
+    pub vulnerability_id: String,
+    pub status_id: Uuid,
+    pub cpe_id: Uuid,
+    pub version_range_id: Uuid,
+    pub context_cpe_id: Option<Uuid>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(belongs_to = "super::version_range::Entity"
+        from = "Column::VersionRangeId",
+        to = "super::version_range::Column::Id"
+    )]
+    VersionRange,
+
+    #[sea_orm(belongs_to = "super::cpe::Entity",
+        from = "Column::CpeId"
+        to = "super::cpe::Column::Id"
+    )]
+    Cpe,
+
+    #[sea_orm(belongs_to = "super::vulnerability::Entity",
+        from = "Column::VulnerabilityId"
+        to = "super::vulnerability::Column::Id"
+    )]
+    Vulnerability,
+
+    #[sea_orm(belongs_to = "super::advisory::Entity",
+        from = "Column::AdvisoryId"
+        to = "super::advisory::Column::Id"
+    )]
+    Advisory,
+
+    #[sea_orm(belongs_to = "super::status::Entity",
+        from = "Column::StatusId"
+        to = "super::status::Column::Id"
+    )]
+    Status,
+
+    #[sea_orm(belongs_to = "super::advisory_vulnerability::Entity",
+        from = "(Column::AdvisoryId, Column::VulnerabilityId)"
+        to = "(super::advisory_vulnerability::Column::AdvisoryId, super::advisory_vulnerability::Column::VulnerabilityId)"
+    )]
+    AdvisoryVulnerability,
+
+    #[sea_orm(belongs_to = "super::cpe::Entity",
+        from = "Column::ContextCpeId"
+        to = "super::cpe::Column::Id"
+    )]
+    ContextCpe,
+}
+
+impl Related<super::version_range::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::VersionRange.def()
+    }
+}
+
+impl Related<super::cpe::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Cpe.def()
+    }
+}
+
+impl Related<super::vulnerability::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Vulnerability.def()
+    }
+}
+
+impl Related<super::advisory::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Advisory.def()
+    }
+}
+
+impl Related<super::status::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Status.def()
+    }
+}
+
+impl Related<super::advisory_vulnerability::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::AdvisoryVulnerability.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/entity/src/lib.rs
+++ b/entity/src/lib.rs
@@ -2,6 +2,7 @@ pub mod advisory;
 pub mod advisory_vulnerability;
 pub mod base_purl;
 pub mod cpe;
+pub mod cpe_status;
 pub mod cvss3;
 pub mod cvss4;
 pub mod importer;

--- a/etc/test-data/cve/CVE-2099-0001.json
+++ b/etc/test-data/cve/CVE-2099-0001.json
@@ -1,0 +1,87 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1",
+    "cveMetadata": {
+        "cveId": "CVE-2099-0001",
+        "assignerOrgId": "00000000-0000-0000-0000-000000000000",
+        "state": "PUBLISHED",
+        "assignerShortName": "synthetic-test",
+        "dateReserved": "2099-01-01T00:00:00.000Z",
+        "datePublished": "2099-01-02T00:00:00.000Z",
+        "dateUpdated": "2099-01-03T00:00:00.000Z"
+    },
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "vendor": "openssl",
+                    "product": "openssl",
+                    "cpes": [
+                        "cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*"
+                    ],
+                    "defaultStatus": "unknown",
+                    "versions": [
+                        {
+                            "version": "0.9.8w",
+                            "status": "affected",
+                            "versionType": "custom"
+                        },
+                        {
+                            "version": "1.0.0",
+                            "lessThan": "1.0.2",
+                            "status": "affected",
+                            "versionType": "semver"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "busybox",
+                    "product": "busybox",
+                    "cpes": [
+                        "cpe:2.3:a:busybox:busybox:1.19.4:*:*:*:*:*:*:*"
+                    ],
+                    "defaultStatus": "affected"
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "SYNTHETIC TEST RECORD (not a real CVE): invented vulnerability used to exercise CPE-keyed status ingestion in trustify's CVE loader test suite. Do not treat as real vulnerability data."
+                }
+            ],
+            "metrics": [
+                {
+                    "cvssV3_1": {
+                        "version": "3.1",
+                        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                        "baseScore": 9.8,
+                        "baseSeverity": "CRITICAL"
+                    }
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "lang": "en",
+                            "description": "CWE-000 Synthetic test weakness",
+                            "cweId": "CWE-000",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "00000000-0000-0000-0000-000000000000",
+                "shortName": "synthetic-test",
+                "dateUpdated": "2099-01-03T00:00:00.000Z"
+            },
+            "references": [
+                {
+                    "url": "https://example.invalid/synthetic/CVE-2099-0001"
+                }
+            ],
+            "title": "Synthetic test record for CPE-keyed status ingestion"
+        }
+    }
+}

--- a/etc/test-data/cve/CVE-2099-0002.json
+++ b/etc/test-data/cve/CVE-2099-0002.json
@@ -1,0 +1,75 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1",
+    "cveMetadata": {
+        "cveId": "CVE-2099-0002",
+        "assignerOrgId": "00000000-0000-0000-0000-000000000000",
+        "state": "PUBLISHED",
+        "assignerShortName": "synthetic-test",
+        "dateReserved": "2099-02-01T00:00:00.000Z",
+        "datePublished": "2099-02-02T00:00:00.000Z",
+        "dateUpdated": "2099-02-03T00:00:00.000Z"
+    },
+    "containers": {
+        "cna": {
+            "affected": [],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "SYNTHETIC TEST RECORD (not a real CVE): invented vulnerability used to exercise ADP-container CPE ingestion in trustify's CVE loader test suite. The CNA did not annotate CPEs; the ADP (vulnrichment-style) container supplies them, as commonly happens for older CVEs. Do not treat as real vulnerability data."
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "lang": "en",
+                            "description": "CWE-000 Synthetic test weakness",
+                            "cweId": "CWE-000",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "00000000-0000-0000-0000-000000000000",
+                "shortName": "synthetic-test",
+                "dateUpdated": "2099-02-03T00:00:00.000Z"
+            },
+            "references": [
+                {
+                    "url": "https://example.invalid/synthetic/CVE-2099-0002"
+                }
+            ],
+            "title": "Synthetic test record for ADP-container CPE ingestion"
+        },
+        "adp": [
+            {
+                "providerMetadata": {
+                    "orgId": "11111111-1111-1111-1111-111111111111",
+                    "shortName": "synthetic-adp",
+                    "dateUpdated": "2099-02-03T00:00:00.000Z"
+                },
+                "title": "Synthetic vulnrichment-style enrichment",
+                "affected": [
+                    {
+                        "vendor": "denx",
+                        "product": "u-boot",
+                        "cpes": [
+                            "cpe:2.3:a:denx:u-boot:*:*:*:*:*:*:*:*"
+                        ],
+                        "defaultStatus": "unknown",
+                        "versions": [
+                            {
+                                "version": "2019.04",
+                                "lessThan": "2020.10",
+                                "status": "affected",
+                                "versionType": "semver"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/etc/test-data/cve/CVE-2099-0003.json
+++ b/etc/test-data/cve/CVE-2099-0003.json
@@ -1,0 +1,64 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1",
+    "cveMetadata": {
+        "cveId": "CVE-2099-0003",
+        "assignerOrgId": "00000000-0000-0000-0000-000000000000",
+        "state": "PUBLISHED",
+        "assignerShortName": "synthetic-test",
+        "dateReserved": "2099-03-01T00:00:00.000Z",
+        "datePublished": "2099-03-02T00:00:00.000Z",
+        "dateUpdated": "2099-03-03T00:00:00.000Z"
+    },
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "vendor": "openssl",
+                    "product": "openssl",
+                    "cpes": [
+                        "cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*"
+                    ],
+                    "defaultStatus": "unknown",
+                    "versions": [
+                        {
+                            "version": "2.0.0",
+                            "lessThan": "3.0.0",
+                            "status": "affected",
+                            "versionType": "semver"
+                        }
+                    ]
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "SYNTHETIC TEST RECORD (not a real CVE): invented vulnerability affecting a version range of openssl that deliberately does NOT include 0.9.8w, used to prove the CPE-keyed matching path does not produce false positives across unrelated version ranges. Do not treat as real vulnerability data."
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "lang": "en",
+                            "description": "CWE-000 Synthetic test weakness",
+                            "cweId": "CWE-000",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "00000000-0000-0000-0000-000000000000",
+                "shortName": "synthetic-test",
+                "dateUpdated": "2099-03-03T00:00:00.000Z"
+            },
+            "references": [
+                {
+                    "url": "https://example.invalid/synthetic/CVE-2099-0003"
+                }
+            ],
+            "title": "Synthetic test record: openssl version range excluding 0.9.8w"
+        }
+    }
+}

--- a/etc/test-data/spdx/cpe23-firmware.json
+++ b/etc/test-data/spdx/cpe23-firmware.json
@@ -1,0 +1,96 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "cpe23-firmware",
+  "documentNamespace": "http://spdx.org/spdxdocs/cpe23-firmware-6b1e6f36-9a24-4a5c-9c4e-0d7c1a2b3c4d",
+  "creationInfo": {
+    "creators": [
+      "Tool: example-firmware-sbom-tool"
+    ],
+    "created": "2023-01-01T00:00:00Z"
+  },
+  "packages": [
+    {
+      "name": "firmware",
+      "SPDXID": "SPDXRef-Package-Main",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false
+    },
+    {
+      "name": "OpenSSL",
+      "SPDXID": "SPDXRef-Package-OpenSSL",
+      "versionInfo": "0.9.8w",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:generic/OpenSSL@0.9.8w"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:openssl:openssl:0.9.8w:*:*:*:*:*:*:*"
+        }
+      ]
+    },
+    {
+      "name": "BusyBox",
+      "SPDXID": "SPDXRef-Package-BusyBox",
+      "versionInfo": "1.19.4",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:generic/BusyBox@1.19.4"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox:busybox:1.19.4:*:*:*:*:*:*:*"
+        }
+      ]
+    },
+    {
+      "name": "libfoo.a(bar.o): in function `baz':",
+      "SPDXID": "SPDXRef-Package-Garbage",
+      "versionInfo": "2.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libfoo.a(bar.o): in function `baz':2.0.0:*:*:*:*:*:*:*"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-Main"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-Main",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-OpenSSL"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-Main",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-BusyBox"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-Main",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-Garbage"
+    }
+  ]
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -35,6 +35,7 @@ mod m0001200_source_document_fk_indexes;
 mod m0002100_analysis_perf_indexes;
 mod m0002110_sbom_describing_cpe;
 mod m0002120_ancestor_walk_index;
+mod m0002132_create_cpe_status;
 
 pub struct Migrator;
 
@@ -77,6 +78,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0002100_analysis_perf_indexes::Migration),
             Box::new(m0002110_sbom_describing_cpe::Migration),
             Box::new(m0002120_ancestor_walk_index::Migration),
+            Box::new(m0002132_create_cpe_status::Migration),
         ]
     }
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -35,7 +35,7 @@ mod m0001200_source_document_fk_indexes;
 mod m0002100_analysis_perf_indexes;
 mod m0002110_sbom_describing_cpe;
 mod m0002120_ancestor_walk_index;
-mod m0002132_create_cpe_status;
+mod m0002250_create_cpe_status;
 
 pub struct Migrator;
 
@@ -78,7 +78,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0002100_analysis_perf_indexes::Migration),
             Box::new(m0002110_sbom_describing_cpe::Migration),
             Box::new(m0002120_ancestor_walk_index::Migration),
-            Box::new(m0002132_create_cpe_status::Migration),
+            Box::new(m0002250_create_cpe_status::Migration),
         ]
     }
 }

--- a/migration/src/m0002132_create_cpe_status.rs
+++ b/migration/src/m0002132_create_cpe_status.rs
@@ -1,0 +1,140 @@
+// Numbered m0002132 to skip main's two m0002130_* files and leave headroom above them;
+// avoids collision on rebase against newer main. Backport of f03b635f (was m0002250 on main).
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Advisory statuses keyed by CPE (vendor/product identity), mirroring
+        // purl_status. The referenced CPE carries the affected vendor/product
+        // with the version component normalized to ANY; the affected versions
+        // are expressed through the version range.
+        manager
+            .create_table(
+                Table::create()
+                    .table(CpeStatus::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(CpeStatus::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(CpeStatus::AdvisoryId).uuid().not_null())
+                    .col(ColumnDef::new(CpeStatus::VulnerabilityId).text().not_null())
+                    .col(ColumnDef::new(CpeStatus::StatusId).uuid().not_null())
+                    .col(ColumnDef::new(CpeStatus::CpeId).uuid().not_null())
+                    .col(ColumnDef::new(CpeStatus::VersionRangeId).uuid().not_null())
+                    .col(ColumnDef::new(CpeStatus::ContextCpeId).uuid())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(CpeStatus::Table, CpeStatus::AdvisoryId)
+                            .to(Advisory::Table, Advisory::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(CpeStatus::Table, CpeStatus::VulnerabilityId)
+                            .to(Vulnerability::Table, Vulnerability::Id),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(CpeStatus::Table, CpeStatus::StatusId)
+                            .to(Status::Table, Status::Id),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(CpeStatus::Table, CpeStatus::CpeId)
+                            .to(Cpe::Table, Cpe::Id),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(CpeStatus::Table, CpeStatus::VersionRangeId)
+                            .to(VersionRange::Table, VersionRange::Id),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(CpeStatus::Table, CpeStatus::ContextCpeId)
+                            .to(Cpe::Table, Cpe::Id),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(CpeStatus::Table)
+                    .name("cpe_status_cpe_id_idx")
+                    .col(CpeStatus::CpeId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(CpeStatus::Table)
+                    .name("cpe_status_advisory_id_vulnerability_id_idx")
+                    .col(CpeStatus::AdvisoryId)
+                    .col(CpeStatus::VulnerabilityId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().if_exists().table(CpeStatus::Table).to_owned())
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+pub enum CpeStatus {
+    Table,
+    Id,
+    AdvisoryId,
+    VulnerabilityId,
+    StatusId,
+    CpeId,
+    VersionRangeId,
+    ContextCpeId,
+}
+
+#[derive(DeriveIden)]
+pub enum Advisory {
+    Table,
+    Id,
+}
+
+#[derive(DeriveIden)]
+pub enum Vulnerability {
+    Table,
+    Id,
+}
+
+#[derive(DeriveIden)]
+pub enum Status {
+    Table,
+    Id,
+}
+
+#[derive(DeriveIden)]
+pub enum Cpe {
+    Table,
+    Id,
+}
+
+#[derive(DeriveIden)]
+pub enum VersionRange {
+    Table,
+    Id,
+}

--- a/migration/src/m0002250_create_cpe_status.rs
+++ b/migration/src/m0002250_create_cpe_status.rs
@@ -1,5 +1,10 @@
-// Numbered m0002132 to skip main's two m0002130_* files and leave headroom above them;
-// avoids collision on rebase against newer main. Backport of f03b635f (was m0002250 on main).
+// Named m0002250_create_cpe_status to match main verbatim so `seaql_migrations`
+// records the identical name (SeaORM tracks migrations by name, not by number).
+// This keeps the 0.4.z -> 0.6.z upgrade path clean: 0.6's m0002250 is seen as
+// already applied and skipped, instead of re-running its non-idempotent
+// CREATE INDEX statements. The table/indexes here are byte-identical to main's.
+// The numeric gap on 0.4.z is cosmetic; migrations run in lib.rs registration
+// order, not by filename number. Backport of f03b635f.
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -35,7 +35,7 @@ use uuid::Uuid;
 #[derive(Debug, Clone)]
 struct IdSet {
     advisory_id: Uuid,
-    qualified_purl_id: Uuid,
+    qualified_purl_id: Option<Uuid>,
     sbom_id: Uuid,
     sbom_node_id: String,
     advisory_vulnerability_advisory_id: Uuid,
@@ -50,7 +50,7 @@ impl FromQueryResult for IdSet {
     fn from_query_result(res: &QueryResult, _pre: &str) -> Result<Self, DbErr> {
         Ok(Self {
             advisory_id: res.try_get("", "advisory_id")?,
-            qualified_purl_id: res.try_get("", "qualified_purl_id")?,
+            qualified_purl_id: res.try_get::<Option<Uuid>>("", "qualified_purl_id")?,
             sbom_id: res.try_get("", "sbom_id")?,
             sbom_node_id: res.try_get("", "node_id")?,
             advisory_vulnerability_advisory_id: res.try_get("", "av_advisory_id")?,
@@ -201,7 +201,9 @@ impl SbomDetails {
 
         for id_set in &id_sets {
             advisory_ids_set.insert(id_set.advisory_id);
-            qualified_purl_ids_set.insert(id_set.qualified_purl_id);
+            if let Some(qp_id) = id_set.qualified_purl_id {
+                qualified_purl_ids_set.insert(qp_id);
+            }
             sbom_package_ids_set.insert((id_set.sbom_id, id_set.sbom_node_id.clone()));
             advisory_vulnerability_ids_set.insert((
                 id_set.advisory_vulnerability_advisory_id,
@@ -359,14 +361,14 @@ impl SbomDetails {
                     id_set.advisory_id
                 ))
             })?;
-            let qualified_purl = qualified_purls_map
-                .get(&id_set.qualified_purl_id)
-                .ok_or_else(|| {
-                    Error::NotFound(format!(
-                        "QualifiedPurl {} not found in lookup",
-                        id_set.qualified_purl_id
-                    ))
-                })?;
+            let qualified_purl = id_set
+                .qualified_purl_id
+                .map(|qp_id| {
+                    qualified_purls_map.get(&qp_id).cloned().ok_or_else(|| {
+                        Error::NotFound(format!("QualifiedPurl {qp_id} not found in lookup"))
+                    })
+                })
+                .transpose()?;
             let sbom_package = sbom_packages_map
                 .get(&(id_set.sbom_id, id_set.sbom_node_id.clone()))
                 .ok_or_else(|| {
@@ -413,7 +415,7 @@ impl SbomDetails {
 
             relevant_advisory_info.push(QueryCatcher {
                 advisory: Arc::clone(advisory),
-                qualified_purl: Arc::clone(qualified_purl),
+                qualified_purl: qualified_purl.clone(),
                 sbom_package: Arc::clone(sbom_package),
                 sbom_node: Arc::clone(sbom_node),
                 advisory_vulnerability: Arc::clone(advisory_vulnerability),
@@ -507,7 +509,11 @@ impl SbomAdvisory {
                 name: each.sbom_node.name.clone(),
                 group: each.sbom_package.group.clone(),
                 version: each.sbom_package.version.clone(),
-                purl: vec![PurlSummary::from_entity(&each.qualified_purl)],
+                purl: each
+                    .qualified_purl
+                    .as_deref()
+                    .map(|qp| vec![PurlSummary::from_entity(qp)])
+                    .unwrap_or_default(),
                 cpe: vec![],
                 licenses: vec![],
                 licenses_ref_mapping: vec![],

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -175,12 +175,30 @@ impl SbomDetails {
             .query_all(Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 raw_sql::product_advisory_info_sql(),
-                [sbom.sbom_id.into(), statuses.into()],
+                [sbom.sbom_id.into(), statuses.clone().into()],
             ))
             .await?;
 
         // Convert raw SQL results to IdSet objects
         for row in raw_results {
+            match IdSet::from_query_result(&row, "") {
+                Ok(result) => id_sets.push(result),
+                Err(err) => return Err(Error::from(err)),
+            }
+        }
+
+        // CPE-based matching: package-level CPE identity (cpe_status) for nodes
+        // whose component CPE matches an advisory's CPE applicability. Includes
+        // CPE-only (PURL-less) nodes (qualified_purl_id may be NULL).
+        let cpe_results = tx
+            .query_all(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                raw_sql::cpe_advisory_info_sql(),
+                [sbom.sbom_id.into(), statuses.into()],
+            ))
+            .await?;
+
+        for row in cpe_results {
             match IdSet::from_query_result(&row, "") {
                 Ok(result) => id_sets.push(result),
                 Err(err) => return Err(Error::from(err)),

--- a/modules/fundamental/src/sbom/model/raw_sql.rs
+++ b/modules/fundamental/src/sbom/model/raw_sql.rs
@@ -146,3 +146,73 @@ pub fn product_advisory_info_sql() -> String {
         "#
     .to_string()
 }
+
+pub fn cpe_advisory_info_sql() -> String {
+    r#"
+        WITH
+        -- Package-level CPEs referenced by this SBOM, joined back to the
+        -- owning package for its purl and (fallback) version.
+        sbom_cpe_pkgs AS (
+            SELECT
+                scr.sbom_id,
+                scr.node_id,
+                c.vendor,
+                c.product,
+                c.part,
+                COALESCE(NULLIF(c.version, '*'), sp.version) AS version,
+                spr.qualified_purl_id
+            FROM sbom_package_cpe_ref scr
+            JOIN cpe c ON scr.cpe_id = c.id
+            JOIN sbom_package sp ON sp.sbom_id = scr.sbom_id AND sp.node_id = scr.node_id
+            LEFT JOIN sbom_package_purl_ref spr ON spr.sbom_id = scr.sbom_id AND spr.node_id = scr.node_id
+            WHERE scr.sbom_id = $1
+        ),
+
+        -- CPE-status matches: identity by vendor+product (application CPEs
+        -- only), affected version range checked via version_matches().
+        cpe_status_matches AS (
+            SELECT DISTINCT
+                cs.advisory_id,
+                cs.vulnerability_id,
+                cs.status_id,
+                cs.context_cpe_id,
+                p.qualified_purl_id,
+                p.sbom_id,
+                p.node_id
+            FROM cpe_status cs
+            JOIN cpe sc ON cs.cpe_id = sc.id
+            JOIN sbom_cpe_pkgs p
+                ON p.vendor = sc.vendor
+               AND p.product = sc.product
+               AND sc.part = 'a'
+               AND p.part = 'a'
+            JOIN version_range vr ON cs.version_range_id = vr.id
+            WHERE version_matches(p.version, vr.*)
+        )
+
+        -- Final query joins to get all required fields (mirrors the tail of
+        -- product_advisory_info_sql).
+        SELECT DISTINCT
+            "advisory"."id" AS "advisory_id",
+            "advisory_vulnerability"."advisory_id" AS "av_advisory_id",
+            "advisory_vulnerability"."vulnerability_id" AS "av_vulnerability_id",
+            "vulnerability"."id" AS "vulnerability_id",
+            m.qualified_purl_id AS "qualified_purl_id",
+            m.sbom_id AS "sbom_id",
+            m.node_id AS "node_id",
+            "status"."id" AS "status_id",
+            "cpe"."id" AS "cpe_id",
+            "organization"."id" AS "organization_id"
+        FROM cpe_status_matches m
+        JOIN "status" ON m.status_id = "status"."id"
+        JOIN "advisory" ON m.advisory_id = "advisory"."id"
+        LEFT JOIN "organization" ON "advisory"."issuer_id" = "organization"."id"
+        JOIN "advisory_vulnerability" ON m.advisory_id = "advisory_vulnerability"."advisory_id"
+            AND m.vulnerability_id = "advisory_vulnerability"."vulnerability_id"
+        JOIN "vulnerability" ON "advisory_vulnerability"."vulnerability_id" = "vulnerability"."id"
+        LEFT JOIN "cpe" ON m.context_cpe_id = "cpe"."id"
+        WHERE ($2::text[] = ARRAY[]::text[] OR "status"."slug" = ANY($2::text[]))
+          AND "advisory"."deprecated" = false
+        "#
+    .to_string()
+}

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -885,7 +885,7 @@ fn package_from_row(row: PackageCatcher, licensing_infos: BTreeMap<String, Strin
 #[derive(Debug)]
 pub struct QueryCatcher {
     pub advisory: Arc<advisory::Model>,
-    pub qualified_purl: Arc<qualified_purl::Model>,
+    pub qualified_purl: Option<Arc<qualified_purl::Model>>,
     pub sbom_package: Arc<sbom_package::Model>,
     pub sbom_node: Arc<sbom_node::Model>,
     pub advisory_vulnerability: Arc<advisory_vulnerability::Model>,
@@ -913,11 +913,12 @@ impl FromQueryResult for QueryCatcher {
                 "",
                 vulnerability::Entity,
             )?),
-            qualified_purl: Arc::new(Self::from_query_result_multi_model(
+            qualified_purl: Self::from_query_result_multi_model_optional(
                 res,
                 "",
                 qualified_purl::Entity,
-            )?),
+            )?
+            .map(Arc::new),
             sbom_package: Arc::new(Self::from_query_result_multi_model(
                 res,
                 "",

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -475,7 +475,7 @@ struct SbomStatusCatcher {
     sbom_package: sbom_package::Model,
     sbom_node: sbom_node::Model,
     status: status::Model,
-    qualified_purl: qualified_purl::Model,
+    qualified_purl: Option<qualified_purl::Model>,
 }
 
 impl FromQueryResult for SbomStatusCatcher {
@@ -486,7 +486,11 @@ impl FromQueryResult for SbomStatusCatcher {
             sbom_package: Self::from_query_result_multi_model(res, "", sbom_package::Entity)?,
             sbom_node: Self::from_query_result_multi_model(res, "", sbom_node::Entity)?,
             status: Self::from_query_result_multi_model(res, "", status::Entity)?,
-            qualified_purl: Self::from_query_result_multi_model(res, "", qualified_purl::Entity)?,
+            qualified_purl: Self::from_query_result_multi_model_optional(
+                res,
+                "",
+                qualified_purl::Entity,
+            )?,
         })
     }
 }
@@ -545,7 +549,9 @@ impl VulnerabilitySbomStatus {
                 .entry(status.status.slug.clone())
                 .or_insert(Default::default());
 
-            purl_status.insert(PurlSummary::from_entity(&status.qualified_purl));
+            if let Some(ref qp) = status.qualified_purl {
+                purl_status.insert(PurlSummary::from_entity(qp));
+            }
         }
 
         Ok(sboms.into_values().collect())

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -276,6 +276,90 @@ impl VulnerabilityAdvisorySummary {
                 .collect::<Result<Vec<_>, _>>()?,
         );
 
+        // Package-level CPE matches: the reverse of `cpe_advisory_info_sql`.
+        // A vulnerability's `cpe_status` rows (vendor/product identity + affected
+        // version range) are matched against the package CPEs an SBOM harvested
+        // into `sbom_package_cpe_ref`. Includes CPE-only (PURL-less) nodes via
+        // the LEFT JOINs on the purl ref / qualified_purl.
+        let cpe_status_query = r#"
+            SELECT
+                "cpe_status"."advisory_id",
+                "sbom_package_purl_ref"."sbom_id",
+                "sbom_package_purl_ref"."node_id",
+                "sbom_package_purl_ref"."qualified_purl_id",
+                "sbom"."sbom_id" AS "sbom$sbom_id",
+                "sbom"."node_id" AS "sbom$node_id",
+                "sbom"."document_id" AS "sbom$document_id",
+                "sbom"."published" AS "sbom$published",
+                "sbom"."authors" AS "sbom$authors",
+                "sbom"."suppliers" AS "sbom$suppliers",
+                "sbom"."data_licenses" AS "sbom$data_licenses",
+                "sbom"."source_document_id" AS "sbom$source_document_id",
+                "sbom"."labels" AS "sbom$labels",
+                "sbom_package"."sbom_id" AS "sbom_package$sbom_id",
+                "sbom_package"."node_id" AS "sbom_package$node_id",
+                "sbom_package"."version" AS "sbom_package$version",
+                "sbom_node"."sbom_id" AS "sbom_node$sbom_id",
+                "sbom_node"."node_id" AS "sbom_node$node_id",
+                "sbom_node"."name" AS "sbom_node$name",
+                "status"."id" AS "status$id",
+                "status"."slug" AS "status$slug",
+                "status"."name" AS "status$name",
+                "status"."description" AS "status$description",
+                "qualified_purl"."id" AS "qualified_purl$id",
+                "qualified_purl"."versioned_purl_id" AS "qualified_purl$versioned_purl_id",
+                "qualified_purl"."qualifiers" AS "qualified_purl$qualifiers",
+                "qualified_purl"."purl" AS "qualified_purl$purl"
+            FROM "cpe_status"
+            JOIN "status" ON "cpe_status"."status_id" = "status"."id"
+            JOIN "advisory" ON "cpe_status"."advisory_id" = "advisory"."id" AND "advisory"."deprecated" = false
+            JOIN "version_range" ON "cpe_status"."version_range_id" = "version_range"."id"
+
+            -- the advisory's identity CPE (application CPEs only)
+            JOIN "cpe" AS "adv_cpe" ON "cpe_status"."cpe_id" = "adv_cpe"."id" AND "adv_cpe"."part" = 'a'
+
+            -- SBOM package CPEs matching that vendor/product identity
+            JOIN "cpe" AS "pkg_cpe" ON "pkg_cpe"."vendor" = "adv_cpe"."vendor"
+                AND "pkg_cpe"."product" = "adv_cpe"."product"
+                AND "pkg_cpe"."part" = 'a'
+            JOIN "sbom_package_cpe_ref" ON "sbom_package_cpe_ref"."cpe_id" = "pkg_cpe"."id"
+            JOIN "sbom" ON "sbom"."sbom_id" = "sbom_package_cpe_ref"."sbom_id"
+
+            -- the matched component package (for the version fallback) and its purl (optional)
+            JOIN "sbom_package" AS "matched_pkg" ON "matched_pkg"."sbom_id" = "sbom_package_cpe_ref"."sbom_id" AND "matched_pkg"."node_id" = "sbom_package_cpe_ref"."node_id"
+            LEFT JOIN "sbom_package_purl_ref" ON "sbom_package_purl_ref"."sbom_id" = "sbom_package_cpe_ref"."sbom_id" AND "sbom_package_purl_ref"."node_id" = "sbom_package_cpe_ref"."node_id"
+            LEFT JOIN "qualified_purl" ON "qualified_purl"."id" = "sbom_package_purl_ref"."qualified_purl_id"
+
+            -- the SBOM's describing node/package (identity; name and version)
+            JOIN "sbom_node" ON "sbom_node"."sbom_id" = "sbom"."sbom_id" AND "sbom_node"."node_id" = "sbom"."node_id"
+            JOIN "package_relates_to_package" ON "package_relates_to_package"."sbom_id" = "sbom_node"."sbom_id" AND "relationship" = $2
+            JOIN "sbom_package" ON "sbom_package"."sbom_id" = "package_relates_to_package"."sbom_id" AND "sbom_package"."node_id" = "package_relates_to_package"."right_node_id"
+
+            WHERE
+                "cpe_status"."vulnerability_id" = $1
+                AND "status"."slug" != 'not_affected'
+                AND version_matches(COALESCE(NULLIF("pkg_cpe"."version", '*'), "matched_pkg"."version"), "version_range".*)
+            "#;
+
+        let cpe_result: Vec<QueryResult> = tx
+            .query_all(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                cpe_status_query,
+                [
+                    vulnerability.id.clone().into(),
+                    Relationship::Describes.into(),
+                ],
+            ))
+            .instrument(info_span!("fetching cpe status"))
+            .await?;
+
+        vuln_sbom_statuses.extend(
+            cpe_result
+                .iter()
+                .map(|row| SbomStatusCatcher::from_query_result(row, ""))
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+
         // Purl statuses might make sense only when we don't have any sboms
         // so we can show what we know about affected purls
         // It's a legacy at this point as some tests depends on it,

--- a/modules/fundamental/tests/sbom/details.rs
+++ b/modules/fundamental/tests/sbom/details.rs
@@ -182,3 +182,72 @@ fn check_advisory(
     );
     assert_eq!("affected", advisory.status[0].status);
 }
+
+/// End-to-end test of the CPE-based matching path (`raw_sql::cpe_advisory_info_sql`):
+/// package-level CPEs harvested from an SPDX SBOM (`sbom_package_cpe_ref`) matched
+/// against `cpe_status` rows written by the CVE loader from `affected[].cpes`.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+#[instrument]
+async fn sbom_details_cpe_matching(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let sbom = SbomService::new(ctx.db.clone());
+
+    let result = ctx.ingest_document("spdx/cpe23-firmware.json").await?;
+
+    let cve1 = ctx.ingest_document("cve/CVE-2099-0001.json").await?;
+    assert_eq!(cve1.document_id, Some("CVE-2099-0001".to_string()));
+    let cve2 = ctx.ingest_document("cve/CVE-2099-0002.json").await?;
+    assert_eq!(cve2.document_id, Some("CVE-2099-0002".to_string()));
+    let cve3 = ctx.ingest_document("cve/CVE-2099-0003.json").await?;
+    assert_eq!(cve3.document_id, Some("CVE-2099-0003".to_string()));
+
+    let details = sbom
+        .fetch_sbom_details(result.id, vec![], &ctx.db)
+        .await?
+        .expect("SBOM details must be found");
+
+    // CVE-2099-0001 must show up with OpenSSL (exact version match) and
+    // BusyBox (concrete-CPE-version fallback) as affected packages.
+    let advisory_1 = details
+        .advisories
+        .iter()
+        .find(|a| a.head.document_id == "CVE-2099-0001")
+        .expect("CVE-2099-0001 advisory must be present");
+    assert_eq!(1, advisory_1.status.len());
+    assert_eq!("affected", advisory_1.status[0].status);
+    let package_names: std::collections::BTreeSet<String> = advisory_1.status[0]
+        .packages
+        .iter()
+        .map(|p| p.name.clone())
+        .collect();
+    assert!(
+        package_names.contains("OpenSSL"),
+        "expected OpenSSL among matched packages, got {package_names:?}"
+    );
+    assert!(
+        package_names.contains("BusyBox"),
+        "expected BusyBox among matched packages, got {package_names:?}"
+    );
+
+    // CVE-2099-0002 (denx:u-boot) must NOT match -- no u-boot package here.
+    assert!(
+        !details
+            .advisories
+            .iter()
+            .any(|a| a.head.document_id == "CVE-2099-0002"),
+        "CVE-2099-0002 (u-boot) must not match any package in this SBOM"
+    );
+
+    // CVE-2099-0003 (openssl 2.0.0..3.0.0) must NOT match 0.9.8w -- the
+    // false-positive guard: identity alone is insufficient, version_matches
+    // must also hold.
+    assert!(
+        !details
+            .advisories
+            .iter()
+            .any(|a| a.head.document_id == "CVE-2099-0003"),
+        "CVE-2099-0003 (openssl 2.0.0..3.0.0) must not match openssl 0.9.8w"
+    );
+
+    Ok(())
+}

--- a/modules/fundamental/tests/sbom/spdx.rs
+++ b/modules/fundamental/tests/sbom/spdx.rs
@@ -142,6 +142,53 @@ async fn ingest_spdx_broken_refs(ctx: &TrustifyContext) -> Result<(), anyhow::Er
     Ok(())
 }
 
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn ingest_spdx_cpe23_refs(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    test_with_spdx(
+        ctx,
+        "spdx/cpe23-firmware.json",
+        |WithContext { service, sbom, .. }| async move {
+            let packages = service
+                .fetch_sbom_packages(
+                    sbom.sbom.sbom_id,
+                    Default::default(),
+                    Paginated {
+                        offset: 0,
+                        limit: 100,
+                    },
+                    &ctx.db,
+                )
+                .await?;
+
+            let find = |name: &str| {
+                packages
+                    .items
+                    .iter()
+                    .find(|p| p.name == name)
+                    .unwrap_or_else(|| panic!("package {name} must exist"))
+            };
+
+            let openssl = find("OpenSSL");
+            assert_eq!(openssl.cpe, vec!["cpe:/a:openssl:openssl:0.9.8w:*:*:*"]);
+
+            let busybox = find("BusyBox");
+            assert_eq!(busybox.cpe, vec!["cpe:/a:busybox:busybox:1.19.4:*:*:*"]);
+
+            // the unparseable CPE reference is skipped, but the package is still ingested
+            let garbage = packages
+                .items
+                .iter()
+                .find(|p| p.name.starts_with("libfoo"))
+                .expect("package with broken CPE must exist");
+            assert!(garbage.cpe.is_empty());
+
+            Ok(())
+        },
+    )
+    .await
+}
+
 #[instrument(skip(ctx, f))]
 pub async fn test_with_spdx<F>(ctx: &TrustifyContext, sbom: &str, f: F) -> anyhow::Result<()>
 where

--- a/modules/fundamental/tests/vuln/mod.rs
+++ b/modules/fundamental/tests/vuln/mod.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use test_context::test_context;
 use test_log::test;
 use trustify_module_fundamental::vulnerability::service::VulnerabilityService;
+use trustify_module_ingestor::common::Deprecation;
 use trustify_test_context::{Dataset, TrustifyContext, subset::ContainsSubset};
 
 #[test_context(TrustifyContext)]
@@ -76,6 +77,55 @@ async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     );
 
     // done
+
+    Ok(())
+}
+
+/// Backlink coverage for the `cpe_status` path (P6/P7 of the CPE-identity
+/// backport): a vulnerability whose CVE record carries CPE applicability must
+/// list the SBOM whose package CPE matches, on `/vulnerability/{id}` — including
+/// when the match is by CPE identity (no PURL needed on the advisory side).
+///
+/// - CVE-2099-0001 affects openssl 0.9.8w (exact + range) → the firmware SBOM
+///   (OpenSSL 0.9.8w via SPDX cpe23Type) MUST appear in the backlink (positive).
+/// - CVE-2099-0003 affects openssl only in 2.0.0..3.0.0 → 0.9.8w is out of range
+///   → the firmware SBOM MUST NOT appear (negative / version guard).
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn cpe_status_vulnerability_backlink(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    ctx.ingest_document("spdx/cpe23-firmware.json").await?;
+    ctx.ingest_document("cve/CVE-2099-0001.json").await?;
+    ctx.ingest_document("cve/CVE-2099-0003.json").await?;
+
+    let service = VulnerabilityService::new();
+
+    // Collect the set of SBOM names backlinked from a vulnerability's advisories.
+    let backlinked_sbom_names = async |id: &str| -> Result<Vec<String>, anyhow::Error> {
+        let details = service
+            .fetch_vulnerability(id, Deprecation::Ignore, &ctx.db)
+            .await?
+            .expect("vulnerability must exist");
+        Ok(details
+            .advisories
+            .iter()
+            .flat_map(|adv| adv.sboms.iter())
+            .map(|sbom| sbom.head.name.clone())
+            .collect())
+    };
+
+    // Positive: 0.9.8w is within CVE-2099-0001's affected range → firmware backlinked.
+    let positive = backlinked_sbom_names("CVE-2099-0001").await?;
+    assert!(
+        positive.iter().any(|n| n == "cpe23-firmware"),
+        "CVE-2099-0001 must backlink the firmware SBOM via cpe_status, got {positive:?}"
+    );
+
+    // Negative: 0.9.8w is outside CVE-2099-0003's 2.0.0..3.0.0 range → not backlinked.
+    let negative = backlinked_sbom_names("CVE-2099-0003").await?;
+    assert!(
+        !negative.iter().any(|n| n == "cpe23-firmware"),
+        "CVE-2099-0003 (openssl 2.0.0..3.0.0) must NOT backlink openssl 0.9.8w, got {negative:?}"
+    );
 
     Ok(())
 }

--- a/modules/ingestor/src/graph/advisory/cpe_status.rs
+++ b/modules/ingestor/src/graph/advisory/cpe_status.rs
@@ -1,0 +1,72 @@
+use crate::graph::advisory::version::VersionInfo;
+use trustify_common::cpe::Cpe;
+use trustify_entity::{cpe_status, version_range};
+use uuid::Uuid;
+
+use sea_orm::Set;
+
+const NAMESPACE: Uuid = Uuid::from_bytes([
+    0x8f, 0x3a, 0x6c, 0x02, 0x4b, 0x1d, 0x4a, 0x7e, 0xb1, 0x0c, 0x2d, 0x9a, 0x77, 0x4e, 0x1f, 0x63,
+]);
+
+/// A vulnerability status keyed by a CPE (vendor/product identity), mirroring
+/// [`crate::graph::advisory::purl_status::PurlStatus`].
+///
+/// `cpe` carries the affected vendor/product identity with its version
+/// component normalized to ANY (see [`Cpe::with_any_version`]); the actual
+/// affected version(s) are expressed through `info` (a `version_range`).
+#[derive(Debug, Eq, Hash, PartialEq, Clone)]
+pub struct CpeStatus {
+    pub cpe: Cpe,
+    pub context_cpe: Option<Cpe>,
+    pub status: Uuid,
+    pub info: VersionInfo,
+}
+
+impl CpeStatus {
+    pub fn new(cpe: Cpe, context_cpe: Option<Cpe>, status: Uuid, info: VersionInfo) -> Self {
+        Self {
+            cpe,
+            context_cpe,
+            status,
+            info,
+        }
+    }
+
+    pub fn into_active_model(
+        self,
+        advisory_id: Uuid,
+        vulnerability_id: String,
+    ) -> (version_range::ActiveModel, cpe_status::ActiveModel) {
+        let cpe_id = self.cpe.uuid();
+        let context_cpe_id = self.context_cpe.as_ref().map(Cpe::uuid);
+
+        let version_range = self.info.clone().into_active_model();
+
+        let cpe_status = cpe_status::ActiveModel {
+            id: Set(self.uuid(advisory_id, vulnerability_id.clone())),
+            advisory_id: Set(advisory_id),
+            vulnerability_id: Set(vulnerability_id),
+            status_id: Set(self.status),
+            cpe_id: Set(cpe_id),
+            context_cpe_id: Set(context_cpe_id),
+            version_range_id: version_range.clone().id,
+        };
+
+        (version_range, cpe_status)
+    }
+
+    pub fn uuid(&self, advisory_id: Uuid, vulnerability_id: String) -> Uuid {
+        let mut result = Uuid::new_v5(&NAMESPACE, self.status.as_bytes());
+        result = Uuid::new_v5(&result, self.cpe.uuid().as_bytes());
+        result = Uuid::new_v5(&result, self.info.uuid().as_bytes());
+        result = Uuid::new_v5(&result, advisory_id.as_bytes());
+        result = Uuid::new_v5(&result, vulnerability_id.as_bytes());
+
+        if let Some(cpe) = &self.context_cpe {
+            result = Uuid::new_v5(&result, cpe.uuid().as_bytes())
+        }
+
+        result
+    }
+}

--- a/modules/ingestor/src/graph/advisory/mod.rs
+++ b/modules/ingestor/src/graph/advisory/mod.rs
@@ -22,6 +22,7 @@ use trustify_entity::{self as entity, advisory, labels::Labels, source_document}
 use uuid::Uuid;
 
 pub mod advisory_vulnerability;
+pub mod cpe_status;
 pub mod product_status;
 pub mod purl_status;
 pub mod version;

--- a/modules/ingestor/src/graph/cpe_status_creator.rs
+++ b/modules/ingestor/src/graph/cpe_status_creator.rs
@@ -1,0 +1,137 @@
+use crate::graph::{
+    advisory::{cpe_status::CpeStatus, version::VersionInfo},
+    error::Error,
+};
+use sea_orm::{ActiveValue::Set, ConnectionTrait, EntityTrait, QueryFilter};
+use sea_query::{Expr, OnConflict, PgFunc};
+use std::collections::{BTreeMap, BTreeSet};
+use tracing::instrument;
+use trustify_common::{cpe::Cpe, db::chunk::EntityChunkedIter};
+use trustify_entity::{cpe_status, status, version_range};
+use uuid::Uuid;
+
+/// Input data for creating a CPE status entry
+#[derive(Clone, Debug)]
+pub struct CpeStatusEntry {
+    pub advisory_id: Uuid,
+    pub vulnerability_id: String,
+    /// The vendor/product identity CPE. Its version component does not need
+    /// to be pre-normalized to ANY -- [`CpeStatusEntry`] callers are expected
+    /// to pass whatever CPE they have; normalization happens upstream in the
+    /// CVE loader via [`Cpe::with_any_version`].
+    pub cpe: Cpe,
+    pub status: String,
+    pub version_info: VersionInfo,
+    pub context_cpe: Option<Cpe>,
+}
+
+/// Creator for batch insertion of CPE statuses.
+///
+/// Mirrors [`crate::graph::purl::status_creator::PurlStatusCreator`], keyed
+/// by `cpe_id` instead of `base_purl_id`.
+#[derive(Default)]
+pub struct CpeStatusCreator {
+    entries: Vec<CpeStatusEntry>,
+}
+
+impl CpeStatusCreator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a CPE status entry to be created
+    pub fn add(&mut self, entry: CpeStatusEntry) {
+        self.entries.push(entry);
+    }
+
+    /// Create all collected CPE statuses in batches
+    #[instrument(skip_all, fields(num = self.entries.len()), err(level=tracing::Level::INFO))]
+    pub async fn create<C>(self, connection: &C) -> Result<(), Error>
+    where
+        C: ConnectionTrait,
+    {
+        if self.entries.is_empty() {
+            return Ok(());
+        }
+
+        // 1. Batch lookup all unique status slugs
+        let unique_statuses: Vec<String> = self
+            .entries
+            .iter()
+            .map(|e| e.status.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+
+        let status_models = status::Entity::find()
+            .filter(Expr::col(status::Column::Slug).eq(PgFunc::any(unique_statuses)))
+            .all(connection)
+            .await?;
+
+        let status_map: BTreeMap<String, Uuid> = status_models
+            .into_iter()
+            .map(|s| (s.slug.clone(), s.id))
+            .collect();
+
+        // 2. Deduplicate and build ActiveModels
+        let mut version_ranges = BTreeMap::new();
+        let mut cpe_statuses = BTreeMap::new();
+
+        for entry in self.entries {
+            // Validate status exists
+            let status_id = *status_map
+                .get(&entry.status)
+                .ok_or_else(|| Error::InvalidStatus(entry.status.clone()))?;
+
+            let cpe_status = CpeStatus {
+                cpe: entry.cpe.clone(),
+                context_cpe: entry.context_cpe.clone(),
+                status: status_id,
+                info: entry.version_info.clone(),
+            };
+
+            let uuid = cpe_status.uuid(entry.advisory_id, entry.vulnerability_id.clone());
+            let cpe_id = entry.cpe.uuid();
+            let version_range_id = entry.version_info.uuid();
+            let context_cpe_id = entry.context_cpe.as_ref().map(|cpe| cpe.uuid());
+
+            // Deduplicate version ranges
+            version_ranges
+                .entry(version_range_id)
+                .or_insert_with(|| entry.version_info.clone().into_active_model());
+
+            // Deduplicate cpe_statuses by UUID
+            cpe_statuses
+                .entry(uuid)
+                .or_insert_with(|| cpe_status::ActiveModel {
+                    id: Set(uuid),
+                    advisory_id: Set(entry.advisory_id),
+                    vulnerability_id: Set(entry.vulnerability_id.clone()),
+                    status_id: Set(status_id),
+                    cpe_id: Set(cpe_id),
+                    version_range_id: Set(version_range_id),
+                    context_cpe_id: Set(context_cpe_id),
+                });
+        }
+
+        // 3. Batch insert version ranges
+        for batch in &version_ranges.into_values().chunked() {
+            version_range::Entity::insert_many(batch)
+                .on_conflict(OnConflict::new().do_nothing().to_owned())
+                .do_nothing()
+                .exec_without_returning(connection)
+                .await?;
+        }
+
+        // 4. Batch insert cpe_statuses
+        for batch in &cpe_statuses.into_values().chunked() {
+            cpe_status::Entity::insert_many(batch)
+                .on_conflict(OnConflict::new().do_nothing().to_owned())
+                .do_nothing()
+                .exec_without_returning(connection)
+                .await?;
+        }
+
+        Ok(())
+    }
+}

--- a/modules/ingestor/src/graph/mod.rs
+++ b/modules/ingestor/src/graph/mod.rs
@@ -1,5 +1,6 @@
 pub mod advisory;
 pub mod cpe;
+pub mod cpe_status_creator;
 pub mod db_context;
 pub mod error;
 pub mod organization;

--- a/modules/ingestor/src/graph/sbom/spdx.rs
+++ b/modules/ingestor/src/graph/sbom/spdx.rs
@@ -237,7 +237,7 @@ impl SbomContext {
                             log::info!("Failed to parse PURL ({}): {err}", r.reference_locator);
                         }
                     },
-                    "cpe22Type" => match Cpe::from_str(&r.reference_locator) {
+                    "cpe22Type" | "cpe23Type" => match Cpe::from_str(&r.reference_locator) {
                         Ok(cpe) => {
                             refs.push(PackageReference::Cpe(cpe.uuid()));
                             cpes.add(cpe.clone());

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -166,13 +166,20 @@ impl<'g> CveLoader<'g> {
                         continue;
                     };
                     let identity_cpe = cpe.with_any_version();
-                    cpes.insert(identity_cpe.clone());
 
                     if !product.versions.is_empty() {
                         for version in &product.versions {
                             let (version_spec, version_type, status) =
                                 version_spec_and_status(version);
 
+                            // `unknown` has no row in the `status` table and
+                            // carries no applicability information; skip it
+                            // instead of failing the whole document.
+                            if matches!(status, Status::Unknown) {
+                                continue;
+                            }
+
+                            cpes.insert(identity_cpe.clone());
                             cpe_status_creator.add(CpeStatusEntry {
                                 advisory_id: advisory_vuln.advisory.advisory.id,
                                 vulnerability_id: advisory_vuln
@@ -194,6 +201,17 @@ impl<'g> CveLoader<'g> {
                     } else if let trustify_common::cpe::Component::Value(version) = cpe.version() {
                         // no explicit versions list: fall back to the concrete
                         // version carried by the CPE itself.
+                        let status = product.default_status.clone().unwrap_or(Status::Unknown);
+
+                        // `unknown` (also the fallback for a missing
+                        // `defaultStatus`) has no row in the `status` table and
+                        // carries no applicability information; skip it instead
+                        // of failing the whole document.
+                        if matches!(status, Status::Unknown) {
+                            continue;
+                        }
+
+                        cpes.insert(identity_cpe.clone());
                         cpe_status_creator.add(CpeStatusEntry {
                             advisory_id: advisory_vuln.advisory.advisory.id,
                             vulnerability_id: advisory_vuln
@@ -201,9 +219,7 @@ impl<'g> CveLoader<'g> {
                                 .vulnerability_id
                                 .clone(),
                             cpe: identity_cpe.clone(),
-                            status: status_slug(
-                                &product.default_status.clone().unwrap_or(Status::Unknown),
-                            ),
+                            status: status_slug(&status),
                             version_info: VersionInfo {
                                 scheme: VersionScheme::Generic,
                                 spec: VersionSpec::Exact(version),

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -5,6 +5,8 @@ use crate::{
             AdvisoryInformation, AdvisoryVulnerabilityInformation,
             version::{Version, VersionInfo, VersionSpec},
         },
+        cpe::CpeCreator,
+        cpe_status_creator::{CpeStatusCreator, CpeStatusEntry},
         purl::{
             self,
             status_creator::{PurlStatusCreator, PurlStatusEntry},
@@ -23,7 +25,7 @@ use serde_json::Value;
 use std::{collections::HashSet, fmt::Debug, str::FromStr};
 use time::OffsetDateTime;
 use tracing::instrument;
-use trustify_common::{hashing::Digests, id::Id};
+use trustify_common::{cpe::Cpe, hashing::Digests, id::Id};
 use trustify_cvss::cvss3::{Cvss3Base, score::Score, severity::Severity};
 use trustify_entity::{labels::Labels, version_scheme::VersionScheme};
 
@@ -117,9 +119,11 @@ impl<'g> CveLoader<'g> {
             }
         }
 
-        // Initialize batch creator for efficient status ingestion
+        // Initialize batch creators for efficient status ingestion
         let mut purl_status_creator = PurlStatusCreator::new();
+        let mut cpe_status_creator = CpeStatusCreator::new();
         let mut base_purls = HashSet::new();
+        let mut cpes = HashSet::new();
 
         if let Some(affected) = affected {
             for product in affected {
@@ -130,31 +134,7 @@ impl<'g> CveLoader<'g> {
                     // okay! we have a purl, now
                     // sort out version bounds & status
                     for version in &product.versions {
-                        let (version_spec, version_type, status) = match version {
-                            cve::common::Version::Single(version) => (
-                                VersionSpec::Exact(version.version.clone()),
-                                version.version_type.clone(),
-                                &version.status,
-                            ),
-                            cve::common::Version::Range(range) => match &range.range {
-                                VersionRange::LessThan(upper) => (
-                                    VersionSpec::Range(
-                                        Version::Inclusive(range.version.clone()),
-                                        Version::Exclusive(upper.clone()),
-                                    ),
-                                    Some(range.version_type.clone()),
-                                    &range.status,
-                                ),
-                                VersionRange::LessThanOrEqual(upper) => (
-                                    VersionSpec::Range(
-                                        Version::Inclusive(range.version.clone()),
-                                        Version::Inclusive(upper.clone()),
-                                    ),
-                                    Some(range.version_type.clone()),
-                                    &range.status,
-                                ),
-                            },
-                        };
+                        let (version_spec, version_type, status) = version_spec_and_status(version);
 
                         // Add package status entry to batch creator
                         purl_status_creator.add(PurlStatusEntry {
@@ -164,11 +144,7 @@ impl<'g> CveLoader<'g> {
                                 .vulnerability_id
                                 .clone(),
                             purl: purl.clone(),
-                            status: match status {
-                                Status::Affected => "affected".to_string(),
-                                Status::Unaffected => "not_affected".to_string(),
-                                Status::Unknown => "unknown".to_string(),
-                            },
+                            status: status_slug(status),
                             version_info: VersionInfo {
                                 scheme: version_type
                                     .as_deref()
@@ -180,14 +156,78 @@ impl<'g> CveLoader<'g> {
                         });
                     }
                 }
+
+                // CPE-keyed applicability: every parseable CPE in `product.cpes`
+                // is stored as a vendor/product identity (version normalized to
+                // ANY), with the affected version(s) expressed via version_range,
+                // mirroring the purl path above.
+                for cpe_str in &product.cpes {
+                    let Ok(cpe) = Cpe::from_str(cpe_str) else {
+                        continue;
+                    };
+                    let identity_cpe = cpe.with_any_version();
+                    cpes.insert(identity_cpe.clone());
+
+                    if !product.versions.is_empty() {
+                        for version in &product.versions {
+                            let (version_spec, version_type, status) =
+                                version_spec_and_status(version);
+
+                            cpe_status_creator.add(CpeStatusEntry {
+                                advisory_id: advisory_vuln.advisory.advisory.id,
+                                vulnerability_id: advisory_vuln
+                                    .advisory_vulnerability
+                                    .vulnerability_id
+                                    .clone(),
+                                cpe: identity_cpe.clone(),
+                                status: status_slug(status),
+                                version_info: VersionInfo {
+                                    scheme: version_type
+                                        .as_deref()
+                                        .map(VersionScheme::from)
+                                        .unwrap_or(VersionScheme::Generic),
+                                    spec: version_spec,
+                                },
+                                context_cpe: None,
+                            });
+                        }
+                    } else if let trustify_common::cpe::Component::Value(version) = cpe.version() {
+                        // no explicit versions list: fall back to the concrete
+                        // version carried by the CPE itself.
+                        cpe_status_creator.add(CpeStatusEntry {
+                            advisory_id: advisory_vuln.advisory.advisory.id,
+                            vulnerability_id: advisory_vuln
+                                .advisory_vulnerability
+                                .vulnerability_id
+                                .clone(),
+                            cpe: identity_cpe.clone(),
+                            status: status_slug(
+                                &product.default_status.clone().unwrap_or(Status::Unknown),
+                            ),
+                            version_info: VersionInfo {
+                                scheme: VersionScheme::Generic,
+                                spec: VersionSpec::Exact(version),
+                            },
+                            context_cpe: None,
+                        });
+                    }
+                }
             }
         }
 
         // Batch create base PURLs (without versions/qualifiers)
         purl::batch_create_base_purls(base_purls, &tx).await?;
 
+        // Batch create CPEs (vendor/product identity, version normalized to ANY)
+        let mut cpe_creator = CpeCreator::new();
+        for cpe in cpes {
+            cpe_creator.add(cpe);
+        }
+        cpe_creator.create(&tx).await?;
+
         // Batch create statuses
         purl_status_creator.create(&tx).await?;
+        cpe_status_creator.create(&tx).await?;
 
         // Manage vulnerability descriptions without needing to query the vulnerability
         Graph::drop_vulnerability_descriptions_for_advisory(advisory.advisory.id, &tx).await?;
@@ -385,6 +425,49 @@ struct VulnerabilityDetails<'a> {
     pub scores: Vec<Cvss3Base>,
 }
 
+/// Maps a CVE 5.x `versions[]` entry to its version bound and CVE status.
+///
+/// Shared by both the purl and CPE ingestion paths so that any future change
+/// to the version-range mapping stays consistent between the two.
+fn version_spec_and_status(
+    version: &cve::common::Version,
+) -> (VersionSpec, Option<String>, &Status) {
+    match version {
+        cve::common::Version::Single(version) => (
+            VersionSpec::Exact(version.version.clone()),
+            version.version_type.clone(),
+            &version.status,
+        ),
+        cve::common::Version::Range(range) => match &range.range {
+            VersionRange::LessThan(upper) => (
+                VersionSpec::Range(
+                    Version::Inclusive(range.version.clone()),
+                    Version::Exclusive(upper.clone()),
+                ),
+                Some(range.version_type.clone()),
+                &range.status,
+            ),
+            VersionRange::LessThanOrEqual(upper) => (
+                VersionSpec::Range(
+                    Version::Inclusive(range.version.clone()),
+                    Version::Inclusive(upper.clone()),
+                ),
+                Some(range.version_type.clone()),
+                &range.status,
+            ),
+        },
+    }
+}
+
+/// Maps a CVE 5.x affected-version status to the trustify status slug.
+fn status_slug(status: &Status) -> String {
+    match status {
+        Status::Affected => "affected".to_string(),
+        Status::Unaffected => "not_affected".to_string(),
+        Status::Unknown => "unknown".to_string(),
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -396,6 +479,108 @@ mod test {
     use time::macros::datetime;
     use trustify_common::purl::Purl;
     use trustify_test_context::{TrustifyContext, document};
+
+    #[test_context(TrustifyContext)]
+    #[test(tokio::test)]
+    async fn cve_loader_stores_cpe_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+        use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+        use trustify_entity::{cpe as cpe_entity, cpe_status, status, version_range};
+
+        let graph = Graph::new(ctx.db.clone());
+
+        let (cve, digests): (Cve, _) = document("cve/CVE-2099-0001.json").await?;
+
+        let loader = CveLoader::new(&graph);
+        loader
+            .load(("file", "CVE-2099-0001.json"), cve.clone(), &digests)
+            .await?;
+
+        let advisory = graph
+            .get_advisory_by_digest(&digests.sha256.encode_hex::<String>(), &ctx.db)
+            .await?
+            .expect("advisory must be ingested");
+
+        let rows = cpe_status::Entity::find()
+            .filter(cpe_status::Column::AdvisoryId.eq(advisory.advisory.id))
+            .all(&ctx.db)
+            .await?;
+
+        // openssl: 1 exact version + 1 range = 2 rows; busybox: no `versions`
+        // list, falls back to the concrete CPE version = 1 row. Total 3.
+        assert_eq!(rows.len(), 3, "expected 3 cpe_status rows, got {rows:?}");
+
+        let mut by_vendor: std::collections::HashMap<String, Vec<cpe_status::Model>> =
+            std::collections::HashMap::new();
+        for row in rows {
+            let cpe = cpe_entity::Entity::find_by_id(row.cpe_id)
+                .one(&ctx.db)
+                .await?
+                .expect("referenced cpe must exist");
+            by_vendor
+                .entry(cpe.vendor.clone().unwrap_or_default())
+                .or_default()
+                .push(row);
+
+            // the identity cpe is version-normalized to ANY
+            assert_eq!(
+                cpe.version.as_deref(),
+                Some("*"),
+                "cpe_status.cpe_id must be version-ANY"
+            );
+        }
+
+        let openssl_rows = by_vendor.get("openssl").expect("openssl rows");
+        assert_eq!(openssl_rows.len(), 2);
+        for row in openssl_rows {
+            let st = status::Entity::find_by_id(row.status_id)
+                .one(&ctx.db)
+                .await?
+                .expect("status must exist");
+            assert_eq!(st.slug, "affected");
+
+            let vr = version_range::Entity::find_by_id(row.version_range_id)
+                .one(&ctx.db)
+                .await?
+                .expect("version_range must exist");
+            assert!(
+                vr.low_version.as_deref() == Some("0.9.8w")
+                    || vr.low_version.as_deref() == Some("1.0.0"),
+                "unexpected version_range: {vr:?}"
+            );
+        }
+
+        let busybox_rows = by_vendor.get("busybox").expect("busybox rows");
+        assert_eq!(busybox_rows.len(), 1);
+        let busybox_row = &busybox_rows[0];
+        let st = status::Entity::find_by_id(busybox_row.status_id)
+            .one(&ctx.db)
+            .await?
+            .expect("status must exist");
+        assert_eq!(st.slug, "affected");
+        let vr = version_range::Entity::find_by_id(busybox_row.version_range_id)
+            .one(&ctx.db)
+            .await?
+            .expect("version_range must exist");
+        assert_eq!(vr.low_version.as_deref(), Some("1.19.4"));
+
+        // Re-ingest idempotency: loading the same document again must not
+        // create duplicate cpe_status rows (deterministic v5 UUIDs).
+        loader
+            .load(("file", "CVE-2099-0001.json"), cve, &digests)
+            .await?;
+
+        let rows_after_reingest = cpe_status::Entity::find()
+            .filter(cpe_status::Column::AdvisoryId.eq(advisory.advisory.id))
+            .all(&ctx.db)
+            .await?;
+        assert_eq!(
+            rows_after_reingest.len(),
+            3,
+            "re-ingest must not duplicate rows"
+        );
+
+        Ok(())
+    }
 
     #[test_context(TrustifyContext)]
     #[test(tokio::test)]

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -125,7 +125,7 @@ impl<'g> CveLoader<'g> {
         let mut base_purls = HashSet::new();
         let mut cpes = HashSet::new();
 
-        if let Some(affected) = affected {
+        {
             for product in affected {
                 if let Some(purl) = divine_purl(product) {
                     // Collect base PURL for batch creation
@@ -287,7 +287,7 @@ impl<'g> CveLoader<'g> {
                     .provider_metadata
                     .short_name
                     .as_deref(),
-                None,
+                Vec::new(),
             ),
             Cve::Published(published) => (
                 published
@@ -326,7 +326,23 @@ impl<'g> CveLoader<'g> {
                     .provider_metadata
                     .short_name
                     .as_deref(),
-                Some(&published.containers.cna.affected),
+                // CNA-reported affected entries are the primary source; ADP
+                // containers (e.g. CISA vulnrichment, Red Hat) supplement them
+                // with additional CPE/version data, particularly for CVEs the
+                // upstream CNA never annotated with CPEs.
+                published
+                    .containers
+                    .cna
+                    .affected
+                    .iter()
+                    .chain(
+                        published
+                            .containers
+                            .adp
+                            .iter()
+                            .flat_map(|adp| adp.affected.iter()),
+                    )
+                    .collect(),
             ),
         };
 
@@ -420,7 +436,7 @@ struct VulnerabilityDetails<'a> {
     pub org_name: Option<&'a str>,
     pub descriptions: &'a Vec<Description>,
     pub assigned: Option<OffsetDateTime>,
-    pub affected: Option<&'a Vec<Product>>,
+    pub affected: Vec<&'a Product>,
     pub information: VulnerabilityInformation,
     pub scores: Vec<Cvss3Base>,
 }
@@ -578,6 +594,60 @@ mod test {
             3,
             "re-ingest must not duplicate rows"
         );
+
+        Ok(())
+    }
+
+    #[test_context(TrustifyContext)]
+    #[test(tokio::test)]
+    async fn cve_loader_stores_cpe_status_from_adp_container(
+        ctx: &TrustifyContext,
+    ) -> Result<(), anyhow::Error> {
+        use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+        use trustify_entity::{cpe as cpe_entity, cpe_status, status, version_range};
+
+        let graph = Graph::new(ctx.db.clone());
+
+        // cna.affected is empty; the ADP (vulnrichment-style) container is the
+        // only source of CPE/version data for this record.
+        let (cve, digests): (Cve, _) = document("cve/CVE-2099-0002.json").await?;
+
+        let loader = CveLoader::new(&graph);
+        loader
+            .load(("file", "CVE-2099-0002.json"), cve, &digests)
+            .await?;
+
+        let advisory = graph
+            .get_advisory_by_digest(&digests.sha256.encode_hex::<String>(), &ctx.db)
+            .await?
+            .expect("advisory must be ingested");
+
+        let rows = cpe_status::Entity::find()
+            .filter(cpe_status::Column::AdvisoryId.eq(advisory.advisory.id))
+            .all(&ctx.db)
+            .await?;
+        assert_eq!(rows.len(), 1, "expected 1 cpe_status row, got {rows:?}");
+
+        let row = &rows[0];
+        let cpe = cpe_entity::Entity::find_by_id(row.cpe_id)
+            .one(&ctx.db)
+            .await?
+            .expect("referenced cpe must exist");
+        assert_eq!(cpe.vendor.as_deref(), Some("denx"));
+        assert_eq!(cpe.product.as_deref(), Some("u-boot"));
+        assert_eq!(cpe.version.as_deref(), Some("*"));
+
+        let st = status::Entity::find_by_id(row.status_id)
+            .one(&ctx.db)
+            .await?
+            .expect("status must exist");
+        assert_eq!(st.slug, "affected");
+
+        let vr = version_range::Entity::find_by_id(row.version_range_id)
+            .one(&ctx.db)
+            .await?
+            .expect("version_range must exist");
+        assert_eq!(vr.low_version.as_deref(), Some("2019.04"));
 
         Ok(())
     }


### PR DESCRIPTION
Backports the CPE-identity vulnerability-correlation feature (`cpe_status`) to
`release/0.4.z`, so SBOM nodes identified only by a package CPE (no PURL) are
correlated against advisory CPE applicability — the reverse and forward paths
that `release/0.4.z` was missing. Fixes **TC-5630** on the z-stream.

Backported from upstream **#2518** (_feat: implement cpe matching and nvd importer_)
and the CPE-only-node fix `0dcab72d` from **#2582** (_fix: vuln correlation fixes_),
adapted to `release/0.4.z`.

## Backport commits (this PR)
| Commit | Upstream | Purpose |
|---|---|---|
| `b732f68f` feat(common): parse CPE 2.3 strings + add with_any_version | `1c104740` + cpe.rs of `2d6fd0e8` (#2518) | parse `cpe:2.3:` (0.4.z only handled `cpe:/`); version→ANY identity |
| `01d36a93` feat(ingestor): ingest cpe23Type external references from SPDX | `087cacd6` (#2518) | accept `cpe23Type` refs so `sbom_package_cpe_ref` is populated |
| `bd19daa0` feat(entity): add cpe_status table + wire optional qualified_purl | `f03b635f` (#2518) + Option parts of `0dcab72d` (#2582) | new `cpe_status` table (migration `m0002132`); optional `qualified_purl` for PURL-less nodes |
| `2f0a179c` feat(ingestor): store CPE applicability from CVE records as cpe_status | `2d6fd0e8` (#2518) | CVE loader populates `cpe_status` |
| `a72a2e07` feat(fundamental): match package CPEs against cpe_status in detail + backlink | `829a118b` + `79551df3` (#2518) + SQL of `0dcab72d` (#2582) | `/sbom/{id}/advisory` + `/vulnerability/{id}` CPE matching, incl. CPE-only nodes |
| `623469a5` feat(ingestor): ingest affected entries from CVE ADP containers | `eadcd740` (#2518) | populate `cpe_status` from ADP containers (Red Hat applicability on upstream-CNA CVEs) |

## Adaptations to `release/0.4.z`
- Entity/SQL rename: `sbom_node_{purl,cpe}_ref` → `sbom_package_{purl,cpe}_ref` (0.4.z predates the rename).
- Kept the existing scoring model (`cvss3` / `average_severity`); did **not** pull in `advisory_vulnerability_score`.
- Migration renumbered `m0002250` → **`m0002132`** (skips main's two `m0002130_*` files); additive `CREATE TABLE`, clean `down`.
- Loader adapted to 0.4.z conventions (`&tx`, self-managed `load` transaction, `Graph::new(db)`); `Paginated` has no `total` field.

## Out of scope (documented parity gaps)
- **NVD importer/loader** from #2518 — `release/0.4.z` has no NVD service. `cpe_status` is populated from CVE records (CNA + ADP) only.
- `batch_severity_counts_sql` CPE additions (`e176a7da`/`d3729549`) — that SBOM-list function does not exist in 0.4.z.

## Verification
- `cargo check` + `clippy -D warnings` clean; migration `m0002132` applies (test-context).
- Tests: `cpe::` (14), `ingest_spdx_cpe23_refs`, `cve_loader` + `cve_loader_stores_cpe_status` + `cve_loader_stores_cpe_status_from_adp_container`, `sbom_details_cpe_matching` (positive OpenSSL/BusyBox; negatives u-boot + out-of-range openssl), regression `sbom::details` / `csaf::reingest`.
- End-to-end: a CPE-only (PURL-less) SBOM node now surfaces its CVEs on both `/sbom/{id}/advisory` and the `/vulnerability/{cve}` backlink. (PURL-keyed `/purl` and `/analyze` do not report PURL-less nodes — same behavior as `main`.)

## Summary by Sourcery

Backport CPE-based vulnerability correlation to release/0.4.z, including CPE applicability ingestion and matching for PURL-less SBOM nodes.

New Features:
- Support parsing CPE 2.3 identifiers and normalize CPEs to vendor/product identities for version-range matching.
- Correlate SBOM package CPEs, including PURL-less nodes, with advisory CPE applicability in SBOM details and vulnerability backlinks.
- Ingest CPE applicability from CVE CNA and ADP affected entries and SPDX cpe23Type references.

Bug Fixes:
- Restore vulnerability correlation for SBOM nodes identified only by CPEs on the release/0.4.z branch.

Enhancements:
- Allow advisory correlation results to represent packages without qualified PURLs.

Tests:
- Add coverage for CPE 2.3 parsing, SPDX CPE reference ingestion, CVE and ADP CPE-status persistence, and forward/reverse vulnerability correlation including version-range negatives.

Chores:
- Add the database model and migration for CPE applicability status records.