### PR TITLE
fix(vuln corr): apply CPE-context filter to the backlink purl_status …

### DIFF
--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -33,6 +33,53 @@ use trustify_entity::{
 use utoipa::ToSchema;
 use uuid::Uuid;
 
+/// Correlated three-way CPE-context filter for the vulnerability backlink
+/// `purl_status` path.
+///
+/// Suppresses advisory statuses whose product CPE context does not apply to
+/// the SBOM being linked, so a status scoped to one product stream (e.g. an
+/// el9 advisory) is not correlated to an SBOM that describes a different
+/// product (e.g. el8). Mirrors the filter used by the `/purl` endpoint
+/// (`cpe_context_subqueries`) and the SBOM-detail path
+/// (`raw_sql::CONTEXT_CPE_FILTER_SQL`), but references the per-row SBOM id
+/// (`sbom_package_purl_ref.sbom_id`) instead of a bound parameter, since the
+/// backlink returns many SBOMs at once.
+///
+/// The three arms are: (1) no context CPE on the status; (2) the context CPE
+/// matches one of the SBOM's describing CPEs (including a generalized,
+/// major-version-only variant); (3) the SBOM declares no describing CPE at all
+/// (escape hatch, preserving prior behavior). See TC-5171.
+const BACKLINK_CPE_CONTEXT_FILTER_SQL: &str = r#"
+(
+    "purl_status"."context_cpe_id" IS NULL OR
+    "purl_status"."context_cpe_id" IN (
+        WITH filtered_cpes AS (
+            SELECT cpe.*
+            FROM sbom_describing_cpe sdc
+            JOIN cpe ON sdc.cpe_id = cpe.id
+            WHERE sdc.sbom_id = "sbom_package_purl_ref"."sbom_id"
+        ),
+        generalized_cpes AS (
+            SELECT *
+            FROM cpe
+            WHERE (edition IS NULL OR edition = '*')
+              AND (vendor, product, version) IN (
+                  SELECT vendor, product, split_part(version, '.', 1)
+                  FROM filtered_cpes
+              )
+        )
+        SELECT id FROM filtered_cpes
+        UNION
+        SELECT id FROM generalized_cpes
+    ) OR (
+        SELECT cpe_id
+        FROM sbom_describing_cpe
+        WHERE sbom_id = "sbom_package_purl_ref"."sbom_id"
+        LIMIT 1
+    ) IS NULL
+)
+"#;
+
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct VulnerabilityAdvisoryHead {
     #[serde(flatten)]
@@ -185,6 +232,9 @@ impl VulnerabilityAdvisorySummary {
                     )))
                     .arg(Expr::col((version_range::Entity, Asterisk))),
             ))
+            // Suppress cross-product/stream correlation: only keep statuses
+            // whose CPE context applies to the linked SBOM. See TC-5171.
+            .filter(Expr::cust(BACKLINK_CPE_CONTEXT_FILTER_SQL))
             .select_only()
             .column(purl_status::Column::AdvisoryId);
 

--- a/modules/fundamental/tests/vuln/mod.rs
+++ b/modules/fundamental/tests/vuln/mod.rs
@@ -129,3 +129,73 @@ async fn cpe_status_vulnerability_backlink(ctx: &TrustifyContext) -> Result<(), 
 
     Ok(())
 }
+
+/// Ingest the `cpe_edition` SBOM plus one advisory and return the set of SBOM
+/// names backlinked from `CVE-2024-99999` via `/vulnerability/{id}`.
+///
+/// The SBOM describes `cpe:/a:acme:widgetos:9.2` (no edition) and contains
+/// `pkg:rpm/acme/libwidget@1.0`. Each advisory creates a `purl_status` for that
+/// PURL with a context CPE that differs only in `edition`.
+async fn cpe_edition_backlinked_sboms(
+    ctx: &TrustifyContext,
+    advisory_path: &str,
+) -> Result<Vec<String>, anyhow::Error> {
+    ctx.ingest_document("cyclonedx/issues/cpe_edition/sbom.json")
+        .await?;
+    ctx.ingest_document(advisory_path).await?;
+
+    let service = VulnerabilityService::new();
+    let details = service
+        .fetch_vulnerability("CVE-2024-99999", Deprecation::Ignore, &ctx.db)
+        .await?
+        .expect("vulnerability must exist");
+
+    Ok(details
+        .advisories
+        .iter()
+        .flat_map(|adv| adv.sboms.iter())
+        .map(|sbom| sbom.head.name.clone())
+        .collect())
+}
+
+/// Regression for TC-5171: the `/vulnerability/{id}` backlink must apply the
+/// same CPE-context filter as `/purl` and `/sbom/{id}/advisory`, so a
+/// `purl_status` scoped to one product stream is not correlated to an SBOM that
+/// describes a different stream.
+///
+/// The advisory's context CPE `cpe:/a:acme:widgetos:9` (no edition) matches the
+/// SBOM's describing CPE `cpe:/a:acme:widgetos:9.2` via generalized
+/// major-version matching, so the SBOM MUST be backlinked.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn backlink_cpe_context_match(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let backlinked =
+        cpe_edition_backlinked_sboms(ctx, "csaf/issues/cpe_edition/advisory-edition-null.json")
+            .await?;
+    assert!(
+        !backlinked.is_empty(),
+        "edition-null context CPE matches the SBOM's describing CPE → SBOM must be backlinked, got {backlinked:?}"
+    );
+
+    Ok(())
+}
+
+/// Regression for TC-5171 (the fix): the advisory's context CPE
+/// `cpe:/a:acme:widgetos:9::el8` (edition `el8`) does NOT match the SBOM's
+/// edition-less describing CPE, so the SBOM MUST NOT be backlinked. Before the
+/// backlink CPE-context filter, this wrong-stream match leaked through.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn backlink_cpe_context_mismatch_suppressed(
+    ctx: &TrustifyContext,
+) -> Result<(), anyhow::Error> {
+    let backlinked =
+        cpe_edition_backlinked_sboms(ctx, "csaf/issues/cpe_edition/advisory-edition-el8.json")
+            .await?;
+    assert!(
+        backlinked.is_empty(),
+        "edition-el8 context CPE must not correlate to the edition-less SBOM, got {backlinked:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
The `GET /v**3/vulnerability/{id}**` backlink ("Related SBOMs") correlated advisory
statuses to SBOMs by base PURL name + version only, with no check that the
status' CPE context actually applied to the SBOM.

As a result, a `purl_status` scoped to one product stream (e.g. an el9 `curl`
advisory) was linked to an SBOM describing a different stream (e.g. el8),
producing wrong-product entries in the backlink and vulnerability report.

This applies the same three-way CPE-context filter already used by `/purl`
(`cpe_context_subqueries`) and `/sbom/{id}/advisory` (`CONTEXT_CPE_FILTER_SQL`)
to the backlink `sbom_status_query`.

Added two regression tests using the existing `cpe_edition` fixtures:

Refs: TC-5171

## Summary by Sourcery

Prevent vulnerability backlinks from associating advisory statuses with SBOMs whose CPE product context does not match.

Bug Fixes:
- Apply CPE-context filtering when correlating vulnerability backlink statuses to SBOMs, preventing advisories for unrelated product streams from appearing in Related SBOMs results.

Tests:
- Add regression coverage for matching and mismatching CPE edition contexts in vulnerability backlinks.