### PR TITLE
fix: backport format permission bypass fix to 0.5

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -157,12 +157,12 @@ impl Database {
 
         format!(
             "postgres://{username}:{password}@{host}:{port}/{db_name}?sslmode={sslmode}",
-            username = &self.username,
-            password = &self.password.0,
-            host = &self.host,
+            username = self.username,
+            password = self.password.0,
+            host = self.host,
             port = self.port,
-            db_name = &self.name,
-            sslmode = &self.sslmode,
+            db_name = self.name,
+            sslmode = self.sslmode,
         )
     }
 

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -212,6 +212,7 @@ pub async fn upload(
     db: web::Data<db::ReadWrite>,
     _: Require<CreateAdvisory>,
 ) -> Result<impl Responder, Error> {
+    let format = format.ensure_allowed_for(Format::Advisory)?;
     let bytes = decompress_async(bytes, content_type.map(|ct| ct.0), config.upload_limit).await??;
 
     let tx = db.begin().await?;

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -1,17 +1,22 @@
 use crate::{
     advisory::model::{AdvisoryDetails, AdvisorySummary},
-    test::{caller, caller_with, label::Api},
+    test::{CallerBuilder, caller, caller_with, label::Api},
 };
 use actix_http::StatusCode;
 use actix_web::{body::MessageBody, test::TestRequest};
 use hex::ToHex;
 use jsonpath_rust::JsonPath;
+use rstest::rstest;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::time::Duration;
 use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
+use trustify_auth::{
+    authenticator::user::UserDetails,
+    authorizer::{Authorizer, AuthorizerConfig},
+};
 use trustify_common::{
     db::pagination_cache::PaginationCache, error::ErrorInformation, hashing::Digests,
     model::PaginatedResults,
@@ -23,7 +28,9 @@ use trustify_module_ingestor::{
     service::Format,
 };
 use trustify_module_storage::service::{StorageBackend, StorageKey};
-use trustify_test_context::{TrustifyContext, call::CallService, document_bytes};
+use trustify_test_context::{
+    TrustifyContext, auth::TestAuthentication, call::CallService, document_bytes,
+};
 use urlencoding::encode;
 
 #[test_context(TrustifyContext)]
@@ -858,6 +865,131 @@ async fn list_advisories_limit_exceeded(ctx: &TrustifyContext) -> Result<(), any
         serde_json::from_slice(&body).expect("response body should be valid JSON");
     assert_eq!(info.error, "LimitExceeded");
     assert!(info.message.contains("10"));
+
+    Ok(())
+}
+
+/// The `?format=` override must not allow uploading a document type that
+/// the endpoint's permission does not cover, and endpoints must enforce
+/// their own permission.
+#[derive(Clone, Copy, Debug)]
+enum Endpoint {
+    Advisory,
+    Sbom,
+}
+
+impl Endpoint {
+    fn uri(self, format: &str) -> String {
+        let base = match self {
+            Self::Advisory => "/api/v3/advisory",
+            Self::Sbom => "/api/v3/sbom",
+        };
+        format!("{base}?format={format}")
+    }
+}
+
+#[test_context(TrustifyContext)]
+#[rstest]
+#[case::advisory_accepts_csaf(
+    Endpoint::Advisory,
+    "csaf",
+    "csaf/cve-2023-33201.json",
+    "create.advisory",
+    StatusCode::CREATED
+)] // correct permission + matching format
+#[case::advisory_rejects_spdx(
+    Endpoint::Advisory,
+    "spdx",
+    "spdx/simple.json",
+    "create.advisory",
+    StatusCode::BAD_REQUEST
+)] // wrong format category
+#[case::advisory_rejects_cyclonedx(
+    Endpoint::Advisory,
+    "cyclonedx",
+    "spdx/simple.json",
+    "create.advisory",
+    StatusCode::BAD_REQUEST
+)] // wrong format category
+#[case::advisory_rejects_sbom_category(
+    Endpoint::Advisory,
+    "sbom",
+    "spdx/simple.json",
+    "create.advisory",
+    StatusCode::BAD_REQUEST
+)] // non-concrete cross-category
+#[case::advisory_forbidden_sbom(
+    Endpoint::Advisory,
+    "csaf",
+    "csaf/cve-2023-33201.json",
+    "create.sbom",
+    StatusCode::FORBIDDEN
+)] // wrong permission
+#[case::sbom_accepts_spdx(
+    Endpoint::Sbom,
+    "spdx",
+    "spdx/simple.json",
+    "create.sbom",
+    StatusCode::CREATED
+)] // correct permission + matching format
+#[case::sbom_rejects_csaf(
+    Endpoint::Sbom,
+    "csaf",
+    "csaf/cve-2023-33201.json",
+    "create.sbom",
+    StatusCode::BAD_REQUEST
+)] // wrong format category
+#[case::sbom_rejects_cve(
+    Endpoint::Sbom,
+    "cve",
+    "csaf/cve-2023-33201.json",
+    "create.sbom",
+    StatusCode::BAD_REQUEST
+)] // wrong format category
+#[case::sbom_rejects_advisory_category(
+    Endpoint::Sbom,
+    "advisory",
+    "csaf/cve-2023-33201.json",
+    "create.sbom",
+    StatusCode::BAD_REQUEST
+)] // non-concrete cross-category
+#[case::sbom_forbidden_advisory(
+    Endpoint::Sbom,
+    "spdx",
+    "spdx/simple.json",
+    "create.advisory",
+    StatusCode::FORBIDDEN
+)] // wrong permission
+#[test_log::test(actix_web::test)]
+async fn format_permission_enforcement(
+    ctx: &TrustifyContext,
+    #[case] endpoint: Endpoint,
+    #[case] format: &str,
+    #[case] document: &str,
+    #[case] permission: &str,
+    #[case] expected: StatusCode,
+) -> Result<(), anyhow::Error> {
+    let app = CallerBuilder::new(ctx)
+        .authorizer(Authorizer::new(Some(AuthorizerConfig {})))
+        .build()
+        .await?;
+
+    let user = UserDetails {
+        id: "test-user".into(),
+        permissions: vec![permission.into()],
+    };
+
+    let payload = document_bytes(document).await?;
+    let uri = endpoint.uri(format);
+
+    let request = TestRequest::post()
+        .uri(&uri)
+        .set_payload(payload)
+        .to_request()
+        .test_auth_details(user);
+
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), expected);
 
     Ok(())
 }

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -703,6 +703,9 @@ pub async fn upload(
     bytes: web::Bytes,
     _: Require<CreateSbom>,
 ) -> Result<impl Responder, Error> {
+    let format = format
+        .ensure_allowed_for(Format::SBOM)
+        .map_err(Error::Ingestor)?;
     let bytes = decompress_async(bytes, content_type.map(|ct| ct.0), config.upload_limit).await??;
 
     let tx = db.begin().await?;

--- a/modules/fundamental/src/test/common.rs
+++ b/modules/fundamental/src/test/common.rs
@@ -1,3 +1,4 @@
+use trustify_auth::authorizer::Authorizer;
 use trustify_common::db::{self, pagination_cache::PaginationCache};
 use trustify_module_analysis::config::AnalysisConfig;
 use trustify_module_analysis::service::AnalysisService;
@@ -7,7 +8,7 @@ use trustify_test_context::{
 };
 
 pub async fn caller(ctx: &TrustifyContext) -> anyhow::Result<impl CallService + '_> {
-    caller_with(ctx, Config::default(), PaginationCache::for_test()).await
+    CallerBuilder::new(ctx).build().await
 }
 
 pub async fn caller_with(
@@ -15,20 +16,61 @@ pub async fn caller_with(
     config: Config,
     cache: PaginationCache,
 ) -> anyhow::Result<impl CallService + '_> {
-    let db_rw = db::ReadWrite::new(ctx.db.clone());
-    let db_ro = db::ReadOnly::new(ctx.db.clone());
-    let analysis = AnalysisService::new(AnalysisConfig::default(), db_ro.clone());
-    call::caller(|svc| {
-        configure(
-            svc,
-            config,
-            db_rw,
-            db_ro.clone(),
-            ctx.storage.clone(),
-            analysis.clone(),
-            cache,
-        );
-        trustify_module_analysis::endpoints::configure(svc, db_ro, analysis);
-    })
-    .await
+    CallerBuilder::new(ctx)
+        .config(config)
+        .pagination_cache(cache)
+        .build()
+        .await
+}
+
+pub struct CallerBuilder<'a> {
+    ctx: &'a TrustifyContext,
+    config: Config,
+    cache: PaginationCache,
+    authorizer: Authorizer,
+}
+
+impl<'a> CallerBuilder<'a> {
+    pub fn new(ctx: &'a TrustifyContext) -> Self {
+        Self {
+            ctx,
+            config: Config::default(),
+            cache: PaginationCache::for_test(),
+            authorizer: Authorizer::new(None),
+        }
+    }
+
+    pub fn config(mut self, config: Config) -> Self {
+        self.config = config;
+        self
+    }
+
+    pub fn pagination_cache(mut self, cache: PaginationCache) -> Self {
+        self.cache = cache;
+        self
+    }
+
+    pub fn authorizer(mut self, authorizer: Authorizer) -> Self {
+        self.authorizer = authorizer;
+        self
+    }
+
+    pub async fn build(self) -> anyhow::Result<impl CallService + 'a> {
+        let db_rw = db::ReadWrite::new(self.ctx.db.clone());
+        let db_ro = db::ReadOnly::new(self.ctx.db.clone());
+        let analysis = AnalysisService::new(AnalysisConfig::default(), db_ro.clone());
+        let config = self.config;
+        let cache = self.cache;
+        let storage = self.ctx.storage.clone();
+        let authorizer = self.authorizer;
+
+        call::caller_app(move |svc| {
+            svc.app_data(actix_web::web::Data::new(authorizer));
+            svc.service(utoipa_actix_web::scope("/api").configure(|svc| {
+                configure(svc, config, db_rw, db_ro.clone(), storage, analysis.clone(), cache);
+                trustify_module_analysis::endpoints::configure(svc, db_ro, analysis);
+            }));
+        })
+        .await
+    }
 }

