### PR TITLE
chore(validator): minor tweaks for logging, some examples for validator

### DIFF
--- a/docs/adrs/00021-semantic-validators-on-ingestion.md
+++ b/docs/adrs/00021-semantic-validators-on-ingestion.md
@@ -1,10 +1,10 @@
-# 00020. Semantic validators on ingestion
+# 00021. Semantic validators on ingestion
 
 Date: 2026-09-03
 
 ## Status
 
-DRAFT
+APPROVED
 
 ## Context
 
@@ -285,3 +285,9 @@ Hard-code a `scheck` call in `ingest`.
 * 👎 The stated requirement is a *set* of validators from *third parties*; a one-off call
   would have to be torn out to support that. The trait is a small, justified abstraction that
   directly serves the requirement.
+
+## Consequences
+
+* need to think about hot reloading 
+* do we want a set of validator endpoints to arbritrarily validate eg. not just a process done at 
+ingest time

--- a/etc/validators/README.md
+++ b/etc/validators/README.md
@@ -1,0 +1,57 @@
+# Example semantic validators
+
+Ready-to-use configuration and rulesets for the ingestion-time semantic
+validators described in ADR 00020. Validation is **disabled by default**;
+enabling it is opt-in via a config file.
+
+## Layout
+
+| File | Purpose |
+|------|---------|
+| `validators.yaml` | The validator set. Referenced by `--validators-config` / `TRUSTD_VALIDATORS_CONFIG`. |
+| `rules/csaf-mandatory.json` | CSAF 2.0 required-field checks (JSON ruleset). |
+| `rules/spdx-min.json` | SPDX 2.2/2.3 minimum-element checks (JSON ruleset). |
+| `rules/cyclonedx-min.json` | CycloneDX minimum checks (JSON ruleset). |
+
+Rulesets use the [`scheck`](https://crates.io/crates/scheck) JSON format
+(`.json`).
+
+## Enabling
+
+```bash
+trustd api --validators-config etc/validators/validators.yaml
+# or
+TRUSTD_VALIDATORS_CONFIG=etc/validators/validators.yaml trustd api
+```
+
+`rules` paths in `validators.yaml` are resolved relative to the process
+working directory. Use absolute paths in production deployments.
+
+To view associated logs set:
+
+```bash
+RUST_LOG=trustify_module_ingestor=debug
+```
+
+## How it works
+
+Each validator declares:
+
+- `formats` — which documents it applies to. Concrete formats (`csaf`, `spdx`,
+  `cyclonedx`, `osv`, `cve`) or categories (`sbom` = SPDX + CycloneDX,
+  `advisory` = CSAF + CVE + OSV).
+- `mode` — `report` records findings but never blocks ingestion; `verify`
+  rejects a document when a finding is at or above `threshold`.
+- `threshold` — lowest severity that gates in `verify` mode (`info` < `warning`
+  < `error` < `fatal`); default `error`.
+- `on_error` — in `verify` mode, what to do if the validator itself fails to
+  run: `block` (treat as a failed gate) or `continue`.
+- `phase` — optional scheck phase to activate; omit to run all patterns.
+
+In the provided config, `csaf-mandatory` and `cyclonedx-min` run in `report`
+mode (observability only) while `spdx-min` runs in `verify` mode and will
+reject non-conforming SPDX documents.
+
+On startup, `trustd` logs the set of engaged validators (name, mode, and
+applicable formats), or a note that validation is disabled when none are
+configured.

--- a/etc/validators/rules/csaf-mandatory.json
+++ b/etc/validators/rules/csaf-mandatory.json
@@ -1,0 +1,140 @@
+{
+  "title": "CSAF 2.0 Mandatory Checks",
+  "description": "A trimmed set of structural checks for CSAF 2.0 advisories: document, tracking and publisher required fields, plus well-formed CVE identifiers. See CSAF 2.0 section 6.1.",
+  "default_phase": "structural",
+  "phases": [
+    {
+      "name": "structural",
+      "active_patterns": ["document-required", "tracking-required", "publisher-required"]
+    },
+    {
+      "name": "full",
+      "active_patterns": [
+        "document-required",
+        "tracking-required",
+        "publisher-required",
+        "vulnerability-fields"
+      ]
+    }
+  ],
+  "patterns": [
+    {
+      "name": "document-required",
+      "title": "Document-level required fields (CSAF 3.1)",
+      "rules": [
+        {
+          "context": "$",
+          "checks": [
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.document" },
+              "message": "document property is required",
+              "severity": "fatal"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.document.category" },
+              "message": "document.category is required",
+              "severity": "fatal"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "matches", "path": "$.document.csaf_version", "pattern": "^2\\.0$" },
+              "message": "document.csaf_version must be 2.0",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.document.title" },
+              "message": "document.title is required",
+              "severity": "error"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "tracking-required",
+      "title": "Tracking required fields (CSAF 3.1.7)",
+      "rules": [
+        {
+          "context": "$.document.tracking",
+          "checks": [
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.id" },
+              "message": "tracking.id is required",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.status" },
+              "message": "tracking.status is required",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": {
+                "type": "matches",
+                "path": "$.status",
+                "pattern": "^(draft|final|interim)$"
+              },
+              "message": "tracking.status must be draft, final, or interim",
+              "severity": "warning"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "publisher-required",
+      "title": "Publisher required fields (CSAF 3.1.8)",
+      "rules": [
+        {
+          "context": "$.document.publisher",
+          "checks": [
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.category" },
+              "message": "publisher.category is required",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.name" },
+              "message": "publisher.name is required",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.namespace" },
+              "message": "publisher.namespace is required",
+              "severity": "error"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "vulnerability-fields",
+      "title": "Vulnerability identifiers must be well-formed",
+      "rules": [
+        {
+          "context": "$..vulnerabilities[*]",
+          "checks": [
+            {
+              "kind": "assert",
+              "test": {
+                "type": "or",
+                "left": { "type": "not_exists", "path": "$.cve" },
+                "right": { "type": "matches", "path": "$.cve", "pattern": "^CVE-\\d{4}-\\d{4,}$" }
+              },
+              "message": "cve must match CVE-YYYY-NNNN+ format",
+              "severity": "warning"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/etc/validators/rules/cyclonedx-min.json
+++ b/etc/validators/rules/cyclonedx-min.json
@@ -1,0 +1,70 @@
+{
+  "title": "CycloneDX Minimum Elements",
+  "description": "Minimum structural checks for a CycloneDX 1.3+ JSON SBOM.",
+  "patterns": [
+    {
+      "name": "document-required",
+      "title": "Document-level required fields",
+      "rules": [
+        {
+          "context": "$",
+          "checks": [
+            {
+              "kind": "assert",
+              "test": { "type": "equals", "path": "$.bomFormat", "value": "CycloneDX" },
+              "message": "bomFormat must be CycloneDX",
+              "severity": "fatal"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "matches", "path": "$.specVersion", "pattern": "^1\\.[3-6]$" },
+              "message": "specVersion must be one of 1.3, 1.4, 1.5, 1.6",
+              "severity": "fatal"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.metadata.timestamp" },
+              "message": "metadata.timestamp is recommended",
+              "severity": "warning"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "components",
+      "title": "Component required fields",
+      "rules": [
+        {
+          "context": "$.components[*]",
+          "checks": [
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.type" },
+              "message": "component.type is required",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.name" },
+              "message": "component.name is required",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.version" },
+              "message": "component.version is recommended",
+              "severity": "warning"
+            },
+            {
+              "kind": "report",
+              "test": { "type": "exists", "path": "$.purl" },
+              "message": "component declares a purl",
+              "severity": "info"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/etc/validators/rules/spdx-min.json
+++ b/etc/validators/rules/spdx-min.json
@@ -1,0 +1,103 @@
+{
+  "title": "SPDX Minimum Elements",
+  "description": "Minimum required fields for a valid SPDX 2.2/2.3 document (JSON format), per the SPDX specification.",
+  "patterns": [
+    {
+      "name": "document-required",
+      "title": "Document-level required fields",
+      "rules": [
+        {
+          "context": "$",
+          "checks": [
+            {
+              "kind": "assert",
+              "test": { "type": "matches", "path": "$.spdxVersion", "pattern": "^SPDX-2\\.[23]$" },
+              "message": "spdxVersion must be SPDX-2.2 or SPDX-2.3",
+              "severity": "fatal"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "equals", "path": "$.dataLicense", "value": "CC0-1.0" },
+              "message": "dataLicense must be CC0-1.0",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "equals", "path": "$.SPDXID", "value": "SPDXRef-DOCUMENT" },
+              "message": "SPDXID must be SPDXRef-DOCUMENT",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.name" },
+              "message": "name is required",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "matches", "path": "$.documentNamespace", "pattern": "^https?://" },
+              "message": "documentNamespace must be a URI",
+              "severity": "error"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "creation-info",
+      "title": "Creation info required fields",
+      "rules": [
+        {
+          "context": "$.creationInfo",
+          "checks": [
+            {
+              "kind": "assert",
+              "test": {
+                "type": "matches",
+                "path": "$.created",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}"
+              },
+              "message": "creationInfo.created must be an ISO 8601 datetime",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "count", "path": "$.creators[*]", "cmp": ">=", "expected": 1 },
+              "message": "creationInfo.creators must have at least one entry",
+              "severity": "error"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "packages",
+      "title": "Package required fields",
+      "rules": [
+        {
+          "context": "$.packages[*]",
+          "checks": [
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.name" },
+              "message": "package.name is required",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.downloadLocation" },
+              "message": "package.downloadLocation is required",
+              "severity": "error"
+            },
+            {
+              "kind": "assert",
+              "test": { "type": "exists", "path": "$.versionInfo" },
+              "message": "package.versionInfo is recommended",
+              "severity": "warning"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/etc/validators/validators.yaml
+++ b/etc/validators/validators.yaml
@@ -1,0 +1,45 @@
+# Semantic validators configuration (ADR 00020).
+#
+# Point the server at this file to enable ingestion-time validation:
+#
+#   trustd api --validators-config etc/validators/validators.yaml
+#   # or
+#   TRUSTD_VALIDATORS_CONFIG=etc/validators/validators.yaml trustd api
+#
+# `rules` paths are resolved relative to the process working directory
+# (use absolute paths in production). When no validators are configured,
+# validation is disabled and ingestion behaves as before.
+
+validators:
+  # CSAF advisories: record findings only, never block ingestion.
+  - name: csaf-mandatory
+    backend: scheck
+    formats: [csaf]
+    rules:
+      - etc/validators/rules/csaf-mandatory.json
+    phase: structural
+    mode: report
+    threshold: error
+    on_error: continue
+
+  # SPDX SBOMs: gate ingestion. Any finding at or above `threshold`
+  # (error) rejects the document; if the validator itself errors,
+  # `on_error: block` treats that as a failed gate.
+  - name: spdx-min
+    backend: scheck
+    formats: [spdx]
+    rules:
+      - etc/validators/rules/spdx-min.json
+    mode: verify
+    threshold: error
+    on_error: block
+
+  # CycloneDX SBOMs: report-only.
+  - name: cyclonedx-min
+    backend: scheck
+    formats: [cyclonedx]
+    rules:
+      - etc/validators/rules/cyclonedx-min.json
+    mode: report
+    threshold: error
+    on_error: continue

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -396,6 +396,7 @@ async fn run_validators(
 
         match validator.validate(&input).await {
             Ok(report) => {
+                log_report(fmt, &report);
                 if validator.mode() == ValidationMode::Verify
                     && report.outcome == ValidationOutcome::Failed
                 {
@@ -424,7 +425,59 @@ async fn run_validators(
     if blocked.is_empty() {
         Ok(reports)
     } else {
+        let validators = blocked
+            .iter()
+            .map(|report| report.validator.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        tracing::warn!(
+            format = %fmt,
+            validators = %validators,
+            "document rejected by validation ({} report(s))",
+            blocked.len(),
+        );
         Err(Error::ValidationRejected(blocked))
+    }
+}
+
+/// Log a validation report and its findings.
+///
+/// The report summary logs at `info`; individual findings log at a level that
+/// reflects their severity, so operators can see validation outcomes in the
+/// server log without needing the ingest API response.
+fn log_report(fmt: Format, report: &ValidationReport) {
+    tracing::info!(
+        validator = %report.validator,
+        format = %fmt,
+        outcome = ?report.outcome,
+        findings = report.findings.len(),
+        "semantic validation report"
+    );
+    for finding in &report.findings {
+        let path = finding.path.as_deref().unwrap_or("-");
+        match finding.severity {
+            Severity::Fatal | Severity::Error => tracing::warn!(
+                validator = %report.validator,
+                severity = ?finding.severity,
+                path,
+                "{}",
+                finding.message,
+            ),
+            Severity::Warning => tracing::info!(
+                validator = %report.validator,
+                severity = ?finding.severity,
+                path,
+                "{}",
+                finding.message,
+            ),
+            Severity::Info => tracing::debug!(
+                validator = %report.validator,
+                severity = ?finding.severity,
+                path,
+                "{}",
+                finding.message,
+            ),
+        }
     }
 }
 

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -495,6 +495,15 @@ impl InitData {
             None => Vec::new(),
         };
 
+        if validators.is_empty() {
+            log::info!("Semantic validation disabled (no validators configured)");
+        } else {
+            log::info!("Semantic validators engaged ({}):", validators.len());
+            for validator in &validators {
+                log::info!("  - {validator:?}");
+            }
+        }
+
         let broadcaster = ChangeBroadcaster::new(
             &db_rw,
             *run.notification.change_log_retention,


### PR DESCRIPTION
## Summary by Sourcery

Provide opt-in ingestion validators with example rulesets and clearer operational logging.

New Features:
- Add opt-in example configurations and rulesets for CSAF, SPDX, and CycloneDX semantic validation during ingestion.

Enhancements:
- Improve semantic validation observability by logging validator engagement, report summaries, individual findings by severity, and document rejection details.

Documentation:
- Document validator configuration, supported formats, modes, thresholds, error handling, and enablement.

Chores:
- Approve the semantic validators ingestion ADR and record follow-up considerations for hot reloading and broader validation endpoints.