### PR TITLE
fix(clippy): on windows and clippy need to address error: queries ove…

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -1,6 +1,8 @@
+#![recursion_limit = "512"]
 use crate::data::{
     Migration, MigrationTraitWithData, MigrationWithData, Migrations, MigratorWithData,
 };
+
 pub use sea_orm_migration::prelude::*;
 
 pub mod data;

--- a/migration/tests/previous.rs
+++ b/migration/tests/previous.rs
@@ -1,4 +1,6 @@
+#![recursion_limit = "512"]
 use migration::data::MigrationWithData;
+
 use test_context::test_context;
 use test_log::test;
 use trustify_db::Database;


### PR DESCRIPTION

## Summary by Sourcery

Bug Fixes:
- Prevent Windows and Clippy builds from failing when migration queries exceed the default recursion depth.