### PR TITLE
test(correlation): add S16 cross-scheme golang PURL-query scenario (TC-5170)

### DIFF
--- a/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/README.md
+++ b/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/README.md
@@ -1,0 +1,48 @@
+# S16 — Cross-scheme PURL query: non-RPM package inherits an RPM/Storage-3 status — TC-5170
+
+Reproduces the **original [TC-5170](https://redhat.atlassian.net/browse/TC-5170) symptom**: querying a
+**non-RPM** PURL (OCI, Maven, …) returns a `product_status` whose version range / context belongs to an
+**RPM under Red Hat Storage 3** — e.g. the ticket's `pkg:oci/golang@1.25` getting an rpm
+`[3.0.0,4.0.0) scheme=rpm` range. Root cause: `get_product_statuses_for_purl` matched by base package
+**name** without checking version **scheme** or product context.
+
+## Data
+`vex/CVE-2023-44487.json` (HTTP/2 Rapid Reset): `golang` `known_affected` in **Red Hat Storage 3**
+(`cpe:/a:redhat:storage:3`), bare component → `product_status`. The correct discriminator is **product
+identity** (is the SBOM Storage 3?) and **scheme** (rpm vs oci/maven) — never base name alone.
+
+> **Synthetic advisory (by design).** Unlike the other scenarios (real Red Hat CSAF), this VEX is a small
+> hand-crafted CSAF: a `golang` `product_version` branch `default_component_of red_hat_storage_3:golang.src`
+> with `known_affected: [red_hat_storage_3:golang.src]`. That is the correct `product_status` shape and it is
+> run-verified to fire, but the real CVE-2023-44487 CSAF is huge — synthetic keeps the scenario focused.
+
+## VEX ↔ SBOM correlation
+
+| SBOM | CPE on | pkg@version (scheme) | Matched VEX entry | Expected | Note |
+|---|---|---|---|---|---|
+| `sbom_golang_rpm_storage3` | describing/**root** | `golang@3.5.0` (rpm) | `golang` known_affected @ `cpe:/a:redhat:storage:3` (range `[3,4)`) | **affected** | positive control — in-context rpm; **coincidental** match: `3.5.0` falls in `[3,4)` only because component-major `3` == product-major `3`; a `5.x` would drop |
+| `sbom_golang_oci` | none | `golang@1.25` (oci) | — (cross-scheme, not Storage 3) | **not_affected** | TC-5170 exact repro — oci must not inherit the rpm/Storage-3 status |
+| `sbom_golang_maven` | none | `golang@3.5.0` (maven) | — (cross-scheme, not Storage 3) | **not_affected** | `3.5.0` *looks* in an rpm `[3,4)` range, but applying an rpm range to a Maven version is a category error |
+
+### Reading the matrix
+- **rpm_storage3** — the positive control. The SBOM is genuinely Red Hat Storage 3 (an rpm `golang` under
+  `cpe:/a:redhat:storage:3` on the describing/root node) ⇒ **affected**. Note this is a **coincidental** pass:
+  the `product_status` range derived from the `storage:3` CPE is `[3,4)`, and `golang@3.5.0` falls inside it
+  only because the component major (`3`) happens to equal the product major (`3`); a `golang@5.x` here would
+  silently drop. It proves the fix does not over-suppress a real in-context match, not that "any version" hits.
+- **oci** — not Storage 3, and rpm↔oci is cross-scheme, so nothing should correlate ⇒ **not_affected**. This
+  is the ticket's exact repro: a `pkg:oci/golang@1.25` must not inherit the Storage-3 rpm status.
+- **maven** — not Storage 3, and rpm↔maven is cross-scheme ⇒ **not_affected**. The `3.5.0` version *looks*
+  like it falls inside an rpm `[3,4)` range, but applying an rpm range to a Maven version is a category error;
+  product identity + scheme decide, not the number.
+
+The rpm_storage3-vs-{oci,maven} contrast (same base name `golang`, only scheme/product context differs)
+isolates the cross-scheme name-only match: on a correct engine only the in-context rpm correlates, while the
+non-RPM packages are **expected to leak per TC-5170** on whichever paths still match by name without checking
+scheme or product context.
+
+**Bug (TC-5170):** get_product_statuses_for_purl matches golang by base name without checking PURL scheme or product context, so a non-RPM golang inherits the Storage-3 rpm status.
+
+## Files
+- SBOMs: `sbom_golang_{oci,maven,rpm_storage3}.{cdx,spdx}.json`.
+- Advisory: `vex/CVE-2023-44487.json` (bare `golang` known_affected under `cpe:/a:redhat:storage:3`).

--- a/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/expected.json
+++ b/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/expected.json
@@ -1,0 +1,22 @@
+{
+  "advisories": [
+    "vex/CVE-2023-44487.json"
+  ],
+  "sboms": {
+    "sbom_golang_oci": {
+      "correct": {
+        "CVE-2023-44487": "not_affected"
+      }
+    },
+    "sbom_golang_maven": {
+      "correct": {
+        "CVE-2023-44487": "not_affected"
+      }
+    },
+    "sbom_golang_rpm_storage3": {
+      "correct": {
+        "CVE-2023-44487": "affected"
+      }
+    }
+  }
+}

--- a/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/sbom_golang_maven.cdx.json
+++ b/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/sbom_golang_maven.cdx.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:16160000-0000-4000-8000-1616golangmaven",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "bom-ref": "root-s16",
+      "type": "application",
+      "name": "s16-crossscheme-target",
+      "version": "1"
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg-golang",
+      "type": "library",
+      "name": "golang",
+      "version": "3.5.0",
+      "purl": "pkg:maven/org.golang/golang@3.5.0?type=jar"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root-s16",
+      "dependsOn": [
+        "pkg-golang"
+      ]
+    }
+  ]
+}

--- a/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/sbom_golang_maven.spdx.json
+++ b/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/sbom_golang_maven.spdx.json
@@ -1,0 +1,49 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "s16-crossscheme-target",
+  "documentNamespace": "https://trust-breaker/s16/golang-maven",
+  "creationInfo": {
+    "created": "2026-09-02T00:00:00Z",
+    "creators": [
+      "Tool: trust-breaker-0.1"
+    ]
+  },
+  "documentDescribes": [
+    "SPDXRef-root"
+  ],
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-root",
+      "name": "s16-crossscheme-target",
+      "versionInfo": "1",
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-golang",
+      "name": "golang",
+      "versionInfo": "3.5.0",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:maven/org.golang/golang@3.5.0?type=jar"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-root"
+    },
+    {
+      "spdxElementId": "SPDXRef-root",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-golang"
+    }
+  ]
+}

--- a/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/sbom_golang_oci.cdx.json
+++ b/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/sbom_golang_oci.cdx.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:16160000-0000-4000-8000-1616golang00oci",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "bom-ref": "root-s16",
+      "type": "application",
+      "name": "s16-crossscheme-target",
+      "version": "1"
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg-golang",
+      "type": "container",
+      "name": "golang",
+      "version": "1.25",
+      "purl": "pkg:oci/golang@1.25?repository_url=docker.io/golang&tag=1.25"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root-s16",
+      "dependsOn": [
+        "pkg-golang"
+      ]
+    }
+  ]
+}

--- a/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/sbom_golang_oci.spdx.json
+++ b/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/sbom_golang_oci.spdx.json
@@ -1,0 +1,49 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "s16-crossscheme-target",
+  "documentNamespace": "https://trust-breaker/s16/golang-oci",
+  "creationInfo": {
+    "created": "2026-09-02T00:00:00Z",
+    "creators": [
+      "Tool: trust-breaker-0.1"
+    ]
+  },
+  "documentDescribes": [
+    "SPDXRef-root"
+  ],
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-root",
+      "name": "s16-crossscheme-target",
+      "versionInfo": "1",
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-golang",
+      "name": "golang",
+      "versionInfo": "1.25",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:oci/golang@1.25?repository_url=docker.io/golang&tag=1.25"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-root"
+    },
+    {
+      "spdxElementId": "SPDXRef-root",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-golang"
+    }
+  ]
+}

--- a/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/sbom_golang_rpm_storage3.cdx.json
+++ b/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/sbom_golang_rpm_storage3.cdx.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:16160000-0000-4000-8000-1616golangstor3",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "bom-ref": "root-s16",
+      "type": "application",
+      "name": "s16-crossscheme-target",
+      "version": "1",
+      "cpe": "cpe:/a:redhat:storage:3"
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg-golang",
+      "type": "library",
+      "name": "golang",
+      "version": "3.5.0",
+      "purl": "pkg:rpm/redhat/golang@3.5.0?arch=x86_64&epoch=0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root-s16",
+      "dependsOn": [
+        "pkg-golang"
+      ]
+    }
+  ]
+}

--- a/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/sbom_golang_rpm_storage3.spdx.json
+++ b/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/sbom_golang_rpm_storage3.spdx.json
@@ -1,0 +1,56 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "s16-crossscheme-target",
+  "documentNamespace": "https://trust-breaker/s16/golang-rpm_storage3",
+  "creationInfo": {
+    "created": "2026-09-02T00:00:00Z",
+    "creators": [
+      "Tool: trust-breaker-0.1"
+    ]
+  },
+  "documentDescribes": [
+    "SPDXRef-root"
+  ],
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-root",
+      "name": "s16-crossscheme-target",
+      "versionInfo": "1",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:redhat:storage:3:*:*:*:*:*:*:*"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-golang",
+      "name": "golang",
+      "versionInfo": "3.5.0",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/golang@3.5.0?arch=x86_64&epoch=0"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-root"
+    },
+    {
+      "spdxElementId": "SPDXRef-root",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-golang"
+    }
+  ]
+}

--- a/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/vex/CVE-2023-44487.json
+++ b/etc/test-data/scenarios/S16_crossscheme_purlquery_golang/vex/CVE-2023-44487.json
@@ -1,0 +1,135 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Important"
+    },
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright \u00a9 Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat products and services.",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://security.access.redhat.com/data/csaf/v2/vex/2023/cve-2023-44487.json"
+      }
+    ],
+    "title": "HTTP/2: Multiple HTTP/2 enabled web servers are vulnerable to a DDoS attack (Rapid Reset Attack)",
+    "tracking": {
+      "current_release_date": "2026-08-19T15:02:30+00:00",
+      "generator": {
+        "date": "2026-08-19T15:02:30+00:00",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "5.3.16"
+        }
+      },
+      "id": "CVE-2023-44487",
+      "initial_release_date": "2023-10-10T00:00:00+00:00",
+      "revision_history": [
+        {
+          "date": "2023-10-10T00:00:00+00:00",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2026-08-18T03:37:17+00:00",
+          "number": "2",
+          "summary": "Current version"
+        },
+        {
+          "date": "2026-08-19T15:02:30+00:00",
+          "number": "3",
+          "summary": "Last generated version"
+        }
+      ],
+      "status": "final",
+      "version": "3"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Red Hat",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "Red Hat Storage 3",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Storage 3",
+                "product": {
+                  "name": "Red Hat Storage 3",
+                  "product_id": "red_hat_storage_3",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:storage:3"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "category": "vendor",
+        "name": "Red Hat",
+        "branches": [
+          {
+            "category": "product_version",
+            "name": "golang",
+            "product": {
+              "name": "golang",
+              "product_id": "golang.src",
+              "product_identification_helper": {}
+            }
+          }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "golang.src as a component of Red Hat Storage 3",
+          "product_id": "red_hat_storage_3:golang.src"
+        },
+        "product_reference": "golang.src",
+        "relates_to_product_reference": "red_hat_storage_3"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-44487",
+      "title": "HTTP/2: Multiple HTTP/2 enabled web servers are vulnerable to a DDoS attack (Rapid Reset Attack)",
+      "product_status": {
+        "known_affected": [
+          "red_hat_storage_3:golang.src"
+        ]
+      }
+    }
+  ]
+}

--- a/modules/fundamental/src/correlation/test.rs
+++ b/modules/fundamental/src/correlation/test.rs
@@ -1035,3 +1035,69 @@ async fn s14_productstatus_version_filter_netty(
 
     Ok(())
 }
+
+// ===========================================================================
+// S16: Cross-scheme PURL query golang (TC-5170)
+//
+// CVE-2023-44487 marks `golang` known_affected only under Red Hat Storage 3
+// (cpe:/a:redhat:storage:3), as a bare component. A non-RPM golang PURL (OCI,
+// Maven) must NOT inherit that rpm/Storage-3 status: get_product_statuses_for_purl
+// matches by base name without checking PURL scheme or product context, so the
+// non-RPM packages leak. The positive control (rpm under Storage 3) is a
+// coincidental version match — the storage:3-derived range [3,4) contains
+// golang@3.5.0 only because the majors coincide.
+//
+// NOTE: the advisory here is a small synthetic CSAF (the real CVE-2023-44487
+// CSAF is huge); it carries the correct product_status shape.
+// ===========================================================================
+
+#[test_context(TrustifyContext)]
+#[rstest]
+#[ignore = "TC-5170: get_product_statuses_for_purl matches golang by name only, ignoring PURL scheme/product (Storage 3) context"]
+#[test_log::test(actix_web::test)]
+async fn s16_crossscheme_purlquery_golang(
+    ctx: &TrustifyContext,
+    #[values("cdx", "spdx")] fmt: &str,
+) -> Result<(), anyhow::Error> {
+    ingest_scenario_advisories(
+        ctx,
+        "S16_crossscheme_purlquery_golang",
+        &["vex/CVE-2023-44487.json"],
+    )
+    .await?;
+
+    let app = caller(ctx).await?;
+
+    // (SBOM base name, expected_affected)
+    let cases: &[(&str, bool)] = &[
+        // in-context rpm under Storage 3 → affected (coincidental major match)
+        ("sbom_golang_rpm_storage3", true),
+        // non-RPM golang must NOT inherit the rpm/Storage-3 status
+        ("sbom_golang_oci", false),
+        ("sbom_golang_maven", false),
+    ];
+
+    let mut mismatches = Vec::new();
+    for (base, expected_affected) in cases {
+        let sbom = ctx
+            .ingest_document(&format!(
+                "scenarios/S16_crossscheme_purlquery_golang/{base}.{fmt}.json"
+            ))
+            .await?;
+        let adv = get_sbom_advisories(&app, &sbom.id.to_string()).await;
+        let present = advisory_cves(&adv).contains(&"CVE-2023-44487");
+        if present != *expected_affected {
+            mismatches.push(format!(
+                "  {base} ({fmt}): expected affected={expected_affected}, /sbom/advisory present={present}"
+            ));
+        }
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "S16 CVE-2023-44487 correlation mismatches:\n{}",
+        mismatches.join("\n")
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Adds the **S16** correlation scenario: a **non-RPM** golang PURL (OCI, Maven) must not inherit a `product_status` whose version range/context belongs to an **RPM golang under Red Hat Storage 3**.
- Reproduces the original [TC-5170](https://redhat.atlassian.net/browse/TC-5170) symptom: `get_product_statuses_for_purl` matches golang by base **name** without checking PURL **scheme** or **product** context.
- 3 SBOMs (cdx+spdx); test asserts `GET /sbom/{id}/advisory`; `#[ignore]` pending TC-5170.

Test-data task: [TC-5677](https://redhat.atlassian.net/browse/TC-5677) · Bug: [TC-5170](https://redhat.atlassian.net/browse/TC-5170) · Epic: [TC-5639](https://redhat.atlassian.net/browse/TC-5639)

## VEX ↔ SBOM correlation

**VEX** `CVE-2023-44487` (HTTP/2 Rapid Reset) — `golang` `known_affected` only under `cpe:/a:redhat:storage:3` (bare component). The correct discriminator is product identity + PURL scheme, never base name.

> **Synthetic advisory (by design):** a small hand-crafted CSAF with the correct `product_status` shape (real CVE-2023-44487 CSAF is huge). Run-verified to fire.

| SBOM | CPE on | pkg@version (scheme) | Matched VEX entry | Expected | Engine today |
|---|---|---|---|---|---|
| `sbom_golang_rpm_storage3` | describing/root | `golang@3.5.0` (rpm) | golang known_affected @ `cpe:/a:redhat:storage:3` (range `[3,4)`) | **affected** | affected ✓ |
| `sbom_golang_oci` | none | `golang@1.25` (oci) | — (cross-scheme, not Storage 3) | **not_affected** | **affected** ✗ TC-5170 |
| `sbom_golang_maven` | none | `golang@3.5.0` (maven) | — (cross-scheme, not Storage 3) | **not_affected** | **affected** ✗ TC-5170 |

**Findings (confirmed by a local run):** the positive control (`rpm_storage3`) fires correctly; `oci` and `maven` both leak as affected — the TC-5170 cross-scheme name-only match.

**Caveat:** the positive control passes by a **coincidental** version match — the `storage:3`-derived range `[3,4)` contains `golang@3.5.0` only because the component major (`3`) equals the product major (`3`); a `golang@5.x` would drop. It proves the match isn't over-suppressed, not that "any version" hits.

## Running
```bash
# runs as ignored (known-failing) until TC-5170 is fixed
cargo test -p trustify-module-fundamental --lib -- correlation::test::s16 --include-ignored
```
Drop `#[ignore]` once TC-5170 is fixed to turn this into a regression guard.

## Notes
- Advisory `vex/CVE-2023-44487.json` is stored **plain** (~4 KB).
- Heads-up: S15–S19 and the S7 update all append to `modules/fundamental/src/correlation/test.rs`. These land in sequence (S15→S16→S17→S18→S19→S7); expect a mechanical conflict-resolution (keep both appended fns) rather than a clean rebase when merging alongside the sibling PRs.


[TC-5170]: https://redhat.atlassian.net/browse/TC-5170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-5677]: https://redhat.atlassian.net/browse/TC-5677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-5170]: https://redhat.atlassian.net/browse/TC-5170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-5639]: https://redhat.atlassian.net/browse/TC-5639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add an ignored regression scenario for preventing non-RPM golang packages from inheriting Red Hat Storage 3 RPM vulnerability statuses.

Documentation:
- Document the S16 cross-scheme golang correlation scenario and its expected product and PURL-scheme behavior.

Tests:
- Add ignored correlation coverage for RPM, OCI, and Maven golang SBOMs across CycloneDX and SPDX formats, validating that only the in-context RPM package is affected.
- Add S16 scenario fixtures, including three SBOM pairs, expected results, and a synthetic CVE-2023-44487 advisory.