### PR TITLE
fix(ingestor): materialize OS-node CPEs into sbom_describing_cpe so the CPE-context filter engages for child-node product CPEs (TC-5749)

### DIFF
--- a/etc/test-data/cyclonedx/TC-5749/sbom_child_cpe.json
+++ b/etc/test-data/cyclonedx/TC-5749/sbom_child_cpe.json
@@ -1,0 +1,37 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:tc5749-child-cpe-0000-000000000001",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-01-01T00:00:00Z",
+    "component": {
+      "type": "application",
+      "name": "eus-target-app",
+      "bom-ref": "root-app",
+      "version": "1.0"
+    }
+  },
+  "components": [
+    {
+      "type": "operating-system",
+      "name": "rhel",
+      "bom-ref": "os-el8",
+      "version": "8",
+      "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "mypkg",
+      "bom-ref": "pkg-mypkg",
+      "version": "1.0.0-1.el8",
+      "purl": "pkg:rpm/redhat/mypkg@1.0.0-1.el8?arch=x86_64"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root-app",
+      "dependsOn": ["os-el8", "pkg-mypkg"]
+    }
+  ]
+}

--- a/etc/test-data/cyclonedx/TC-5749/sbom_no_cpe.json
+++ b/etc/test-data/cyclonedx/TC-5749/sbom_no_cpe.json
@@ -1,0 +1,30 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:tc5749-no-cpe-00000-000000000003",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-01-01T00:00:00Z",
+    "component": {
+      "type": "application",
+      "name": "no-cpe-app",
+      "bom-ref": "root-nocpe",
+      "version": "1.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "mypkg",
+      "bom-ref": "pkg-mypkg",
+      "version": "1.0.0-1.el8",
+      "purl": "pkg:rpm/redhat/mypkg@1.0.0-1.el8?arch=x86_64"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root-nocpe",
+      "dependsOn": ["pkg-mypkg"]
+    }
+  ]
+}

--- a/etc/test-data/cyclonedx/TC-5749/sbom_root_cpe.json
+++ b/etc/test-data/cyclonedx/TC-5749/sbom_root_cpe.json
@@ -1,0 +1,31 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:tc5749-root-cpe-0000-000000000002",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-01-01T00:00:00Z",
+    "component": {
+      "type": "operating-system",
+      "name": "rhel",
+      "bom-ref": "root-os",
+      "version": "8",
+      "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "mypkg",
+      "bom-ref": "pkg-mypkg",
+      "version": "1.0.0-1.el8",
+      "purl": "pkg:rpm/redhat/mypkg@1.0.0-1.el8?arch=x86_64"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root-os",
+      "dependsOn": ["pkg-mypkg"]
+    }
+  ]
+}

--- a/etc/test-data/cyclonedx/TC-5749/wrong-product-satellite.json
+++ b/etc/test-data/cyclonedx/TC-5749/wrong-product-satellite.json
@@ -1,0 +1,91 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "text": "Important"
+    },
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "tlp": {
+        "label": "WHITE"
+      }
+    },
+    "lang": "en",
+    "publisher": {
+      "category": "vendor",
+      "name": "Red Hat",
+      "namespace": "https://www.redhat.com"
+    },
+    "title": "TC-5749 wrong-product context reproducer (mypkg tracked only by Satellite)",
+    "tracking": {
+      "current_release_date": "2025-01-15T00:00:00Z",
+      "id": "TC-5749-WRONGPRODUCT",
+      "initial_release_date": "2025-01-15T00:00:00Z",
+      "revision_history": [
+        {
+          "date": "2025-01-15T00:00:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Red Hat",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "Red Hat Satellite 6",
+            "product": {
+              "name": "Red Hat Satellite 6",
+              "product_id": "satellite_6",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:satellite:6"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "mypkg",
+            "product": {
+              "name": "mypkg",
+              "product_id": "mypkg"
+            }
+          }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "mypkg as a component of Red Hat Satellite 6",
+          "product_id": "satellite_6:mypkg"
+        },
+        "product_reference": "mypkg",
+        "relates_to_product_reference": "satellite_6"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-77749",
+      "notes": [
+        {
+          "category": "description",
+          "text": "Synthetic vulnerability affecting mypkg only under the Red Hat Satellite product context."
+        }
+      ],
+      "product_status": {
+        "known_affected": [
+          "satellite_6:mypkg"
+        ]
+      }
+    }
+  ]
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -72,6 +72,7 @@ mod m0002270_fix_vulnerability_base_score_type;
 mod m0002280_backfill_sbom_suppliers;
 mod m0002290_create_exploit_intelligence_job;
 mod m0002300_create_exploit;
