### PR TITLE
feat(semantic validation): add semantic validator adr, add initial validator using scheck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,6 +3844,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4258,6 +4267,16 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
 ]
 
 [[package]]
@@ -6529,6 +6548,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheck"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb496e6f62b13c7148482b3dd4c7469d1b62d17f784fdcab3ab2df7e1f78effc"
+dependencies = [
+ "clap",
+ "regex",
+ "roxmltree",
+ "serde",
+ "serde_json",
+ "serde_json_path",
+ "serde_yml",
+ "thiserror 2.0.19",
+ "txt2data",
+]
+
+[[package]]
 name = "schemafy_core"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7000,6 +7036,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json_path"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b992cea3194eea663ba99a042d61cea4bd1872da37021af56f6a37e0359b9d33"
+dependencies = [
+ "inventory",
+ "nom",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_json_path_core",
+ "serde_json_path_macros",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "serde_json_path_core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde67d8dfe7d4967b5a95e247d4148368ddd1e753e500adb34b3ffe40c6bc1bc"
+dependencies = [
+ "inventory",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "serde_json_path_macros"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517acfa7f77ddaf5c43d5f119c44a683774e130b4247b7d3210f8924506cfac8"
+dependencies = [
+ "inventory",
+ "serde_json_path_core",
+ "serde_json_path_macros_internal",
+]
+
+[[package]]
+name = "serde_json_path_macros_internal"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "serde_norway"
 version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7101,6 +7187,21 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]
@@ -8811,6 +8912,7 @@ dependencies = [
  "roxmltree",
  "rstest",
  "sbom-walker",
+ "scheck",
  "sea-orm",
  "sea-query",
  "semver",
@@ -8821,6 +8923,7 @@ dependencies = [
  "spdx-expression",
  "spdx-rs",
  "strum 0.28.0",
+ "tempfile",
  "test-context",
  "test-log",
  "thiserror 2.0.19",
@@ -8976,6 +9079,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "test-context",
  "test-log",
  "tokio",
@@ -9116,6 +9220,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "txt2data"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc25092e08636ff74b83888641275ea87aac449ffaa59b9522f6f299690a5dc"
+dependencies = [
+ "thiserror 2.0.19",
+ "unicode-general-category",
+]
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9144,6 +9258,12 @@ name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,16 +4270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6549,9 +6539,9 @@ dependencies = [
 
 [[package]]
 name = "scheck"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb496e6f62b13c7148482b3dd4c7469d1b62d17f784fdcab3ab2df7e1f78effc"
+checksum = "9300bbcf74ce990d5a84f8fd47bb9fe3887dfa2bd810a80c5fa9a68168af117b"
 dependencies = [
  "clap",
  "regex",
@@ -6559,7 +6549,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_path",
- "serde_yml",
+ "serde_norway",
  "thiserror 2.0.19",
  "txt2data",
 ]
@@ -7187,21 +7177,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ roxmltree = "0.21.1"
 rstest = "0.26.1"
 sanitize-filename = "0.6.0"
 sbom-walker = { version = "0.17.0", default-features = false, features = ["crypto-openssl", "serde-cyclonedx", "spdx-rs"] }
+scheck = "0.7.0"
 schemars = "1.0"
 sea-orm = { version = "1.1.20", features = ["debug-print"] }
 sea-orm-migration = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ roxmltree = "0.21.1"
 rstest = "0.26.1"
 sanitize-filename = "0.6.0"
 sbom-walker = { version = "0.17.0", default-features = false, features = ["crypto-openssl", "serde-cyclonedx", "spdx-rs"] }
-scheck = "0.7.0"
+scheck = "0.8.0"
 schemars = "1.0"
 sea-orm = { version = "1.1.20", features = ["debug-print"] }
 sea-orm-migration = "1"

--- a/docs/adrs/00020-semantic-validators-on-ingestion.md
+++ b/docs/adrs/00020-semantic-validators-on-ingestion.md
@@ -1,0 +1,287 @@
+# 00020. Semantic validators on ingestion
+
+Date: 2026-09-03
+
+## Status
+
+DRAFT
+
+## Context
+
+Trustify ingests documents (SBOMs, CSAF/CVE/OSV advisories, and others) via two paths:
+the HTTP API (`POST /v3/sbom`, `POST /v3/advisory`, `POST /v3/dataset`) and the importers.
+Both paths funnel through a single choke point, `IngestorService::ingest`
+(`modules/ingestor/src/service/mod.rs:220`), which detects the document format, stores the
+raw bytes, and loads the parsed content into the graph.
+
+Today the only quality signal we surface is the free-form `warnings: Vec<String>` field on
+`IngestResult` (`modules/ingestor/src/model.rs:4`), populated by the `Warnings` sink
+(`modules/ingestor/src/service/mod.rs:320`). These warnings come from our own parsers and
+are structural in nature. We have no mechanism to answer *semantic* questions about a
+document:
+
+* Does this CSAF advisory carry a well-formed CVE ID?
+* Does every remediation reference a vulnerability that actually exists in the document?
+* Does this SBOM contain at least one package with a valid PURL?
+* Does a `status: final` advisory also carry a `release_date`?
+
+These are cross-field, cross-reference, cardinality, and conditional constraints that schema
+validation cannot express. We want to let operators define **sets of validators** that run
+on ingestion, in one of two modes:
+
+* **report** — record findings as data-quality signals; never block ingestion.
+* **verify** — a gate; if it fails, ingestion is blocked.
+
+The first validator we intend to integrate is [`scheck`](https://github.com/rh-jfuller/scheck),
+a semantic-validation tool that runs assertion-based rules (rules-as-data JSON, JSONPath
+predicates, Schematron-style `assert`/`report` duality) against JSON/YAML documents. `scheck`
+is available as a Rust crate (`scheck::validate_json`, `check_json`, `validate_all`), a static
+CLI binary, and a WASM module. Its report model carries severities `fatal`, `error`,
+`warning`, `info`.
+
+The long-term goal is to surface validation results in the UX (particularly for importer
+runs). This ADR scopes the first increment to the **API path** and to the **ingest-time
+plumbing** that both paths already share, so the importer/UX surfacing can be layered on
+later without rework.
+
+### Assumptions
+
+* All ingestion flows through `IngestorService::ingest`; a single hook there covers both API
+  and importer paths.
+* The raw document bytes and the resolved concrete `Format` are both available at
+  `service/mod.rs:232-233`, before blob storage and before graph insertion.
+* Validators operate on the raw document (JSON/YAML), not on Trustify's parsed graph model.
+* Ingestion is fully `async` (tokio); an in-process validator is a cheap function call.
+
+## Decision
+
+### 1. A `Validator` abstraction, `scheck` as the first in-process backend
+
+Introduce an async `Validator` trait in the ingestor module. The trait takes the raw bytes,
+the resolved `Format`, and minimal metadata, and returns a structured `ValidationReport`
+(never an ad-hoc string). It is deliberately backend-agnostic:
+
+```rust
+#[async_trait]
+pub trait Validator: Send + Sync {
+    /// Stable identifier used in config, reports, and logs.
+    fn name(&self) -> &str;
+
+    /// Which formats this validator applies to.
+    fn applies_to(&self, format: Format) -> bool;
+
+    /// Run the validator. Returning Err means the validator could not
+    /// produce a verdict (crash, timeout, backend unavailable) — this is
+    /// distinct from a report that contains failing findings.
+    async fn validate(&self, input: &ValidatorInput<'_>) -> Result<ValidationReport, ValidatorError>;
+}
+```
+
+The first implementation, `ScheckValidator`, links `scheck` as a **workspace dependency and
+runs it in-process**. There is no subprocess spawn and no network call in the ingest hot
+path. This keeps the first increment deterministic, cheap, and free of new runtime operational
+requirements (no sidecar, no binary-on-PATH assumption).
+
+The trait is shaped so that alternative backends — a subprocess wrapper around the `scheck`
+CLI, or an HTTP client to an external validator service — can be added later as additional
+`Validator` implementations without changing the ingest hook, the report model, or config.
+Those backends are explicitly **not** implemented in this ADR (see Alternatives).
+
+### 2. Report model
+
+`ValidationReport` is a typed, serializable model, not a bag of strings:
+
+```rust
+pub struct ValidationReport {
+    pub validator: String,           // Validator::name()
+    pub findings: Vec<Finding>,
+    pub outcome: ValidationOutcome,  // Passed | Failed
+}
+
+pub struct Finding {
+    pub severity: Severity,          // Fatal | Error | Warning | Info
+    pub message: String,
+    pub path: Option<String>,        // JSONPath / location in the document
+    pub rule: Option<String>,        // rule id / flag
+}
+```
+
+`scheck`'s severities map 1:1. The mapping from findings to `outcome` is governed by the
+validator's configured **blocking threshold** (see §4).
+
+### 3. Single hook point in `IngestorService::ingest`
+
+Validators run inside `IngestorService::ingest`, immediately after format detection and
+before graph insertion (`service/mod.rs:232-243`). At that point we have the raw `bytes` and
+the concrete `fmt`. Concretely:
+
+1. `DocumentDetector::detect_as(bytes, format)` → concrete `Format` (unchanged).
+2. **NEW:** run the configured validators whose `applies_to(fmt)` is true.
+3. If any **verify** validator blocks → return an error **before** `storage.store` and before
+   `detector.load`. Nothing is persisted (see §6).
+4. Otherwise proceed with storage + graph load as today, attaching the reports to the result
+   (see §7).
+
+Because this is the shared choke point, both API and importer ingestion get validation for
+free. The importer runner already threads warnings into its report
+(`modules/importer/src/runner/sbom/storage.rs:93`); the structured reports will flow through
+the same return value.
+
+### 4. Modes: `report` vs `verify`, driven by a blocking severity threshold
+
+Each validator is configured with:
+
+* a **mode**: `report` or `verify`;
+* for `verify`, a **blocking threshold** severity (default `error`): any finding at or above
+  the threshold sets `outcome = Failed` and blocks ingestion.
+
+`report` validators never block regardless of severity — their findings are recorded only.
+
+### 5. Verify failures are fail-closed by default
+
+If a **verify** validator returns `Err(ValidatorError)` — it crashed, timed out, or (for a
+future external backend) was unreachable — ingestion is **blocked by default**, exactly as if
+the gate had failed. A validator that cannot produce a verdict is not allowed to silently wave
+a document through unless `on_error: continue` is explicitly configured as a fail-open
+exception. This is configurable per validator via `on_error: block | continue`; the default is
+`block`. `report`-mode validator errors are logged and ingestion continues.
+
+Choosing `on_error: continue` is a deliberate trade of the verification guarantee for
+availability, and should be reserved for validators where a missing verdict is acceptable.
+
+### 6. Blocked documents are not persisted
+
+When a `verify` validator blocks, ingestion is rejected **before** the raw bytes are written
+to blob storage and before any `source_document`/graph rows are created. The API returns the
+validation report in a structured error body; nothing enters the system. This keeps the store
+free of known-bad documents and avoids partial state. (Auditing rejected documents is a
+possible future extension — see Open items.)
+
+### 7. Surfacing results
+
+For this increment, validation reports are returned to the caller via `IngestResult`:
+
+* Extend `IngestResult` (`modules/ingestor/src/model.rs:4`) with
+  `validation: Vec<ValidationReport>`.
+* Continue to fold human-readable finding messages into the existing `warnings: Vec<String>`
+  for backward compatibility with current API consumers.
+
+The API upload handlers (`modules/fundamental/src/sbom/endpoints/mod.rs:710`,
+`modules/fundamental/src/advisory/endpoints/mod.rs:219`) already return `IngestResult` as JSON,
+so no new endpoint is required. Persisting reports (labels or a dedicated table) and rendering
+them in the importer UX are **deferred** to a later increment.
+
+### 8. Configuration and rulesets
+
+Validator definitions live in a **config section**, and ruleset files live **on disk**
+(bundled with Trustify and/or mounted via ConfigMap). No database schema changes.
+
+Extend `trustify_module_ingestor::endpoints::Config`
+(`modules/ingestor/src/endpoints.rs:30`) with a validators configuration, mirrored on
+`ModuleConfig` (`server/src/profile/api.rs:370`) and the CLI `Run` args. Each entry declares:
+
+```toml
+[[ingestor.validators]]
+name       = "scheck-csaf"
+backend    = "scheck"        # selects the in-process scheck impl
+formats    = ["csaf"]        # maps to Format variants
+rules      = ["rulesets/security/csaf-2.0-mandatory.json"]
+phase      = "full"          # scheck phase (optional)
+mode       = "report"        # report | verify
+threshold  = "error"         # blocking severity for verify
+on_error   = "block"         # block | continue (verify only)
+```
+
+`IngestorService::new` (`modules/ingestor/src/service/mod.rs:204`) gains a
+`Vec<Arc<dyn Validator>>` parameter, constructed from config at server assembly
+(`endpoints.rs:22`) and at each importer runner's `IngestorService::new(...)` site. When no
+validators are configured, ingestion behaves exactly as today.
+
+### 9. Format applicability
+
+`scheck` validates JSON and YAML. The initial integration therefore applies to JSON/YAML
+documents (CSAF, CVE, OSV, SPDX-JSON, CycloneDX-JSON). XML CycloneDX is out of scope for the
+first backend; `applies_to` returns false for documents whose wire format the validator
+cannot consume, so they pass through unvalidated rather than erroring.
+
+## Consequences
+
+* A new `Validator` trait and `ValidationReport` model are added to the ingestor module.
+* `scheck` becomes a workspace dependency (in-process). Its footprint and license (MIT) must
+  be recorded in `deny.toml`.
+* `IngestResult` gains a `validation` field; existing clients that ignore unknown JSON fields
+  are unaffected, and `warnings` continues to carry finding messages.
+* `IngestorService::new` gains a validators parameter — every construction site (API assembly
+  and all importer runners in `modules/importer/src/runner/*`) must pass it, even if empty.
+* Ingestion latency increases by the validator run time; in-process `scheck` on a single
+  document is cheap, and validation happens before the (more expensive) graph load.
+* With no validators configured, behaviour is unchanged — the feature is opt-in.
+* `verify` validators can reject uploads; API consumers and importers must handle a new
+  "rejected by validation" error outcome.
+
+## Incremental delivery plan
+
+1. **Plumbing (this ADR):** `Validator` trait, `ValidationReport` model, the ingest hook,
+   `IngestResult.validation`, and config wiring — with a no-op/empty validator set so nothing
+   changes by default.
+2. **scheck backend:** `ScheckValidator` in-process impl + bundled starter rulesets; wire
+   `report` mode first (never blocks) to gather signal safely.
+3. **verify mode:** enable blocking with fail-closed semantics and the rejected-document
+   error path on the API.
+4. **Persistence + importer/UX:** store reports (labels or a table) and surface them in the
+   importer run views.
+
+## Open items
+
+* [ ] Do we persist validation reports for **successful** ingests (labels vs a dedicated
+  table), and with what retention?
+* [ ] Should rejected documents be optionally auditable (store blob + report under a
+  `rejected` label) as a per-instance toggle, despite the default of persisting nothing?
+* [ ] Config format: extend the existing typed `Config` vs a standalone validators config
+  file discovered by path. Rulesets are files either way.
+* [ ] Timeout/resource bounds for validators (matters more once subprocess/HTTP backends
+  exist). `scheck` honours `SCHECK_MAX_FILE_SIZE` for input bounds.
+* [ ] How do validator definitions interact with importer-specific configuration (per-importer
+  overrides vs a single global set)?
+* [ ] Versioning of bundled rulesets and how ruleset changes interact with re-processing
+  (ADR 00011).
+
+## Alternatives considered
+
+### Subprocess (scheck CLI)
+
+Shell out to the `scheck` binary (`scheck validate --rules … --format json`) and parse its
+JSON output. Decouples validator releases from Trustify's build.
+
+* 👍 Independent versioning; matches how `scheck` ships (static musl binary, RPM).
+* 👎 Process-spawn cost on every ingest; requires the binary on PATH / in the image.
+* 👎 Sandboxing and resource limiting become our problem.
+
+Deferred: the `Validator` trait is designed to accommodate this as an added backend.
+
+### External HTTP validator service
+
+Call a validator over HTTP (sidecar or shared service).
+
+* 👍 Fully decoupled, independently scalable, language-agnostic validators.
+* 👎 Adds a network dependency in the ingest hot path; more moving parts and failure modes.
+* 👎 Fail-closed verify semantics turn validator outages into ingestion outages.
+
+Deferred: also expressible as a `Validator` backend later.
+
+### WASM-sandboxed validators
+
+Run validators as WASM modules (scheck has a WASM build).
+
+* 👍 Strong sandboxing with in-process locality; pluggable without native linking.
+* 👎 Heavier integration (runtime embedding, host bindings) than justified for the first
+  validator, which we already own as a Rust crate.
+
+### No abstraction — call scheck directly
+
+Hard-code a `scheck` call in `ingest`.
+
+* 👍 Least code now.
+* 👎 The stated requirement is a *set* of validators from *third parties*; a one-off call
+  would have to be torn out to support that. The trait is a small, justified abstraction that
+  directly serves the requirement.

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -58,6 +58,7 @@
 | `TRUSTD_SLOW_SQL_THRESHOLD`              | Override threshold for slow SQL statements (humantime)                              | `1m`                                    |
 | `TRUSTD_STORAGE_FS_PATH`                 | Path for storage file system strategy                                               | `./.trustify/storage`                   |
 | `TRUSTD_STORAGE_STRATEGY`                | Specifies the storage strategy to use                                               | `File system`                           |
+| `TRUSTD_VALIDATORS_CONFIG`               | Path to a semantic validators configuration file (YAML); unset disables validation  |                                         |
 | `UI_CLIENT_ID`                           | Client ID used by the UI                                                            | `frontend`                              |
 | `UI_ISSUER_URL`                          | Issuer URL used by the UI                                                           | `http://localhost:8090/realms/trustify` |
 | `UI_LOAD_USER`                           | Whether to load user info                                                           | `true`                                  |

--- a/modules/fundamental/src/endpoints.rs
+++ b/modules/fundamental/src/endpoints.rs
@@ -1,9 +1,10 @@
 use actix_web::web;
+use std::sync::Arc;
 use trustify_common::db::{self, pagination_cache::PaginationCache};
 use trustify_module_analysis::service::AnalysisService;
 use trustify_module_ingestor::common;
 use trustify_module_ingestor::graph::Graph;
-use trustify_module_ingestor::service::IngestorService;
+use trustify_module_ingestor::service::{IngestorService, validation::Validator};
 use trustify_module_storage::service::dispatch::DispatchBackend;
 use utoipa::{IntoParams, ToSchema};
 
@@ -29,8 +30,10 @@ pub fn configure(
     analysis: AnalysisService,
     cache: PaginationCache,
     graph: Graph,
+    validators: Vec<Arc<dyn Validator>>,
 ) {
-    let ingestor_service = IngestorService::new(graph, storage, Some(analysis));
+    let ingestor_service =
+        IngestorService::new(graph, storage, Some(analysis)).with_validators(validators);
     svc.app_data(web::Data::new(ingestor_service.clone()));
 
     advisory::endpoints::configure(

--- a/modules/fundamental/src/test/common.rs
+++ b/modules/fundamental/src/test/common.rs
@@ -30,6 +30,7 @@ pub async fn caller_with(
             analysis.clone(),
             cache,
             graph,
+            Vec::new(),
         );
         trustify_module_analysis::endpoints::configure(svc, db_ro, analysis);
     })

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -568,6 +568,7 @@ async fn cvss_v4_score_after_migration(
             analysis.clone(),
             PaginationCache::for_test(),
             trustify_module_ingestor::graph::Graph::new(),
+            Vec::new(),
         );
         trustify_module_analysis::endpoints::configure(svc, db_ro, analysis);
     })

--- a/modules/ingestor/Cargo.toml
+++ b/modules/ingestor/Cargo.toml
@@ -31,6 +31,7 @@ parking_lot = { workspace = true }
 quick-xml = { workspace = true }
 roxmltree = { workspace = true }
 sbom-walker = { workspace = true }
+scheck = { workspace = true }
 sea-orm = { workspace = true }
 sea-query = { workspace = true }
 semver = { workspace = true }
@@ -60,6 +61,7 @@ criterion = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
 serde_yml = { workspace = true }
+tempfile = { workspace = true }
 test-context = { workspace = true }
 test-log = { workspace = true, features = ["log", "trace"] }
 tokio = { workspace = true, features = ["full"] }

--- a/modules/ingestor/src/endpoints.rs
+++ b/modules/ingestor/src/endpoints.rs
@@ -1,9 +1,10 @@
 use crate::{
     graph::Graph,
-    service::{Error, IngestorService},
+    service::{Error, IngestorService, validation::Validator},
 };
 use actix_web::{HttpResponse, Responder, post, web};
 use sea_orm::TransactionTrait;
+use std::sync::Arc;
 use trustify_auth::{UploadDataset, authorizer::Require};
 use trustify_common::{db, model::BinaryData};
 use trustify_entity::labels::Labels;
@@ -18,8 +19,10 @@ pub fn configure(
     db: db::ReadWrite,
     storage: impl Into<DispatchBackend>,
     analysis: Option<AnalysisService>,
+    validators: Vec<Arc<dyn Validator>>,
 ) {
-    let ingestor_service = IngestorService::new(Graph::new(), storage, analysis);
+    let ingestor_service =
+        IngestorService::new(Graph::new(), storage, analysis).with_validators(validators);
 
     svc.app_data(web::Data::new(ingestor_service))
         .app_data(web::Data::new(config))

--- a/modules/ingestor/src/model.rs
+++ b/modules/ingestor/src/model.rs
@@ -1,7 +1,8 @@
+use crate::service::validation::ValidationReport;
 use trustify_common::id::Id;
 
 /// The result of the ingestion process
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
 pub struct IngestResult {
     #[schema(value_type = Id)]
     /// The internal ID of the document
@@ -11,4 +12,10 @@ pub struct IngestResult {
     /// Warnings that occurred during the import process
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
+    /// Structured reports from semantic validators run during ingestion.
+    ///
+    /// See ADR 00020. Empty when no validators are configured or none apply
+    /// to the document's format.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub validation: Vec<ValidationReport>,
 }

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -102,6 +102,7 @@ impl<'g> CsafLoader<'g> {
                 id: found.advisory.id.to_string(),
                 document_id: Some(advisory_id),
                 warnings: warnings.into(),
+                validation: Vec::new(),
             });
         }
 
@@ -133,6 +134,7 @@ impl<'g> CsafLoader<'g> {
             id: advisory.advisory.id.to_string(),
             document_id: Some(advisory_id),
             warnings: warnings.into(),
+            validation: Vec::new(),
         })
     }
 

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -265,6 +265,7 @@ impl<'g> CveLoader<'g> {
             id: advisory.advisory.id.to_string(),
             document_id: Some(id.to_string()),
             warnings: warnings.into(),
+            validation: Vec::new(),
         })
     }
 

