### PR TITLE
fix(ci): fix migration dump branch resolution for commits and merge queues

### DIFF
--- a/test-context/src/ctx/migration/mod.rs
+++ b/test-context/src/ctx/migration/mod.rs
@@ -149,12 +149,12 @@ impl<ID: DumpId> TrustifyMigrationContext<ID> {
 
         let snapshot = match source {
             Source::Migration(migration) => {
-                let id: Cow<'static, str> = match migration {
-                    Some(id) => format!("commit-{id}").into(),
-                    None => "latest".into(),
+                let (id, branch): (Cow<'static, str>, Option<&str>) = match migration {
+                    Some(id) => (format!("commit-{id}").into(), Some("main")),
+                    None => ("latest".into(), None),
                 };
                 let migration =
-                    Migration::new(&id).context("failed to create migration manager")?;
+                    Migration::new(&id, branch).context("failed to create migration manager")?;
 
                 let base = dumps.provide_raw("migration", migration.as_dump()).await?;
 

--- a/test-context/src/migration.rs
+++ b/test-context/src/migration.rs
@@ -34,6 +34,7 @@ impl Migration {
                 };
 
                 env::var("TRUSTIFY_MIGRATION_BRANCH")
+                    .map(|b| is_merge_queue(&b).unwrap_or(b))
                     .or_else(|_| current_branch(cwd))
                     .context(
                         "unable to determine branch, consider using 'TRUSTIFY_MIGRATION_BRANCH'",

--- a/test-context/src/migration.rs
+++ b/test-context/src/migration.rs
@@ -19,20 +19,27 @@ pub struct Migration {
 }
 
 impl Migration {
-    /// Create a new instance, detecting paths and the branch
-    pub fn new(commit: &str) -> anyhow::Result<Self> {
-        // get the base of the source code
+    /// Create a new instance.
+    ///
+    /// When `branch` is `Some`, that value is used directly. Otherwise the
+    /// branch is detected from `TRUSTIFY_MIGRATION_BRANCH` or the local git
+    /// checkout.
+    pub fn new(commit: &str, branch: Option<&str>) -> anyhow::Result<Self> {
+        let branch = match branch {
+            Some(b) => b.to_string(),
+            None => {
+                let cwd: PathBuf = match option_env!("CARGO_MANIFEST_DIR") {
+                    Some(cwd) => cwd.into(),
+                    None => env::current_dir().context("unable to determine current directory")?,
+                };
 
-        let cwd: PathBuf = match option_env!("CARGO_MANIFEST_DIR") {
-            Some(cwd) => cwd.into(),
-            None => env::current_dir().context("unable to determine current directory")?,
+                env::var("TRUSTIFY_MIGRATION_BRANCH")
+                    .or_else(|_| current_branch(cwd))
+                    .context(
+                        "unable to determine branch, consider using 'TRUSTIFY_MIGRATION_BRANCH'",
+                    )?
+            }
         };
-
-        // evaluate the branch
-
-        let branch = env::var("TRUSTIFY_MIGRATION_BRANCH")
-            .or_else(|_| current_branch(cwd))
-            .context("unable to determine branch, consider using 'TRUSTIFY_MIGRATION_BRANCH'")?;
 
         log::info!("Using migration for branch: '{branch}'");
 


### PR DESCRIPTION
## Summary
- Commit-specific migration dumps (`commit!()` macro) are only uploaded under `main/` in S3, but on release branches the auto-detected branch resolves to `release/0.6.z`, producing a URL that does not exist (403 Forbidden)
- Add an explicit `branch` parameter to `Migration::new()` so commit-specific lookups always use `main/` while `latest` lookups continue to use the auto-detected branch
- Backport from `hotfix/format_permission_bypass_0.6` where this was the root cause of CI failure

## Test plan
- [ ] CI passes — the `m0002010::examples` migration test should now resolve the correct S3 path on any branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix migration dump branch selection so commit-specific lookups resolve valid S3 paths across release branches and merge queues.

Bug Fixes:
- Ensure commit-specific migration dump lookups consistently use the main branch, preventing invalid paths on release branches and merge queues.

Enhancements:
- Allow migration lookup callers to explicitly provide a branch while preserving automatic branch detection for latest dumps and merge-queue environments.