### PR TITLE
fix(migration): make fully-unbounded version ranges match any version (TC-5732) on release/0.4.z

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -36,6 +36,7 @@ mod m0002100_analysis_perf_indexes;
 mod m0002110_sbom_describing_cpe;
 mod m0002120_ancestor_walk_index;
 mod m0002250_create_cpe_status;
+mod m0002260_version_matches_unbounded;
 
 pub struct Migrator;
 
@@ -79,6 +80,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0002110_sbom_describing_cpe::Migration),
             Box::new(m0002120_ancestor_walk_index::Migration),
             Box::new(m0002250_create_cpe_status::Migration),
+            Box::new(m0002260_version_matches_unbounded::Migration),
         ]
     }
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "512"]
+
 pub use sea_orm_migration::prelude::*;
 
 mod m0000010_init;

--- a/migration/src/m0002260_version_matches_unbounded.rs
+++ b/migration/src/m0002260_version_matches_unbounded.rs
@@ -1,0 +1,38 @@
+// Make a fully-unbounded version range (both bounds NULL) match any version, so
+// a bare CSAF `known_affected` (version-less) becomes matchable instead of being
+// silently dropped by the per-scheme comparators. See TC-5732.
+//
+// Implemented as a CREATE OR REPLACE of the `version_matches` dispatcher, so it
+// is idempotent and safe to re-run (which also keeps any future 0.4.z -> 0.6.z
+// upgrade path clean regardless of the migration name recorded upstream).
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0002260_version_matches_unbounded/version_matches_up.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0002260_version_matches_unbounded/version_matches_down.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m0002260_version_matches_unbounded/version_matches_down.sql
+++ b/migration/src/m0002260_version_matches_unbounded/version_matches_down.sql
@@ -1,0 +1,59 @@
+--
+-- Revert to the dispatcher without the fully-unbounded short-circuit (restores
+-- the m0001130 definition). A (NULL, NULL) range once again matches nothing.
+--
+CREATE OR REPLACE FUNCTION public.version_matches(version_p text, range_p public.version_range) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+declare
+begin
+    -- for an authoritative list of support schemes, see the enum
+    -- `trustify_entity::version_scheme::VersionScheme`
+    return case
+        when range_p.version_scheme_id = 'git'
+            -- Git is git, and hard.
+            then gitver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'semver'
+            -- Semver is semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'gem'
+            -- RubyGems claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'npm'
+            -- NPM claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'golang'
+            -- Golang claims to be semver
+            then golang_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'nuget'
+            -- NuGet claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'generic'
+            -- Just check if it is equal
+            then generic_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'rpm'
+            -- Look at me! I'm an RPM! I'm special!
+            then rpmver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'maven'
+            -- Look at me! I'm a Maven! I'm kinda special!
+            then maven_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'python'
+            -- Python versioning
+            then python_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'packagist'
+            -- Packagist PHP strongly encourages semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'hex'
+            -- Erlang Hex claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'swift'
+            -- Swift Package Manager claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'pub'
+            -- Pub Dart Flutter claims to be semver
+            then semver_version_matches(version_p, range_p)
+        else
+            false
+    end;
+end
+$$;

--- a/migration/src/m0002260_version_matches_unbounded/version_matches_up.sql
+++ b/migration/src/m0002260_version_matches_unbounded/version_matches_up.sql
@@ -1,0 +1,78 @@
+--
+-- Make a fully-unbounded version range (both bounds NULL) match any version.
+--
+-- A bare CSAF `known_affected` (version-less) is stored as an unbounded range
+-- (see modules/ingestor/src/service/advisory/csaf/creator.rs and
+-- .../csaf/product_status.rs, which emit VersionSpec::Range(Unbounded, Unbounded)).
+-- The per-scheme comparators (rpmver/semver/maven/python) return FALSE when both
+-- bounds are NULL, so those assertions never matched -> genuine vulnerabilities
+-- were silently missed (false negative, TC-5732).
+--
+-- Guard for it here in the dispatcher, before delegating to the scheme-specific
+-- comparators, so the fix applies uniformly across all schemes. This keys off
+-- the stored bounds being NULL (not the comparison result), so ranges that carry
+-- a bound that merely fails to parse are unaffected and still flow through to the
+-- comparators (which continue to return FALSE for them).
+--
+CREATE OR REPLACE FUNCTION public.version_matches(version_p text, range_p public.version_range) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+declare
+begin
+    -- A fully-unbounded range means "all versions" (e.g. a bare, version-less
+    -- known_affected). Without this, every per-scheme comparator returns false
+    -- for a (NULL, NULL) range and the assertion is unmatchable. See TC-5732.
+    if range_p.low_version is null and range_p.high_version is null then
+        return true;
+    end if;
+
+    -- for an authoritative list of support schemes, see the enum
+    -- `trustify_entity::version_scheme::VersionScheme`
+    return case
+        when range_p.version_scheme_id = 'git'
+            -- Git is git, and hard.
+            then gitver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'semver'
+            -- Semver is semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'gem'
+            -- RubyGems claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'npm'
+            -- NPM claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'golang'
+            -- Golang claims to be semver
+            then golang_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'nuget'
+            -- NuGet claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'generic'
+            -- Just check if it is equal
+            then generic_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'rpm'
+            -- Look at me! I'm an RPM! I'm special!
+            then rpmver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'maven'
+            -- Look at me! I'm a Maven! I'm kinda special!
+            then maven_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'python'
+            -- Python versioning
+            then python_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'packagist'
+            -- Packagist PHP strongly encourages semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'hex'
+            -- Erlang Hex claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'swift'
+            -- Swift Package Manager claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'pub'
+            -- Pub Dart Flutter claims to be semver
+            then semver_version_matches(version_p, range_p)
+        else
+            false
+    end;
+end
+$$;

