### PR TITLE
fix(ci): add gate job to prevent silent-skip merges

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" # for embedded postgresql
         run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
 
-  ci:
+  test:
     runs-on: ubuntu-24.04
 
     steps:
@@ -149,6 +149,21 @@ jobs:
           cd docs/book
           npm ci
           make all
+
+  ci:
+    runs-on: ubuntu-slim
+    needs:
+      - supply-chain
+      - check
+      - test
+    if: always()
+    steps:
+      - name: Success
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Failure
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
 
   container:
     needs:


### PR DESCRIPTION
## Summary
- Rename the `ci` job to `test` and add a new `ci` gate job
- The gate depends on `supply-chain`, `check`, and `test` with `if: always()`
- Fails explicitly when any dependency failed, preventing GitHub from treating "skipped" as passing for branch protection

**Problem**: When a dependency of the `ci` job fails (e.g., clippy in `check`), `ci` is skipped. GitHub treats skipped jobs as passing for branch protection, allowing PRs to merge despite failures.

**Pattern**: Based on [trunk-rs/trunk](https://github.com/trunk-rs/trunk/blob/7403c41cb4a58a25f1f845056a7ae3fabe2d70b5/.github/workflows/ci.yaml#L231-L243).

## Test plan
- [ ] Verify `ci` gate job appears in PR checks
- [ ] Verify that when `check` fails, `ci` gate also fails (not skipped)
- [ ] Verify normal green builds still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent silent-skip merges by adding an always-evaluated CI gate for the required workflow jobs.

Bug Fixes:
- Add an explicit CI gate that fails when any required workflow job fails, preventing skipped dependencies from being treated as passing by branch protection.

Enhancements:
- Rename the existing CI workflow job to test and use the new aggregate ci job to report the overall required status.

CI:
- Ensure the aggregate CI status remains evaluated even when supply-chain, check, or test jobs fail.