### PR TITLE
fix: remove dead id field from RemediationSummary

### DIFF
--- a/modules/fundamental/src/purl/model/summary/remediation.rs
+++ b/modules/fundamental/src/purl/model/summary/remediation.rs
@@ -1,12 +1,9 @@
 use serde::{Deserialize, Serialize};
 use trustify_entity::remediation::{self, RemediationCategory};
 use utoipa::ToSchema;
-use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema, PartialEq)]
 pub struct RemediationSummary {
-    #[serde(skip_serializing)]
-    pub id: Uuid,
     pub category: RemediationCategory,
     pub details: Option<String>,
     pub url: Option<String>,
@@ -20,7 +17,6 @@ impl RemediationSummary {
         remediations
             .iter()
             .map(|r| Self {
-                id: r.id,
                 category: r.category.clone(),
                 details: r.details.clone(),
                 url: r.url.clone(),

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -716,7 +716,6 @@ GROUP BY
 
         #[derive(Debug, Clone, serde::Deserialize)]
         struct RemediationEntry {
-            id: Uuid,
             category: RemediationCategory,
             details: Option<String>,
             url: Option<String>,
@@ -760,7 +759,6 @@ GROUP BY
                     .remediations
                     .iter()
                     .map(|r| RemediationSummary {
-                        id: r.id,
                         category: r.category.clone(),
                         details: r.details.clone(),
                         url: r.url.clone(),

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -22,7 +22,6 @@ use trustify_common::{
 };
 use trustify_entity::remediation::RemediationCategory;
 use trustify_test_context::TrustifyContext;
-use uuid::Uuid;
 
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
@@ -1021,14 +1020,11 @@ async fn analyze_purls_product_status(ctx: &TrustifyContext) -> Result<(), anyho
         })
         .unwrap();
 
-    let mut remediations = jboss_fuse_service_works.remediations.clone();
-    let (slice1, _slice2) = remediations.split_at_mut(1);
-    slice1[0].id = Uuid::nil();
+    let remediations = jboss_fuse_service_works.remediations.clone();
 
     assert_eq!(
-        slice1[0],
+        remediations[0],
         RemediationSummary {
-            id: Uuid::nil(),
             category: RemediationCategory::NoFixPlanned,
             details: Some("Out of support scope".to_string()),
             url: None,
@@ -1090,9 +1086,6 @@ async fn analyze_purls_product_status_0044(ctx: &TrustifyContext) -> Result<(), 
     assert_eq!(remediations.len(), 2);
 
     remediations.sort_by_key(|r| format!("{:?}", r.category));
-    for r in &mut remediations {
-        r.id = Uuid::nil();
-    }
 
     // Only red_hat_build_of_quarkus:io.quarkus/quarkus-vertx-http product ID ends up in the output here, as all other
     // product IDs in CVE-2023-0044.json are either in `product_status.fixed` or `product_status.known_not_affected`
@@ -1100,7 +1093,6 @@ async fn analyze_purls_product_status_0044(ctx: &TrustifyContext) -> Result<(), 
         remediations,
         vec![
             RemediationSummary {
-                id: Uuid::nil(),
                 category: RemediationCategory::NoneAvailable,
                 details: Some("Affected".to_string()),
                 url: None,
@@ -1113,7 +1105,6 @@ async fn analyze_purls_product_status_0044(ctx: &TrustifyContext) -> Result<(), 
                 })
             },
             RemediationSummary {
-                id: Uuid::nil(),
                 category: RemediationCategory::Workaround,
                 details: Some(
                     "This attack can be prevented with the Quarkus CSRF Prevention feature."


### PR DESCRIPTION
## Summary

- Remove the unused `id: Uuid` field from `RemediationSummary`
- The field was marked `#[serde(skip_serializing)]` (f839bb43) which skipped serialization but still **required** the field during deserialization — causing a `missing field 'id'` panic when round-tripping `/vulnerability/analyze` responses that include remediations
- The field was never read after construction; tests only used it to zero it out before comparison

## Test plan

- [x] `analyze_purls_product_status` — passes without zeroing `id`
- [x] `analyze_purls_product_status_0044` — passes without zeroing `id`
- [x] `analyze_purls_product_status_version_filtering` — passes
- [x] Correlation tests S6/S7 — still pass (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the unused `id` field from remediation summaries to fix vulnerability analysis response deserialization and simplify related tests.

Bug Fixes:
- Remove the unused remediation identifier so vulnerability analysis responses deserialize and round-trip without missing-field failures.

Enhancements:
- Simplify remediation summaries and service mappings by retaining only the fields exposed and used by consumers.

Tests:
- Update vulnerability analysis tests to compare remediation summaries directly without clearing obsolete identifiers, while preserving correlation regression coverage.