+mod m0002310_sbom_describing_cpe_child_nodes;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -159,6 +160,7 @@ impl MigratorExt for Migrator {
             .data(m0002280_backfill_sbom_suppliers::Migration)
             .normal(m0002290_create_exploit_intelligence_job::Migration)
             .normal(m0002300_create_exploit::Migration)
+            .normal(m0002310_sbom_describing_cpe_child_nodes::Migration)
     }
 }
 

--- a/migration/src/m0002310_sbom_describing_cpe_child_nodes.rs
+++ b/migration/src/m0002310_sbom_describing_cpe_child_nodes.rs
@@ -1,0 +1,72 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Re-materialize `sbom_describing_cpe` for already-ingested SBOMs under the
+        // broadened rule introduced alongside this migration: operating-system CPEs
+        // (`part = 'o'`) on ANY node count as product/OS context, not only CPEs on
+        // `Describes`-relationship (relationship = 13) nodes.
+        //
+        // Real RHEL image SBOMs attach the platform CPE (e.g.
+        // `cpe:/o:redhat:enterprise_linux:8`) to a child/OS component rather than the
+        // Describes node, so the original backfill (m0002110_sbom_describing_cpe) left
+        // the table empty for them and the CPE-context filter was disabled via its
+        // escape hatch, leaking wrong-product / wrong-scheme matches (TC-5170 /
+        // TC-5171). The Describes-node rows are already present from that earlier
+        // backfill; this migration only ADDS the OS-CPE rows.
+        //
+        // Additive and idempotent (`ON CONFLICT DO NOTHING`). Component-identity CPEs
+        // (`part = 'a'`, used by cpe_status matching — TC-5630) are intentionally
+        // excluded.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                INSERT INTO sbom_describing_cpe (sbom_id, cpe_id)
+                SELECT DISTINCT spcr.sbom_id, spcr.cpe_id
+                FROM sbom_node_cpe_ref spcr
+                JOIN cpe ON cpe.id = spcr.cpe_id
+                WHERE cpe.part = 'o'
+                ON CONFLICT DO NOTHING
+                "#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Reverse only what `up` added: OS-CPE (`part = 'o'`) describing rows that are
+        // NOT justified by a `Describes` relationship (relationship = 13). Rows that a
+        // Describes node contributes — including OS CPEs on the Describes node itself —
+        // are preserved, matching the pre-migration state produced by
+        // m0002110_sbom_describing_cpe.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                DELETE FROM sbom_describing_cpe sdc
+                USING cpe
+                WHERE sdc.cpe_id = cpe.id
+                  AND cpe.part = 'o'
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM sbom_node_cpe_ref spcr
+                      JOIN package_relates_to_package prtp
+                        ON prtp.sbom_id = spcr.sbom_id
+                       AND (prtp.right_node_id = spcr.node_id OR prtp.left_node_id = spcr.node_id)
+                      WHERE spcr.sbom_id = sdc.sbom_id
+                        AND spcr.cpe_id = sdc.cpe_id
+                        AND prtp.relationship = 13
+                  )
+                "#,
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/modules/fundamental/tests/sbom/details.rs
+++ b/modules/fundamental/tests/sbom/details.rs
@@ -835,6 +835,119 @@ async fn sbom_details_purlless_cpe_node_consistency(
     Ok(())
 }
 
