### PR TITLE
feat(exploit): add dedicated exploit permissions

### DIFF
--- a/common/auth/src/authenticator/default.rs
+++ b/common/auth/src/authenticator/default.rs
@@ -11,6 +11,7 @@ pub const DEFAULT_SCOPE_MAPPINGS: &[(&str, &[&str])] = &[
         "create:document",
         &[
             "create.advisory",
+            "create.exploit",
             "create.exploitIntelligence",
             "create.importer",
             "create.metadata",
@@ -25,6 +26,7 @@ pub const DEFAULT_SCOPE_MAPPINGS: &[(&str, &[&str])] = &[
         &[
             "ai",
             "read.advisory",
+            "read.exploit",
             "read.exploitIntelligence",
             "read.importer",
             "read.metadata",
@@ -38,6 +40,7 @@ pub const DEFAULT_SCOPE_MAPPINGS: &[(&str, &[&str])] = &[
         "update:document",
         &[
             "update.advisory",
+            "update.exploit",
             "update.importer",
             "update.metadata",
             "update.sbom",
@@ -49,6 +52,7 @@ pub const DEFAULT_SCOPE_MAPPINGS: &[(&str, &[&str])] = &[
         "delete:document",
         &[
             "delete.advisory",
+            "delete.exploit",
             "delete.importer",
             "delete.metadata",
             "delete.sbom",

--- a/common/auth/src/permission.rs
+++ b/common/auth/src/permission.rs
@@ -122,6 +122,15 @@ permission! {
         CreateExploitIntelligence,
         #[strum(serialize = "read.exploitIntelligence")]
         ReadExploitIntelligence,
+
+        #[strum(serialize = "create.exploit")]
+        CreateExploit,
+        #[strum(serialize = "read.exploit")]
+        ReadExploit,
+        #[strum(serialize = "update.exploit")]
+        UpdateExploit,
+        #[strum(serialize = "delete.exploit")]
+        DeleteExploit,
     }
 }
 

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -81,6 +81,7 @@ The CLI alternative provides predefined scope mappings that cannot be customized
         "scopeMappings": {
           "create:document": [
             "create.advisory",
+            "create.exploit",
             "create.importer",
             "create.metadata",
             "create.sbom",
@@ -90,6 +91,7 @@ The CLI alternative provides predefined scope mappings that cannot be customized
           "read:document": [
             "ai",
             "read.advisory",
+            "read.exploit",
             "read.importer",
             "read.metadata",
             "read.sbom",
@@ -98,6 +100,7 @@ The CLI alternative provides predefined scope mappings that cannot be customized
           ],
           "update:document": [
             "update.advisory",
+            "update.exploit",
             "update.importer",
             "update.metadata",
             "update.sbom",
@@ -105,6 +108,7 @@ The CLI alternative provides predefined scope mappings that cannot be customized
           ],
           "delete:document": [
             "delete.advisory",
+            "delete.exploit",
             "delete.importer",
             "delete.metadata",
             "delete.sbom",

--- a/modules/fundamental/src/exploit/endpoints/mod.rs
+++ b/modules/fundamental/src/exploit/endpoints/mod.rs
@@ -1,6 +1,6 @@
 use crate::exploit::{model::Exploit, service::ExploitService};
 use actix_web::{HttpResponse, Responder, get, web};
-use trustify_auth::{ReadAdvisory, authorizer::Require};
+use trustify_auth::{ReadExploit, authorizer::Require};
 use trustify_common::{
     db::{self, pagination_cache::PaginationCache, query::Query},
     model::{Paginated, PaginatedResults},
@@ -41,7 +41,7 @@ pub async fn list_exploits(
     db: web::Data<db::ReadOnly>,
     web::Query(search): web::Query<Query>,
     web::Query(paginated): web::Query<Paginated>,
-    _: Require<ReadAdvisory>,
+    _: Require<ReadExploit>,
 ) -> actix_web::Result<impl Responder> {
     let tx = db.begin().await?;
     Ok(HttpResponse::Ok().json(state.list_exploits(search, paginated, &tx).await?))
@@ -61,7 +61,7 @@ pub async fn get_exploit(
     state: web::Data<ExploitService>,
     db: web::Data<db::ReadOnly>,
     id: web::Path<String>,
-    _: Require<ReadAdvisory>,
+    _: Require<ReadExploit>,
 ) -> actix_web::Result<impl Responder> {
     let tx = db.begin().await?;
     if let Some(exploit) = state.get_exploit(&id, &tx).await? {

--- a/modules/fundamental/src/exploit/endpoints/test.rs
+++ b/modules/fundamental/src/exploit/endpoints/test.rs
@@ -1,10 +1,21 @@
-use crate::{exploit::model::Exploit, test::caller};
+use crate::{
+    exploit::{endpoints::configure, model::Exploit},
+    test::caller,
+};
 use actix_http::StatusCode;
-use actix_web::test::TestRequest;
+use actix_web::{App, test::TestRequest, web};
 use test_context::test_context;
 use test_log::test;
-use trustify_common::model::PaginatedResults;
-use trustify_test_context::{TrustifyContext, call::CallService};
+use trustify_auth::{
+    authenticator::user::UserDetails,
+    authorizer::{Authorizer, AuthorizerConfig},
+};
+use trustify_common::{
+    db::{self, pagination_cache::PaginationCache},
+    model::PaginatedResults,
+};
+use trustify_test_context::{TrustifyContext, auth::TestAuthentication, call::CallService};
+use utoipa_actix_web::AppExt;
 
 async fn list(app: &impl CallService, query: &str) -> PaginatedResults<Exploit> {
     let request = TestRequest::get()
@@ -142,6 +153,82 @@ async fn paging_is_stable_across_a_resync(ctx: &TrustifyContext) -> Result<(), a
     let mut all = [first, second].concat();
     all.sort();
     assert_eq!(all, ["CVE-2021-44228", "CVE-2023-35078", "CVE-2025-6965"]);
+
+    Ok(())
+}
+
+/// Build the exploit endpoints with an active authorizer, so permission checks are enforced.
+async fn caller_with_authorization(ctx: &TrustifyContext) -> anyhow::Result<impl CallService + '_> {
+    let db_ro = db::ReadOnly::new(ctx.db.clone());
+    Ok(actix_web::test::init_service(
+        App::new()
+            .into_utoipa_app()
+            .app_data(web::Data::new(Authorizer::new(Some(AuthorizerConfig {}))))
+            .configure(|svc| {
+                svc.service(utoipa_actix_web::scope("/api").configure(|svc| {
+                    configure(svc, db_ro, PaginationCache::for_test());
+                }));
+            })
+            .into_app(),
+    )
+    .await)
+}
+
+fn user_with_permissions(permissions: &[&str]) -> UserDetails {
+    UserDetails {
+        id: "test-user".into(),
+        permissions: permissions.iter().map(ToString::to_string).collect(),
+    }
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn exploit_endpoints_require_read_exploit(
+    ctx: &TrustifyContext,
+) -> Result<(), anyhow::Error> {
+    ctx.ingest_documents(["kev/known_exploited_vulnerabilities.json"])
+        .await?;
+    let app = caller_with_authorization(ctx).await?;
+
+    // a user without any permission is rejected
+    let request = TestRequest::get()
+        .uri("/api/v3/exploit")
+        .to_request()
+        .test_auth_details(user_with_permissions(&[]));
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // advisory permissions do not grant access to exploit entries
+    let request = TestRequest::get()
+        .uri("/api/v3/exploit")
+        .to_request()
+        .test_auth_details(user_with_permissions(&["read.advisory"]));
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // the dedicated exploit permission grants access to the list ...
+    let request = TestRequest::get()
+        .uri("/api/v3/exploit?total=true")
+        .to_request()
+        .test_auth_details(user_with_permissions(&["read.exploit"]));
+    let listed: PaginatedResults<Exploit> = app.call_and_read_body_json(request).await;
+    assert_eq!(listed.total, Some(3));
+
+    // ... and to a single entry
+    let id = &listed.items[0].id;
+    let request = TestRequest::get()
+        .uri(&format!("/api/v3/exploit/{id}"))
+        .to_request()
+        .test_auth_details(user_with_permissions(&["read.exploit"]));
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let request = TestRequest::get()
+        .uri(&format!("/api/v3/exploit/{id}"))
+        .to_request()
+        .test_auth_details(user_with_permissions(&["read.advisory"]));
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add a dedicated `read.exploit` permission and require it on `GET /api/v3/exploit` and `GET /api/v3/exploit/{id}`, which previously reused `read.advisory`
- Map `read.exploit` into the default `read:document` scope so existing Keycloak setups keep working without realm changes
- Document the new permission in `docs/oidc.md`

Only a read permission is added: exploit entries are written by the KEV importer and dataset upload, and there are no create/update/delete endpoints yet. `create.exploit` should come with the upload endpoint proposed in #2605.

Closes #2596
Jira: [TC-5743](https://redhat.atlassian.net/browse/TC-5743)

## Test plan
- [x] serde round-trip for `read.exploit` in `trustify-auth`
- [x] Endpoint test with an active authorizer: no permissions → 403, `read.advisory` only → 403 on list and get, `read.exploit` → 200 on list and get
- [x] `cargo fmt --check`, `cargo clippy` with CI flags on the touched crates

[TC-5743]: https://redhat.atlassian.net/browse/TC-5743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Separate exploit endpoint authorization from advisory access with dedicated exploit permissions and default scope mappings.

New Features:
- Add dedicated exploit permissions and require `read.exploit` for exploit list and detail endpoints.

Enhancements:
- Include exploit permissions in the default document scope mappings so existing authorization configurations continue to grant access.

Documentation:
- Document exploit permissions in the OIDC scope mapping documentation.

Tests:
- Add authorization coverage confirming exploit endpoints reject missing or advisory-only permissions and accept `read.exploit`.