--- a/modules/ingestor/src/service/advisory/nvd/loader.rs
+++ b/modules/ingestor/src/service/advisory/nvd/loader.rs
@@ -202,6 +202,7 @@ impl<'g> NvdLoader<'g> {
             id: advisory.advisory.id.to_string(),
             document_id: Some(id),
             warnings: warnings.into(),
+            validation: Vec::new(),
         })
     }
 }

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -320,6 +320,7 @@ impl<'g> OsvLoader<'g> {
             id: advisory.advisory.id.to_string(),
             document_id: Some(osv.id),
             warnings: warnings.into(),
+            validation: Vec::new(),
         })
     }
 }

--- a/modules/ingestor/src/service/kev/mod.rs
+++ b/modules/ingestor/src/service/kev/mod.rs
@@ -90,6 +90,7 @@ impl KevLoader {
             id: digests.sha512.encode_hex(),
             document_id: Some(format!("{source}/{}", catalog.catalog_version)),
             warnings: dropped.into_warnings(),
+            validation: Vec::new(),
         })
     }
 }

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -3,6 +3,7 @@ pub mod dataset;
 mod detect;
 pub mod kev;
 pub mod sbom;
+pub mod validation;
 pub mod weakness;
 
 mod format;
@@ -15,7 +16,13 @@ use crate::graph::Graph;
 use crate::graph::error::Error as GraphError;
 use crate::{
     model::IngestResult,
-    service::dataset::{DatasetIngestResult, DatasetLoader},
+    service::{
+        dataset::{DatasetIngestResult, DatasetLoader},
+        validation::{
+            Finding, OnError, Severity, ValidationMode, ValidationOutcome, ValidationReport,
+            Validator, ValidatorInput,
+        },
+    },
 };
 use actix_web::{HttpResponse, ResponseError, body::BoxBody};
 use anyhow::anyhow;
