### PR TITLE
fix: reject format overrides that bypass endpoint permissions

### DIFF
--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -212,6 +212,7 @@ pub async fn upload(
     db: web::Data<db::ReadWrite>,
     _: Require<CreateAdvisory>,
 ) -> Result<impl Responder, Error> {
+    let format = format.ensure_allowed_for(default_format())?;
     let bytes = decompress_async(bytes, content_type.map(|ct| ct.0), config.upload_limit).await??;
 
     let tx = db.begin().await?;

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -1,7 +1,8 @@
 use crate::{
     advisory::model::{AdvisoryDetails, AdvisorySummary},
     test::{
-        caller, caller_with, label::Api, label::update_labels as do_update_labels,
+        CallerBuilder, caller, caller_with, label::Api,
+        label::update_labels as do_update_labels,
         label::update_labels_not_found as do_update_labels_not_found,
     },
 };
@@ -9,17 +10,22 @@ use actix_http::StatusCode;
 use actix_web::{body::MessageBody, test::TestRequest};
 use hex::ToHex;
 use jsonpath_rust::JsonPath;
+use sea_orm::EntityTrait;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::time::Duration;
 use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
+use trustify_auth::{
+    authenticator::user::UserDetails,
+    authorizer::{Authorizer, AuthorizerConfig},
+};
 use trustify_common::{
     db::pagination_cache::PaginationCache, error::ErrorInformation, hashing::Digests,
     model::PaginatedResults,
 };
-use trustify_entity::{advisory_vulnerability_score, labels::Labels};
+use trustify_entity::{advisory_vulnerability_score, labels::Labels, sbom};
 use trustify_module_ingestor::{
     graph::{
         advisory::AdvisoryInformation,
@@ -29,8 +35,14 @@ use trustify_module_ingestor::{
     service::Format,
 };
 use trustify_module_storage::service::{StorageBackend, StorageKey};
-use trustify_test_context::{TrustifyContext, call::CallService, document_bytes};
+use trustify_test_context::{
+    TrustifyContext,
+    auth::TestAuthentication,
+    call::CallService,
+    document_bytes,
+};
 use urlencoding::encode;
+use uuid::Uuid;
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
@@ -864,6 +876,63 @@ async fn list_advisories_limit_exceeded(ctx: &TrustifyContext) -> Result<(), any
         serde_json::from_slice(&body).expect("response body should be valid JSON");
     assert_eq!(info.error, "LimitExceeded");
     assert!(info.message.contains("10"));
+
+    Ok(())
+}
+
+/// PoC: A user with only `CreateAdvisory` (no `CreateSbom`) can upload an
+/// SPDX SBOM through the advisory endpoint by setting `?format=spdx`.
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn upload_sbom_via_advisory_endpoint(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = CallerBuilder::new(ctx)
+        .authorizer(Authorizer::new(Some(AuthorizerConfig {})))
+        .build()
+        .await?;
+
+    let user_with_advisory_only = UserDetails {
+        id: "test-user".into(),
+        permissions: vec!["create.advisory".into()],
+    };
+
+    let payload = document_bytes("spdx/simple.json").await?;
+
+    // Control: the same user is rejected on the SBOM endpoint
+    let request = TestRequest::post()
+        .uri("/api/v3/sbom")
+        .set_payload(payload.clone())
+        .to_request()
+        .test_auth_details(user_with_advisory_only.clone());
+
+    let response = app.call_service(request).await;
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "SBOM endpoint correctly rejects user without CreateSbom"
+    );
+
+    // Bypass: the same user succeeds on the advisory endpoint with ?format=spdx
+    let request = TestRequest::post()
+        .uri("/api/v3/advisory?format=spdx")
+        .set_payload(payload)
+        .to_request()
+        .test_auth_details(user_with_advisory_only);
+
+    let response = app.call_service(request).await;
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "Advisory endpoint accepted an SBOM with ?format=spdx — permission bypass"
+    );
+
+    let result: IngestResult = actix_web::test::read_body_json(response).await;
+
+    let sbom_id: Uuid = result.id.parse()?;
+    let sbom = sbom::Entity::find_by_id(sbom_id).one(&ctx.db).await?;
+    assert!(
+        sbom.is_some(),
+        "SBOM was stored in the sbom table via the advisory endpoint without CreateSbom"
+    );
 
     Ok(())
 }

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -40,6 +40,7 @@ use trustify_test_context::{
     call::CallService,
     document_bytes,
 };
