### PR TITLE
fix(db): match a fully-unbounded version range against all versions (TC-5732)

### DIFF
--- a/etc/test-data/cyclonedx/TC-5752/advisory-firefox.json
+++ b/etc/test-data/cyclonedx/TC-5752/advisory-firefox.json
@@ -1,0 +1,106 @@
+{
+  "document": {
+    "aggregate_severity": { "text": "Important" },
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": { "tlp": { "label": "WHITE" } },
+    "lang": "en",
+    "publisher": {
+      "category": "vendor",
+      "name": "Red Hat",
+      "namespace": "https://www.redhat.com"
+    },
+    "title": "TC-5752 version-less known_affected reproducer (firefox)",
+    "tracking": {
+      "current_release_date": "2025-01-15T00:00:00Z",
+      "id": "TC-5752-FIREFOX",
+      "initial_release_date": "2025-01-15T00:00:00Z",
+      "revision_history": [
+        { "date": "2025-01-15T00:00:00Z", "number": "1", "summary": "Initial version" }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Red Hat",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8",
+              "product_id": "rhel_8",
+              "product_identification_helper": { "cpe": "cpe:/o:redhat:enterprise_linux:8" }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.8 Extended Update Support",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.8 EUS",
+              "product_id": "rhel_eus_8.8",
+              "product_identification_helper": { "cpe": "cpe:/a:redhat:rhel_eus:8.8::appstream" }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox",
+              "product_identification_helper": { "purl": "pkg:rpm/redhat/firefox" }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox-0:128.2.0-1.el8_8",
+            "product": {
+              "name": "firefox-0:128.2.0-1.el8_8",
+              "product_id": "firefox_eus",
+              "product_identification_helper": { "purl": "pkg:rpm/redhat/firefox@128.2.0-1.el8_8" }
+            }
+          }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 8",
+          "product_id": "rhel_8:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 8.8 EUS",
+          "product_id": "rhel_eus_8.8:firefox_eus"
+        },
+        "product_reference": "firefox_eus",
+        "relates_to_product_reference": "rhel_eus_8.8"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2098-5732",
+      "notes": [
+        {
+          "category": "description",
+          "text": "Synthetic advisory: main enterprise_linux:8 firefox is known_affected without a version; only the 8.8 EUS sub-stream is fixed."
+        }
+      ],
+      "product_status": {
+        "known_affected": ["rhel_8:firefox"],
+        "fixed": ["rhel_eus_8.8:firefox_eus"]
+      }
+    }
+  ]
+}

--- a/etc/test-data/cyclonedx/TC-5752/sbom_firefox_eus88_patched.json
+++ b/etc/test-data/cyclonedx/TC-5752/sbom_firefox_eus88_patched.json
@@ -1,0 +1,28 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:tc5752-firefox-eus-0000-000000002",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-01-01T00:00:00Z",
+    "component": {
+      "type": "operating-system",
+      "name": "rhel-eus",
+      "bom-ref": "root-os",
+      "version": "8.8",
+      "cpe": "cpe:/a:redhat:rhel_eus:8.8::appstream"
+    }
+  },
+  "components": [
+    {
+      "type": "application",
+      "name": "firefox",
+      "bom-ref": "pkg-firefox",
+      "version": "128.2.0-1.el8_8",
+      "purl": "pkg:rpm/redhat/firefox@128.2.0-1.el8_8?arch=x86_64"
+    }
+  ],
+  "dependencies": [
+    { "ref": "root-os", "dependsOn": ["pkg-firefox"] }
+  ]
+}

--- a/etc/test-data/cyclonedx/TC-5752/sbom_firefox_main_el8.json
+++ b/etc/test-data/cyclonedx/TC-5752/sbom_firefox_main_el8.json
@@ -1,0 +1,28 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:tc5752-firefox-main-0000-00000001",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-01-01T00:00:00Z",
+    "component": {
+      "type": "operating-system",
+      "name": "rhel",
+      "bom-ref": "root-os",
+      "version": "8",
+      "cpe": "cpe:/o:redhat:enterprise_linux:8"
+    }
+  },
+  "components": [
+    {
+      "type": "application",
+      "name": "firefox",
+      "bom-ref": "pkg-firefox",
+      "version": "115.15.0-1.el8",
+      "purl": "pkg:rpm/redhat/firefox@115.15.0-1.el8?arch=x86_64"
+    }
+  ],
+  "dependencies": [
+    { "ref": "root-os", "dependsOn": ["pkg-firefox"] }
+  ]
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -72,6 +72,7 @@ mod m0002270_fix_vulnerability_base_score_type;
 mod m0002280_backfill_sbom_suppliers;
 mod m0002290_create_exploit_intelligence_job;
 mod m0002300_create_exploit;