@@ -69,6 +76,8 @@ pub enum Error {
     PayloadTooLarge,
     #[error("unavailable")]
     Unavailable,
+    #[error("document rejected by validation")]
+    ValidationRejected(Vec<ValidationReport>),
 }
 
 impl From<DbErr> for Error {
@@ -169,6 +178,16 @@ impl ResponseError for Error {
                 message: self.to_string(),
                 details: None,
             }),
+            Self::ValidationRejected(reports) => {
+                // Return the reports as a structured array (not an escaped JSON
+                // string) so clients can consume findings directly. The
+                // `error`/`message` fields mirror `ErrorInformation`.
+                HttpResponse::UnprocessableEntity().json(serde_json::json!({
+                    "error": "ValidationRejected",
+                    "message": self.to_string(),
+                    "validation": reports,
+                }))
+            }
         }
     }
 }
@@ -200,6 +219,7 @@ pub struct IngestorService {
     graph: Graph,
     storage: DispatchBackend,
     analysis: Option<AnalysisService>,
+    validators: Arc<[Arc<dyn Validator>]>,
 }
 
 impl IngestorService {
@@ -212,11 +232,37 @@ impl IngestorService {
             graph,
             storage: storage.into(),
             analysis,
+            validators: Vec::new().into(),
         }
+    }
+
+    /// Attach the set of semantic validators run on every ingest.
+    ///
+    /// With an empty set (the default), ingestion behaves as if validation did
+    /// not exist. See ADR 00020.
+    pub fn with_validators(mut self, validators: Vec<Arc<dyn Validator>>) -> Self {
+        self.validators = validators.into();
+        self
     }
 
     pub fn storage(&self) -> &DispatchBackend {
         &self.storage
+    }
+
+    /// Run all applicable validators against a document.
+    ///
+    /// Returns the collected reports on success. Returns
+    /// [`Error::ValidationRejected`] if any [`ValidationMode::Verify`] validator
+    /// blocks the document — either because its outcome is
+    /// [`ValidationOutcome::Failed`], or because it errored while configured to
+    /// [`OnError::Block`].
+    #[instrument(skip(self, bytes), fields(bytes = bytes.len()), err(level = tracing::Level::INFO))]
+    async fn run_validators(
+        &self,
+        bytes: &[u8],
+        fmt: Format,
+    ) -> Result<Vec<ValidationReport>, Error> {
+        run_validators(&self.validators, bytes, fmt).await
     }
 
     #[instrument(skip_all, err(level=tracing::Level::INFO))]
