### PR TITLE
fix!: Serve swagger UI on the /openapi endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8936,7 +8936,6 @@ dependencies = [
  "url",
  "utoipa",
  "utoipa-actix-web",
- "utoipa-rapidoc",
 ]
 
 [[package]]
@@ -9349,8 +9348,6 @@ dependencies = [
  "urlencoding",
  "utoipa",
  "utoipa-actix-web",
- "utoipa-rapidoc",
- "utoipa-redoc",
 ]
 
 [[package]]
@@ -9605,30 +9602,6 @@ dependencies = [
  "syn 2.0.119",
  "url",
  "uuid",
-]
-
-[[package]]
-name = "utoipa-rapidoc"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f8f5abd341cce16bb4f09a8bafc087d4884a004f25fb980e538d51d6501dab"
-dependencies = [
- "actix-web",
- "serde",
- "serde_json",
- "utoipa",
-]
-
-[[package]]
-name = "utoipa-redoc"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6427547f6db7ec006cbbef95f7565952a16f362e298b416d2d497d9706fef72d"
-dependencies = [
- "actix-web",
- "serde",
- "serde_json",
- "utoipa",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,8 +148,6 @@ url = "2.5.0"
 urlencoding = "2"
 utoipa = "5.1.3"
 utoipa-actix-web = { version = "0.1.0" }
-utoipa-rapidoc = { version = "6.0.0", features = ["actix-web"] }
-utoipa-redoc = { version = "6.0.0", features = ["actix-web"] }
 utoipa-swagger-ui = "9.0.0"
 uuid = "1.23.3"
 walkdir = "2.5"

--- a/common/infrastructure/Cargo.toml
+++ b/common/infrastructure/Cargo.toml
@@ -33,7 +33,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "ansi", "trac
 url = { workspace = true }
 utoipa = { workspace = true }
 utoipa-actix-web = { workspace = true }
-utoipa-rapidoc = { workspace = true }
 
 trustify-auth = { workspace = true }
 trustify-common = { workspace = true }

--- a/common/infrastructure/src/app/http.rs
+++ b/common/infrastructure/src/app/http.rs
@@ -6,7 +6,7 @@ use crate::{
 use actix_cors::Cors;
 use actix_tls::{accept::openssl::reexports::SslAcceptor, connect::openssl::reexports::SslMethod};
 use actix_web::{
-    App, HttpResponse, HttpServer,
+    App, HttpServer,
     dev::{ServiceFactory, ServiceRequest},
     web::{self, JsonConfig},
 };
@@ -32,7 +32,6 @@ use trustify_auth::{
 use trustify_common::model::BinaryByteSize;
 use utoipa::openapi::Info;
 use utoipa_actix_web::AppExt;
-use utoipa_rapidoc::RapiDoc;
 
 const DEFAULT_ADDR: SocketAddr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080);
 
@@ -596,31 +595,9 @@ where
 
         // register OpenAPI UIs
 
-        let app = app
-            .service({
-                if let Some(oidc) = &swagger_ui_oidc {
-                    oidc.apply_to_schema(&mut openapi);
-                }
-                RapiDoc::with_openapi("/openapi.json", openapi.clone()).path("/openapi/")
-            })
-            .service(web::redirect("/openapi", "/openapi/"))
-            .route(
-                "/openapi/oauth-receiver.html",
-                web::get().to(|| async {
-                    HttpResponse::Ok().content_type(mime::TEXT_HTML).body(
-                        r#"<!doctype html>
-<head>
-  <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
-</head>
-
-<body>
-  <oauth-receiver> </oauth-receiver>
-</body>"#,
-                    )
-                }),
-            );
-
         app.service(swagger_ui_with_auth(openapi, swagger_ui_oidc))
+            .service(web::redirect("/openapi", "/swagger-ui/"))
+            .service(web::redirect("/openapi/", "/swagger-ui/"))
             .service(web::redirect("/swagger-ui", "/swagger-ui/"))
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -39,8 +39,6 @@ tokio_schedule = { workspace = true }
 url = { workspace = true }
 utoipa = { workspace = true, features = ["actix_extras", "yaml"] }
 utoipa-actix-web = { workspace = true }
-utoipa-rapidoc = { workspace = true }
-utoipa-redoc = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/server/src/embedded_oidc.rs
+++ b/server/src/embedded_oidc.rs
@@ -38,11 +38,7 @@ fn create(enabled: bool) -> anyhow::Result<Option<Server>> {
                     ignore_localhost_port: true,
                 },
                 RedirectUrl::Exact {
-                    url: "http://localhost/openapi/oauth2-redirect.html".into(),
-                    ignore_localhost_port: true,
-                },
-                RedirectUrl::Exact {
-                    url: "http://localhost/rapidoc/oauth-receiver.html".into(),
+                    url: "http://localhost/swagger-ui/oauth2-redirect.html".into(),
                     ignore_localhost_port: true,
                 },
             ],

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -565,12 +565,13 @@ mod test {
         let text = std::str::from_utf8(&body)?;
         assert!(text.contains("<title>Trustification</title>"));
 
-        // rapidoc UI
+        // openapi redirects to swagger-ui
 
         let req = TestRequest::get().uri("/openapi/").to_request();
-        let body = call_and_read_body(&app, req).await;
-        let text = std::str::from_utf8(&body)?;
-        assert!(text.contains("<rapi-doc"));
+        let resp = call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
+        let loc = resp.headers().get(header::LOCATION);
+        assert!(loc.is_some_and(|x| x.eq("/swagger-ui/")));
 
         // swagger ui
 


### PR DESCRIPTION
## Summary
- Backport of #2427 to `release/0.4.z`
- Drops `utoipa-rapidoc` and `utoipa-redoc` dependencies, which were loading content from a CDN
- Redirects `/openapi` to `/swagger-ui/` instead of serving RapiDoc

## Test plan
- [ ] Verify `/openapi` and `/openapi/` redirect to `/swagger-ui/`
- [ ] Verify Swagger UI loads and is functional
- [ ] Verify OAuth flow works with the updated redirect URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Serve the Swagger UI from the OpenAPI entry points and remove the legacy CDN-backed documentation interfaces.

Bug Fixes:
- Redirect `/openapi` and `/openapi/` to the Swagger UI instead of serving the legacy RapiDoc interface.
- Update the embedded OAuth redirect URL to use the Swagger UI callback endpoint.

Enhancements:
- Remove the RapiDoc and ReDoc dependencies and associated endpoint implementation.
- Update API tests to verify the OpenAPI redirect behavior.

Build:
- Remove unused RapiDoc and ReDoc workspace dependencies and lockfile entries.

Tests:
- Update profile API coverage to assert the OpenAPI endpoint returns the Swagger UI redirect.