+/// Reproducer for TC-5749 (SBOM-scale manifestation of TC-5170 / TC-5171):
+/// the CPE-context filter must engage when the SBOM's product/OS CPE sits on a
+/// *child* node, not only on the `Describes` root.
+///
+/// All three SBOMs contain `pkg:rpm/redhat/mypkg@1.0.0-1.el8`. The advisory
+/// (`CVE-2024-77749`) tracks `mypkg` **only** under the Red Hat Satellite product
+/// context (`cpe:/a:redhat:satellite:6`) — el8-OS does not track it at all — so a
+/// correct, context-aware result reports `mypkg` as NOT affected for a RHEL-8
+/// SBOM. It only appears via the wrong-product Satellite row when the context
+/// filter is disabled.
+///
+/// - **child-cpe** (`sbom_child_cpe.json`): the `enterprise_linux:8` CPE is on
+///   a child OS component; the `Describes` root carries no CPE. Before the fix
+///   `sbom_describing_cpe` was empty (only `Describes`-relationship CPEs were
+///   materialized), the escape hatch disabled filtering, and the Satellite row
+///   leaked. After the fix the OS CPE (`part = 'o'`) is materialized, so the
+///   Satellite context is filtered out — identical to root-cpe.
+/// - **root-cpe** (`sbom_root_cpe.json`): the CPE is on the `Describes` root
+///   (already materialized) — the parity control; must filter both before and
+///   after.
+/// - **no-cpe** (`sbom_no_cpe.json`): no product/OS CPE anywhere — the escape
+///   hatch legitimately applies, so the Satellite row still surfaces. Proves the
+///   fix is scoped to SBOMs that actually carry an OS CPE and introduces no new
+///   false negatives.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+#[instrument]
+async fn sbom_details_describing_cpe_on_child_node(
+    ctx: &TrustifyContext,
+) -> Result<(), anyhow::Error> {
+    let sbom = SbomService::new(PaginationCache::for_test());
+
+    const BASE: &str = "cyclonedx/TC-5749";
+
+    // Given a wrong-product advisory (mypkg tracked only under Satellite) and
+    // three SBOMs differing only in where (or whether) the el8 OS CPE sits.
+    ctx.ingest_document(format!("{BASE}/wrong-product-satellite.json"))
+        .await?;
+    let child = ctx
+        .ingest_document(format!("{BASE}/sbom_child_cpe.json"))
+        .await?;
+    let root = ctx
+        .ingest_document(format!("{BASE}/sbom_root_cpe.json"))
+        .await?;
+    let no_cpe = ctx
+        .ingest_document(format!("{BASE}/sbom_no_cpe.json"))
+        .await?;
+
+    // Collects every `affected` status entry for a CVE across all advisories.
+    let affected = |details: &SbomDetails, cve: &str| -> Vec<SbomStatus> {
+        details
+            .advisories
+            .iter()
+            .flat_map(|a| a.status.iter())
+            .filter(|s| s.vulnerability.identifier == cve && s.status == "affected")
+            .cloned()
+            .collect()
+    };
+    // True if any status on the SBOM is attributed to a Satellite CPE context.
+    let has_satellite_context = |details: &SbomDetails| -> bool {
+        details.advisories.iter().flat_map(|a| a.status.iter()).any(
+            |s| matches!(&s.context, Some(StatusContext::Cpe(cpe)) if cpe.contains("satellite")),
+        )
+    };
+
+    let child_details = sbom
+        .fetch_sbom_details(Id::parse_uuid(child.id)?, vec![], &ctx.db)
+        .await?
+        .expect("child-cpe SBOM details must be found");
+    let root_details = sbom
+        .fetch_sbom_details(Id::parse_uuid(root.id)?, vec![], &ctx.db)
+        .await?
+        .expect("root-cpe SBOM details must be found");
+    let no_cpe_details = sbom
+        .fetch_sbom_details(Id::parse_uuid(no_cpe.id)?, vec![], &ctx.db)
+        .await?
+        .expect("no-cpe SBOM details must be found");
+
+    // Then: the child-cpe SBOM must be filtered exactly like the root-cpe control
+    // -- no Satellite mis-attribution and no affected CVE-2024-77749 at all.
+    assert!(
+        !has_satellite_context(&child_details),
+        "child-cpe SBOM leaked a Satellite (wrong-product) context: the OS CPE on \
+         the child node did not engage the context filter"
+    );
+    assert!(
+        affected(&child_details, "CVE-2024-77749").is_empty(),
+        "child-cpe SBOM must not report CVE-2024-77749 affected (el8-OS mypkg is \
+         only tracked by Satellite); got {:?}",
+        affected(&child_details, "CVE-2024-77749")
+    );
+
+    // Parity control: root-cpe already filtered before the fix and must still.
+    assert!(
+        !has_satellite_context(&root_details),
+        "root-cpe SBOM must not carry a Satellite context"
+    );
+    assert!(
+        affected(&root_details, "CVE-2024-77749").is_empty(),
+        "root-cpe SBOM must not report CVE-2024-77749 affected"
+    );
+
+    // Scope control: an SBOM with no product/OS CPE keeps the escape hatch, so
+    // the Satellite row still surfaces -- the fix must not change this.
+    assert!(
+        !affected(&no_cpe_details, "CVE-2024-77749").is_empty(),
+        "no-cpe SBOM must still surface CVE-2024-77749 via the escape hatch \
+         (fix must be scoped to SBOMs that carry an OS CPE)"
+    );
+
+    Ok(())
+}
+
 /// Constructs a `ScoredVector` from its parts, deriving the severity from the type and value.
 fn sv(r#type: ScoreType, value: f64, vector: impl Into<String>) -> ScoredVector {
     ScoredVector {

--- a/modules/ingestor/src/graph/sbom/mod.rs
+++ b/modules/ingestor/src/graph/sbom/mod.rs
@@ -585,8 +585,23 @@ impl SbomContext {
         Ok(())
     }
 
-    /// Materializes describing CPE associations from the relationship and CPE ref
-    /// data already inserted for this SBOM into the `sbom_describing_cpe` table.
+    /// Materializes describing CPE associations into the `sbom_describing_cpe`
+    /// table from the relationship and CPE-ref data already inserted for this
+    /// SBOM. Two kinds of CPE qualify as product/OS *context* for the SBOM:
+    ///
+    /// 1. CPEs on nodes participating in a `Describes` relationship
+    ///    (`relationship = 13`) — the SBOM's declared product node, any part.
+    /// 2. Operating-system CPEs (`part = 'o'`) on *any* node. Real RHEL image
+    ///    SBOMs attach the platform CPE (e.g. `cpe:/o:redhat:enterprise_linux:8`)
+    ///    to a child/OS component rather than the `Describes` node. Without this,
+    ///    `sbom_describing_cpe` stays empty for those SBOMs and the CPE-context
+    ///    filter is disabled via its escape hatch, leaking wrong-product /
+    ///    wrong-scheme matches (TC-5170 / TC-5171).
+    ///
+    /// Component-identity CPEs (`part = 'a'`, used by `cpe_status` matching — e.g.
+    /// TC-5630) are deliberately NOT treated as describing context unless they sit
+    /// on a `Describes` node, so package identities are never mistaken for product
+    /// context.
     pub async fn populate_describing_cpes<C: ConnectionTrait>(&self, db: &C) -> Result<(), Error> {
         db.execute(Statement::from_sql_and_values(
             DbBackend::Postgres,
@@ -594,11 +609,13 @@ impl SbomContext {
             INSERT INTO sbom_describing_cpe (sbom_id, cpe_id)
             SELECT DISTINCT spcr.sbom_id, spcr.cpe_id
             FROM sbom_node_cpe_ref spcr
-            JOIN package_relates_to_package prtp
+            JOIN cpe ON cpe.id = spcr.cpe_id
+            LEFT JOIN package_relates_to_package prtp
               ON prtp.sbom_id = spcr.sbom_id
              AND (prtp.right_node_id = spcr.node_id OR prtp.left_node_id = spcr.node_id)
-            WHERE prtp.sbom_id = $1
-              AND prtp.relationship = 13
+             AND prtp.relationship = 13
+            WHERE spcr.sbom_id = $1
+              AND (prtp.sbom_id IS NOT NULL OR cpe.part = 'o')
             ON CONFLICT DO NOTHING
             "#,
             [self.sbom.sbom_id.into()],


### PR DESCRIPTION
## Summary

The vulnerability-correlation **CPE-context filter** suppresses wrong-product ([TC-5171](https://redhat.atlassian.net/browse/TC-5171)) and wrong-scheme ([TC-5170](https://redhat.atlassian.net/browse/TC-5170)) advisory matches by comparing an advisory's context CPE against the SBOM's *describing* CPEs (materialized in `sbom_describing_cpe`). It works today only when the product/OS CPE sits on the SBOM's `Describes` (root) node.

Real Red Hat RHEL image SBOMs (CycloneDX/SPDX) attach the product/OS CPE — e.g. `cpe:/o:redhat:enterprise_linux:8` — to a **child/OS component**, not the `Describes` node. `populate_describing_cpes` only captured CPEs on `Describes`-relationship (`relationship = 13`) nodes, so for those SBOMs `sbom_describing_cpe` was empty, the filter fell through its escape hatch (`OR sbom_id NOT IN sbom_has_cpes`), and cross-product / wrong-scheme matches leaked on `/sbom/{id}/advisory`, the SBOM list, and `/purl`. This is the **SBOM-scale root cause behind [TC-5170](https://redhat.atlassian.net/browse/TC-5170) / [TC-5171](https://redhat.atlassian.net/browse/TC-5171)**.

## Change

Broaden describing-CPE detection in **both** population sites so a product/OS CPE on a child node is materialized:

- **Ingest-time** `populate_describing_cpes` (`modules/ingestor/src/graph/sbom/mod.rs`): operating-system CPEs (`part = 'o'`) on **any** node now count as product/OS context, in addition to `Describes`-node CPEs of any part (a `LEFT JOIN` preserves the existing `relationship = 13` behaviour exactly).
- **Re-backfill migration** `m0002310_sbom_describing_cpe_child_nodes` for already-ingested SBOMs — additive, idempotent (`INSERT … ON CONFLICT DO NOTHING`), with a precise `down()` that removes only the OS-CPE rows not justified by a `Describes` relationship.

Component-identity CPEs (`part = 'a'`, used by `cpe_status` matching — [TC-5630](https://redhat.atlassian.net/browse/TC-5630) / S7 hummingbird) are **deliberately excluded**, so package identities are never mistaken for product context. The consumers (`CONTEXT_CPE_FILTER_SQL`, `product_advisory_info_sql`, `batch_severity_counts_sql`, `cpe_context_subqueries`) are unchanged — the fix is purely upstream population. The codebase already treats `part = 'a'` as the component-identity space (`cpe_advisory_info_sql` / `cpe_version_matches` gate on `part = 'a'`), so `part = 'o'` for describing context is consistent by construction.

## Tests

New integration test `sbom_details_describing_cpe_on_child_node` (`modules/fundamental/tests/sbom/details.rs`) with synthetic fixtures under `etc/test-data/cyclonedx/TC-5749/`:

- **child-cpe** SBOM (OS CPE on a child node) — the wrong-product advisory is now filtered, **identically to the root-cpe control**.
- **root-cpe** SBOM — parity control (already filtered).
- **no-cpe** SBOM — the escape hatch still applies (no product CPE ⇒ the match still surfaces), proving the fix is scoped and introduces no new false negatives for genuinely context-less SBOMs.

Migration `refresh()` (down+up) passes; the [TC-5630](https://redhat.atlassian.net/browse/TC-5630) purl-less regression control (`sbom_details_purlless_cpe_node_consistency`) still passes; `cargo xtask precommit` is clean (clippy `-D warnings`, fmt, check; no OpenAPI/schema drift).

## Scenario validation ([TC-5639](https://redhat.atlassian.net/browse/TC-5639) suite)

Against a build with this change, the child-node-CPE SBOMs now behave like their root-CPE counterparts on `/sbom/{id}/advisory` and `/purl`: **S10 child-cpe** flips to the golden `not_affected` for CVE-2024-6602, and the wrong-product (S3/S4) and cross-**major** (S1 el8→el9/el10) leaks are dropped.

## Known coupling — [TC-5732](https://redhat.atlassian.net/browse/TC-5732) (bare `known_affected`)

Engaging the CPE-context filter for these SBOMs surfaces a **documented, pre-existing** coupling with **[TC-5732](https://redhat.atlassian.net/browse/TC-5732)** (bare / version-less `known_affected` entries are unmatchable). Two scenario rows go false-negative because the genuine el8 match is a *bare* `known_affected` and was previously only "caught" by the very wrong-product/by-name leak this PR removes:

- **S3 / CVE-2025-13034** — el8 curl is genuinely affected but stated version-less; its only prior match was the spurious `hummingbird` row.
- **S11 / firefox `main_el8` / CVE-2023-6135** — el8 affected bare; only sub-stream `fixed` rows are versioned.

Per the scenario READMEs: *"the describing-CPE filter and the bare-entry bug are coupled — the same filter that rescues thunderbird (S10) breaks firefox — to get main-8 right you must also make bare `known_affected` entries matchable."* **[TC-5732](https://redhat.atlassian.net/browse/TC-5732) should land together with (or immediately after) this PR** to close that window.

## Follow-up (out of scope here)

The `/vulnerability/{cve}` backlink endpoint does not apply the CPE-context filter, so it over-reports relative to the now-correct `/sbom/advisory` and `/purl` paths — a separate 4th-endpoint-consistency follow-up.

Implements [TC-5749](https://redhat.atlassian.net/browse/TC-5749)
Root-cause bug: [TC-5750](https://redhat.atlassian.net/browse/TC-5750) · Symptoms: [TC-5170](https://redhat.atlassian.net/browse/TC-5170) / [TC-5171](https://redhat.atlassian.net/browse/TC-5171)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TC-5749]: https://redhat.atlassian.net/browse/TC-5749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure product-context filtering applies consistently when SBOM operating-system CPEs are attached to child nodes.

Bug Fixes:
- Materialize operating-system CPEs attached to child SBOM nodes so the CPE-context filter correctly suppresses wrong-product and wrong-scheme advisory matches.

Tests:
- Add integration coverage for child-node, root-node, and CPE-less SBOM scenarios to verify filtering behavior and preserve the context-less escape hatch.

Chores:
- Add an idempotent migration to backfill child-node OS CPE associations for existing SBOMs, with a targeted rollback.


[TC-5171]: https://redhat.atlassian.net/browse/TC-5171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-5170]: https://redhat.atlassian.net/browse/TC-5170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-5170]: https://redhat.atlassian.net/browse/TC-5170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