--- a/modules/ingestor/src/service/format.rs
+++ b/modules/ingestor/src/service/format.rs
@@ -54,6 +54,43 @@ pub enum Format {
 }
 
 impl Format {
+    /// Whether this is a concrete (fully-specified) format, not a category or unknown.
+    pub fn is_concrete(&self) -> bool {
+        !matches!(self, Format::Unknown | Format::Advisory | Format::SBOM)
+    }
+
+    /// Check whether this format satisfies a given hint.
+    pub fn matches_hint(&self, hint: Format) -> bool {
+        match hint {
+            Format::Unknown => true,
+            Format::Advisory => {
+                matches!(self, Format::CSAF | Format::CVE | Format::OSV)
+            }
+            Format::SBOM => matches!(
+                self,
+                Format::SPDX
+                    | Format::CycloneDX
+                    | Format::ClearlyDefined
+                    | Format::ClearlyDefinedCuration
+            ),
+            concrete => *self == concrete,
+        }
+    }
+
+    /// Validate that this format is allowed for an endpoint whose default
+    /// category is `endpoint_default`.
+    pub fn ensure_allowed_for(self, endpoint_default: Format) -> Result<Self, Error> {
+        if self == Format::Unknown {
+            return Ok(endpoint_default);
+        }
+        if self.matches_hint(endpoint_default) || self == endpoint_default {
+            return Ok(self);
+        }
+        Err(Error::UnsupportedFormat(format!(
+            "format '{self}' is not allowed on this endpoint"
+        )))
+    }
+
     #[instrument(skip_all)]
     pub async fn load(
         &self,


### PR DESCRIPTION
## Summary
- Backport of #2638 to `release/0.5.z`
- Adds `ensure_allowed_for()` to `Format` to validate format query parameters against the endpoint's category
- Rejects cross-category format overrides (e.g., `?format=spdx` on the advisory endpoint)
- Adds `CallerBuilder` to test infrastructure for permission-aware integration tests
- Includes 10 parameterized regression tests covering format validation and permission enforcement

## Test plan
- [x] All 10 `format_permission_enforcement` test cases pass
- [x] Existing upload tests (`upload_default_csaf_format`, `upload_osv_format`, `upload_cve_format`, SBOM uploads) pass
- [x] Compilation clean with `cargo check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Backport format and permission enforcement for advisory and SBOM uploads.

Bug Fixes:
- Prevent format query parameters from bypassing endpoint category restrictions during advisory and SBOM uploads.
- Enforce endpoint-specific permissions alongside format validation for upload requests.

Enhancements:
- Add configurable test application construction through CallerBuilder, including custom authorizers.

Tests:
- Add parameterized integration coverage for valid formats, cross-category overrides, and permission enforcement on advisory and SBOM endpoints.

Chores:
- Simplify database connection string formatting by passing owned configuration values directly.