@@ -234,15 +280,22 @@ impl IngestorService {
         let detector = DocumentDetector::detect_as(bytes, format)?;
         let fmt = detector.format();
 
+        // Run semantic validators before persisting anything. A blocking
+        // (verify) failure returns an error here, so no bytes are stored and no
+        // graph rows are created. See ADR 00020.
+        let reports = self.run_validators(bytes, fmt).await?;
+
         let result = self
             .storage
             .store(bytes)
             .await
             .map_err(|err| Error::Storage(anyhow!("{err}")))?;
 
-        let result = detector
+        let mut result = detector
             .load(&self.graph, labels.into(), issuer, &result.digests, tx)
             .await?;
+
+        attach_validation(&mut result, reports);
 
         let change_entity = match fmt {
             Format::CSAF | Format::CVE | Format::OSV => Some(ChangeEntity::Advisory),
@@ -319,6 +372,91 @@ impl IngestorService {
     }
 }
 
+/// Run all applicable validators against a document.
+///
+/// Returns the collected reports, or [`Error::ValidationRejected`] if a
+/// [`ValidationMode::Verify`] validator blocks the document. See ADR 00020.
+async fn run_validators(
+    validators: &[Arc<dyn Validator>],
+    bytes: &[u8],
+    fmt: Format,
+) -> Result<Vec<ValidationReport>, Error> {
+    if validators.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let input = ValidatorInput { bytes, format: fmt };
+    let mut reports = Vec::new();
+    let mut blocked = Vec::new();
+
+    for validator in validators {
+        if !validator.applies_to(fmt) {
+            continue;
+        }
+
+        match validator.validate(&input).await {
+            Ok(report) => {
+                if validator.mode() == ValidationMode::Verify
+                    && report.outcome == ValidationOutcome::Failed
+                {
+                    blocked.push(report.clone());
+                }
+                reports.push(report);
+            }
+            Err(err) => match (validator.mode(), validator.on_error()) {
+                (ValidationMode::Verify, OnError::Block) => {
+                    tracing::warn!(
+                        validator = validator.name(),
+                        "verify validator errored, blocking ingestion: {err}"
+                    );
+                    blocked.push(errored_report(validator.name(), &err));
+                }
+                _ => {
+                    tracing::warn!(
+                        validator = validator.name(),
+                        "validator errored, continuing ingestion: {err}"
+                    );
+                }
+            },
+        }
+    }
+
+    if blocked.is_empty() {
+        Ok(reports)
+    } else {
+        Err(Error::ValidationRejected(blocked))
+    }
+}
+
+/// Build a report representing a validator that failed to run.
+fn errored_report(name: &str, err: &validation::ValidatorError) -> ValidationReport {
+    ValidationReport {
+        validator: name.to_string(),
+        findings: vec![Finding {
+            severity: Severity::Fatal,
+            message: format!("validator failed to run: {err}"),
+            path: None,
+            rule: None,
+        }],
+        outcome: ValidationOutcome::Failed,
+    }
+}
+
+/// Attach validation reports to an ingest result, folding notable findings into
+/// the human-readable `warnings` list for backward compatibility.
+fn attach_validation(result: &mut IngestResult, reports: Vec<ValidationReport>) {
+    for report in &reports {
+        for finding in &report.findings {
+            if finding.severity >= Severity::Warning {
+                result
+                    .warnings
+                    .push(format!("[{}] {}", report.validator, finding.message));
+            }
+        }
+    }
+    result.validation = reports;
+}
+
 /// Capture warnings from the import process
 #[derive(Default)]
 pub(crate) struct Warnings(Arc<Mutex<Vec<String>>>);
@@ -352,4 +490,178 @@ pub struct Discard;
 
 impl ReportSink for Discard {
     fn error(&self, _msg: String) {}
+}
+
+#[cfg(test)]
+mod validation_tests {
+    use super::*;
+    use crate::service::validation::{
+        Finding, OnError, Severity, ValidationMode, ValidationOutcome, ValidationReport, Validator,
+        ValidatorError, ValidatorInput,
+    };
+    use sea_orm::prelude::async_trait;
+
+    /// A configurable mock validator for exercising the runner.
+    #[derive(Debug)]
+    struct MockValidator {
+        name: &'static str,
+        mode: ValidationMode,
+        on_error: OnError,
+        applies: bool,
+        result: MockResult,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum MockResult {
+        Passed,
+        Failed,
+        Errored,
+    }
+
+    impl MockValidator {
+        fn new(name: &'static str, mode: ValidationMode, result: MockResult) -> Self {
+            Self {
+                name,
+                mode,
+                on_error: OnError::Block,
+                applies: true,
+                result,
+            }
+        }
+
+        fn on_error(mut self, on_error: OnError) -> Self {
+            self.on_error = on_error;
+            self
+        }
+
+        fn applies(mut self, applies: bool) -> Self {
+            self.applies = applies;
+            self
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Validator for MockValidator {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn mode(&self) -> ValidationMode {
+            self.mode
+        }
+        fn threshold(&self) -> Severity {
+            Severity::Error
+        }
+        fn on_error(&self) -> OnError {
+            self.on_error
+        }
+        fn applies_to(&self, _format: Format) -> bool {
+            self.applies
+        }
+        async fn validate(
+            &self,
+            _input: &ValidatorInput<'_>,
+        ) -> Result<ValidationReport, ValidatorError> {
+            match self.result {
+                MockResult::Errored => Err(ValidatorError::Timeout),
+                outcome => Ok(ValidationReport {
+                    validator: self.name.to_string(),
+                    findings: vec![Finding {
+                        severity: Severity::Error,
+                        message: "finding".into(),
+                        path: None,
+                        rule: None,
+                    }],
+                    outcome: match outcome {
+                        MockResult::Passed => ValidationOutcome::Passed,
+                        _ => ValidationOutcome::Failed,
+                    },
+                }),
+            }
+        }
+    }
+
+    fn run(validators: Vec<Arc<dyn Validator>>) -> Result<Vec<ValidationReport>, Error> {
+        tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(run_validators(&validators, b"{}", Format::CSAF))
+    }
+
+    #[test]
+    fn empty_set_is_noop() {
+        let reports = run(vec![]).expect("ok");
+        assert!(reports.is_empty());
+    }
+
+    #[test]
+    fn report_mode_never_blocks_even_when_failed() {
+        let reports = run(vec![Arc::new(MockValidator::new(
+            "r",
+            ValidationMode::Report,
+            MockResult::Failed,
+        ))])
+        .expect("report mode must not block");
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].outcome, ValidationOutcome::Failed);
+    }
+
+    #[test]
+    fn verify_mode_blocks_on_failed() {
+        let err = run(vec![Arc::new(MockValidator::new(
+            "v",
+            ValidationMode::Verify,
+            MockResult::Failed,
+        ))])
+        .expect_err("verify + failed must block");
+        match err {
+            Error::ValidationRejected(reports) => assert_eq!(reports.len(), 1),
+            other => panic!("expected ValidationRejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_mode_passes_when_ok() {
+        let reports = run(vec![Arc::new(MockValidator::new(
+            "v",
+            ValidationMode::Verify,
+            MockResult::Passed,
+        ))])
+        .expect("verify + passed must not block");
+        assert_eq!(reports.len(), 1);
+    }
+
+    #[test]
+    fn verify_error_is_fail_closed_by_default() {
+        let err = run(vec![Arc::new(MockValidator::new(
+            "v",
+            ValidationMode::Verify,
+            MockResult::Errored,
+        ))])
+        .expect_err("verify validator error must block (fail-closed)");
+        match err {
+            Error::ValidationRejected(reports) => {
+                assert_eq!(reports[0].outcome, ValidationOutcome::Failed);
+                assert_eq!(reports[0].findings[0].severity, Severity::Fatal);
+            }
+            other => panic!("expected ValidationRejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_error_can_be_fail_open() {
+        let reports = run(vec![Arc::new(
+            MockValidator::new("v", ValidationMode::Verify, MockResult::Errored)
+                .on_error(OnError::Continue),
+        )])
+        .expect("on_error=continue must not block");
+        assert!(reports.is_empty());
+    }
+
+    #[test]
+    fn non_applicable_validator_is_skipped() {
+        let reports = run(vec![Arc::new(
+            MockValidator::new("v", ValidationMode::Verify, MockResult::Failed).applies(false),
+        )])
+        .expect("non-applicable validator must be skipped");
+        assert!(reports.is_empty());
+    }
 }

--- a/modules/ingestor/src/service/sbom/clearly_defined.rs
+++ b/modules/ingestor/src/service/sbom/clearly_defined.rs
@@ -70,6 +70,7 @@ impl<'g> ClearlyDefinedLoader<'g> {
                 id: sbom.sbom.sbom_id.to_string(),
                 document_id: sbom.sbom.document_id,
                 warnings: vec![],
+                validation: Vec::new(),
             })
         } else {
             Err(Error::Generic(anyhow!("No valid information")))

--- a/modules/ingestor/src/service/sbom/clearly_defined_curation.rs
+++ b/modules/ingestor/src/service/sbom/clearly_defined_curation.rs
@@ -44,6 +44,7 @@ impl<'g> ClearlyDefinedCurationLoader<'g> {
             id: sbom.sbom.sbom_id.to_string(),
             document_id: sbom.sbom.document_id,
             warnings: vec![],
+            validation: Vec::new(),
         })
     }
 }

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -84,6 +84,7 @@ impl<'g> CyclonedxLoader<'g> {
             id: ctx.sbom.sbom_id.to_string(),
             document_id,
             warnings: warnings.into(),
+            validation: Vec::new(),
         })
     }
 }

