### PR TITLE
fix(openapi): Descriptions for component count fields reference

### DIFF
--- a/modules/exploit-intelligence/src/model/mod.rs
+++ b/modules/exploit-intelligence/src/model/mod.rs
@@ -50,11 +50,11 @@ pub struct ExploitIntelligenceJobSummary {
     pub failed_components: Option<i32>,
     /// Number of components excluded by the EI service (computed at query time, not stored).
     pub excluded_components: Option<i32>,
-    /// Number of completed components with Vulnerable finding (computed at query time).
+    /// Number of completed components with finding=vulnerable (computed at query time).
     pub vulnerable_components: Option<i32>,
-    /// Number of completed components with NotVulnerable finding (computed at query time).
+    /// Number of completed components with finding=not_vulnerable (computed at query time).
     pub not_vulnerable_components: Option<i32>,
-    /// Number of completed components with Uncertain finding (computed at query time).
+    /// Number of completed components with finding=uncertain (computed at query time).
     pub uncertain_components: Option<i32>,
     /// Timestamp when the job was created.
     #[serde(with = "time::serde::rfc3339")]
@@ -91,11 +91,11 @@ pub struct ExploitIntelligenceJobDetails {
     pub failed_components: Option<i32>,
     /// Number of components excluded by the EI service (computed at query time, not stored).
     pub excluded_components: Option<i32>,
-    /// Number of completed components with Vulnerable finding (computed at query time).
+    /// Number of completed components with finding=vulnerable (computed at query time).
     pub vulnerable_components: Option<i32>,
-    /// Number of completed components with NotVulnerable finding (computed at query time).
+    /// Number of completed components with finding=not_vulnerable (computed at query time).
     pub not_vulnerable_components: Option<i32>,
-    /// Number of completed components with Uncertain finding (computed at query time).
+    /// Number of completed components with finding=uncertain (computed at query time).
     pub uncertain_components: Option<i32>,
     /// Per-component analysis results (populated for multi-component jobs).
     pub components: Vec<ComponentResult>,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5105,7 +5105,7 @@ components:
           - integer
           - 'null'
           format: int32
-          description: Number of completed components with NotVulnerable finding (computed at query time).
+          description: Number of completed components with finding=not_vulnerable (computed at query time).
         product_id:
           type:
           - string
@@ -5134,7 +5134,7 @@ components:
           - integer
           - 'null'
           format: int32
-          description: Number of completed components with Uncertain finding (computed at query time).
+          description: Number of completed components with finding=uncertain (computed at query time).
         updated:
           type: string
           description: Timestamp when the job was last updated.
@@ -5146,7 +5146,7 @@ components:
           - integer
           - 'null'
           format: int32
-          description: Number of completed components with Vulnerable finding (computed at query time).
+          description: Number of completed components with finding=vulnerable (computed at query time).
     ExploitIntelligenceJobStatus:
       type: string
       description: Lifecycle status of an Exploit Intelligence analysis job.
@@ -5201,7 +5201,7 @@ components:
           - integer
           - 'null'
           format: int32
-          description: Number of completed components with NotVulnerable finding (computed at query time).
+          description: Number of completed components with finding=not_vulnerable (computed at query time).
         product_id:
           type:
           - string
@@ -5230,7 +5230,7 @@ components:
           - integer
           - 'null'
           format: int32
-          description: Number of completed components with Uncertain finding (computed at query time).
+          description: Number of completed components with finding=uncertain (computed at query time).
         updated:
           type: string
           description: Timestamp when the job was last updated.
@@ -5242,7 +5242,7 @@ components:
           - integer
           - 'null'
           format: int32
-          description: Number of completed components with Vulnerable finding (computed at query time).
+          description: Number of completed components with finding=vulnerable (computed at query time).
     ExternalReferenceQuery:
       type: object
       properties:
@@ -5911,7 +5911,7 @@ components:
                 - integer
                 - 'null'
                 format: int32
-                description: Number of completed components with NotVulnerable finding (computed at query time).
+                description: Number of completed components with finding=not_vulnerable (computed at query time).
               product_id:
                 type:
                 - string
@@ -5940,7 +5940,7 @@ components:
                 - integer
                 - 'null'
                 format: int32
-                description: Number of completed components with Uncertain finding (computed at query time).
+                description: Number of completed components with finding=uncertain (computed at query time).
               updated:
                 type: string
                 description: Timestamp when the job was last updated.
@@ -5952,7 +5952,7 @@ components:
                 - integer
                 - 'null'
                 format: int32
-                description: Number of completed components with Vulnerable finding (computed at query time).
+                description: Number of completed components with finding=vulnerable (computed at query time).
         total:
           type:
           - integer


### PR DESCRIPTION
The following was discovered by sourcery-ai in trustify-ui https://github.com/guacsec/trustify-ui/pull/1187

Descriptions for component count fields reference capitalized finding names that don't match the enum values.

The ExploitIntelligenceFinding enum uses lowercase values (vulnerable, not_vulnerable, uncertain), but the *_components field descriptions reference NotVulnerable, Vulnerable, and Uncertain. Please update the descriptions to match the enum values (e.g., "components with finding=not_vulnerable") to avoid ambiguity for clients.

## Summary by Sourcery

Correct component count descriptions to reference the canonical ExploitIntelligenceFinding enum values.

Bug Fixes:
- Align component count field descriptions with the lowercase ExploitIntelligenceFinding enum values to remove ambiguity for API clients.

Documentation:
- Update Rust model and OpenAPI descriptions for vulnerable, not_vulnerable, and uncertain component counts.