### PR TITLE
fix: backport format permission bypass fix to 0.4

### DIFF
--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -214,6 +214,7 @@ pub async fn upload(
     bytes: web::Bytes,
     _: Require<CreateAdvisory>,
 ) -> Result<impl Responder, Error> {
+    let format = format.ensure_allowed_for(default_format())?;
     let bytes = decompress_async(bytes, content_type.map(|ct| ct.0), config.upload_limit).await??;
     let result = service
         .ingest(

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -6,6 +6,7 @@ use actix_http::StatusCode;
 use actix_web::test::TestRequest;
 use hex::ToHex;
 use jsonpath_rust::JsonPath;
+use rstest::rstest;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use test_context::test_context;
@@ -742,6 +743,93 @@ async fn all_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         ]),
     )
     .await?;
+
+    Ok(())
+}
+
+/// The `?format=` override must not allow uploading a document type that
+/// the endpoint's permission does not cover.
+#[derive(Clone, Copy, Debug)]
+enum Endpoint {
+    Advisory,
+    Sbom,
+}
+
+impl Endpoint {
+    fn uri(self, format: &str) -> String {
+        let base = match self {
+            Self::Advisory => "/api/v2/advisory",
+            Self::Sbom => "/api/v2/sbom",
+        };
+        format!("{base}?format={format}")
+    }
+}
+
+#[test_context(TrustifyContext)]
+#[rstest]
+#[case::advisory_accepts_csaf(
+    Endpoint::Advisory,
+    "csaf",
+    "csaf/cve-2023-33201.json",
+    StatusCode::CREATED
+)]
+#[case::advisory_rejects_spdx(
+    Endpoint::Advisory,
+    "spdx",
+    "spdx/simple.json",
+    StatusCode::BAD_REQUEST
+)]
+#[case::advisory_rejects_cyclonedx(
+    Endpoint::Advisory,
+    "cyclonedx",
+    "spdx/simple.json",
+    StatusCode::BAD_REQUEST
+)]
+#[case::advisory_rejects_sbom_category(
+    Endpoint::Advisory,
+    "sbom",
+    "spdx/simple.json",
+    StatusCode::BAD_REQUEST
+)]
+#[case::sbom_accepts_spdx(Endpoint::Sbom, "spdx", "spdx/simple.json", StatusCode::CREATED)]
+#[case::sbom_rejects_csaf(
+    Endpoint::Sbom,
+    "csaf",
+    "csaf/cve-2023-33201.json",
+    StatusCode::BAD_REQUEST
+)]
+#[case::sbom_rejects_cve(
+    Endpoint::Sbom,
+    "cve",
+    "csaf/cve-2023-33201.json",
+    StatusCode::BAD_REQUEST
+)]
+#[case::sbom_rejects_advisory_category(
+    Endpoint::Sbom,
+    "advisory",
+    "csaf/cve-2023-33201.json",
+    StatusCode::BAD_REQUEST
+)]
+#[test_log::test(actix_web::test)]
+async fn format_permission_enforcement(
+    ctx: &TrustifyContext,
+    #[case] endpoint: Endpoint,
+    #[case] format: &str,
+    #[case] document: &str,
+    #[case] expected: StatusCode,
+) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    let payload = document_bytes(document).await?;
+    let uri = endpoint.uri(format);
+
+    let request = TestRequest::post()
+        .uri(&uri)
+        .set_payload(payload)
+        .to_request();
+
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), expected);
 
     Ok(())
 }

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -491,6 +491,7 @@ pub async fn upload(
     bytes: web::Bytes,
     _: Require<CreateSbom>,
 ) -> Result<impl Responder, Error> {
+    let format = format.ensure_allowed_for(default_format())?;
     let bytes = decompress_async(bytes, content_type.map(|ct| ct.0), config.upload_limit).await??;
     let result = service.ingest(&bytes, format, labels, None, cache).await?;
     log::info!("Uploaded SBOM: {}", result.id);

--- a/modules/ingestor/src/service/format.rs
+++ b/modules/ingestor/src/service/format.rs
@@ -53,6 +53,38 @@ pub enum Format {
 }
 
 impl Format {
+    /// Check whether this format satisfies a given hint.
+    pub fn matches_hint(&self, hint: Format) -> bool {
+        match hint {
+            Format::Unknown => true,
+            Format::Advisory => {
+                matches!(self, Format::CSAF | Format::CVE | Format::OSV)
+            }
+            Format::SBOM => matches!(
+                self,
+                Format::SPDX
+                    | Format::CycloneDX
+                    | Format::ClearlyDefined
+                    | Format::ClearlyDefinedCuration
+            ),
+            concrete => *self == concrete,
+        }
+    }
+
+    /// Validate that this format is allowed for an endpoint whose default
+    /// category is `endpoint_default`.
+    pub fn ensure_allowed_for(self, endpoint_default: Format) -> Result<Self, Error> {
+        if self == Format::Unknown {
+            return Ok(endpoint_default);
+        }
+        if self.matches_hint(endpoint_default) || self == endpoint_default {
+            return Ok(self);
+        }
+        Err(Error::UnsupportedFormat(format!(
+            "format '{self}' is not allowed on this endpoint"
+        )))
+    }
+
     #[instrument(skip_all)]
     pub async fn load(
         &self,


### PR DESCRIPTION
## Summary
- Backport of #2638 to `release/0.4.z`
- Adds `matches_hint` and `ensure_allowed_for` to `Format` to validate `?format=` query parameters against the endpoint's category
- Rejects cross-category format overrides (e.g., `?format=spdx` on the advisory endpoint)
- Includes regression tests covering matching, cross-category, and category-level format scenarios

## Test plan
- [x] Existing upload tests pass (`upload_default_csaf_format`, `upload_osv_format`, `upload_cve_format`, `sbom::upload`)
- [x] New `format_permission_enforcement` parameterized test covers 8 cases across both endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce endpoint-specific permissions for upload format overrides.

Bug Fixes:
- Prevent format query parameters from bypassing endpoint category permissions during advisory and SBOM uploads.

Enhancements:
- Add format matching and endpoint-compatibility validation, including defaulting unspecified formats to the endpoint category.

Tests:
- Add parameterized regression coverage for accepted and rejected format overrides across advisory and SBOM endpoints.