--- a/modules/ingestor/src/service/sbom/spdx.rs
+++ b/modules/ingestor/src/service/sbom/spdx.rs
@@ -67,6 +67,7 @@ impl<'g> SpdxLoader<'g> {
             id: sbom.sbom.sbom_id.to_string(),
             document_id: Some(document_id),
             warnings: warnings.into(),
+            validation: Vec::new(),
         })
     }
 }

--- a/modules/ingestor/src/service/validation/config.rs
+++ b/modules/ingestor/src/service/validation/config.rs
@@ -1,0 +1,142 @@
+//! Configuration for semantic validators and construction of the validator set.
+//!
+//! The default configuration is empty, which disables validation entirely and
+//! preserves the pre-existing ingestion behaviour. See ADR 00020.
+
+use crate::service::{
+    Format,
+    validation::{OnError, ScheckValidator, Severity, ValidationMode, Validator, scheck},
+};
+use anyhow::Context;
+use std::{fs, path::PathBuf, sync::Arc};
+
+/// Configuration for the complete set of validators.
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+pub struct ValidatorsConfig {
+    /// The validators to run, in order.
+    #[serde(default)]
+    pub validators: Vec<ValidatorConfig>,
+}
+
+/// Which backend implements a validator.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Backend {
+    /// The in-process `scheck` semantic validator.
+    #[default]
+    Scheck,
+}
+
+/// Configuration for a single validator.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct ValidatorConfig {
+    /// Stable identifier used in reports and logs.
+    pub name: String,
+    /// The backend implementing this validator.
+    #[serde(default)]
+    pub backend: Backend,
+    /// Formats this validator applies to. A category (e.g. `sbom`) matches all
+    /// of its concrete formats.
+    #[serde(default)]
+    pub formats: Vec<Format>,
+    /// Ruleset files to load (scheck JSON `.json` or DSL `.scheck`).
+    #[serde(default)]
+    pub rules: Vec<PathBuf>,
+    /// Optional backend-specific phase to activate.
+    #[serde(default)]
+    pub phase: Option<String>,
+    /// Whether findings only report, or gate ingestion.
+    #[serde(default)]
+    pub mode: ValidationMode,
+    /// For verify mode, the lowest severity that blocks ingestion.
+    #[serde(default = "default_threshold")]
+    pub threshold: Severity,
+    /// For verify mode, the behaviour when the validator itself errors.
+    #[serde(default)]
+    pub on_error: OnError,
+}
+
+fn default_threshold() -> Severity {
+    Severity::Error
+}
+
+/// Build the validator set from configuration.
+///
+/// Returns an empty set when no validators are configured, preserving the
+/// default validation-disabled behaviour.
+pub fn build(config: &ValidatorsConfig) -> Result<Vec<Arc<dyn Validator>>, anyhow::Error> {
+    let mut validators: Vec<Arc<dyn Validator>> = Vec::with_capacity(config.validators.len());
+    for validator in &config.validators {
+        match validator.backend {
+            Backend::Scheck => validators.push(Arc::new(build_scheck(validator)?)),
+        }
+    }
+    Ok(validators)
+}
+
+fn build_scheck(config: &ValidatorConfig) -> Result<ScheckValidator, anyhow::Error> {
+    let mut schemas = Vec::with_capacity(config.rules.len());
+    for path in &config.rules {
+        let contents = fs::read_to_string(path)
+            .with_context(|| format!("reading scheck ruleset {}", path.display()))?;
+        schemas.push(scheck::parse_ruleset(path, &contents)?);
+    }
+    Ok(ScheckValidator::new(config, schemas))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_builds_empty_set() {
+        let config = ValidatorsConfig::default();
+        let validators = build(&config).expect("builds");
+        assert!(validators.is_empty());
+    }
+
+    #[test]
+    fn yaml_round_trips_with_defaults() {
+        let yaml = r#"
+validators:
+  - name: scheck-csaf
+    formats: [csaf]
+    rules: []
+"#;
+        let config: ValidatorsConfig = serde_yml::from_str(yaml).expect("parses");
+        assert_eq!(config.validators.len(), 1);
+        let validator = &config.validators[0];
+        assert_eq!(validator.backend, Backend::Scheck);
+        assert_eq!(validator.mode, ValidationMode::Report);
+        assert_eq!(validator.threshold, Severity::Error);
+        assert_eq!(validator.on_error, OnError::Block);
+    }
+
+    #[test]
+    fn builds_scheck_validator_from_ruleset_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("rules.json");
+        std::fs::write(
+            &path,
+            r#"{"title":"t","patterns":[{"name":"p","title":"p","rules":[{"context":"$","checks":[{"kind":"assert","test":{"type":"exists","path":"$.x"},"message":"needs x"}]}]}]}"#,
+        )
+        .expect("write ruleset");
+
+        let config = ValidatorsConfig {
+            validators: vec![ValidatorConfig {
+                name: "scheck".into(),
+                backend: Backend::Scheck,
+                formats: vec![Format::CSAF],
+                rules: vec![path],
+                phase: None,
+                mode: ValidationMode::Report,
+                threshold: Severity::Error,
+                on_error: OnError::Block,
+            }],
+        };
+
+        let validators = build(&config).expect("builds");
+        assert_eq!(validators.len(), 1);
+        assert_eq!(validators[0].name(), "scheck");
+    }
+}

