### PR TITLE
perf(migration): create advisory_id index before data migration

### DIFF
--- a/migration/src/m0002010_add_advisory_scores.rs
+++ b/migration/src/m0002010_add_advisory_scores.rs
@@ -97,6 +97,17 @@ impl MigrationTraitWithData for Migration {
             .await?;
 
         manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(AdvisoryVulnerabilityScore::Table)
+                    .name("idx_adv_vuln_score_advisory_id")
+                    .col(AdvisoryVulnerabilityScore::AdvisoryId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
             .process(self, async |advisory, id: Id, tx: &DatabaseTransaction| {
                 let mut creator = ScoreCreator::new(id.advisory);
                 match advisory {


### PR DESCRIPTION
## Summary
- Adds `idx_adv_vuln_score_advisory_id` index in migration `m0002010` right after table creation and before the data migration loop
- Speeds up `ScoreCreator`'s wipe-and-replace `DELETE` that runs for every advisory during data migration
- Both this and the existing `m0002180` index creation use `if_not_exists`, keeping them idempotent regardless of execution order

Implements [TC-5690](https://issues.redhat.com/browse/TC-5690)

## Test plan
- [ ] Fresh install: index is created by `m0002010`, `m0002180` skips it (no-op)
- [ ] Existing install: `m0002010` won't re-run, `m0002180` creates the index as before
- [ ] Migration `down()` works: dropping the table in `m0002010` drops the index with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-5690]: https://redhat.atlassian.net/browse/TC-5690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Create the advisory ID index before advisory score data migration to improve the performance of per-advisory score replacement operations while preserving idempotent migration behavior.