### PR TITLE
fix(deps): update js-yaml to fix CVE-2026-59870

### DIFF
--- a/.github/scripts/map-users/package-lock.json
+++ b/.github/scripts/map-users/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "js-yaml": "^4.3.0"
+        "js-yaml": "^4.3.1"
       }
     },
     "node_modules/argparse": {
@@ -14,9 +14,9 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/.github/scripts/map-users/package.json
+++ b/.github/scripts/map-users/package.json
@@ -6,6 +6,6 @@
   "main": "main.mjs",
   "private": true,
   "dependencies": {
-    "js-yaml": "^4.3.0"
+    "js-yaml": "^4.3.1"
   }
 }


### PR DESCRIPTION
details: https://github.com/guacsec/trustify/security/dependabot/57

## Summary by Sourcery

Update js-yaml to remediate the reported security vulnerability.

Bug Fixes:
- Update js-yaml to address CVE-2026-59870.

Build:
- Bump the map-users script dependency on js-yaml to version 4.3.1.