### PR TITLE
Fix recursion and migration issue on 0.6.z

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,9 @@ jobs:
           RUST_LOG: info,sqlx=error,sea_orm=error
           TRUSTIFY_S3_AWS_REGION: eu-west-1
           TRUSTIFY_S3_AWS_BUCKET: guacsec-migration-dumps
+          # the base branch of this run, used to pick the migration dump. On a PR the checkout is
+          # detached, so the branch can't be discovered from git.
+          TRUSTIFY_MIGRATION_BRANCH: ${{ github.base_ref || github.ref_name }}
           TMPDIR: /mnt/trustify
 
       - name: Doc tests

--- a/common/db/src/embedded.rs
+++ b/common/db/src/embedded.rs
@@ -1,6 +1,9 @@
 use anyhow::Context;
 use postgresql_embedded::{PostgreSQL, Settings, VersionReq};
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 use tracing::{Instrument, info_span};
 use trustify_common::{db::Database, decompress::decompress_async_read};
 
@@ -14,6 +17,9 @@ pub fn default_settings() -> anyhow::Result<Settings> {
         username: "postgres".to_string(),
         password: "trustify".to_string(),
         temporary: true,
+        // The default of 5s is not enough for `initdb` (and the other commands) on a loaded CI
+        // runner, where several test binaries bring up their own instance in parallel.
+        timeout: Some(Duration::from_secs(60)),
         ..Default::default()
     })
 }

--- a/migration/tests/data/main.rs
+++ b/migration/tests/data/main.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "512"]
 mod m0002010;
 
 use migration::{

--- a/test-context/src/ctx/migration/mod.rs
+++ b/test-context/src/ctx/migration/mod.rs
@@ -3,9 +3,9 @@ mod snapshot;
 use crate::{
     TrustifyTestContext,
     ctx::migration::snapshot::Snapshot,
-    migration::{Dump, Dumps, Migration},
+    migration::{Dump, Dumps, Migration, is_missing},
 };
-use anyhow::Context;
+use anyhow::{Context, bail};
 use std::{borrow::Cow, marker::PhantomData, ops::Deref};
 use test_context::AsyncTestContext;
 use uuid::Uuid;
@@ -156,7 +156,30 @@ impl<ID: DumpId> TrustifyMigrationContext<ID> {
                 let migration =
                     Migration::new(&id).context("failed to create migration manager")?;
 
-                let base = dumps.provide_raw("migration", migration.as_dump()).await?;
+                let mut base = None;
+                let mut last = None;
+
+                for dump in migration.as_dumps() {
+                    let url = dump.url.to_string();
+                    match dumps.provide_raw("migration", dump).await {
+                        Ok(path) => {
+                            base = Some(path);
+                            break;
+                        }
+                        // only fall back to the next candidate if the dump is simply not there
+                        Err(err) if is_missing(&err) => {
+                            log::info!("no migration dump at '{url}', trying next: {err}");
+                            last = Some(err);
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
+
+                let base = match (base, last) {
+                    (Some(base), _) => base,
+                    (None, Some(err)) => return Err(err),
+                    (None, None) => bail!("no migration dump candidates"),
+                };
 
                 Snapshot {
                     id: source_id,

--- a/test-context/src/migration.rs
+++ b/test-context/src/migration.rs
@@ -15,7 +15,8 @@ use tokio::{
 /// Manage the download of migration dumps
 #[derive(Debug)]
 pub struct Migration {
-    url: String,
+    /// Base URLs to try, in order.
+    urls: Vec<String>,
 }
 
 impl Migration {
@@ -53,26 +54,43 @@ impl Migration {
 
         // done
 
-        Ok(Self {
-            url: format!(
-                "https://{bucket}.s3.{region}.amazonaws.com/{branch}/{commit}",
-                bucket = bucket,
-                region = region,
-                branch = branch,
-            ),
-        })
+        let base =
+            |branch: &str| format!("https://{bucket}.s3.{region}.amazonaws.com/{branch}/{commit}");
+
+        let mut urls = vec![base(&branch)];
+
+        // Commit specific dumps are only uploaded for the branch the commit was pushed to. So a
+        // branch forked off `main` (like `release/*`) doesn't have them, even though the commit is
+        // part of its history. As the content of such a dump only depends on the commit, and not on
+        // the branch, we can fall back to `main`.
+        if commit.starts_with("commit-") && branch != "main" {
+            urls.push(base("main"));
+        }
+
+        Ok(Self { urls })
     }
 
-    /// Provide the base dump path, for this branch.
+    /// Provide the base dumps to try, in order of preference.
     ///
     /// This may include downloading content from S3.
-    pub fn as_dump(&self) -> Dump<'_, &'static str> {
-        Dump {
-            url: &self.url,
+    pub fn as_dumps(&self) -> impl Iterator<Item = Dump<'_, &'static str>> {
+        self.urls.iter().map(|url| Dump {
+            url,
             files: &["dump.sql.xz", "dump.tar"],
             digests: true,
-        }
+        })
     }
+}
+
+/// Check if an error was caused by a dump not being present in the bucket.
+///
+/// The bucket doesn't allow listing its content, so a missing object is reported as `403` instead
+/// of `404`.
+pub fn is_missing(err: &anyhow::Error) -> bool {
+    err.chain()
+        .filter_map(|err| err.downcast_ref::<reqwest::Error>())
+        .filter_map(|err| err.status())
+        .any(|status| status == StatusCode::NOT_FOUND || status == StatusCode::FORBIDDEN)
 }
 
 /// Discover the base branch name

--- a/test-context/src/migration.rs
+++ b/test-context/src/migration.rs
@@ -30,9 +30,18 @@ impl Migration {
 
         // evaluate the branch
 
-        let branch = env::var("TRUSTIFY_MIGRATION_BRANCH")
-            .or_else(|_| current_branch(cwd))
-            .context("unable to determine branch, consider using 'TRUSTIFY_MIGRATION_BRANCH'")?;
+        let branch = match env::var("TRUSTIFY_MIGRATION_BRANCH")
+            .ok()
+            .filter(|branch| !branch.is_empty())
+        {
+            Some(branch) => branch,
+            None => current_branch(cwd).context(
+                "unable to determine branch, consider using 'TRUSTIFY_MIGRATION_BRANCH'",
+            )?,
+        };
+
+        // the provided branch may still be a merge queue branch, in which case we need its base
+        let branch = is_merge_queue(&branch).unwrap_or(branch);
 
         log::info!("Using migration for branch: '{branch}'");
 


### PR DESCRIPTION
Assisted by Opus 5
## Summary by Sourcery

Fix migration test setup by making branch dump selection resilient and allowing embedded PostgreSQL instances more time to initialize in CI.

Bug Fixes:
- Improve migration dump resolution by using the PR base branch, handling merge queue branches, and falling back to the main branch when branch-specific commit dumps are unavailable.
- Increase embedded PostgreSQL startup timeouts to prevent failures on loaded CI runners.

CI:
- Pass the workflow’s base branch to migration tests when running pull requests.

Tests:
- Raise the migration test data recursion limit to support deeper migration test modules.