--- a/modules/ingestor/src/service/validation/mod.rs
+++ b/modules/ingestor/src/service/validation/mod.rs
@@ -1,0 +1,159 @@
+//! Third-party semantic validators run during ingestion.
+//!
+//! A [`Validator`] inspects a raw document (before it is parsed into the graph)
+//! and returns a structured [`ValidationReport`]. Validators run in one of two
+//! modes: [`ValidationMode::Report`] (findings are recorded but never block) or
+//! [`ValidationMode::Verify`] (a failing outcome blocks ingestion).
+//!
+//! See ADR 00020 for the design and rationale.
+
+pub mod config;
+pub mod scheck;
+
+pub use config::{Backend, ValidatorConfig, ValidatorsConfig, build};
+pub use scheck::ScheckValidator;
+
+use crate::service::Format;
+use sea_orm::prelude::async_trait;
+use std::fmt::Debug;
+
+/// Severity of a single validation finding.
+///
+/// Ordered from least to most severe, so `>=` comparisons express a threshold.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    utoipa::ToSchema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Info,
+    Warning,
+    Error,
+    Fatal,
+}
+
+/// A single validation finding produced by a validator.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+pub struct Finding {
+    /// The severity of this finding.
+    pub severity: Severity,
+    /// Human-readable description of the finding.
+    pub message: String,
+    /// Location within the document (e.g. a JSONPath), when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Identifier of the rule that produced the finding, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rule: Option<String>,
+}
+
+/// Whether a validator considered the document acceptable.
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, utoipa::ToSchema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum ValidationOutcome {
+    /// No finding met the validator's blocking threshold.
+    Passed,
+    /// At least one finding met the validator's blocking threshold.
+    Failed,
+}
+
+/// A structured report produced by a single validator run.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+pub struct ValidationReport {
+    /// The [`Validator::name`] that produced this report.
+    pub validator: String,
+    /// Findings produced by the validator.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub findings: Vec<Finding>,
+    /// The overall outcome, derived from the findings and the validator's threshold.
+    pub outcome: ValidationOutcome,
+}
+
+/// How a validator's findings affect ingestion.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ValidationMode {
+    /// Record findings only; never block ingestion.
+    #[default]
+    Report,
+    /// Block ingestion when the outcome is [`ValidationOutcome::Failed`].
+    Verify,
+}
+
+/// What to do when a [`ValidationMode::Verify`] validator cannot produce a verdict.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OnError {
+    /// Treat an errored validator as a failed gate and block ingestion.
+    #[default]
+    Block,
+    /// Log the error and let ingestion continue.
+    Continue,
+}
+
+/// Input handed to a validator.
+///
+/// Borrows the raw bytes; validators must not assume they can outlive the call.
+#[derive(Debug)]
+pub struct ValidatorInput<'a> {
+    /// Raw document bytes, before parsing.
+    pub bytes: &'a [u8],
+    /// The concrete format resolved by detection.
+    pub format: Format,
+}
+
+/// An error that prevented a validator from producing a verdict.
+///
+/// Distinct from a [`ValidationReport`] whose outcome is
+/// [`ValidationOutcome::Failed`]: this means the validator itself could not run.
+#[derive(Debug, thiserror::Error)]
+pub enum ValidatorError {
+    /// The validator backend failed to execute.
+    #[error("validator backend failed: {0}")]
+    Backend(#[source] anyhow::Error),
+    /// The validator did not complete within its time budget.
+    #[error("validator timed out")]
+    Timeout,
+}
+
+/// A third-party semantic validator run during ingestion.
+///
+/// Implementations are shared behind an `Arc` and may run concurrently, so they
+/// must be `Send + Sync`.
+#[async_trait::async_trait]
+pub trait Validator: Send + Sync + Debug {
+    /// Stable identifier, used in configuration, reports, and logs.
+    fn name(&self) -> &str;
+
+    /// The mode this validator runs in.
+    fn mode(&self) -> ValidationMode;
+
+    /// For [`ValidationMode::Verify`], the lowest severity that blocks ingestion.
+    fn threshold(&self) -> Severity;
+
+    /// For [`ValidationMode::Verify`], the behaviour when the validator errors.
+    fn on_error(&self) -> OnError;
+
+    /// Whether this validator applies to the given document format.
+    fn applies_to(&self, format: Format) -> bool;
+
+    /// Run the validator against a document.
+    ///
+    /// Returns a [`ValidationReport`] on success. Returning `Err` means the
+    /// validator could not produce a verdict, which is handled according to
+    /// [`Validator::on_error`].
+    async fn validate(
+        &self,
+        input: &ValidatorInput<'_>,
+    ) -> Result<ValidationReport, ValidatorError>;
+}

--- a/modules/ingestor/src/service/validation/scheck.rs
+++ b/modules/ingestor/src/service/validation/scheck.rs
@@ -1,0 +1,263 @@
+//! In-process [`Validator`] backend using the [`scheck`] semantic validator.
+//!
+//! Rulesets are parsed once at construction; each document is validated against
+//! every configured ruleset. See ADR 00020.
+
+use crate::service::{
+    Format,
+    validation::{
+        Finding, OnError, Severity, ValidationMode, ValidationOutcome, ValidationReport, Validator,
+        ValidatorError, ValidatorInput, config::ValidatorConfig,
+    },
+};
+use anyhow::{Context, anyhow};
+use sea_orm::prelude::async_trait;
+use std::{fmt, path::Path};
+
+/// A [`Validator`] that runs one or more `scheck` rulesets in-process.
+pub struct ScheckValidator {
+    name: String,
+    schemas: Vec<scheck::Schema>,
+    /// scheck phase to activate; empty string runs all patterns.
+    phase: String,
+    formats: Vec<Format>,
+    mode: ValidationMode,
+    threshold: Severity,
+    on_error: OnError,
+}
+
+impl ScheckValidator {
+    /// Construct a validator from its configuration and pre-parsed rulesets.
+    pub fn new(config: &ValidatorConfig, schemas: Vec<scheck::Schema>) -> Self {
+        Self {
+            name: config.name.clone(),
+            schemas,
+            phase: config.phase.clone().unwrap_or_default(),
+            formats: config.formats.clone(),
+            mode: config.mode,
+            threshold: config.threshold,
+            on_error: config.on_error,
+        }
+    }
+}
+
+impl fmt::Debug for ScheckValidator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScheckValidator")
+            .field("name", &self.name)
+            .field("rulesets", &self.schemas.len())
+            .field("phase", &self.phase)
+            .field("formats", &self.formats)
+            .field("mode", &self.mode)
+            .field("threshold", &self.threshold)
+            .field("on_error", &self.on_error)
+            .finish()
+    }
+}
+
+/// Parse a ruleset from file contents, choosing the format by file extension.
+///
+/// Supports scheck's JSON rule format (`.json`) and its DSL (`.scheck`).
+pub fn parse_ruleset(path: &Path, contents: &str) -> Result<scheck::Schema, anyhow::Error> {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("json") => serde_json::from_str(contents)
+            .with_context(|| format!("parsing JSON scheck ruleset {}", path.display())),
+        Some("scheck") => scheck::parse_schema(contents)
+            .map_err(|err| anyhow!("parsing scheck DSL ruleset {}: {err}", path.display())),
+        other => Err(anyhow!(
+            "unsupported scheck ruleset extension {other:?} for {}",
+            path.display()
+        )),
+    }
+}
+
+fn map_severity(severity: scheck::Severity) -> Severity {
+    match severity {
+        scheck::Severity::Info => Severity::Info,
+        scheck::Severity::Warning => Severity::Warning,
+        scheck::Severity::Error => Severity::Error,
+        scheck::Severity::Fatal => Severity::Fatal,
+    }
+}
+
+fn to_finding(result: &scheck::CheckResult) -> Finding {
+    let rule = if !result.rule_id.is_empty() {
+        Some(result.rule_id.clone())
+    } else if !result.pattern.is_empty() {
+        Some(result.pattern.clone())
+    } else {
+        None
+    };
+
+    Finding {
+        severity: map_severity(result.severity),
+        message: result.message.clone(),
+        path: (!result.path.is_empty()).then(|| result.path.clone()),
+        rule,
+    }
+}
+
+#[async_trait::async_trait]
+impl Validator for ScheckValidator {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn mode(&self) -> ValidationMode {
+        self.mode
+    }
+
+    fn threshold(&self) -> Severity {
+        self.threshold
+    }
+
+    fn on_error(&self) -> OnError {
+        self.on_error
+    }
+
+    fn applies_to(&self, format: Format) -> bool {
+        self.formats
+            .iter()
+            .any(|configured| format.matches_hint(*configured))
+    }
+
+    async fn validate(
+        &self,
+        input: &ValidatorInput<'_>,
+    ) -> Result<ValidationReport, ValidatorError> {
+        let text = std::str::from_utf8(input.bytes).map_err(|err| {
+            ValidatorError::Backend(anyhow!("document is not valid UTF-8: {err}"))
+        })?;
+        let doc = scheck::load(text)
+            .map_err(|err| ValidatorError::Backend(anyhow!("failed to load document: {err}")))?;
+
+        let mut findings = Vec::new();
+        let mut failed = false;
+
+        for schema in &self.schemas {
+            let report = scheck::validate_phase(schema, &doc, &self.phase);
+            for result in report.findings() {
+                findings.push(to_finding(result));
+            }
+            // Only failed asserts (problems) gate ingestion; successful reports
+            // are positive findings and never block.
+            if report
+                .failures()
+                .iter()
+                .any(|result| map_severity(result.severity) >= self.threshold)
+            {
+                failed = true;
+            }
+        }
+
+        let outcome = if failed {
+            ValidationOutcome::Failed
+        } else {
+            ValidationOutcome::Passed
+        };
+
+        Ok(ValidationReport {
+            validator: self.name.clone(),
+            findings,
+            outcome,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::validation::ValidatorConfig;
+
+    /// A ruleset asserting the document has a `document` object at the root.
+    const RULESET: &str = r#"{
+        "title": "test",
+        "patterns": [
+            {
+                "name": "required",
+                "title": "required",
+                "rules": [
+                    {
+                        "context": "$",
+                        "checks": [
+                            {
+                                "kind": "assert",
+                                "test": { "type": "exists", "path": "$.document" },
+                                "message": "must have a document object"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    fn config(formats: Vec<Format>, mode: ValidationMode) -> ValidatorConfig {
+        ValidatorConfig {
+            name: "test".into(),
+            backend: Default::default(),
+            formats,
+            rules: Vec::new(),
+            phase: None,
+            mode,
+            threshold: Severity::Error,
+            on_error: OnError::Block,
+        }
+    }
+
+    fn validator(mode: ValidationMode) -> ScheckValidator {
+        let schema = serde_json::from_str(RULESET).expect("valid ruleset");
+        ScheckValidator::new(&config(vec![Format::CSAF], mode), vec![schema])
+    }
+
+    #[tokio::test]
+    async fn passing_document_yields_passed() {
+        let validator = validator(ValidationMode::Verify);
+        let input = ValidatorInput {
+            bytes: br#"{"document":{}}"#,
+            format: Format::CSAF,
+        };
+        let report = validator.validate(&input).await.expect("validates");
+        assert_eq!(report.outcome, ValidationOutcome::Passed);
+    }
+
+    #[tokio::test]
+    async fn failing_document_yields_failed_with_findings() {
+        let validator = validator(ValidationMode::Verify);
+        let input = ValidatorInput {
+            bytes: br#"{"other":true}"#,
+            format: Format::CSAF,
+        };
+        let report = validator.validate(&input).await.expect("validates");
+        assert_eq!(report.outcome, ValidationOutcome::Failed);
+        assert!(!report.findings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn non_utf8_is_backend_error() {
+        let validator = validator(ValidationMode::Report);
+        let input = ValidatorInput {
+            bytes: &[0xff, 0xfe, 0x00],
+            format: Format::CSAF,
+        };
+        assert!(validator.validate(&input).await.is_err());
+    }
+
+    #[test]
+    fn applies_to_matches_category_hint() {
+        let schema = serde_json::from_str(RULESET).expect("valid ruleset");
+        let validator = ScheckValidator::new(
+            &config(vec![Format::SBOM], ValidationMode::Report),
+            vec![schema],
+        );
+        assert!(validator.applies_to(Format::SPDX));
+        assert!(validator.applies_to(Format::CycloneDX));
+        assert!(!validator.applies_to(Format::CSAF));
+    }
+
+    #[test]
+    fn parse_ruleset_rejects_unknown_extension() {
+        let err = parse_ruleset(Path::new("rules.txt"), "{}").unwrap_err();
+        assert!(err.to_string().contains("unsupported"));
+    }
+}

--- a/modules/ingestor/src/service/weakness/mod.rs
+++ b/modules/ingestor/src/service/weakness/mod.rs
@@ -144,6 +144,7 @@ impl CweCatalogLoader {
             id: digests.sha512.encode_hex(),
             document_id: Some("CWE".to_string()),
             warnings: vec![],
+            validation: Vec::new(),
         })
     }
 }

--- a/modules/ingestor/tests/common.rs
+++ b/modules/ingestor/tests/common.rs
@@ -19,6 +19,7 @@ pub async fn caller_with(
             db::ReadWrite::new(ctx.db.clone()),
             ctx.storage.clone(),
             Some(analysis),
+            Vec::new(),
         )
     })
     .await

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5290,6 +5290,29 @@ components:
           items:
             type: string
           description: warnings while parsing
+    Finding:
+      type: object
+      description: A single validation finding produced by a validator.
+      required:
+      - severity
+      - message
+      properties:
+        message:
+          type: string
+          description: Human-readable description of the finding.
+        path:
+          type:
+          - string
+          - 'null'
+          description: Location within the document (e.g. a JSONPath), when available.
+        rule:
+          type:
+          - string
+          - 'null'
+          description: Identifier of the rule that produced the finding, when available.
+        severity:
+          $ref: '#/components/schemas/Severity'
+          description: The severity of this finding.
     Format:
       type: string
       enum:
@@ -5527,6 +5550,15 @@ components:
         id:
           $ref: '#/components/schemas/Id'
           description: The internal ID of the document
+        validation:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationReport'
+          description: |-
+            Structured reports from semantic validators run during ingestion.
+
+            See ADR 00020. Empty when no validators are configured or none apply
+            to the document's format.
         warnings:
           type: array
           items:
@@ -7423,6 +7455,30 @@ components:
         oneOf:
         - type: 'null'
         - type: string
+    ValidationOutcome:
+      type: string
+      description: Whether a validator considered the document acceptable.
+      enum:
+      - passed
+      - failed
+    ValidationReport:
+      type: object
+      description: A structured report produced by a single validator run.
+      required:
+      - validator
+      - outcome
+      properties:
+        findings:
+          type: array
+          items:
+            $ref: '#/components/schemas/Finding'
+          description: Findings produced by the validator.
+        outcome:
+          $ref: '#/components/schemas/ValidationOutcome'
+          description: The overall outcome, derived from the findings and the validator's threshold.
+        validator:
+          type: string
+          description: The [`Validator::name`] that produced this report.
     VersionRange:
       oneOf:
       - type: object

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -32,6 +32,7 @@ humantime = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
+serde_yml = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 utoipa = { workspace = true, features = ["actix_extras", "yaml"] }

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -39,6 +39,7 @@ pub async fn create_openapi() -> anyhow::Result<utoipa::openapi::OpenApi> {
                     read_only: false,
                     ei_service,
                     graph: Graph::new(),
+                    validators: Vec::new(),
                 },
             );
         })

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -40,7 +40,10 @@ use trustify_module_exploit_intelligence::{
     runner::worker::start_worker,
     service::{ExploitIntelligenceConfig, ExploitIntelligenceService},
 };
-use trustify_module_ingestor::graph::Graph;
+use trustify_module_ingestor::{
+    graph::Graph,
+    service::validation::{self, Validator, ValidatorsConfig},
+};
 use trustify_module_notification::config::NotificationConfig;
 use trustify_module_storage::{config::StorageConfig, service::dispatch::DispatchBackend};
 use trustify_module_ui::{UI, endpoints::UiResources};
@@ -371,7 +374,7 @@ struct InitData {
     broadcaster: ChangeBroadcaster,
     read_only: bool,
     ei_config: Option<ExploitIntelligenceConfig>,
-    validators: Vec<Arc<dyn trustify_module_ingestor::service::validation::Validator>>,
+    validators: Vec<Arc<dyn Validator>>,
 }
 
 /// Groups all module configurations.
@@ -485,10 +488,9 @@ impl InitData {
                 let raw = tokio::fs::read_to_string(path)
                     .await
                     .with_context(|| format!("reading validators config {}", path.display()))?;
-                let config: trustify_module_ingestor::service::validation::ValidatorsConfig =
-                    serde_yml::from_str(&raw)
-                        .with_context(|| format!("parsing validators config {}", path.display()))?;
-                trustify_module_ingestor::service::validation::build(&config)?
+                let config: ValidatorsConfig = serde_yml::from_str(&raw)
+                    .with_context(|| format!("parsing validators config {}", path.display()))?;
+                validation::build(&config)?
             }
             None => Vec::new(),
         };
@@ -645,7 +647,7 @@ pub(crate) struct Config {
     pub(crate) read_only: bool,
     pub(crate) ei_service: ExploitIntelligenceService,
     pub(crate) graph: Graph,
-    pub(crate) validators: Vec<Arc<dyn trustify_module_ingestor::service::validation::Validator>>,
+    pub(crate) validators: Vec<Arc<dyn Validator>>,
 }
 
 pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfig, config: Config) {

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -3,9 +3,10 @@ use crate::embedded_oidc;
 
 use crate::{endpoints, profile::spawn_db_check, sample_data};
 use actix_web::web;
+use anyhow::Context;
 use bytesize::ByteSize;
 use futures::FutureExt;
-use std::{env, process::ExitCode, sync::Arc};
+use std::{env, path::PathBuf, process::ExitCode, sync::Arc};
 use tokio::sync::oneshot;
 use trustify_auth::{
     auth::AuthConfigArguments,
@@ -99,6 +100,13 @@ pub struct Run {
         default_value_t = default::scan_limit()
     )]
     pub scan_limit: BinaryByteSize,
+
+    /// Path to a semantic validators configuration file (YAML).
+    ///
+    /// When unset (the default), no validators run and ingestion behaves as
+    /// before. See ADR 00020.
+    #[arg(long, env = "TRUSTD_VALIDATORS_CONFIG")]
+    pub validators_config: Option<PathBuf>,
 
     // flattened commands must go last
     //
@@ -363,6 +371,7 @@ struct InitData {
     broadcaster: ChangeBroadcaster,
     read_only: bool,
     ei_config: Option<ExploitIntelligenceConfig>,
+    validators: Vec<Arc<dyn trustify_module_ingestor::service::validation::Validator>>,
 }
 
 /// Groups all module configurations.
@@ -469,6 +478,21 @@ impl InitData {
 
         let ei_config = run.exploit_intelligence.into_config().await?;
 
+        // Build the semantic validator set (ADR 00020). With no config file,
+        // this is empty and ingestion behaves exactly as before.
+        let validators = match &run.validators_config {
+            Some(path) => {
+                let raw = tokio::fs::read_to_string(path)
+                    .await
+                    .with_context(|| format!("reading validators config {}", path.display()))?;
+                let config: trustify_module_ingestor::service::validation::ValidatorsConfig =
+                    serde_yml::from_str(&raw)
+                        .with_context(|| format!("parsing validators config {}", path.display()))?;
+                trustify_module_ingestor::service::validation::build(&config)?
+            }
+            None => Vec::new(),
+        };
+
         let broadcaster = ChangeBroadcaster::new(
             &db_rw,
             *run.notification.change_log_retention,
@@ -495,6 +519,7 @@ impl InitData {
             ui,
             read_only: run.read_only,
             ei_config,
+            validators,
         })
     }
 
@@ -532,6 +557,7 @@ impl InitData {
                             read_only: self.read_only,
                             ei_service: ei_service.clone(),
                             graph: graph.clone(),
+                            validators: self.validators.clone(),
                         },
                     );
                 })
