### PR TITLE
Recursion fix

### DIFF
--- a/migration/tests/previous.rs
+++ b/migration/tests/previous.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "512"]
+
 use migration::data::MigrationWithData;
 use test_context::test_context;
 use test_log::test;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Increase the recursion limit for migration tests to prevent recursion-related compilation failures.