### PR TITLE
ci: use immutable version tag for setup-uv in perf-test

### DIFF
--- a/.github/workflows/perf-test.yaml
+++ b/.github/workflows/perf-test.yaml
@@ -90,7 +90,7 @@ jobs:
           python -m pip install httpie
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Build
         run: |


### PR DESCRIPTION
## Summary

- Fix `/perf-test` CI workflow failing at action resolution because `astral-sh/setup-uv@v9` does not exist
- Since v8.0.0, `setup-uv` stopped publishing major version alias tags (`v8`, `v9`, …) for supply chain security — only immutable exact version tags are published
- Pin to `v10.0.1` (latest release)

## Test plan

- [ ] Comment `/perf-test` on a PR and verify the workflow progresses past action resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix setup-uv resolution in the performance-test workflow by replacing the unavailable major-version alias with an immutable release tag.

Bug Fixes:
- Fix the performance-test workflow by pinning setup-uv to the published immutable v10.0.1 tag.

CI:
- Update the performance-test CI workflow to use an immutable setup-uv version tag.