### PR TITLE
fix(sbom): version-filter product_status on the advisory and severity paths (TC-5641)

### DIFF
--- a/etc/test-data/cyclonedx/TC-5751/advisory-product-status.json
+++ b/etc/test-data/cyclonedx/TC-5751/advisory-product-status.json
@@ -1,0 +1,91 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "text": "Important"
+    },
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "tlp": {
+        "label": "WHITE"
+      }
+    },
+    "lang": "en",
+    "publisher": {
+      "category": "vendor",
+      "name": "Example",
+      "namespace": "https://example.com"
+    },
+    "title": "TC-5751 product_status version-filtering reproducer",
+    "tracking": {
+      "current_release_date": "2025-01-15T00:00:00Z",
+      "id": "TC-5751-PRODSTATUS",
+      "initial_release_date": "2025-01-15T00:00:00Z",
+      "revision_history": [
+        {
+          "date": "2025-01-15T00:00:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Example",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "Example Product 8",
+            "product": {
+              "name": "Example Product 8",
+              "product_id": "example_product_8",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:example:product:8"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "widget",
+            "product": {
+              "name": "widget",
+              "product_id": "widget"
+            }
+          }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "widget as a component of Example Product 8",
+          "product_id": "example_product_8:widget"
+        },
+        "product_reference": "widget",
+        "relates_to_product_reference": "example_product_8"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2098-0001",
+      "notes": [
+        {
+          "category": "description",
+          "text": "Synthetic product_status version-filtering test: widget is affected only within the Example Product 8 version range."
+        }
+      ],
+      "product_status": {
+        "known_affected": [
+          "example_product_8:widget"
+        ]
+      }
+    }
+  ]
+}

--- a/etc/test-data/cyclonedx/TC-5751/sbom_inrange.json
+++ b/etc/test-data/cyclonedx/TC-5751/sbom_inrange.json
@@ -1,0 +1,30 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:tc5751-inrange-0000-000000000002",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-01-01T00:00:00Z",
+    "component": {
+      "type": "application",
+      "name": "inrange-app",
+      "bom-ref": "root",
+      "version": "1.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "widget",
+      "bom-ref": "pkg-widget",
+      "version": "8.1.0-1.el8",
+      "purl": "pkg:rpm/redhat/widget@8.1.0-1.el8?arch=x86_64"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root",
+      "dependsOn": ["pkg-widget"]
+    }
+  ]
+}

--- a/etc/test-data/cyclonedx/TC-5751/sbom_pastfix.json
+++ b/etc/test-data/cyclonedx/TC-5751/sbom_pastfix.json
@@ -1,0 +1,30 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:tc5751-pastfix-0000-000000000001",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-01-01T00:00:00Z",
+    "component": {
+      "type": "application",
+      "name": "pastfix-app",
+      "bom-ref": "root",
+      "version": "1.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "widget",
+      "bom-ref": "pkg-widget",
+      "version": "1.2.3-1.el8",
+      "purl": "pkg:rpm/redhat/widget@1.2.3-1.el8?arch=x86_64"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root",
+      "dependsOn": ["pkg-widget"]
+    }
+  ]
+}

--- a/modules/fundamental/src/sbom/model/raw_sql.rs
+++ b/modules/fundamental/src/sbom/model/raw_sql.rs
@@ -126,7 +126,11 @@ pub fn batch_severity_counts_sql() -> &'static str {
         )
     ),
 
