### PR TITLE
fix(purl): add edition predicate to generalized CPE context filter

### DIFF
--- a/etc/test-data/csaf/issues/cpe_edition/advisory-edition-el8.json
+++ b/etc/test-data/csaf/issues/cpe_edition/advisory-edition-el8.json
@@ -1,0 +1,92 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": { "tlp": { "label": "WHITE" } },
+    "publisher": {
+      "category": "vendor",
+      "name": "Test Vendor",
+      "namespace": "https://test.example.com"
+    },
+    "title": "TEST-EDITION-EL8",
+    "tracking": {
+      "current_release_date": "2024-01-01T00:00:00Z",
+      "id": "TEST-EDITION-EL8",
+      "initial_release_date": "2024-01-01T00:00:00Z",
+      "revision_history": [
+        {
+          "date": "2024-01-01T00:00:00Z",
+          "number": "1",
+          "summary": "Initial"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Test Vendor",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "Test Product",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "WidgetOS 9 el8",
+                "product": {
+                  "name": "WidgetOS 9 el8",
+                  "product_id": "widgetos-9-el8",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:acme:widgetos:9::el8"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "category": "architecture",
+            "name": "noarch",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "libwidget-1.0",
+                "product": {
+                  "name": "libwidget-1.0",
+                  "product_id": "libwidget-1.0",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/acme/libwidget@1.0"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libwidget-1.0 as a component of WidgetOS 9 el8",
+          "product_id": "widgetos-9-el8:libwidget-1.0"
+        },
+        "product_reference": "libwidget-1.0",
+        "relates_to_product_reference": "widgetos-9-el8"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-99999",
+      "product_status": {
+        "known_affected": [
+          "widgetos-9-el8:libwidget-1.0"
+        ]
+      }
+    }
+  ]
+}

--- a/etc/test-data/csaf/issues/cpe_edition/advisory-edition-null.json
+++ b/etc/test-data/csaf/issues/cpe_edition/advisory-edition-null.json
@@ -1,0 +1,92 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": { "tlp": { "label": "WHITE" } },
+    "publisher": {
+      "category": "vendor",
+      "name": "Test Vendor",
+      "namespace": "https://test.example.com"
+    },
+    "title": "TEST-EDITION-NULL",
+    "tracking": {
+      "current_release_date": "2024-01-01T00:00:00Z",
+      "id": "TEST-EDITION-NULL",
+      "initial_release_date": "2024-01-01T00:00:00Z",
+      "revision_history": [
+        {
+          "date": "2024-01-01T00:00:00Z",
+          "number": "1",
+          "summary": "Initial"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Test Vendor",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "Test Product",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "WidgetOS 9",
+                "product": {
+                  "name": "WidgetOS 9",
+                  "product_id": "widgetos-9",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:acme:widgetos:9"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "category": "architecture",
+            "name": "noarch",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "libwidget-1.0",
+                "product": {
+                  "name": "libwidget-1.0",
+                  "product_id": "libwidget-1.0",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/acme/libwidget@1.0"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libwidget-1.0 as a component of WidgetOS 9",
+          "product_id": "widgetos-9:libwidget-1.0"
+        },
+        "product_reference": "libwidget-1.0",
+        "relates_to_product_reference": "widgetos-9"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-99999",
+      "product_status": {
+        "known_affected": [
+          "widgetos-9:libwidget-1.0"
+        ]
+      }
+    }
+  ]
+}

--- a/etc/test-data/cyclonedx/issues/cpe_edition/sbom.json
+++ b/etc/test-data/cyclonedx/issues/cpe_edition/sbom.json
@@ -1,0 +1,29 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "timestamp": "1970-01-01T00:00:00Z",
+    "component": {
+      "name": "widgetos",
+      "type": "application",
+      "cpe": "cpe:/a:acme:widgetos:9.2",
+      "bom-ref": "root"
+    }
+  },
+  "components": [
+    {
+      "name": "libwidget",
+      "version": "1.0",
+      "bom-ref": "libwidget",
+      "purl": "pkg:rpm/acme/libwidget@1.0",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root",
+      "dependsOn": ["libwidget"]
+    }
+  ]
+}

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -221,6 +221,11 @@ fn cpe_context_subqueries(
             Expr::col((sdc.clone(), sbom_describing_cpe::Column::SbomId))
                 .in_subquery(sbom_ids.clone()),
         )