@@ -619,6 +645,7 @@ pub(crate) struct Config {
     pub(crate) read_only: bool,
     pub(crate) ei_service: ExploitIntelligenceService,
     pub(crate) graph: Graph,
+    pub(crate) validators: Vec<Arc<dyn trustify_module_ingestor::service::validation::Validator>>,
 }
 
 pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfig, config: Config) {
@@ -639,6 +666,7 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
         read_only,
         ei_service,
         graph,
+        validators,
     } = config;
 
     let limit = ByteSize::gb(1).as_u64() as usize;
@@ -667,6 +695,7 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
                     db_rw.clone(),
                     storage.clone(),
                     Some(analysis.clone()),
+                    validators.clone(),
                 );
                 trustify_module_fundamental::endpoints::configure(
                     svc,
@@ -677,6 +706,7 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
                     analysis.clone(),
                     cache,
                     graph,
+                    validators,
                 );
                 trustify_module_exploit_intelligence::endpoints::configure(
                     svc,
@@ -775,6 +805,7 @@ mod test {
                             ei_service: ExploitIntelligenceService::new(None)
                                 .expect("disabled EI service"),
                             graph: Graph::new(),
+                            validators: Vec::new(),
                         },
                     );
                 })
@@ -861,6 +892,7 @@ mod test {
                     read_only,
                     ei_service,
                     graph,
+                    validators: Vec::new(),
                 },
             );
         })