--- a/migration/tests/previous.rs
+++ b/migration/tests/previous.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "512"]
+
 use test_context::test_context;
 use test_log::test;
 use trustify_db::Database;

--- a/modules/ingestor/tests/version/mavenver.rs
+++ b/modules/ingestor/tests/version/mavenver.rs
@@ -153,6 +153,18 @@ async fn test_version_matches(ctx: TrustifyContext) -> Result<(), anyhow::Error>
         .await?
     );
 
+    // A fully-unbounded range (both bounds NULL) matches any version — a bare
+    // version-less known_affected. See TC-5732.
+    assert!(
+        version_matches(
+            db,
+            "1.0.2",
+            VersionRange::Range(Version::Unbounded, Version::Unbounded),
+            "maven"
+        )
+        .await?
+    );
+
     Ok(())
 }
 

--- a/modules/ingestor/tests/version/pythonver.rs
+++ b/modules/ingestor/tests/version/pythonver.rs
@@ -137,6 +137,18 @@ async fn test_version_matches(ctx: TrustifyContext) -> Result<(), anyhow::Error>
         .await?
     );
 
+    // A fully-unbounded range (both bounds NULL) matches any version — a bare
+    // version-less known_affected. See TC-5732.
+    assert!(
+        version_matches(
+            db,
+            "1.0.2",
+            VersionRange::Range(Version::Unbounded, Version::Unbounded),
+            "python"
+        )
+        .await?
+    );
+
     Ok(())
 }
 

--- a/modules/ingestor/tests/version/rpmver.rs
+++ b/modules/ingestor/tests/version/rpmver.rs
@@ -1,3 +1,4 @@
+use crate::version::common::{Version, VersionRange, version_matches};
 use sea_orm::{ConnectionTrait, Statement};
 use test_context::test_context;
 use test_log::test;
@@ -34,6 +35,28 @@ async fn test_rpmver_cmp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(Some(0), rpmver_cmp(&ctx.db, "1.8.3", "1.8.3").await?);
 
     assert_eq!(Some(1), rpmver_cmp(&ctx.db, "1.8.3", "1.8.2").await?);
+
+    Ok(())
+}
+
+/// A fully-unbounded range (both bounds NULL) must match any version. A bare
+/// CSAF `known_affected` (version-less) is stored this way; before TC-5732 it
+/// was unmatchable, silently dropping genuine vulnerabilities.
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn test_version_matches_unbounded(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
+    let db = &ctx.db;
+
+    assert!(
+        version_matches(
+            db,
+            "8.0p1-19.el8_8",
+            VersionRange::Range(Version::Unbounded, Version::Unbounded),
+            "rpm"
+        )
+        .await?,
+        "a fully-unbounded rpm range must match any version"
+    );
 
     Ok(())
 }

--- a/modules/ingestor/tests/version/semver.rs
+++ b/modules/ingestor/tests/version/semver.rs
@@ -205,6 +205,18 @@ async fn test_version_matches(ctx: TrustifyContext) -> Result<(), anyhow::Error>
         .await?
     );
 
+    // A fully-unbounded range (both bounds NULL) matches any version — a bare
+    // version-less known_affected. See TC-5732.
+    assert!(
+        version_matches(
+            db,
+            "1.0.2",
+            VersionRange::Range(Version::Unbounded, Version::Unbounded),
+            "semver"
+        )
+        .await?
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
A bare, version-less CSAF `known_affected` is ingested as an unbounded version
range (both bounds NULL). Every per-scheme comparator
(`rpmver/semver/maven/python_version_matches`) returns `false` when both bounds
are NULL, so the row is created but never matches — genuine vulnerabilities were
silently missed (false negative). Example: firefox main-el8 `known_affected` in
CVE-2023-6135.

Add an early guard to the top-level `version_matches` dispatcher: a range with
both bounds NULL means "all versions" → return `true`, before delegating to the
scheme-specific comparators.

Added both-unbounded regression tests for rpm, semver, maven, and python
(verified they fail with the guard removed, pass with it).

Refs: TC-5732

## Summary by Sourcery

Ensure version-less affected-product ranges are treated as matching all versions.

Bug Fixes:
- Make fully unbounded version ranges match every version across supported version schemes, preventing version-less CSAF affected entries from being silently missed.

Enhancements:
- Add an idempotent database migration that updates the version-matching dispatcher while preserving rollback support.

Build:
- Increase Rust recursion limits for migration crates and tests.

Tests:
- Add regression coverage for fully unbounded RPM, SemVer, Maven, and Python version ranges.