+use rstest::rstest;
 use urlencoding::encode;
 
 #[test_context(TrustifyContext)]
@@ -878,50 +879,155 @@ async fn list_advisories_limit_exceeded(ctx: &TrustifyContext) -> Result<(), any
     Ok(())
 }
 
-/// Uploading an SBOM through the advisory endpoint via `?format=spdx`
-/// must not bypass the `CreateSbom` permission check.
+/// The `?format=` override must not allow uploading a document type that
+/// the endpoint's permission does not cover, and endpoints must enforce
+/// their own permission.
+#[derive(Clone, Copy, Debug)]
+enum Endpoint {
+    Advisory,
+    Sbom,
+}
+
+impl Endpoint {
+    fn uri(self, format: &str) -> String {
+        let base = match self {
+            Self::Advisory => "/api/v3/advisory",
+            Self::Sbom => "/api/v3/sbom",
+        };
+        format!("{base}?format={format}")
+    }
+}
+
 #[test_context(TrustifyContext)]
-#[test(actix_web::test)]
-async fn upload_sbom_via_advisory_endpoint(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+#[rstest]
+#[case::advisory_accepts_csaf(
+    Endpoint::Advisory,
+    "csaf",
+    "csaf/cve-2023-33201.json",
+    "create.advisory",
+    StatusCode::CREATED
+)] // correct permission + matching format
+#[case::advisory_rejects_spdx(
+    Endpoint::Advisory,
+    "spdx",
+    "spdx/simple.json",
+    "create.advisory",
+    StatusCode::BAD_REQUEST
+)] // wrong format category
+#[case::advisory_rejects_cyclonedx(
+    Endpoint::Advisory,
+    "cyclonedx",
+    "spdx/simple.json",
+    "create.advisory",
+    StatusCode::BAD_REQUEST
+)] // wrong format category
+#[case::advisory_rejects_unknown_sbom(
+    Endpoint::Advisory,
+    "unknown",
+    "spdx/simple.json",
+    "create.advisory",
+    StatusCode::BAD_REQUEST
+)] // unknown narrows to advisory
+#[case::advisory_rejects_sbom_category(
+    Endpoint::Advisory,
+    "sbom",
+    "spdx/simple.json",
+    "create.advisory",
+    StatusCode::BAD_REQUEST
+)] // non-concrete cross-category
+#[case::advisory_forbidden_sbom(
+    Endpoint::Advisory,
+    "csaf",
+    "csaf/cve-2023-33201.json",
+    "create.sbom",
+    StatusCode::FORBIDDEN
+)] // wrong permission
+#[case::advisory_forbidden_exploit(
+    Endpoint::Advisory,
+    "csaf",
+    "csaf/cve-2023-33201.json",
+    "create.exploit",
+    StatusCode::FORBIDDEN
+)] // exploit permission doesn't grant advisory upload
+#[case::sbom_accepts_spdx(
+    Endpoint::Sbom,
+    "spdx",
+    "spdx/simple.json",
+    "create.sbom",
+    StatusCode::CREATED
+)] // correct permission + matching format
+#[case::sbom_rejects_csaf(
+    Endpoint::Sbom,
+    "csaf",
+    "csaf/cve-2023-33201.json",
+    "create.sbom",
+    StatusCode::BAD_REQUEST
+)] // wrong format category
+#[case::sbom_rejects_cve(
+    Endpoint::Sbom,
+    "cve",
+    "csaf/cve-2023-33201.json",
+    "create.sbom",
+    StatusCode::BAD_REQUEST
+)] // wrong format category
+#[case::sbom_rejects_unknown_advisory(
+    Endpoint::Sbom,
+    "unknown",
+    "csaf/cve-2023-33201.json",
+    "create.sbom",
+    StatusCode::BAD_REQUEST
+)] // unknown narrows to sbom
+#[case::sbom_rejects_advisory_category(
+    Endpoint::Sbom,
+    "advisory",
+    "csaf/cve-2023-33201.json",
+    "create.sbom",
+    StatusCode::BAD_REQUEST
+)] // non-concrete cross-category
+#[case::sbom_forbidden_advisory(
+    Endpoint::Sbom,
+    "spdx",
+    "spdx/simple.json",
+    "create.advisory",
+    StatusCode::FORBIDDEN
+)] // wrong permission
+#[case::sbom_forbidden_exploit(
+    Endpoint::Sbom,
+    "spdx",
+    "spdx/simple.json",
+    "create.exploit",
+    StatusCode::FORBIDDEN
+)] // exploit permission doesn't grant sbom upload
+#[test_log::test(actix_web::test)]
+async fn format_permission_enforcement(
+    ctx: &TrustifyContext,
+    #[case] endpoint: Endpoint,
+    #[case] format: &str,
+    #[case] document: &str,
+    #[case] permission: &str,
+    #[case] expected: StatusCode,
+) -> Result<(), anyhow::Error> {
     let app = CallerBuilder::new(ctx)
         .authorizer(Authorizer::new(Some(AuthorizerConfig {})))
         .build()
         .await?;
 
-    let user_with_advisory_only = UserDetails {
+    let user = UserDetails {
         id: "test-user".into(),
-        permissions: vec!["create.advisory".into()],
+        permissions: vec![permission.into()],
     };
 
-    let payload = document_bytes("spdx/simple.json").await?;
+    let payload = document_bytes(document).await?;
+    let uri = endpoint.uri(format);
 
-    // Control: the SBOM endpoint rejects a user without CreateSbom
     let request = TestRequest::post()
-        .uri("/api/v3/sbom")
-        .set_payload(payload.clone())
-        .to_request()
-        .test_auth_details(user_with_advisory_only.clone());
-
-    let response = app.call_service(request).await;
-    assert_eq!(
-        response.status(),
-        StatusCode::FORBIDDEN,
-        "SBOM endpoint correctly rejects user without CreateSbom"
-    );
-
-    // The advisory endpoint must also reject an SBOM upload with ?format=spdx
-    let request = TestRequest::post()
-        .uri("/api/v3/advisory?format=spdx")
+        .uri(&uri)
         .set_payload(payload)
         .to_request()
-        .test_auth_details(user_with_advisory_only);
+        .test_auth_details(user);
 
     let response = app.call_service(request).await;
-    assert_ne!(
-        response.status(),
-        StatusCode::CREATED,
-        "Advisory endpoint must not accept an SBOM without CreateSbom permission"
-    );
+    assert_eq!(response.status(), expected);
 
     Ok(())
 }

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -1,10 +1,6 @@
 use crate::{
     advisory::model::{AdvisoryDetails, AdvisorySummary},
-    test::{
-        CallerBuilder, caller, caller_with, label::Api,
-        label::update_labels as do_update_labels,
-        label::update_labels_not_found as do_update_labels_not_found,
-    },
+    test::{CallerBuilder, caller, caller_with, label, label::Api},
 };
 use actix_http::StatusCode;
 use actix_web::{body::MessageBody, test::TestRequest};
@@ -612,14 +608,14 @@ async fn download_advisory_by_id(ctx: &TrustifyContext) -> Result<(), anyhow::Er
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn update_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    do_update_labels(ctx, Api::Advisory, DOC, "csaf").await
+    label::update_labels(ctx, Api::Advisory, DOC, "csaf").await
 }
 
 /// Test updating labels, for a document that does not exist
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn update_labels_not_found(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    do_update_labels_not_found(ctx, Api::Advisory, DOC).await
+    label::update_labels_not_found(ctx, Api::Advisory, DOC).await
 }
 
 /// Test deleing an advisory

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -6,6 +6,7 @@ use actix_http::StatusCode;
 use actix_web::{body::MessageBody, test::TestRequest};
 use hex::ToHex;
 use jsonpath_rust::JsonPath;
