### PR TITLE
chore(migration): drop unused GiST index purl_status_vulnerability_id_gist

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -78,6 +78,7 @@ mod m0002310_create_change_log;
 mod m0002320_fix_unbounded_version_matches;
 mod m0002330_fix_rpmver_cmp;
 mod m0002340_backfill_rpm_epoch;
+mod m0002350_drop_purl_status_gist_index;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -169,6 +170,7 @@ impl MigratorExt for Migrator {
             .normal(m0002320_fix_unbounded_version_matches::Migration)
             .normal(m0002330_fix_rpmver_cmp::Migration)
             .normal(m0002340_backfill_rpm_epoch::Migration)
+            .normal(m0002350_drop_purl_status_gist_index::Migration)
     }
 }
 

--- a/migration/src/m0002350_drop_purl_status_gist_index.rs
+++ b/migration/src/m0002350_drop_purl_status_gist_index.rs
@@ -1,0 +1,43 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Drop GiST trigram index on purl_status.vulnerability_id introduced
+        // in m0000050. The index uses gist_trgm_ops (substring/LIKE matching)
+        // but every access in the codebase uses equality (=), which is served
+        // by the existing B-tree indexes purl_status_vuln_id_idx and
+        // purl_status_combo_idx. The GiST index is never chosen by the
+        // query planner (0 scans in production) and wastes ~47 GB of disk.
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .name("purl_status_vulnerability_id_gist")
+                    .table(PurlStatus::Table)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"CREATE INDEX IF NOT EXISTS purl_status_vulnerability_id_gist
+                   ON purl_status
+                   USING GIST (vulnerability_id gist_trgm_ops)"#,
+            )
+            .await
+            .map(|_| ())
+    }
+}
+
+#[derive(DeriveIden)]
+enum PurlStatus {
+    Table,
+}


### PR DESCRIPTION
## Summary

- Adds migration `m0002360` that drops the `purl_status_vulnerability_id_gist` index
- The index uses `gist_trgm_ops` (LIKE/similarity matching) but every codebase access on `vulnerability_id` is an equality join served by existing B-tree indexes
- Confirmed 0 query planner scans and ~47 GB wasted disk in a production v2.2.6 instance
- `down()` re-creates the index for rollback safety

## Test plan

- [ ] Verify `purl_status_vulnerability_id_gist` absent from `pg_indexes` after migration runs
- [ ] Confirm B-tree (`purl_status_vuln_id_idx` / `purl_status_combo_idx`) still chosen by planner for equality joins on `vulnerability_id`
- [ ] Full integration test suite passes
- [ ] `down()` restores the index

Implements [TC-6169](https://redhat.atlassian.net/browse/TC-6169)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-6169]: https://redhat.atlassian.net/browse/TC-6169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Remove the unused `purl_status.vulnerability_id` GiST index and support restoring it during rollback.

Enhancements:
- Remove the unused GiST trigram index on `purl_status.vulnerability_id` to reduce database storage overhead while retaining existing equality-query indexes.
- Provide rollback support that recreates the removed index.

Chores:
- Register the new database migration in the migration sequence.