+        .cond_where(
+            Condition::any()
+                .add(Expr::col((c.clone(), cpe::Column::Edition)).is_null())
+                .add(Expr::col((c.clone(), cpe::Column::Edition)).eq("*")),
+        )
         .to_owned();
 
     let mut allowed_cpe_ids = sbom_describing_cpe::Entity::find()

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -1,4 +1,5 @@
 use crate::purl::{model::details::purl::StatusContext, service::PurlService};
+use rstest::rstest;
 use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
@@ -1204,6 +1205,54 @@ async fn product_status_cross_domain_version(ctx: &TrustifyContext) -> Result<()
             "CVE-2023-44487",
             "CVE-2023-4853",
         ]
+    );
+
+    Ok(())
+}
+
+/// Test that CPE context filtering on purl_statuses correctly handles
+/// the `edition` field when using generalized (major-version) matching.
+///
+/// Setup (all via document ingestion):
+/// - A CycloneDX SBOM with describing CPE `cpe:/a:acme:widgetos:9.2`
+///   (version 9.2, no edition) containing `pkg:rpm/acme/libwidget@1.0`
+/// - A CSAF advisory creating a purl_status for the same base purl,
+///   with a context CPE that varies in `edition` per test case
+///
+/// The generalized CPE match expands version 9.2 to major "9", but should
+/// only admit CPEs whose edition is NULL or `*`.  A CPE with a specific
+/// edition (e.g. "el8") must NOT pass the filter.
+#[test_context(TrustifyContext)]
+#[rstest]
+#[case::edition_null("csaf/issues/cpe_edition/advisory-edition-null.json", true)]
+#[case::edition_specific("csaf/issues/cpe_edition/advisory-edition-el8.json", false)]
+#[test_log::test(actix_web::test)]
+async fn cpe_context_edition_filtering(
+    ctx: &TrustifyContext,
+    #[case] advisory_path: &str,
+    #[case] expect_status_visible: bool,
+) -> Result<(), anyhow::Error> {
+    let service = PurlService::new(PaginationCache::for_test());
+
+    ctx.ingest_document("cyclonedx/issues/cpe_edition/sbom.json")
+        .await?;
+    ctx.ingest_document(advisory_path).await?;
+
+    let purl: Purl = "pkg:rpm/acme/libwidget@1.0".try_into()?;
+    let details = service
+        .purl_by_purl(&purl, Default::default(), &ctx.db)
+        .await?
+        .expect("purl should exist");
+
+    let has_status = details
+        .advisories
+        .iter()
+        .flat_map(|a| &a.status)
+        .any(|s| s.vulnerability.identifier == "CVE-2024-99999");
+
+    assert_eq!(
+        has_status, expect_status_visible,
+        "advisory {advisory_path}: expected status visible={expect_status_visible}, got {has_status}"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

Cherry-pick of commit `daefab787c` from PR #2597 (`release/0.4.z` backport) to `main`.

- Adds an edition predicate (`edition IS NULL OR edition = '*'`) to the generalized CPE context filter in `cpe_context_subqueries`, preventing CPEs with specific editions (e.g. `el8`) from incorrectly matching via major-version generalization
- Adds regression tests (`cpe_context_edition_filtering`) with parameterized CSAF advisory fixtures for null and specific edition cases

Original PR: #2597

## Test plan

- [x] `cargo check --all-targets --all-features` passes
- [ ] `cpe_context_edition_filtering` tests pass against a live database

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct generalized CPE context filtering so edition-specific CPEs do not incorrectly match major-version generalized contexts.

Bug Fixes:
- Prevent generalized CPE context matching from admitting CPEs with specific editions by restricting matches to null or wildcard editions.

Tests:
- Add parameterized regression coverage verifying advisory visibility for null, wildcard-compatible, and specific CPE editions using ingested CSAF and CycloneDX fixtures.