-    -- CPE product_status matches by name
+    -- CPE product_status matches by name. Version-filtered via
+    -- product_version_range → version_range, mirroring purl_version_matches
+    -- and product_advisory_info_sql() so the severity summary agrees with the
+    -- /sbom/{id}/advisory detail (product_version_range_id is NOT NULL, so the
+    -- inner join drops nothing that would otherwise match).
     cpe_matches_name AS (
         SELECT DISTINCT
             sp.sbom_id,
@@ -136,8 +140,11 @@ pub fn batch_severity_counts_sql() -> &'static str {
         JOIN sbom_purl_info sp ON ps.package = sp.name
         JOIN status ON ps.status_id = status.id
         JOIN advisory ON ps.advisory_id = advisory.id
+        JOIN product_version_range pvr ON pvr.id = ps.product_version_range_id
+        JOIN version_range vr ON vr.id = pvr.version_range_id
         WHERE status.slug = 'affected'
           AND advisory.deprecated = false
+          AND version_matches(sp.version, vr.*)
           AND (
               ps.context_cpe_id IS NULL
               OR ps.context_cpe_id IN (SELECT cpe_id FROM sbom_allowed_cpes sac WHERE sac.sbom_id = sp.sbom_id)
@@ -155,9 +162,12 @@ pub fn batch_severity_counts_sql() -> &'static str {
         JOIN sbom_purl_info sp ON ps.package = CONCAT(sp.namespace, '/', sp.name)
         JOIN status ON ps.status_id = status.id
         JOIN advisory ON ps.advisory_id = advisory.id
+        JOIN product_version_range pvr ON pvr.id = ps.product_version_range_id
+        JOIN version_range vr ON vr.id = pvr.version_range_id
         WHERE sp.namespace IS NOT NULL
           AND status.slug = 'affected'
           AND advisory.deprecated = false
+          AND version_matches(sp.version, vr.*)
           AND (
               ps.context_cpe_id IS NULL
               OR ps.context_cpe_id IN (SELECT cpe_id FROM sbom_allowed_cpes sac WHERE sac.sbom_id = sp.sbom_id)
@@ -362,6 +372,7 @@ pub fn product_advisory_info_sql() -> String {
                 qp.id as qualified_purl_id,
                 bp.name,
                 bp.namespace,
+                vp.version,
                 spr.sbom_id,
                 spr.node_id
             FROM sbom_node_purl_ref spr
@@ -385,7 +396,16 @@ pub fn product_advisory_info_sql() -> String {
                 sp.node_id
             FROM product_status ps
             JOIN sbom_purls sp ON ps.package = sp.name
-            WHERE (ps.context_cpe_id IS NULL
+            -- Filter by installed version, mirroring the purl_status/cpe_status
+            -- paths and the /purl + /analyze endpoints: a product_status whose
+            -- version range does not include the installed version is not
+            -- affected. product_status.product_version_range_id is NOT NULL, so
+            -- an inner join drops nothing (bare known_affected with no version
+            -- never creates a product_status row -- see csaf/creator.rs).
+            JOIN product_version_range pvr ON pvr.id = ps.product_version_range_id
+            JOIN version_range vr ON vr.id = pvr.version_range_id
+            WHERE version_matches(sp.version, vr.*)
+              AND (ps.context_cpe_id IS NULL
                    OR ps.context_cpe_id IN (SELECT id FROM allowed_cpe_ids)
                    OR NOT EXISTS (SELECT 1 FROM filtered_cpes LIMIT 1))
         ),
@@ -403,7 +423,10 @@ pub fn product_advisory_info_sql() -> String {
                 sp.node_id
             FROM product_status ps
             JOIN sbom_purls sp ON ps.package = CONCAT(sp.namespace, '/', sp.name)
+            JOIN product_version_range pvr ON pvr.id = ps.product_version_range_id
+            JOIN version_range vr ON vr.id = pvr.version_range_id
             WHERE sp.namespace IS NOT NULL
+              AND version_matches(sp.version, vr.*)
               AND (ps.context_cpe_id IS NULL
                    OR ps.context_cpe_id IN (SELECT id FROM allowed_cpe_ids)
                    OR NOT EXISTS (SELECT 1 FROM filtered_cpes LIMIT 1))

--- a/modules/fundamental/tests/sbom/details.rs
+++ b/modules/fundamental/tests/sbom/details.rs
@@ -835,6 +835,122 @@ async fn sbom_details_purlless_cpe_node_consistency(
     Ok(())
 }
 
+/// Reproducer for TC-5641: the SBOM `/advisory` detail and severity-summary
+/// paths must apply `version_matches` to Red Hat `product_status` matches, as
+/// the `/purl` and `/analyze` endpoints already do. A product whose installed
+/// version falls outside the advisory's version range must not be reported.
+///
+/// `CVE-2098-0001` marks package `widget` affected under `cpe:/a:example:product:8`
+/// (version range major 8 → `[8, 9)`). Two SBOMs, each with **no** describing CPE
+/// (so the CPE-context escape hatch is on and the installed version is the only
+/// discriminator):
+/// - `sbom_pastfix` — `widget 1.2.3-1.el8` (outside `[8, 9)`) → must NOT be
+///   reported (fails before the fix — no `version_matches` — passes after).
+/// - `sbom_inrange` — `widget 8.1.0-1.el8` (inside `[8, 9)`) → must still be
+///   reported (true positive preserved).
+///
+/// Also asserts detail count == severity-summary count for both SBOMs (the
+/// TC-5630 detail==list invariant).
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+#[instrument]
+async fn sbom_details_product_status_version_filtering(
+    ctx: &TrustifyContext,
+) -> Result<(), anyhow::Error> {
+    let sbom = SbomService::new(PaginationCache::for_test());
+
+    const BASE: &str = "cyclonedx/TC-5751";
+
+    // Given a product_status advisory (widget affected under product:8) plus a
+    // past-fix SBOM and an in-range SBOM, neither carrying a describing CPE.
+    ctx.ingest_document(format!("{BASE}/advisory-product-status.json"))
+        .await?;
+    let pastfix = ctx
+        .ingest_document(format!("{BASE}/sbom_pastfix.json"))
+        .await?;
+    let inrange = ctx
+        .ingest_document(format!("{BASE}/sbom_inrange.json"))
+        .await?;
+
+    let pastfix_id = Id::parse_uuid(pastfix.id)?;
+    let inrange_id = Id::parse_uuid(inrange.id)?;
+    let Id::Uuid(pastfix_uuid) = pastfix_id else {
+        panic!("expected a UUID sbom id");
+    };
+    let Id::Uuid(inrange_uuid) = inrange_id else {
+        panic!("expected a UUID sbom id");
+    };
+
+    // Counts every `affected` status entry for a CVE across all advisories.
+    let affected = |details: &SbomDetails, cve: &str| -> usize {
+        details
+            .advisories
+            .iter()
+            .flat_map(|a| a.status.iter())
+            .filter(|s| s.vulnerability.identifier == cve && s.status == "affected")
+            .count()
+    };
+
+    // When fetching the SBOM detail for each.
+    let pastfix_details = sbom
+        .fetch_sbom_details(pastfix_id, vec![], &ctx.db)
+        .await?
+        .expect("past-fix SBOM details must be found");
+    let inrange_details = sbom
+        .fetch_sbom_details(inrange_id, vec![], &ctx.db)
+        .await?
+        .expect("in-range SBOM details must be found");
+
+    // Then: the past-fix widget (1.2.3, outside [8, 9)) is filtered out...
+    assert_eq!(
+        affected(&pastfix_details, "CVE-2098-0001"),
+        0,
+        "past-fix widget 1.2.3-1.el8 must not be reported affected \
+         (outside the product_status [8, 9) range)"
+    );
+    // ...while the in-range widget (8.1.0, inside [8, 9)) is still reported.
+    assert!(
+        affected(&inrange_details, "CVE-2098-0001") >= 1,
+        "in-range widget 8.1.0-1.el8 must still be reported affected"
+    );
+
+    // And the severity summary (batch counts) must agree with the detail count
+    // for both SBOMs -- the detail==list invariant (TC-5630).
+    let counts = sbom
+        .batch_advisory_severity_counts(&[pastfix_uuid, inrange_uuid], &ctx.db)
+        .await?;
+    let pastfix_list: u64 = counts
+        .get(&pastfix_uuid)
+        .map(|c| c.values().sum())
+        .unwrap_or_default();
+    let inrange_list: u64 = counts
+        .get(&inrange_uuid)
+        .map(|c| c.values().sum())
+        .unwrap_or_default();
+    let detail_affected = |details: &SbomDetails| -> u64 {
+        details
+            .advisories
+            .iter()
+            .filter(|a| a.status.iter().any(|s| s.status == "affected"))
+            .count() as u64
+    };
+
+    assert_eq!(
+        pastfix_list,
+        detail_affected(&pastfix_details),
+        "past-fix: severity summary must equal the details affected count"
+    );
+    assert_eq!(
+        inrange_list,
+        detail_affected(&inrange_details),
+        "in-range: severity summary must equal the details affected count"
+    );
+    assert_eq!(pastfix_list, 0, "past-fix widget must not be counted");
+    assert!(inrange_list >= 1, "in-range widget must be counted");
+
+    Ok(())
+}
+
 /// Constructs a `ScoredVector` from its parts, deriving the severity from the type and value.
 fn sv(r#type: ScoreType, value: f64, vector: impl Into<String>) -> ScoredVector {
     ScoredVector {


### PR DESCRIPTION
## What this fixes

`GET /sbom/{id}/advisory` and the severity summary matched Red Hat `product_status` rows by package **name** only — reporting RPMs already **past the fix** as affected. `purl_status`/`cpe_status` and the `/purl` + `/analyze` endpoints already version-match; these two SBOM paths were missed.

## Change

In `modules/fundamental/src/sbom/model/raw_sql.rs`, add `version_matches` to the `product_status` CTEs in `product_advisory_info_sql` and `batch_severity_counts_sql` — joining `product_status → product_version_range → version_range`, mirroring the sibling `purl_version_matches` CTE (and adding `vp.version` to `sbom_purls`). `product_version_range_id` is NOT NULL and bare `known_affected` creates no `product_status` row, so the inner join drops nothing that would otherwise match.

## Tests

New `sbom_details_product_status_version_filtering` (`tests/sbom/details.rs`, fixtures in `etc/test-data/cyclonedx/TC-5751/`): a past-fix RPM is filtered, an in-range RPM is kept, and detail count == severity-summary count. `sbom::details` suite green; `cargo xtask precommit` clean.

Implements [TC-5641](https://redhat.atlassian.net/browse/TC-5641)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TC-5641]: https://redhat.atlassian.net/browse/TC-5641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Apply version-range filtering to product-status matches in SBOM advisory details and severity summaries.

Bug Fixes:
- Filter Red Hat product-status advisory matches by the installed package version so past-fix packages are no longer reported as affected.
- Keep SBOM advisory details and severity summaries consistent when applying product-status version filtering.

Tests:
- Add coverage for past-fix and in-range product versions, including consistency checks between advisory details and severity summaries.