### PR TITLE
build: Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8532,7 +8532,6 @@ name = "trustify-db"
 version = "0.6.0-rc.1"
 dependencies = [
  "anyhow",
- "async-compression",
  "log",
  "postgresql_commands",
  "postgresql_embedded",
@@ -8548,7 +8547,6 @@ dependencies = [
 name = "trustify-entity"
 version = "0.6.0-rc.1"
 dependencies = [
- "anyhow",
  "cpe",
  "csaf",
  "cvss",
@@ -8561,13 +8559,10 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.28.0",
- "test-context",
  "test-log",
  "thiserror 2.0.19",
  "time",
- "tokio",
  "trustify-common",
- "trustify-test-context",
  "utoipa",
 ]
 
@@ -8586,7 +8581,6 @@ dependencies = [
  "futures",
  "http 1.5.0",
  "log",
- "mime",
  "openssl",
  "opentelemetry",
  "opentelemetry-instrumentation-actix-web",
@@ -8629,7 +8623,6 @@ dependencies = [
  "test-context",
  "test-log",
  "tokio",
- "tokio-util",
  "tracing",
  "tracing-subscriber",
  "trustify-common",
@@ -8648,22 +8641,17 @@ dependencies = [
  "actix-http",
  "actix-web",
  "anyhow",
- "bytes",
  "bytesize",
  "clap",
  "cpe",
- "csaf",
  "deepsize",
  "fixedbitset",
  "futures",
- "hex",
  "humantime",
- "itertools 0.14.0",
  "jsonpath-rust",
  "log",
  "moka",
  "opentelemetry",
- "packageurl",
  "parking_lot",
  "petgraph",
  "rstest",
@@ -8671,13 +8659,11 @@ dependencies = [
  "sea-query",
  "serde",
  "serde_json",
- "sha2 0.11.0",
  "test-context",
  "test-log",
  "thiserror 2.0.19",
  "time",
  "tokio",
- "tokio-util",
  "tracing",
  "trustify-auth",
  "trustify-common",
@@ -8687,21 +8673,18 @@ dependencies = [
  "utoipa",
  "utoipa-actix-web",
  "uuid",
- "zip 8.6.0",
 ]
 
 [[package]]
 name = "trustify-module-exploit-intelligence"
 version = "0.6.0-rc.1"
 dependencies = [
- "actix-http",
  "actix-web",
  "anyhow",
  "bytes",
  "futures-util",
  "reqwest 0.13.4",
  "sea-orm",
- "sea-query",
  "serde",
  "serde_json",
  "test-context",
@@ -8732,9 +8715,7 @@ dependencies = [
  "actix-http",
  "actix-web",
  "anyhow",
- "async-trait",
  "bytes",
- "bytesize",
  "chrono",
  "cpe",
  "criterion",
@@ -8767,11 +8748,9 @@ dependencies = [
  "serde-cyclonedx",
  "serde_json",
  "serde_qs",
- "serde_yaml_ng",
  "sha2 0.11.0",
  "spdx",
  "spdx-expression",
- "spdx-rs",
  "strum 0.28.0",
  "tar",
  "test-context",
@@ -8779,7 +8758,6 @@ dependencies = [
  "thiserror 2.0.19",
  "time",
  "tokio",
- "tokio-util",
  "tracing",
  "tracing-core",
  "tracing-futures",
@@ -8801,7 +8779,6 @@ dependencies = [
  "utoipa-actix-web",
  "uuid",
  "walkdir",
- "wiremock",
  "zip 8.6.0",
 ]
 
@@ -8883,7 +8860,6 @@ dependencies = [
  "packageurl",
  "parking_lot",
  "quick-xml",
- "rand 0.10.2",
  "roxmltree",
  "rstest",
  "sbom-walker",
@@ -8922,7 +8898,6 @@ dependencies = [
 name = "trustify-module-notification"
 version = "0.6.0-rc.1"
 dependencies = [
- "actix-http",
  "actix-web",
  "actix-ws",
  "anyhow",
@@ -8962,11 +8937,9 @@ dependencies = [
  "log",
  "rand 0.10.2",
  "rstest",
- "serde_json",
  "sha2 0.11.0",
  "strum 0.28.0",
  "tempfile",
- "test-context",
  "test-log",
  "thiserror 2.0.19",
  "tokio",
@@ -9073,7 +9046,6 @@ dependencies = [
  "trustify-module-user",
  "trustify-test-context",
  "url",
- "urlencoding",
  "utoipa",
  "utoipa-actix-web",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ license = "Apache-2.0"
 rust-version = "1.92.0"
 
 [workspace.dependencies]
-actix = "0.13.3"
 actix-cors = "0.7"
 actix-http = "3.3.1"
 actix-tls = "3"
@@ -44,7 +43,6 @@ actix-web-httpauth = "0.8"
 actix-web-static-files = "4.0.1"
 anyhow = "1.0.72"
 async-compression = "0.4.13"
-async-recursion = "1"
 async-tar = { version = "0.6", default-features = false, features = ["runtime-tokio"] }
 async-trait = "0.1.74"
 aws-config = { version = "1.8.14", features = ["behavior-version-latest"] }
@@ -55,7 +53,6 @@ base16ct = "1"
 base64 = "0.22"
 build-info = "0.0.44"
 build-info-build = "0.0.44"
-build-info-common = "0.0.44"
 bytes = "1.5"
 bytesize = "2.0"
 chrono = { version = "0.4.35", default-features = false }
@@ -92,7 +89,6 @@ liblzma = "0.4"
 lzma-rust2 = "0.16.1"
 libz-sys = "*"
 log = "0.4.19"
-mime = "0.3.17"
 moka = "0.12.15"
 native-tls = "0.2"
 num-traits = "0.2"
@@ -144,7 +140,6 @@ thiserror = "2"
 time = "0.3"
 tokio = "1.52"
 tokio-util = "0.7"
-tokio_schedule = "0.3"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-flame = "0.2.0"
@@ -185,12 +180,6 @@ trustify-query-derive = {path = "query/query-derive" }
 trustify-server = { path = "server", default-features = false }
 trustify-test-context = { path = "test-context" }
 trustify-ui = { git = "https://github.com/guacsec/trustify-ui.git", branch = "publish/main" }
-
-# These dependencies are active during both the build time and the run time. So they are normal dependencies
-# as well as build-dependencies. However, we can't control feature flags for build dependencies the way we do
-# it for normal dependencies. So enabling the vendor feature for openssl-sys doesn't work for the build-dependencies.
-# This will fail the build on targets where we need vendoring for openssl. Using rustls instead works around this issue.
-postgresql_archive = { version = "0.20.0", default-features = false, features = ["theseus", "rustls"] }
 postgresql_embedded = { version = "0.20.0", default-features = false, features = ["theseus", "rustls"] }
 postgresql_commands = { version = "0.20.0", default-features = false, features = ["tokio"] }
 

--- a/common/db/Cargo.toml
+++ b/common/db/Cargo.toml
@@ -11,7 +11,6 @@ trustify-migration = { workspace = true }
 trustify-common = { workspace = true }
 
 anyhow = { workspace = true }
-async-compression = { workspace = true, features = ["tokio", "lzma", "gzip"] }
 log = { workspace = true }
 postgresql_commands = { workspace = true, features = ["tokio"] }
 postgresql_embedded = { workspace = true, features = ["blocking", "tokio"] }

--- a/common/infrastructure/Cargo.toml
+++ b/common/infrastructure/Cargo.toml
@@ -18,7 +18,6 @@ clap = { workspace = true, features = ["derive", "env", "string"] }
 futures = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-mime = { workspace = true }
 openssl = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"] }

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -24,11 +24,6 @@ thiserror = { workspace = true }
 utoipa = { workspace = true }
 
 [dev-dependencies]
-anyhow = { workspace = true }
 log = { workspace = true }
 rstest = { workspace = true }
-test-context = { workspace = true }
 test-log = { workspace = true, features = ["log", "trace"] }
-tokio = { workspace = true, features = ["full"] }
-
-trustify-test-context = { workspace = true }

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -49,4 +49,3 @@ trustify-test-context = { workspace = true }
 anyhow = { workspace = true }
 test-context = { workspace = true }
 test-log = { workspace = true, features = ["log", "trace"] }
-tokio-util = { workspace = true }

--- a/modules/analysis/Cargo.toml
+++ b/modules/analysis/Cargo.toml
@@ -39,26 +39,18 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 actix-http = { workspace = true }
-bytes = { workspace = true }
 bytesize = { workspace = true }
-csaf = { workspace = true }
 time = { workspace = true, features = ["macros"] }
 futures = { workspace = true }
-hex = { workspace = true }
 humantime = { workspace = true }
-itertools = { workspace = true }
 jsonpath-rust = { workspace = true }
 log = { workspace = true }
-packageurl = { workspace = true }
 petgraph = { workspace = true }
 rstest = { workspace = true }
 serde_json = { workspace = true }
-sha2 = { workspace = true }
 test-context = { workspace = true }
 test-log = { workspace = true, features = ["log", "trace"] }
 tokio = { workspace = true, features = ["full"] }
-tokio-util = { workspace = true, features = ["full"] }
 trustify-test-context = { workspace = true }
 urlencoding = { workspace = true }
 uuid = { workspace = true, features = ["v8"] }
-zip = { workspace = true }

--- a/modules/exploit-intelligence/Cargo.toml
+++ b/modules/exploit-intelligence/Cargo.toml
@@ -21,7 +21,6 @@ bytes = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true, features = ["form", "json", "multipart"] }
 sea-orm = { workspace = true }
-sea-query = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -34,7 +33,6 @@ utoipa-actix-web = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-actix-http = { workspace = true }
 serde_json = { workspace = true }
 test-context = { workspace = true }
 test-log = { workspace = true, features = ["log", "trace"] }

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -22,7 +22,6 @@ trustify-query-derive = { workspace = true }
 actix-http = { workspace = true }
 actix-web = { workspace = true }
 anyhow = { workspace = true }
-async-trait = { workspace = true }
 cpe = { workspace = true }
 csv = { workspace = true }
 flate2 ={ workspace = true }
@@ -43,7 +42,6 @@ tar = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tokio-util = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-futures = { workspace = true, features = ["futures-03"] }
 urlencoding = { workspace = true }
@@ -57,7 +55,6 @@ lenient_semver = { workspace = true }
 [dev-dependencies]
 actix-http = { workspace = true }
 bytes = { workspace = true }
-bytesize = { workspace = true }
 chrono = { workspace = true }
 criterion = { workspace = true, features = ["html_reports", "async_tokio"] }
 csaf = { workspace = true }
@@ -81,9 +78,7 @@ sanitize-filename = { workspace = true }
 semver = { workspace = true }
 serde-cyclonedx = { workspace = true }
 serde_json = { workspace = true }
-serde_yml = { workspace = true }
 sha2 = { workspace = true }
-spdx-rs = { workspace = true }
 strum = { workspace = true }
 tar = { workspace = true }
 test-context = { workspace = true }
@@ -97,7 +92,6 @@ trustify-migration = { workspace = true }
 trustify-test-context = { workspace = true }
 urlencoding = { workspace = true }
 walkdir = { workspace = true }
-wiremock = { workspace = true }
 zip = { workspace = true }
 
 [[bench]]

--- a/modules/ingestor/Cargo.toml
+++ b/modules/ingestor/Cargo.toml
@@ -58,7 +58,6 @@ trustify-test-context = { workspace = true }
 
 actix-http = { workspace = true }
 criterion = { workspace = true }
-rand = { workspace = true }
 rstest = { workspace = true }
 serde_yml = { workspace = true }
 tempfile = { workspace = true }

--- a/modules/notification/Cargo.toml
+++ b/modules/notification/Cargo.toml
@@ -13,8 +13,6 @@ trustify-infrastructure = { workspace = true }
 
 clap = { workspace = true }
 humantime = { workspace = true }
-
-actix-http = { workspace = true }
 actix-web = { workspace = true }
 actix-ws = { workspace = true }
 anyhow = { workspace = true }

--- a/modules/storage/Cargo.toml
+++ b/modules/storage/Cargo.toml
@@ -32,9 +32,7 @@ uuid = { workspace = true, features = ["v4"] }
 [dev-dependencies]
 rand = { workspace = true }
 rstest = { workspace = true }
-serde_json = { workspace = true }
 sha2 = { workspace = true }
-test-context = { workspace = true }
 test-log = { workspace = true, features = ["log", "trace"] }
 uuid = { workspace = true, features = ["v4"] }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -41,7 +41,6 @@ utoipa-actix-web = { workspace = true }
 [dev-dependencies]
 rstest = { workspace = true }
 serde_json = { workspace = true }
-urlencoding = { workspace = true }
 test-context = { workspace = true }
 test-log = { workspace = true, features = ["log", "trace"] }
 trustify-test-context = { workspace = true }


### PR DESCRIPTION
* Analysis done using `cargo-shear`.
* Verified using the `precommit` task using `cargo-xtask`.
* ~Removes the `vendored` feature flag from `trustd` which relied on unused dependencies. Note that they are used transitively, but the build issue mentioned in the removed comment did not occur on a local x86 linux machine.~

## Summary by Sourcery

Remove unused dependencies and the obsolete vendored build configuration.

Enhancements:
- Remove unused workspace, runtime, and development dependencies across the project to simplify dependency management.

Build:
- Update the lockfile and macOS binary builds to no longer use the removed vendored dependency configuration.