+mod m0002310_version_matches_unbounded;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -159,6 +160,7 @@ impl MigratorExt for Migrator {
             .data(m0002280_backfill_sbom_suppliers::Migration)
             .normal(m0002290_create_exploit_intelligence_job::Migration)
             .normal(m0002300_create_exploit::Migration)
+            .normal(m0002310_version_matches_unbounded::Migration)
     }
 }
 

--- a/migration/src/m0002310_version_matches_unbounded.rs
+++ b/migration/src/m0002310_version_matches_unbounded.rs
@@ -1,0 +1,133 @@
+use sea_orm_migration::prelude::*;
+
+/// A fully-unbounded version range (no low **and** no high bound) means "all
+/// versions are affected" — e.g. a CSAF `known_affected` stated without a
+/// version, a product CPE with version `*`, or an NVD affected CPE with no
+/// version constraints. The per-scheme matchers historically returned `false`
+/// for such a range, so those rows were silently dropped everywhere
+/// `version_matches` runs (`/sbom/{id}/advisory`, `/purl`, `/analyze`),
+/// producing false negatives (TC-5732 / scenario S11).
+///
+/// Fix: short-circuit at the top of the `version_matches` **dispatch** function
+/// so a both-NULL range matches every version, uniformly across all schemes,
+/// without touching the individual matcher bodies. Only the three-line guard is
+/// new; the `CASE` below is the current dispatch body verbatim.
+///
+/// Backport note: the guard is branch-independent. When backporting to
+/// release/0.4.z / 0.5.z / 0.6.z, keep the guard and use that branch's own
+/// dispatch `CASE` (its set of supported schemes may differ).
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const UP: &str = r#"
+CREATE OR REPLACE FUNCTION public.version_matches(version_p text, range_p public.version_range) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE
+    AS $$
+declare
+begin
+    -- A fully-unbounded range (neither a low nor a high bound) means
+    -- "all versions affected"; match every version regardless of scheme.
+    if range_p.low_version is null and range_p.high_version is null then
+        return true;
+    end if;
+
+    -- for an authoritative list of support schemes, see the enum
+    -- `trustify_entity::version_scheme::VersionScheme`
+    return case
+        when range_p.version_scheme_id = 'git'
+            then gitver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'semver'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'gem'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'npm'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'golang'
+            then golang_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'nuget'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'generic'
+            then generic_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'rpm'
+            then rpmver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'maven'
+            then maven_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'python'
+            then python_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'packagist'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'hex'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'swift'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'pub'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'cargo'
+            then semver_version_matches(version_p, range_p)
+        else
+            false
+    end;
+end
+$$;
+"#;
+
+/// Restores the pre-fix dispatch (a fully-unbounded range yields whatever the
+/// per-scheme matcher returns — historically `false`).
+const DOWN: &str = r#"
+CREATE OR REPLACE FUNCTION public.version_matches(version_p text, range_p public.version_range) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE
+    AS $$
+declare
+begin
+    -- for an authoritative list of support schemes, see the enum
+    -- `trustify_entity::version_scheme::VersionScheme`
+    return case
+        when range_p.version_scheme_id = 'git'
+            then gitver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'semver'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'gem'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'npm'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'golang'
+            then golang_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'nuget'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'generic'
+            then generic_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'rpm'
+            then rpmver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'maven'
+            then maven_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'python'
+            then python_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'packagist'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'hex'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'swift'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'pub'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'cargo'
+            then semver_version_matches(version_p, range_p)
+        else
+            false
+    end;
+end
+$$;
+"#;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager.get_connection().execute_unprepared(UP).await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager.get_connection().execute_unprepared(DOWN).await?;
+        Ok(())
+    }
+}