@@ -1077,6 +1109,7 @@ mod test {
             #[cfg(feature = "garage-door")]
             embedded_oidc: None,
             ui: Default::default(),
+            validators: Vec::new(),
         };
         let graph = Graph::new();
 
@@ -1136,6 +1169,7 @@ mod test {
                     ei_service,
                     graph,
                     broadcaster,
+                    validators: Vec::new(),
                 },
             );
         })


### PR DESCRIPTION
Added [ADR](https://github.com/rh-jfuller/trustify/blob/aa41899bc2ac175d1ab7c8cf773306edc978b6dd/docs/adrs/00020-semantic-validators-on-ingestion.md) outlining how we might bring in semantic validation.

Added validator with [scheck](https://github.com/rh-jfuller/scheck) as first one as example.

## Summary by Sourcery

Introduce opt-in semantic validation for ingested documents with configurable scheck rules, structured reports, and optional ingestion blocking.

New Features:
- Add configurable semantic validation during document ingestion using an in-process scheck backend.
- Expose structured validation findings in ingestion results and return validation details when verification rejects a document.

Enhancements:
- Introduce a backend-independent validator abstraction with report and verify modes, severity thresholds, and configurable error handling.
- Run applicable validators before persistence while preserving existing warning messages and default behavior when validation is disabled.

Build:
- Add the scheck and YAML configuration dependencies.

Documentation:
- Document the semantic validation design and ingestion behavior in ADR 00020.
- Document the TRUSTD_VALIDATORS_CONFIG environment variable.

Tests:
- Add coverage for validator configuration, scheck rule evaluation, applicability, failure handling, and ingestion gating.

Chores:
- Update the OpenAPI schema with structured validation report types.