### PR TITLE
#2636 Add arg to analyze and advisory endpoints to allow resolved statuses

### DIFF
--- a/etc/test-data/csaf/vex-cve-2023-0044-backport.json
+++ b/etc/test-data/csaf/vex-cve-2023-0044-backport.json
@@ -1,0 +1,97 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "tlp": {
+        "label": "WHITE"
+      }
+    },
+    "lang": "en",
+    "publisher": {
+      "category": "vendor",
+      "name": "Example Vendor",
+      "namespace": "https://example.com"
+    },
+    "title": "Backport VEX for CVE-2023-0044",
+    "tracking": {
+      "current_release_date": "2024-06-01T00:00:00Z",
+      "id": "VEX-CVE-2023-0044-BACKPORT",
+      "initial_release_date": "2024-06-01T00:00:00Z",
+      "revision_history": [
+        {
+          "date": "2024-06-01T00:00:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Example Vendor",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "Quarkus Application",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "2.0.5",
+                "product": {
+                  "name": "quarkus-vertx-http 2.0.5",
+                  "product_id": "quarkus-vertx-http-2.0.5",
+                  "product_identification_helper": {
+                    "purl": "pkg:maven/io.quarkus/quarkus-vertx-http@2.0.5"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "2.13.8.Final-redhat-00004",
+                "product": {
+                  "name": "quarkus-vertx-http 2.13.8.Final-redhat-00004",
+                  "product_id": "quarkus-vertx-http-2.13.8",
+                  "product_identification_helper": {
+                    "purl": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00004"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-0044",
+      "notes": [
+        {
+          "category": "description",
+          "text": "Backport fix applied; these specific builds are not affected."
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "quarkus-vertx-http-2.0.5",
+          "quarkus-vertx-http-2.13.8"
+        ]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "The fix for CVE-2023-0044 was backported to these builds.",
+          "product_ids": [
+            "quarkus-vertx-http-2.0.5",
+            "quarkus-vertx-http-2.13.8"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -367,12 +367,21 @@ pub async fn get(
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Default, serde::Deserialize, IntoParams)]
+pub struct SbomAdvisoryParams {
+    /// When true, include resolved statuses (fixed, not_affected)
+    /// alongside affected.
+    #[serde(default)]
+    pub include_resolved: bool,
+}
+
 /// Get advisories for an SBOM
 #[utoipa::path(
     tag = "sbom",
     operation_id = "getSbomAdvisories",
     params(
         ("id" = Id, Path),
+        SbomAdvisoryParams,
     ),
     responses(
         (status = 200, description = "Matching SBOM", body = Vec<SbomAdvisory>),
@@ -384,12 +393,17 @@ pub async fn get_sbom_advisories(
     fetcher: web::Data<SbomService>,
     db: web::Data<db::ReadOnly>,
     id: web::Path<String>,
+    web::Query(SbomAdvisoryParams { include_resolved }): web::Query<SbomAdvisoryParams>,
     _: Require<GetSbomAdvisories>,
 ) -> Result<impl Responder, Error> {
     let id = Id::from_str(&id).map_err(Error::IdKey)?;
     let tx = db.begin().await?;
 
-    let statuses: Vec<String> = vec!["affected".to_string()];
+    let statuses: Vec<String> = if include_resolved {
+        vec![]
+    } else {
+        vec!["affected".to_string()]
+    };
     match fetcher.fetch_sbom_details(id, statuses, &tx).await? {
         Some(v) => Ok(HttpResponse::Ok().json(v.advisories)),
         None => Ok(HttpResponse::NotFound().finish()),

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -400,7 +400,11 @@ pub async fn get_sbom_advisories(
     let tx = db.begin().await?;
 
     let statuses: Vec<String> = if include_resolved {
-        vec![]
+        vec![
+            "affected".to_string(),
+            "fixed".to_string(),
+            "not_affected".to_string(),
+        ]
     } else {
         vec!["affected".to_string()]
     };

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1481,6 +1481,67 @@ async fn get_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
+async fn get_advisories_include_resolved(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let id = ctx
+        .ingest_documents([
+            "quarkus-bom-2.13.8.Final-redhat-00004.json",
+            "csaf/cve-2023-0044.json",
+        ])
+        .await?[0]
+        .id
+        .to_string();
+
+    let app = caller(ctx).await?;
+
+    // Default: only affected statuses
+    let default_result: Value = app
+        .call_and_read_body_json(
+            TestRequest::get()
+                .uri(&format!("/api/v3/sbom/urn:uuid:{id}/advisory"))
+                .to_request(),
+        )
+        .await;
+    let default_statuses: Vec<&str> = default_result[0]["status"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|s| s["status"].as_str())
+        .collect();
+    assert!(
+        default_statuses.iter().all(|s| *s == "affected"),
+        "Default should only return affected, got: {default_statuses:?}"
+    );
+
+    // With include_resolved=true: additional statuses appear
+    let resolved_result: Value = app
+        .call_and_read_body_json(
+            TestRequest::get()
+                .uri(&format!(
+                    "/api/v3/sbom/urn:uuid:{id}/advisory?include_resolved=true"
+                ))
+                .to_request(),
+        )
+        .await;
+    let resolved_statuses: Vec<&str> = resolved_result[0]["status"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|s| s["status"].as_str())
+        .collect();
+    assert!(
+        resolved_statuses.len() >= default_statuses.len(),
+        "include_resolved should return at least as many statuses"
+    );
+    assert!(
+        resolved_statuses.iter().any(|s| *s != "affected"),
+        "include_resolved should include non-affected statuses, got: {resolved_statuses:?}"
+    );
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
 async fn get_advisories_with_deprecated_filtering(
     ctx: &TrustifyContext,
 ) -> Result<(), anyhow::Error> {

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1533,8 +1533,16 @@ async fn get_advisories_include_resolved(ctx: &TrustifyContext) -> Result<(), an
         "include_resolved should return at least as many statuses"
     );
     assert!(
-        resolved_statuses.iter().any(|s| *s != "affected"),
-        "include_resolved should include non-affected statuses, got: {resolved_statuses:?}"
+        resolved_statuses
+            .iter()
+            .all(|s| matches!(*s, "affected" | "fixed" | "not_affected")),
+        "include_resolved returned an unexpected status, got: {resolved_statuses:?}"
+    );
+    assert!(
+        resolved_statuses
+            .iter()
+            .any(|s| *s == "fixed" || *s == "not_affected"),
+        "include_resolved should include fixed or not_affected statuses, got: {resolved_statuses:?}"
     );
 
     Ok(())

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1479,13 +1479,18 @@ async fn get_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// VEX reconciliation via the SBOM advisory endpoint: the quarkus BOM contains
+/// quarkus-vertx-http which cve-2023-0044 marks as affected. A backport VEX
+/// declares the BOM's specific version as known_not_affected. Without
+/// include_resolved only the affected status is visible; with it, both surface.
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn get_advisories_include_resolved(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+async fn get_advisories_vex_reconciliation(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let id = ctx
         .ingest_documents([
             "quarkus-bom-2.13.8.Final-redhat-00004.json",
             "csaf/cve-2023-0044.json",
+            "csaf/vex-cve-2023-0044-backport.json",
         ])
         .await?[0]
         .id
@@ -1512,7 +1517,7 @@ async fn get_advisories_include_resolved(ctx: &TrustifyContext) -> Result<(), an
         "Default should only return affected, got: {default_statuses:?}"
     );
 
-    // With include_resolved=true: additional statuses appear
+    // With include_resolved=true: backport VEX not_affected status also appears
     let resolved_result: Value = app
         .call_and_read_body_json(
             TestRequest::get()
@@ -1522,15 +1527,21 @@ async fn get_advisories_include_resolved(ctx: &TrustifyContext) -> Result<(), an
                 .to_request(),
         )
         .await;
-    let resolved_statuses: Vec<&str> = resolved_result[0]["status"]
+    let resolved_statuses: Vec<&str> = resolved_result
         .as_array()
         .unwrap()
         .iter()
-        .filter_map(|s| s["status"].as_str())
+        .flat_map(|adv| {
+            adv["status"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|s| s["status"].as_str())
+        })
         .collect();
     assert!(
-        resolved_statuses.len() >= default_statuses.len(),
-        "include_resolved should return at least as many statuses"
+        !resolved_statuses.is_empty(),
+        "include_resolved should return statuses"
     );
     assert!(
         resolved_statuses

--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -136,11 +136,16 @@ pub async fn get(
 pub async fn analyze(
     service: web::Data<VulnerabilityService>,
     db: web::Data<db::ReadOnly>,
-    web::Json(AnalysisRequest { purls, include_resolved }): web::Json<AnalysisRequest>,
+    web::Json(AnalysisRequest {
+        purls,
+        include_resolved,
+    }): web::Json<AnalysisRequest>,
     _: Require<ReadAdvisory>,
 ) -> Result<impl Responder, Error> {
     let tx = db.begin().await?;
-    let details = service.analyze_purls_v2(purls, &tx, include_resolved).await?;
+    let details = service
+        .analyze_purls_v2(purls, &tx, include_resolved)
+        .await?;
 
     Ok(HttpResponse::Ok().json(details))
 }
@@ -157,11 +162,16 @@ pub async fn analyze(
 pub async fn analyze_v3(
     service: web::Data<VulnerabilityService>,
     db: web::Data<db::ReadOnly>,
-    web::Json(AnalysisRequest { purls, include_resolved }): web::Json<AnalysisRequest>,
+    web::Json(AnalysisRequest {
+        purls,
+        include_resolved,
+    }): web::Json<AnalysisRequest>,
     _: Require<ReadAdvisory>,
 ) -> Result<impl Responder, Error> {
     let tx = db.begin().await?;
-    let details = service.analyze_purls_v3(purls, &tx, include_resolved).await?;
+    let details = service
+        .analyze_purls_v3(purls, &tx, include_resolved)
+        .await?;
 
     Ok(HttpResponse::Ok().json(details))
 }

--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -136,11 +136,11 @@ pub async fn get(
 pub async fn analyze(
     service: web::Data<VulnerabilityService>,
     db: web::Data<db::ReadOnly>,
-    web::Json(AnalysisRequest { purls }): web::Json<AnalysisRequest>,
+    web::Json(AnalysisRequest { purls, include_resolved }): web::Json<AnalysisRequest>,
     _: Require<ReadAdvisory>,
 ) -> Result<impl Responder, Error> {
     let tx = db.begin().await?;
-    let details = service.analyze_purls_v2(purls, &tx).await?;
+    let details = service.analyze_purls_v2(purls, &tx, include_resolved).await?;
 
     Ok(HttpResponse::Ok().json(details))
 }
@@ -157,11 +157,11 @@ pub async fn analyze(
 pub async fn analyze_v3(
     service: web::Data<VulnerabilityService>,
     db: web::Data<db::ReadOnly>,
-    web::Json(AnalysisRequest { purls }): web::Json<AnalysisRequest>,
+    web::Json(AnalysisRequest { purls, include_resolved }): web::Json<AnalysisRequest>,
     _: Require<ReadAdvisory>,
 ) -> Result<impl Responder, Error> {
     let tx = db.begin().await?;
-    let details = service.analyze_purls_v3(purls, &tx).await?;
+    let details = service.analyze_purls_v3(purls, &tx, include_resolved).await?;
 
     Ok(HttpResponse::Ok().json(details))
 }

--- a/modules/fundamental/src/vulnerability/model/analyze.rs
+++ b/modules/fundamental/src/vulnerability/model/analyze.rs
@@ -9,6 +9,10 @@ use utoipa::ToSchema;
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct AnalysisRequest {
     pub purls: Vec<String>,
+    /// When true, include resolved statuses (fixed, not_affected)
+    /// alongside affected.
+    #[serde(default)]
+    pub include_resolved: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema, Default)]

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -473,7 +473,7 @@ impl VulnerabilityService {
         include_resolved: bool,
     ) -> String {
         let status_filter = if include_resolved {
-            "AND status.slug != 'recommended'"
+            "AND status.slug IN ('affected', 'fixed', 'not_affected')"
         } else {
             "AND status.slug NOT IN ('fixed', 'not_affected', 'recommended')"
         };

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -156,12 +156,13 @@ impl VulnerabilityService {
         &self,
         purls: impl IntoIterator<Item = impl AsRef<str>>,
         connection: &C,
+        include_resolved: bool,
     ) -> Result<AnalysisResponseV3, Error>
     where
         C: ConnectionTrait,
     {
         let data = self
-            .fetch_vulnerability_analysis_data(purls, connection)
+            .fetch_vulnerability_analysis_data(purls, connection, include_resolved)
             .await?;
         self.format_response(data, connection).await
     }
@@ -177,12 +178,13 @@ impl VulnerabilityService {
         &self,
         purls: impl IntoIterator<Item = impl AsRef<str>>,
         connection: &C,
+        include_resolved: bool,
     ) -> Result<AnalysisResponse, Error>
     where
         C: ConnectionTrait,
     {
         let data = self
-            .fetch_vulnerability_analysis_data(purls, connection)
+            .fetch_vulnerability_analysis_data(purls, connection, include_resolved)
             .await?;
         self.format_response_v2(data, connection).await
     }
@@ -191,12 +193,13 @@ impl VulnerabilityService {
         &self,
         purls: impl IntoIterator<Item = impl AsRef<str>>,
         connection: &C,
+        include_resolved: bool,
     ) -> Result<AnalysisData, Error>
     where
         C: ConnectionTrait,
     {
         let mut warnings = HashMap::new();
-        let query = Self::build_query(purls, connection, &mut warnings)?;
+        let query = Self::build_query(purls, connection, &mut warnings, include_resolved)?;
 
         let stmt = Statement::from_string(connection.get_database_backend(), query);
         log::debug!("Analyzing using: {stmt}");
@@ -467,7 +470,13 @@ impl VulnerabilityService {
         vulnerabilities_tables: &str,
         conditions: &str,
         remediations_data_expression: &str,
+        include_resolved: bool,
     ) -> String {
+        let status_filter = if include_resolved {
+            "AND status.slug != 'recommended'"
+        } else {
+            "AND status.slug NOT IN ('fixed', 'not_affected', 'recommended')"
+        };
         format!(
             r#"
 SELECT
@@ -507,11 +516,7 @@ SELECT
   ) AS advisories
 FROM {vulnerabilities_tables}
 WHERE {conditions}
-  AND status.slug NOT IN (
-    'fixed',
-    'not_affected',
-    'recommended'
-  )
+  {status_filter}
 GROUP BY
   vulnerability.id,
   vulnerability.title,
@@ -531,6 +536,7 @@ GROUP BY
         purls: impl IntoIterator<Item = impl AsRef<str>>,
         connection: &impl ConnectionTrait,
         warnings: &mut HashMap<String, Vec<String>>,
+        include_resolved: bool,
     ) -> Result<String, Error> {
         let query = purls
             .into_iter()
@@ -577,6 +583,7 @@ GROUP BY
                         AND version_matches($4, version_range.*) = TRUE
                     "#).as_str(),
                     "r.data",
+                    include_resolved,
                 );
 
                 let purl_status_query = Statement::from_sql_and_values(
@@ -644,6 +651,7 @@ GROUP BY
                              )
                             ), '[]'::jsonb)
                     ) "#,
+                    include_resolved,
                 );
                 let product_status_query = Statement::from_sql_and_values(
                     connection.get_database_backend(),

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -705,51 +705,55 @@ async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// VEX reconciliation: an upstream advisory marks a version range as affected,
+/// then a backport VEX declares a specific version within that range as
+/// not_affected. With include_resolved=false only the affected status is
+/// visible; with include_resolved=true both statuses surface for reconciliation.
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
-async fn analyze_purls_include_resolved(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+async fn analyze_purls_vex_reconciliation(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let service = VulnerabilityService::new(PaginationCache::for_test());
 
-    ctx.ingest_documents(["osv/RUSTSEC-2021-0079.json", "osv/GHSA-2ccf-ffrj-m4qw.json"])
-        .await?;
+    // cve-2023-0044 marks quarkus-vertx-http [2.0.0, 3.0.0) as affected.
+    // The backport VEX declares quarkus-vertx-http@2.0.5 as known_not_affected.
+    ctx.ingest_documents([
+        "csaf/cve-2023-0044.json",
+        "csaf/vex-cve-2023-0044-backport.json",
+    ])
+    .await?;
 
-    let items = vec![
-        "pkg:cargo/hyper@0.14.9",            // SEMVER:affected
-        "pkg:cargo/hyper@0.14.11",           // SEMVER:fixed
-        "pkg:npm/%40fastify/passport@1.0.0", // ECOSYSTEM:affected
-        "pkg:npm/%40fastify/passport@2.3.0", // ECOSYSTEM:fixed
-    ];
+    let purl = "pkg:maven/io.quarkus/quarkus-vertx-http@2.0.5";
 
-    // Without include_resolved: only affected PURLs appear
-    let result = service
-        .analyze_purls_v3(items.clone(), &ctx.db, false)
-        .await?;
-    assert!(result.contains_key("pkg:cargo/hyper@0.14.9"));
-    assert!(result.contains_key("pkg:npm/%40fastify/passport@1.0.0"));
-    assert!(!result.contains_key("pkg:cargo/hyper@0.14.11"));
-    assert!(!result.contains_key("pkg:npm/%40fastify/passport@2.3.0"));
-
-    // With include_resolved: fixed PURLs also appear
-    let result = service.analyze_purls_v3(items, &ctx.db, true).await?;
-    assert!(result.contains_key("pkg:cargo/hyper@0.14.9"));
-    assert!(result.contains_key("pkg:npm/%40fastify/passport@1.0.0"));
+    // Without include_resolved: only the affected status is visible
+    let result = service.analyze_purls_v3([purl], &ctx.db, false).await?;
+    assert!(result.contains_key(purl), "PURL should appear as affected");
+    let statuses: Vec<&str> = result[purl]
+        .details
+        .iter()
+        .flat_map(|d| d.purl_statuses.iter())
+        .map(|s| s.purl_status.status.as_str())
+        .collect();
     assert!(
-        result.contains_key("pkg:cargo/hyper@0.14.11"),
-        "Fixed PURL should appear when include_resolved is true"
-    );
-    assert!(
-        result.contains_key("pkg:npm/%40fastify/passport@2.3.0"),
-        "Fixed PURL should appear when include_resolved is true"
+        statuses.iter().all(|s| *s == "affected"),
+        "Without include_resolved only affected should appear, got: {statuses:?}"
     );
 
-    // Verify the fixed entries have the correct status
-    let hyper_fixed = &result["pkg:cargo/hyper@0.14.11"];
+    // With include_resolved: the backport VEX's not_affected status also surfaces
+    let result = service.analyze_purls_v3([purl], &ctx.db, true).await?;
+    assert!(result.contains_key(purl));
+    let statuses: Vec<&str> = result[purl]
+        .details
+        .iter()
+        .flat_map(|d| d.purl_statuses.iter())
+        .map(|s| s.purl_status.status.as_str())
+        .collect();
     assert!(
-        hyper_fixed.details.iter().any(|d| d
-            .purl_statuses
-            .iter()
-            .any(|s| s.purl_status.status == "fixed")),
-        "Fixed PURL should have status 'fixed'"
+        statuses.contains(&"affected"),
+        "Affected status should still be present, got: {statuses:?}"
+    );
+    assert!(
+        statuses.contains(&"not_affected"),
+        "Backport VEX not_affected status should appear with include_resolved, got: {statuses:?}"
     );
 
     Ok(())
@@ -827,12 +831,12 @@ async fn analyze_purls_v2(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         "pkg:cargo/hyper@0.14.9",              // SEMVER:affected - no namespace
         "pkg:golang/golang.org/x/text@v0.3.6", // GOLANG:affected
         "pkg:golang/golang.org/x/text@0.3.6",  // SEMVER:affected
-        "pkg:npm/%40fastify/passport@2.3.0",   // ECOSYSTEM:fixed
-        "pkg:cargo/hyper@0.14.11",             // SEMVER:fixed - no namespace
     ];
 
     let not_found = [
+        "pkg:npm/%40fastify/passport@2.3.0", // ECOSYSTEM:fixed
         "pkg:golang/github.com/metal3-io/baremetal-operator/apis@0.8.0", // Missing
+        "pkg:cargo/hyper@0.14.11",           // SEMVER:fixed - no namespace
     ];
 
     let items: Vec<&str> = expected.iter().chain(&not_found).copied().collect();

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -646,21 +646,21 @@ async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // test empty request
 
     let result = service
-        .analyze_purls_v3(Vec::<&str>::new(), &ctx.db)
+        .analyze_purls_v3(Vec::<&str>::new(), &ctx.db, false)
         .await?;
     assert!(result.is_empty());
 
     // test some invalid PURLs
 
     for purl in ["this is not valid"].iter() {
-        let result = service.analyze_purls_v3(vec![purl], &ctx.db).await;
+        let result = service.analyze_purls_v3(vec![purl], &ctx.db, false).await;
         assert!(result.is_err());
     }
 
     // test some unsuitable PURLs
 
     for purl in ["pkg:npm/missing.version"].iter() {
-        let result = service.analyze_purls_v3(vec![purl], &ctx.db).await;
+        let result = service.analyze_purls_v3(vec![purl], &ctx.db, false).await;
         // must still be ok
         assert!(result.is_ok(), "{purl} should not fail the request");
         let result = result.unwrap();
@@ -688,7 +688,7 @@ async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let items: Vec<&str> = expected.iter().chain(&not_found).copied().collect();
 
-    let result = service.analyze_purls_v3(items, &ctx.db).await?;
+    let result = service.analyze_purls_v3(items, &ctx.db, false).await?;
 
     expected.iter().for_each(|&item| {
         assert!(
@@ -707,6 +707,57 @@ async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
+async fn analyze_purls_include_resolved(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let service = VulnerabilityService::new(PaginationCache::for_test());
+
+    ctx.ingest_documents([
+        "osv/RUSTSEC-2021-0079.json",
+        "osv/GHSA-2ccf-ffrj-m4qw.json",
+    ])
+    .await?;
+
+    let items = vec![
+        "pkg:cargo/hyper@0.14.9",  // SEMVER:affected
+        "pkg:cargo/hyper@0.14.11", // SEMVER:fixed
+        "pkg:npm/%40fastify/passport@1.0.0", // ECOSYSTEM:affected
+        "pkg:npm/%40fastify/passport@2.3.0", // ECOSYSTEM:fixed
+    ];
+
+    // Without include_resolved: only affected PURLs appear
+    let result = service.analyze_purls_v3(items.clone(), &ctx.db, false).await?;
+    assert!(result.contains_key("pkg:cargo/hyper@0.14.9"));
+    assert!(result.contains_key("pkg:npm/%40fastify/passport@1.0.0"));
+    assert!(!result.contains_key("pkg:cargo/hyper@0.14.11"));
+    assert!(!result.contains_key("pkg:npm/%40fastify/passport@2.3.0"));
+
+    // With include_resolved: fixed PURLs also appear
+    let result = service.analyze_purls_v3(items, &ctx.db, true).await?;
+    assert!(result.contains_key("pkg:cargo/hyper@0.14.9"));
+    assert!(result.contains_key("pkg:npm/%40fastify/passport@1.0.0"));
+    assert!(
+        result.contains_key("pkg:cargo/hyper@0.14.11"),
+        "Fixed PURL should appear when include_resolved is true"
+    );
+    assert!(
+        result.contains_key("pkg:npm/%40fastify/passport@2.3.0"),
+        "Fixed PURL should appear when include_resolved is true"
+    );
+
+    // Verify the fixed entries have the correct status
+    let hyper_fixed = &result["pkg:cargo/hyper@0.14.11"];
+    assert!(
+        hyper_fixed.details.iter().any(|d| d
+            .purl_statuses
+            .iter()
+            .any(|s| s.purl_status.status == "fixed")),
+        "Fixed PURL should have status 'fixed'"
+    );
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
 #[ignore = "Requires #1873"]
 async fn analyze_purls_no_score(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     const PURL: &str = "pkg:cargo/hyper@0.14.9";
@@ -715,7 +766,7 @@ async fn analyze_purls_no_score(ctx: &TrustifyContext) -> Result<(), anyhow::Err
 
     ctx.ingest_documents(["osv/RUSTSEC-2022-0022.json"]).await?;
 
-    let result = service.analyze_purls_v3([PURL], &ctx.db).await?;
+    let result = service.analyze_purls_v3([PURL], &ctx.db, false).await?;
 
     // ensure there is no warning
     assert!(result[PURL].warnings.is_empty());
@@ -745,21 +796,21 @@ async fn analyze_purls_v2(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // test empty request
 
     let result = service
-        .analyze_purls_v2(Vec::<&str>::new(), &ctx.db)
+        .analyze_purls_v2(Vec::<&str>::new(), &ctx.db, false)
         .await?;
     assert!(result.is_empty());
 
     // test some invalid PURLs
 
     for purl in ["this is not valid"].iter() {
-        let result = service.analyze_purls_v2(vec![purl], &ctx.db).await;
+        let result = service.analyze_purls_v2(vec![purl], &ctx.db, false).await;
         assert!(result.is_err());
     }
 
     // test some unsuitable PURLs
 
     for purl in ["pkg:npm/missing.version"].iter() {
-        let result = service.analyze_purls_v2(vec![purl], &ctx.db).await;
+        let result = service.analyze_purls_v2(vec![purl], &ctx.db, false).await;
         // must still be ok
         assert!(result.is_ok(), "{purl} should not fail the request");
         let result = result.unwrap();
@@ -777,17 +828,17 @@ async fn analyze_purls_v2(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         "pkg:cargo/hyper@0.14.9",              // SEMVER:affected - no namespace
         "pkg:golang/golang.org/x/text@v0.3.6", // GOLANG:affected
         "pkg:golang/golang.org/x/text@0.3.6",  // SEMVER:affected
+        "pkg:npm/%40fastify/passport@2.3.0",   // ECOSYSTEM:fixed
+        "pkg:cargo/hyper@0.14.11",             // SEMVER:fixed - no namespace
     ];
 
     let not_found = [
-        "pkg:npm/%40fastify/passport@2.3.0", // ECOSYSTEM:fixed
         "pkg:golang/github.com/metal3-io/baremetal-operator/apis@0.8.0", // Missing
-        "pkg:cargo/hyper@0.14.11",           // SEMVER:fixed - no namespace
     ];
 
     let items: Vec<&str> = expected.iter().chain(&not_found).copied().collect();
 
-    let result = service.analyze_purls_v2(items, &ctx.db).await?;
+    let result = service.analyze_purls_v2(items, &ctx.db, false).await?;
 
     expected.iter().for_each(|&item| {
         assert!(
@@ -826,6 +877,7 @@ async fn analyze_purls_remediations_synthetic(ctx: &TrustifyContext) -> Result<(
                 "pkg:npm/another-package@1.0.0",
             ],
             &ctx.db,
+            false,
         )
         .await?;
 
@@ -933,6 +985,7 @@ async fn analyze_purls_remediations(ctx: &TrustifyContext) -> Result<(), anyhow:
         .analyze_purls_v3(
             vec!["pkg:rpm/redhat/eap7-bouncycastle@1.76.0-4.redhat_00001.1.el8eap?arch=noarch"],
             &ctx.db,
+            false,
         )
         .await?;
 
@@ -977,7 +1030,7 @@ async fn analyze_purls_product_status(ctx: &TrustifyContext) -> Result<(), anyho
     // Products with other ranges (e.g., [7.0.0, 8.0.0)) or unbounded ranges are excluded
     // by version_matches filtering.
     let result = service
-        .analyze_purls_v3(vec!["pkg:maven/spring-security@6.0.5"], &ctx.db)
+        .analyze_purls_v3(vec!["pkg:maven/spring-security@6.0.5"], &ctx.db, false)
         .await?;
 
     assert_eq!(result.len(), 1);
@@ -1053,6 +1106,7 @@ async fn analyze_purls_product_status_0044(ctx: &TrustifyContext) -> Result<(), 
         .analyze_purls_v3(
             vec!["pkg:maven/io.quarkus/quarkus-vertx-http@2.0.5"],
             &ctx.db,
+            false,
         )
         .await?;
 
@@ -1146,6 +1200,7 @@ async fn analyze_purls_product_status_version_filtering(
         .analyze_purls_v3(
             vec!["pkg:maven/io.netty/netty-handler@4.1.78.Final"],
             &ctx.db,
+            false,
         )
         .await?;
 
@@ -1185,7 +1240,7 @@ async fn analyze_purls_product_status_version_filtering(
 
     // Negative case: a version outside all product stream ranges returns no product_statuses
     let result = service
-        .analyze_purls_v3(vec!["pkg:maven/io.netty/netty-handler@99.0.0"], &ctx.db)
+        .analyze_purls_v3(vec!["pkg:maven/io.netty/netty-handler@99.0.0"], &ctx.db, false)
         .await?;
 
     let no_match = result

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -710,21 +710,20 @@ async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn analyze_purls_include_resolved(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let service = VulnerabilityService::new(PaginationCache::for_test());
 
-    ctx.ingest_documents([
-        "osv/RUSTSEC-2021-0079.json",
-        "osv/GHSA-2ccf-ffrj-m4qw.json",
-    ])
-    .await?;
+    ctx.ingest_documents(["osv/RUSTSEC-2021-0079.json", "osv/GHSA-2ccf-ffrj-m4qw.json"])
+        .await?;
 
     let items = vec![
-        "pkg:cargo/hyper@0.14.9",  // SEMVER:affected
-        "pkg:cargo/hyper@0.14.11", // SEMVER:fixed
+        "pkg:cargo/hyper@0.14.9",            // SEMVER:affected
+        "pkg:cargo/hyper@0.14.11",           // SEMVER:fixed
         "pkg:npm/%40fastify/passport@1.0.0", // ECOSYSTEM:affected
         "pkg:npm/%40fastify/passport@2.3.0", // ECOSYSTEM:fixed
     ];
 
     // Without include_resolved: only affected PURLs appear
-    let result = service.analyze_purls_v3(items.clone(), &ctx.db, false).await?;
+    let result = service
+        .analyze_purls_v3(items.clone(), &ctx.db, false)
+        .await?;
     assert!(result.contains_key("pkg:cargo/hyper@0.14.9"));
     assert!(result.contains_key("pkg:npm/%40fastify/passport@1.0.0"));
     assert!(!result.contains_key("pkg:cargo/hyper@0.14.11"));
@@ -1240,7 +1239,11 @@ async fn analyze_purls_product_status_version_filtering(
 
     // Negative case: a version outside all product stream ranges returns no product_statuses
     let result = service
-        .analyze_purls_v3(vec!["pkg:maven/io.netty/netty-handler@99.0.0"], &ctx.db, false)
+        .analyze_purls_v3(
+            vec!["pkg:maven/io.netty/netty-handler@99.0.0"],
+            &ctx.db,
+            false,
+        )
         .await?;
 
     let no_match = result

--- a/modules/fundamental/tests/vuln/mod.rs
+++ b/modules/fundamental/tests/vuln/mod.rs
@@ -56,7 +56,7 @@ async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let service = VulnerabilityService::new(PaginationCache::for_test());
 
     let result = service
-        .analyze_purls_v3(["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"], &ctx.db)
+        .analyze_purls_v3(["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"], &ctx.db, false)
         .await?;
 
     log::debug!("{:#?}", result);
@@ -167,7 +167,7 @@ async fn version_filtering(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // Version BELOW the fix threshold — known affected by CVE-2024-28834
     // (3.7.6-23.el9 < 3.7.6-23.el9_3.4, the fix version)
     let affected_result = service
-        .analyze_purls_v3(["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"], &ctx.db)
+        .analyze_purls_v3(["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"], &ctx.db, false)
         .await?;
 
     let affected_entry = &affected_result["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"];
@@ -188,7 +188,7 @@ async fn version_filtering(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // Version ABOVE the fix threshold — not affected
     // (3.8.3-5.el9 > 3.8.3-4.el9_4, the highest fix range, so version_matches returns false)
     let fixed_result = service
-        .analyze_purls_v3(["pkg:rpm/redhat/gnutls@3.8.3-5.el9?arch=aarch64"], &ctx.db)
+        .analyze_purls_v3(["pkg:rpm/redhat/gnutls@3.8.3-5.el9?arch=aarch64"], &ctx.db, false)
         .await?;
 
     let fixed_entry = fixed_result.get("pkg:rpm/redhat/gnutls@3.8.3-5.el9?arch=aarch64");

--- a/modules/fundamental/tests/vuln/mod.rs
+++ b/modules/fundamental/tests/vuln/mod.rs
@@ -56,7 +56,11 @@ async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let service = VulnerabilityService::new(PaginationCache::for_test());
 
     let result = service
-        .analyze_purls_v3(["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"], &ctx.db, false)
+        .analyze_purls_v3(
+            ["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"],
+            &ctx.db,
+            false,
+        )
         .await?;
 
     log::debug!("{:#?}", result);
@@ -167,7 +171,11 @@ async fn version_filtering(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // Version BELOW the fix threshold — known affected by CVE-2024-28834
     // (3.7.6-23.el9 < 3.7.6-23.el9_3.4, the fix version)
     let affected_result = service
-        .analyze_purls_v3(["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"], &ctx.db, false)
+        .analyze_purls_v3(
+            ["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"],
+            &ctx.db,
+            false,
+        )
         .await?;
 
     let affected_entry = &affected_result["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"];
@@ -188,7 +196,11 @@ async fn version_filtering(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // Version ABOVE the fix threshold — not affected
     // (3.8.3-5.el9 > 3.8.3-4.el9_4, the highest fix range, so version_matches returns false)
     let fixed_result = service
-        .analyze_purls_v3(["pkg:rpm/redhat/gnutls@3.8.3-5.el9?arch=aarch64"], &ctx.db, false)
+        .analyze_purls_v3(
+            ["pkg:rpm/redhat/gnutls@3.8.3-5.el9?arch=aarch64"],
+            &ctx.db,
+            false,
+        )
         .await?;
 
     let fixed_entry = fixed_result.get("pkg:rpm/redhat/gnutls@3.8.3-5.el9?arch=aarch64");

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3458,6 +3458,14 @@ paths:
         required: true
         schema:
           $ref: '#/components/schemas/Id'
+      - name: include_resolved
+        in: query
+        description: |-
+          When true, include resolved statuses (fixed, not_affected)
+          alongside affected.
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: Matching SBOM
@@ -4538,6 +4546,11 @@ components:
       required:
       - purls
       properties:
+        include_resolved:
+          type: boolean
+          description: |-
+            When true, include resolved statuses (fixed, not_affected)
+            alongside affected.
         purls:
           type: array
           items:


### PR DESCRIPTION
Resolves #2636

The SBOM advisory endpoint (`GET /v3/sbom/{id}/advisory`) and the analyze endpoint (`POST /v3/vulnerability/analyze`) currently hardcode filters that exclude `fixed` and `not_affected` statuses from results. This means consumers cannot see VEX resolutions — even though Trustify correctly ingests and stores them.

This PR adds a backwards-compatible `include_resolved` flag to both endpoints:

- Analyze endpoint: include_resolved field in the JSON request body (defaults to false)
- SBOM advisory endpoint: ?include_resolved=true query parameter (defaults to false)

When `include_resolved=true`, the `fixed` and `not_affected` statuses are included in the response alongside `affected`. The `recommended` status (a remediation hint, not a vulnerability status) remains excluded in both modes. When `include_resolved` is omitted or false, behavior is identical to before this change.

This enables VEX-aware consumers such as pipeline gates and UI components to see which vulnerabilities have been resolved. For example, a pipeline can call the analyze endpoint with `include_resolved: true` and gate on whether any entries have status: "affected", rather than just checking whether any entries exist at all.

## Summary by Sourcery

Allow consumers to opt in to resolved vulnerability statuses from advisory and analysis endpoints.

New Features:
- Add an optional `include_resolved` parameter to SBOM advisory and vulnerability analysis endpoints to expose `fixed` and `not_affected` statuses alongside `affected` results.

Enhancements:
- Preserve existing filtering behavior by default while continuing to exclude `recommended` statuses.

Documentation:
- Update the OpenAPI specification for the new advisory query parameter and analysis request field.

Tests:
- Add VEX reconciliation coverage for resolved statuses in SBOM advisory and vulnerability analysis responses.