+use rstest::rstest;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::time::Duration;
@@ -31,12 +32,8 @@ use trustify_module_ingestor::{
 };
 use trustify_module_storage::service::{StorageBackend, StorageKey};
 use trustify_test_context::{
-    TrustifyContext,
-    auth::TestAuthentication,
-    call::CallService,
-    document_bytes,
+    TrustifyContext, auth::TestAuthentication, call::CallService, document_bytes,
 };
-use rstest::rstest;
 use urlencoding::encode;
 
 #[test_context(TrustifyContext)]

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -10,7 +10,6 @@ use actix_http::StatusCode;
 use actix_web::{body::MessageBody, test::TestRequest};
 use hex::ToHex;
 use jsonpath_rust::JsonPath;
-use sea_orm::EntityTrait;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::time::Duration;
@@ -25,7 +24,7 @@ use trustify_common::{
     db::pagination_cache::PaginationCache, error::ErrorInformation, hashing::Digests,
     model::PaginatedResults,
 };
-use trustify_entity::{advisory_vulnerability_score, labels::Labels, sbom};
+use trustify_entity::{advisory_vulnerability_score, labels::Labels};
 use trustify_module_ingestor::{
     graph::{
         advisory::AdvisoryInformation,
@@ -42,7 +41,6 @@ use trustify_test_context::{
     document_bytes,
 };
 use urlencoding::encode;
-use uuid::Uuid;
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
@@ -880,8 +878,8 @@ async fn list_advisories_limit_exceeded(ctx: &TrustifyContext) -> Result<(), any
     Ok(())
 }
 
-/// PoC: A user with only `CreateAdvisory` (no `CreateSbom`) can upload an
-/// SPDX SBOM through the advisory endpoint by setting `?format=spdx`.
+/// Uploading an SBOM through the advisory endpoint via `?format=spdx`
+/// must not bypass the `CreateSbom` permission check.
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn upload_sbom_via_advisory_endpoint(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
@@ -897,7 +895,7 @@ async fn upload_sbom_via_advisory_endpoint(ctx: &TrustifyContext) -> Result<(), 
 
     let payload = document_bytes("spdx/simple.json").await?;
 
-    // Control: the same user is rejected on the SBOM endpoint
+    // Control: the SBOM endpoint rejects a user without CreateSbom
     let request = TestRequest::post()
         .uri("/api/v3/sbom")
         .set_payload(payload.clone())
@@ -911,7 +909,7 @@ async fn upload_sbom_via_advisory_endpoint(ctx: &TrustifyContext) -> Result<(), 
         "SBOM endpoint correctly rejects user without CreateSbom"
     );
 
-    // Bypass: the same user succeeds on the advisory endpoint with ?format=spdx
+    // The advisory endpoint must also reject an SBOM upload with ?format=spdx
     let request = TestRequest::post()
         .uri("/api/v3/advisory?format=spdx")
         .set_payload(payload)
@@ -919,19 +917,10 @@ async fn upload_sbom_via_advisory_endpoint(ctx: &TrustifyContext) -> Result<(), 
         .test_auth_details(user_with_advisory_only);
 
     let response = app.call_service(request).await;
-    assert_eq!(
+    assert_ne!(
         response.status(),
         StatusCode::CREATED,
-        "Advisory endpoint accepted an SBOM with ?format=spdx — permission bypass"
-    );
-
-    let result: IngestResult = actix_web::test::read_body_json(response).await;
-
-    let sbom_id: Uuid = result.id.parse()?;
-    let sbom = sbom::Entity::find_by_id(sbom_id).one(&ctx.db).await?;
-    assert!(
-        sbom.is_some(),
-        "SBOM was stored in the sbom table via the advisory endpoint without CreateSbom"
+        "Advisory endpoint must not accept an SBOM without CreateSbom permission"
     );
 
     Ok(())

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -703,7 +703,9 @@ pub async fn upload(
     bytes: web::Bytes,
     _: Require<CreateSbom>,
 ) -> Result<impl Responder, Error> {
-    let format = format.ensure_allowed_for(default_format()).map_err(Error::Ingestor)?;
+    let format = format
+        .ensure_allowed_for(default_format())
+        .map_err(Error::Ingestor)?;
     let bytes = decompress_async(bytes, content_type.map(|ct| ct.0), config.upload_limit).await??;
 
     let tx = db.begin().await?;

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -703,6 +703,7 @@ pub async fn upload(
     bytes: web::Bytes,
     _: Require<CreateSbom>,
 ) -> Result<impl Responder, Error> {
+    let format = format.ensure_allowed_for(default_format()).map_err(Error::Ingestor)?;
     let bytes = decompress_async(bytes, content_type.map(|ct| ct.0), config.upload_limit).await??;
 
     let tx = db.begin().await?;

--- a/modules/fundamental/src/test/common.rs
+++ b/modules/fundamental/src/test/common.rs
@@ -1,17 +1,21 @@
+use actix_web::{App, web};
 use trustify_auth::authorizer::Authorizer;
-use trustify_common::db::{self, pagination_cache::PaginationCache};
+use trustify_common::{
+    db::{self, pagination_cache::PaginationCache},
+    middleware::StdMiddleware,
+};
 use trustify_module_analysis::config::AnalysisConfig;
 use trustify_module_analysis::service::AnalysisService;
 use trustify_module_ingestor::graph::Graph;
-use trustify_test_context::{
-    TrustifyContext,
-    call::{self, CallService},
-};
+use trustify_test_context::{TrustifyContext, call::CallService};
+use utoipa_actix_web::AppExt;
 
 pub async fn caller(ctx: &TrustifyContext) -> anyhow::Result<impl CallService + '_> {
     CallerBuilder::new(ctx).build().await
 }
 
+// include!'d by integration tests that don't all use every item
+#[allow(dead_code)]
 pub async fn caller_with(
     ctx: &TrustifyContext,
     config: Config,
@@ -24,6 +28,8 @@ pub async fn caller_with(
         .await
 }
 
+// include!'d by integration tests that don't all use every item
+#[allow(dead_code)]
 pub struct CallerBuilder<'a> {
     ctx: &'a TrustifyContext,
     config: Config,
@@ -31,6 +37,8 @@ pub struct CallerBuilder<'a> {
     authorizer: Authorizer,
 }
 
+// include!'d by integration tests that don't all use every item
+#[allow(dead_code)]
 impl<'a> CallerBuilder<'a> {
     pub fn new(ctx: &'a TrustifyContext) -> Self {
         Self {
@@ -65,12 +73,20 @@ impl<'a> CallerBuilder<'a> {
         let cache = self.cache;
         let storage = self.ctx.storage.clone();
 
-        call::caller_app_auth(self.authorizer, |svc| {
-            svc.service(utoipa_actix_web::scope("/api").configure(|svc| {
-                configure(svc, config, db_rw, db_ro.clone(), storage, analysis.clone(), cache, graph, Vec::new());
-                trustify_module_analysis::endpoints::configure(svc, db_ro, analysis);
-            }));
-        })
-        .await
+        Ok(actix_web::test::init_service(
+            App::new()
+                .std_middleware()
+                .into_utoipa_app()
+                .app_data(web::PayloadConfig::default().limit(5 * 1024 * 1024))
+                .app_data(web::Data::new(self.authorizer))
+                .configure(|svc| {
+                    svc.service(utoipa_actix_web::scope("/api").configure(|svc| {
+                        configure(svc, config, db_rw, db_ro.clone(), storage, analysis.clone(), cache, graph, Vec::new());
+                        trustify_module_analysis::endpoints::configure(svc, db_ro, analysis);
+                    }));
+                })
+                .into_app(),
+        )
+        .await)
     }
 }

--- a/modules/fundamental/src/test/common.rs
+++ b/modules/fundamental/src/test/common.rs
@@ -1,3 +1,4 @@
+use trustify_auth::authorizer::Authorizer;
 use trustify_common::db::{self, pagination_cache::PaginationCache};
 use trustify_module_analysis::config::AnalysisConfig;
 use trustify_module_analysis::service::AnalysisService;
@@ -8,7 +9,7 @@ use trustify_test_context::{
 };
 
 pub async fn caller(ctx: &TrustifyContext) -> anyhow::Result<impl CallService + '_> {
-    caller_with(ctx, Config::default(), PaginationCache::for_test()).await
+    CallerBuilder::new(ctx).build().await
 }
 
 pub async fn caller_with(
@@ -16,23 +17,60 @@ pub async fn caller_with(
     config: Config,
     cache: PaginationCache,
 ) -> anyhow::Result<impl CallService + '_> {
-    let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let db_ro = db::ReadOnly::new(ctx.db.clone());
-    let analysis = AnalysisService::new(AnalysisConfig::default(), db_ro.clone());
-    let graph = Graph::new();
-    call::caller(|svc| {
-        configure(
-            svc,
-            config,
-            db_rw,
-            db_ro.clone(),
-            ctx.storage.clone(),
-            analysis.clone(),
-            cache,
-            graph,
-            Vec::new(),
-        );
-        trustify_module_analysis::endpoints::configure(svc, db_ro, analysis);
-    })
-    .await
+    CallerBuilder::new(ctx)
+        .config(config)
+        .pagination_cache(cache)
+        .build()
+        .await
+}
+
+pub struct CallerBuilder<'a> {
+    ctx: &'a TrustifyContext,
+    config: Config,
+    cache: PaginationCache,
+    authorizer: Authorizer,
+}
+
+impl<'a> CallerBuilder<'a> {
+    pub fn new(ctx: &'a TrustifyContext) -> Self {
+        Self {
+            ctx,
+            config: Config::default(),
+            cache: PaginationCache::for_test(),
+            authorizer: Authorizer::new(None),
+        }
+    }
+
+    pub fn config(mut self, config: Config) -> Self {
+        self.config = config;
+        self
+    }
+
+    pub fn pagination_cache(mut self, cache: PaginationCache) -> Self {
+        self.cache = cache;
+        self
+    }
+
+    pub fn authorizer(mut self, authorizer: Authorizer) -> Self {
+        self.authorizer = authorizer;
+        self
+    }
+
+    pub async fn build(self) -> anyhow::Result<impl CallService + 'a> {
+        let db_rw = db::ReadWrite::new(self.ctx.db.clone());
+        let db_ro = db::ReadOnly::new(self.ctx.db.clone());
+        let analysis = AnalysisService::new(AnalysisConfig::default(), db_ro.clone());
+        let graph = Graph::new();
+        let config = self.config;
+        let cache = self.cache;
+        let storage = self.ctx.storage.clone();
+
+        call::caller_app_auth(self.authorizer, |svc| {
+            svc.service(utoipa_actix_web::scope("/api").configure(|svc| {
+                configure(svc, config, db_rw, db_ro.clone(), storage, analysis.clone(), cache, graph, Vec::new());
+                trustify_module_analysis::endpoints::configure(svc, db_ro, analysis);
+            }));
+        })
+        .await
+    }
 }

--- a/modules/ingestor/src/service/format.rs
+++ b/modules/ingestor/src/service/format.rs
@@ -43,7 +43,9 @@ impl Format {
     pub fn matches_hint(&self, hint: Format) -> bool {
         match hint {
             Format::Unknown => true,
-            Format::Advisory => matches!(self, Format::CSAF | Format::CVE | Format::OSV | Format::NVD),
+            Format::Advisory => {
+                matches!(self, Format::CSAF | Format::CVE | Format::OSV | Format::NVD)
+            }
             Format::SBOM => matches!(
                 self,
                 Format::SPDX

--- a/modules/ingestor/src/service/format.rs
+++ b/modules/ingestor/src/service/format.rs
@@ -1,3 +1,4 @@
+use super::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
 
@@ -42,7 +43,7 @@ impl Format {
     pub fn matches_hint(&self, hint: Format) -> bool {
         match hint {
             Format::Unknown => true,
-            Format::Advisory => matches!(self, Format::CSAF | Format::CVE | Format::OSV),
+            Format::Advisory => matches!(self, Format::CSAF | Format::CVE | Format::OSV | Format::NVD),
             Format::SBOM => matches!(
                 self,
                 Format::SPDX
@@ -52,6 +53,20 @@ impl Format {
             ),
             concrete => *self == concrete,
         }
+    }
+
+    /// Validate that this format is allowed for an endpoint whose default
+    /// category is `endpoint_default`.
+    pub fn ensure_allowed_for(self, endpoint_default: Format) -> Result<Self, Error> {
+        if self == Format::Unknown {
+            return Ok(endpoint_default);
+        }
+        if self.matches_hint(endpoint_default) || self == endpoint_default {
+            return Ok(self);
+        }
+        Err(Error::UnsupportedFormat(format!(
+            "format '{self}' is not allowed on this endpoint"
+        )))
     }
 }
 

--- a/test-context/src/call.rs
+++ b/test-context/src/call.rs
@@ -51,23 +51,12 @@ pub async fn caller_app<F>(cfg_fn: F) -> anyhow::Result<impl CallService>
 where
     F: FnOnce(&mut ServiceConfig),
 {
-    caller_app_auth(Authorizer::new(None), cfg_fn).await
-}
-
-/// Creates a test app with a custom [`Authorizer`] for testing permission checks.
-pub async fn caller_app_auth<F>(
-    authorizer: Authorizer,
-    cfg_fn: F,
-) -> anyhow::Result<impl CallService>
-where
-    F: FnOnce(&mut ServiceConfig),
-{
     Ok(actix_web::test::init_service(
         App::new()
             .std_middleware()
             .into_utoipa_app()
             .app_data(web::PayloadConfig::default().limit(5 * 1024 * 1024))
-            .app_data(web::Data::new(authorizer))
+            .app_data(web::Data::new(Authorizer::new(None)))
             .configure(cfg_fn)
             .into_app(),
     )

--- a/test-context/src/call.rs
+++ b/test-context/src/call.rs
@@ -51,12 +51,23 @@ pub async fn caller_app<F>(cfg_fn: F) -> anyhow::Result<impl CallService>
 where
     F: FnOnce(&mut ServiceConfig),
 {
+    caller_app_auth(Authorizer::new(None), cfg_fn).await
+}
+
+/// Creates a test app with a custom [`Authorizer`] for testing permission checks.
+pub async fn caller_app_auth<F>(
+    authorizer: Authorizer,
+    cfg_fn: F,
+) -> anyhow::Result<impl CallService>
+where
+    F: FnOnce(&mut ServiceConfig),
+{
     Ok(actix_web::test::init_service(
         App::new()
             .std_middleware()
             .into_utoipa_app()
             .app_data(web::PayloadConfig::default().limit(5 * 1024 * 1024))
-            .app_data(web::Data::new(Authorizer::new(None)))
+            .app_data(web::Data::new(authorizer))
             .configure(cfg_fn)
             .into_app(),
     )


### PR DESCRIPTION
## Summary

- Adds `Format::ensure_allowed_for()` validation to advisory and SBOM upload endpoints, rejecting format query parameters that don't match the endpoint's category (e.g., `format=spdx` on the advisory endpoint)
- Introduces `CallerBuilder` in test infrastructure to support permission-aware integration tests
- Includes regression tests that verify the permission boundary is enforced

Fixes [TC-6082](https://issues.redhat.com/browse/TC-6082)
Related: PSIRTSUPT-22533

## Test plan

- [x] PoC test demonstrates the bypass scenario (advisory endpoint accepting SBOM format)
- [x] Regression test verifies the fix rejects cross-category format overrides
- [x] Existing advisory and SBOM upload tests pass
- [x] `cargo clippy --all-targets --all-features` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-6082]: https://redhat.atlassian.net/browse/TC-6082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enforce endpoint-specific format permissions for advisory and SBOM uploads.

Bug Fixes:
- Reject format query overrides that do not belong to the advisory or SBOM endpoint’s permitted format category, preventing cross-category permission bypasses.

Enhancements:
- Add configurable caller construction for permission-aware integration tests.

Tests:
- Add regression coverage for valid, invalid, and unauthorized advisory and SBOM uploads across format and permission combinations.