--- a/modules/fundamental/tests/sbom/details.rs
+++ b/modules/fundamental/tests/sbom/details.rs
@@ -835,6 +835,92 @@ async fn sbom_details_purlless_cpe_node_consistency(
     Ok(())
 }
 
+/// Reproducer for TC-5732: a version-less Red Hat CSAF `known_affected` on the
+/// main stream must surface as `affected`. Such an entry is ingested as a
+/// `purl_status` with a fully-unbounded version range (all versions affected);
+/// before the fix, `version_matches` returned false for a both-NULL range, so
+/// the row was dropped everywhere and the genuinely-affected main-stream package
+/// went false-negative once the describing-CPE filter engaged.
+///
+/// `CVE-2098-5732`: main `enterprise_linux:8` firefox is `known_affected`
+/// (version-less); only the 8.8 EUS sub-stream is `fixed` at `128.2.0-1.el8_8`.
+/// - `firefox_main_el8` (describing CPE `enterprise_linux:8`, firefox
+///   `115.15.0-1.el8`) → **affected** under the `enterprise_linux:8` context
+///   (fails before the fix — empty — passes after).
+/// - `firefox_eus88_patched` (describing CPE `rhel_eus:8.8`, firefox
+///   `128.2.0-1.el8_8` = the EUS fix) → **not affected**: the main-stream
+///   `enterprise_linux:8` row is excluded by the describing-CPE filter (wrong
+///   product context), and the EUS `affected-below-fix` row is version-filtered.
+///   Proves the version-less match is stream-scoped and does not over-report.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+#[instrument]
+async fn sbom_details_versionless_known_affected(
+    ctx: &TrustifyContext,
+) -> Result<(), anyhow::Error> {
+    let sbom = SbomService::new(PaginationCache::for_test());
+
+    const BASE: &str = "cyclonedx/TC-5752";
+
+    // Given the version-less known_affected advisory plus a main-el8 SBOM and a
+    // patched-EUS control SBOM.
+    ctx.ingest_document(format!("{BASE}/advisory-firefox.json"))
+        .await?;
+    let main = ctx
+        .ingest_document(format!("{BASE}/sbom_firefox_main_el8.json"))
+        .await?;
+    let eus = ctx
+        .ingest_document(format!("{BASE}/sbom_firefox_eus88_patched.json"))
+        .await?;
+
+    // Collects every `affected` status entry for a CVE across all advisories.
+    let affected = |details: &SbomDetails, cve: &str| -> Vec<SbomStatus> {
+        details
+            .advisories
+            .iter()
+            .flat_map(|a| a.status.iter())
+            .filter(|s| s.vulnerability.identifier == cve && s.status == "affected")
+            .cloned()
+            .collect()
+    };
+
+    let main_details = sbom
+        .fetch_sbom_details(Id::parse_uuid(main.id)?, vec![], &ctx.db)
+        .await?
+        .expect("main-el8 SBOM details must be found");
+    let eus_details = sbom
+        .fetch_sbom_details(Id::parse_uuid(eus.id)?, vec![], &ctx.db)
+        .await?
+        .expect("EUS SBOM details must be found");
+
+    // Then: the main-el8 firefox is reported affected via the version-less
+    // known_affected, under the enterprise_linux:8 context.
+    let main_affected = affected(&main_details, "CVE-2098-5732");
+    assert!(
+        !main_affected.is_empty(),
+        "main-el8 firefox must be reported affected via the version-less \
+         known_affected (empty before the fix)"
+    );
+    assert!(
+        main_affected.iter().any(|s| matches!(
+            &s.context,
+            Some(StatusContext::Cpe(cpe)) if cpe.contains("enterprise_linux:8")
+        )),
+        "the affected status must carry the enterprise_linux:8 context, got {:?}",
+        main_affected.iter().map(|s| &s.context).collect::<Vec<_>>()
+    );
+
+    // And: the patched EUS box is not affected -- the main-stream row is
+    // context-filtered (wrong product) and the EUS fix row is version-filtered.
+    assert!(
+        affected(&eus_details, "CVE-2098-5732").is_empty(),
+        "patched EUS firefox (128.2.0-1.el8_8 = the fix) must not be affected; \
+         the enterprise_linux:8 known_affected must not over-report onto it"
+    );
+
+    Ok(())
+}
+
 /// Constructs a `ScoredVector` from its parts, deriving the severity from the type and value.
 fn sv(r#type: ScoreType, value: f64, vector: impl Into<String>) -> ScoredVector {
     ScoredVector {

--- a/modules/ingestor/tests/version/mod.rs
+++ b/modules/ingestor/tests/version/mod.rs
@@ -4,7 +4,7 @@ mod pythonver;
 mod rpmver;
 mod semver;
 
-use crate::version::common::{VersionRange, version_matches};
+use crate::version::common::{Version, VersionRange, version_matches};
 use rstest::rstest;
 use test_context::AsyncTestContext;
 use trustify_entity::version_scheme::VersionScheme;
@@ -18,6 +18,39 @@ use trustify_test_context::TrustifyContext;
 #[case("1.0.1", VersionRange::range("1".."2"), VersionScheme::Semver, true)]
 #[case("1.0.1", VersionRange::range("1".."1.2"), VersionScheme::Semver, true)]
 #[case("1.0.1", VersionRange::range("1".."1.0.2"), VersionScheme::Semver, true)]
+// A fully-unbounded range (no low and no high bound) means "all versions
+// affected" (e.g. a version-less CSAF known_affected) and must match every
+// version, across all schemes (TC-5732). Before the fix these returned false.
+#[case(
+    "1.2.3-1.el8",
+    VersionRange::Range(Version::Unbounded, Version::Unbounded),
+    VersionScheme::Rpm,
+    true
+)]
+#[case(
+    "115.15.0",
+    VersionRange::Range(Version::Unbounded, Version::Unbounded),
+    VersionScheme::Semver,
+    true
+)]
+#[case(
+    "1.0.0",
+    VersionRange::Range(Version::Unbounded, Version::Unbounded),
+    VersionScheme::Generic,
+    true
+)]
+#[case(
+    "1.0.0",
+    VersionRange::Range(Version::Unbounded, Version::Unbounded),
+    VersionScheme::Maven,
+    true
+)]
+#[case(
+    "1.0.0",
+    VersionRange::Range(Version::Unbounded, Version::Unbounded),
+    VersionScheme::Python,
+    true
+)]
 #[test_log::test(tokio::test)]
 async fn versions(
     #[case] candidate: &str,


### PR DESCRIPTION
## What this fixes

A CSAF `known_affected` with **no version** (all versions affected) is stored as a fully-unbounded version range, but `version_matches` returned **false** for a range with neither a low nor a high bound — so the row was dropped everywhere and a genuinely-affected main-stream package went **false-negative** once the CPE-context filter engaged ([TC-5732](https://redhat.atlassian.net/browse/TC-5732) / scenario S11).

## Change

New migration `m0002310_version_matches_unbounded` adds a three-line guard at the top of the `version_matches` dispatch: a both-NULL range matches all versions, uniformly across schemes (dispatch `CASE` unchanged; `down()` restores it). Minimal and backport-friendly for release/0.4.z, 0.5.z, 0.6.z.

## Tests

- `tests/version/mod.rs` — both-NULL cases per scheme assert `true` (fail before, pass after).
- `sbom_details_versionless_known_affected` + `etc/test-data/cyclonedx/[TC-5752](https://redhat.atlassian.net/browse/TC-5752)/` — version-less `known_affected` under `enterprise_linux:8` is reported for a main-el8 SBOM; a patched-EUS control is not (stream-scoped, no over-report).

Migration refresh + correlation/CSAF/version suites green; `cargo xtask precommit` clean.

Implements [TC-5732](https://redhat.atlassian.net/browse/TC-5732)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Summary by Sourcery

Fix version matching so version-less affected advisories correctly report impacted packages across supported version schemes.

Bug Fixes:
- Make fully unbounded version ranges match all candidate versions, preventing false negatives for version-less affected advisories.
- Ensure version-less known-affected advisories remain scoped to the correct product stream without over-reporting patched EUS packages.

Tests:
- Add cross-scheme coverage for fully unbounded version ranges.
- Add end-to-end SBOM coverage for version-less CSAF affected status and stream-specific filtering.

[TC-5732]: https://redhat.atlassian.net/browse/TC-5732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-5752]: https://redhat.atlassian.net/browse/TC-5752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-5732]: https://redhat.atlassian.net/browse/TC-5732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